### PR TITLE
feat(odata2model): actions & function on collection level

### DIFF
--- a/packages/odata2model/src/data-model/DataModelDigestionV4.ts
+++ b/packages/odata2model/src/data-model/DataModelDigestionV4.ts
@@ -134,7 +134,11 @@ class DigesterV4 extends Digester<SchemaV4, EntityTypeV4, ComplexTypeV4> {
       }
 
       const bindingProp = isBound ? params.shift() : undefined;
-      const binding = bindingProp ? bindingProp.type : DigesterV4.ROOT_OPERATION;
+      const binding = bindingProp
+        ? bindingProp.isCollection
+          ? `Collection(${bindingProp.type})`
+          : bindingProp.type
+        : DigesterV4.ROOT_OPERATION;
       this.dataModel.addOperationType(binding, {
         odataName: op.$.Name,
         name: this.getOperationName(op.$.Name),

--- a/packages/odata2model/src/generator/ServiceGenerator.ts
+++ b/packages/odata2model/src/generator/ServiceGenerator.ts
@@ -249,6 +249,7 @@ class ServiceGenerator {
       if (model.modelType === ModelTypes.EntityType) {
         importContainer.addFromService(entitySetServiceType);
 
+        const collectionOperations = this.dataModel.getOperationTypeByBinding(`Collection(${model.name})`);
         const isSingleKey = model.keys.length === 1;
         const exactKeyType = `{ ${model.keys.map((k) => `${k.odataName}: ${this.sanitizeType(k.type)}`).join(", ")} }`;
         const keyType = `${isSingleKey ? this.sanitizeType(model.keys[0].type) + " | " : ""}${exactKeyType}`;
@@ -269,6 +270,7 @@ class ServiceGenerator {
               statements: [`super(client, path, ${firstCharLowerCase(model.qName)}, ${serviceName}, ${keySpec});`],
             },
           ],
+          methods: [...this.generateBoundOperations(collectionOperations, importContainer)],
         });
       }
 


### PR DESCRIPTION
SAP RAP specialty: instead of unbound actions / functions we have static methods which are bound to the entity and hence should appear on the CollectionService

This specialty is detected by virtue of the first parameter which is a collection of entities instead of being one specific instance.