### PR TITLE
feat: createKey and parseKey for EntitySetService & correct V2 type prefixing

### DIFF
--- a/packages/odata-service/src/EntityModel.ts
+++ b/packages/odata-service/src/EntityModel.ts
@@ -8,6 +8,12 @@ export interface InlineUrlProp {
    */
   isLiteral: boolean;
   /**
+   * Only required for V2 types like datetime or guid, e.g. guid'12345678-BBBb-cCCCC-0000-123456789012'.
+   *
+   * If specified, property isLiteral is ignored (it's automatically true).
+   */
+  typePrefix?: string;
+  /**
    *
    */
   value?: any;
@@ -22,12 +28,24 @@ export type InlineUrlProps = { [prop: string]: InlineUrlProp };
 /**
  * All information about a property which is part of the entity key.
  */
-export interface KeyProp {
+export interface EntityKeyProp {
   /**
    * Whether the value of the property should be used as-is.
    * If false, values need to be quoted with single quotes.
    */
   isLiteral: boolean;
+  /**
+   * Only required for V2 types like datetime or guid, e.g. guid'12345678-BBBb-cCCCC-0000-123456789012'.
+   *
+   * If specified, property isLiteral is ignored (it's automatically true).
+   */
+  typePrefix?: string;
+  /**
+   * JS type of the property, e.g. "string" or "number"
+   *
+   * Required for parsing a key and converting it
+   */
+  type: string;
   /**
    * The name of the property.
    */
@@ -43,4 +61,4 @@ export interface KeyProp {
  * In the most simple case, the array contains one KeyProp, e.g. the id.
  * However, it also allows for complex keys.
  */
-export type KeySpec = Array<KeyProp>;
+export type EntityKeySpec = Array<EntityKeyProp>;

--- a/packages/odata-service/src/ServiceModel.ts
+++ b/packages/odata-service/src/ServiceModel.ts
@@ -1,13 +1,17 @@
 import { ODataResponse } from "@odata2ts/odata-client-api";
+import { EntityKeySpec } from "./EntityModel";
 
-export interface EntityKeySpec {
-  isLiteral: boolean;
-  name: string;
-  odataName: string;
+export interface ParsedKey<KeySpec = {}> {
+  path: string | undefined;
+  keys: KeySpec;
 }
 
 export interface EntitySetService<KeySpec> {
-  getKeySpec: () => [EntityKeySpec];
+  getKeySpec: () => EntityKeySpec;
+
+  createKey(id: KeySpec): string;
+
+  parseKey(keyPath: string): ParsedKey<KeySpec>;
 
   create: <CreateModel, ResponseModel>(model: CreateModel) => ODataResponse<ResponseModel>;
 

--- a/packages/odata-service/src/helper/UrlHelper.ts
+++ b/packages/odata-service/src/helper/UrlHelper.ts
@@ -1,4 +1,5 @@
-import { InlineUrlProps, KeySpec } from "../EntityModel";
+import { InlineUrlProps, EntityKeySpec } from "../EntityModel";
+import { ParsedKey } from "../ServiceModel";
 
 /**
  * Constructs an url path for an entity with the given values as key props.
@@ -13,7 +14,11 @@ import { InlineUrlProps, KeySpec } from "../EntityModel";
  * @param values either a primitive number or string or an dedicated object with name-value-pairs.
  * @returns url path
  */
-export const compileId = (path: string, keySpec: KeySpec, values: string | number | { [key: string]: any }): string => {
+export const compileId = (
+  path: string,
+  keySpec: EntityKeySpec,
+  values: string | number | { [key: string]: any }
+): string => {
   if (typeof values === "string" || typeof values === "number") {
     if (Object.keys(keySpec).length !== 1) {
       throw Error("Only primitive value for id provided, but complex key spec is required!");
@@ -26,7 +31,7 @@ export const compileId = (path: string, keySpec: KeySpec, values: string | numbe
       throw Error(`Key [${ks.odataName}] not mapped in provided values!`);
     }
 
-    collector[ks.odataName] = { isLiteral: ks.isLiteral, value };
+    collector[ks.odataName] = { isLiteral: ks.isLiteral, value, typePrefix: ks.typePrefix };
     return collector;
   }, {} as InlineUrlProps);
 
@@ -37,9 +42,96 @@ const compileSingleParamPath = (path: string, isLiteral: boolean, value: string 
   return `${path || ""}(${getValue(isLiteral, value)})`;
 };
 
-const getValue = (isLiteral: boolean, value: any): string => {
+const getValue = (isLiteral: boolean, value: any, typePrefix?: string): string => {
+  if (typePrefix?.trim().length) {
+    return typePrefix + compileLiteralValue(value);
+  }
   return isLiteral ? compileLiteralValue(value) : compileQuotedValue(value);
 };
+
+export const parseId = <T>(id: string, keySpec: EntityKeySpec): ParsedKey<T> => {
+  if (!id?.trim()) {
+    throw new Error("parseId failed: Irregular id passed!");
+  }
+
+  let path = id.replace(/(^[^(]+)\(.*/, "$1");
+  if (path === id) {
+    path = "";
+  }
+  let keys = id.replace(/.*\(([^)]+)\)/, "$1").split(",");
+  if (keys.length === 1 && keys[0] === id) {
+    keys = [];
+  }
+
+  let result: Record<string, unknown> = {};
+
+  // handle short form => myEntity(123)
+  if (keySpec.length === 1 && keys.length === 1 && keys[0].indexOf("=") === -1) {
+    const key = keySpec[0].odataName;
+    result[key] = parseValue(key, keys[0], keySpec);
+  }
+  // complex / explicit form => myEntity(id=123[,...])
+  else if (keys.length) {
+    result = keys.reduce((coll, cur) => {
+      const [key, value] = cur.split("=");
+
+      coll[key] = parseValue(key, value, keySpec);
+      return coll;
+    }, result);
+  }
+
+  if (keys.length !== keySpec.length) {
+    throw new Error("ParseId failed: given keys do not comply with key specification!");
+  }
+
+  return {
+    path,
+    // @ts-ignore => too much magic especially regarding poor man's conversion logic
+    keys: result,
+  };
+};
+
+function parseValue(key: string, value: string, keySpec: EntityKeySpec) {
+  if (!key || !value) {
+    throw new Error(`ParseId failed: Key and value must be specified!`);
+  }
+
+  const keyFromSpec = keySpec.find((ks) => ks.odataName === key);
+  if (!keyFromSpec) {
+    throw new Error(`ParseId failed: Key "${key}" is not part of the key spec!`);
+  }
+
+  const { typePrefix, type, isLiteral } = keyFromSpec;
+
+  // clean from typePrefix (v2 only) and from quoted values
+  const cleanedValue = typePrefix
+    ? value.replace(new RegExp(`^${typePrefix}'([^']*)'`), "$1")
+    : !isLiteral
+    ? value.replace(/'([^']*)'/, "$1")
+    : value;
+
+  // poor man's conversion
+  let convertedValue: string | number | boolean;
+  if (type === "boolean") {
+    if (cleanedValue === "true") {
+      convertedValue = true;
+    } else if (cleanedValue === "false") {
+      convertedValue = false;
+    } else {
+      throw new Error(
+        `ParseId failed: Invalid value for boolean attribute "${key}"! Only the literals "true" or "false" are valid.`
+      );
+    }
+  } else if (type === "number") {
+    convertedValue = Number(cleanedValue);
+  } else if (!cleanedValue) {
+    throw new Error(`ParseId failed: Key and value must be specified!`);
+  } else {
+    convertedValue = cleanedValue;
+  }
+
+  return convertedValue;
+}
 
 /**
  * Constructs an url path suitable for OData functions.
@@ -80,9 +172,9 @@ const compileParams = (id: InlineUrlProps) => {
     throw Error("Only object types are valid for compileParams!");
   }
   return Object.entries(id)
-    .map(([key, { value, isLiteral }]) => {
+    .map(([key, { value, isLiteral, typePrefix }]) => {
       // TODO: "null" for optional params via config or does this work for every OData provider?
-      const val = value === undefined || value === null ? "null" : getValue(isLiteral, value);
+      const val = value === undefined || value === null ? "null" : getValue(isLiteral, value, typePrefix);
       return key + "=" + val;
     })
     .join(",");

--- a/packages/odata-service/src/v2/EntitySetServiceV2.ts
+++ b/packages/odata-service/src/v2/EntitySetServiceV2.ts
@@ -5,8 +5,9 @@ import { ODataUriBuilderV2 } from "@odata2ts/odata-uri-builder";
 import { ODataCollectionResponseV2, ODataModelResponseV2 } from "./ResponseModelV2";
 import { EntityTypeServiceV2 } from "./EntityTypeServiceV2";
 import { ServiceBaseV2 } from "./ServiceBaseV2";
-import { EntityKeySpec } from "../ServiceModel";
-import { compileId } from "../helper/UrlHelper";
+import { EntityKeySpec } from "../EntityModel";
+import { compileId, parseId } from "../helper/UrlHelper";
+import { ParsedKey } from "../ServiceModel";
 
 export abstract class EntitySetServiceV2<
   T,
@@ -31,7 +32,7 @@ export abstract class EntitySetServiceV2<
     path: string,
     qModel: Q,
     protected entityTypeServiceConstructor: new (client: ODataClient, path: string) => ETS,
-    protected keySpec: Array<EntityKeySpec>
+    protected keySpec: EntityKeySpec
   ) {
     super(client, path, qModel);
   }
@@ -42,6 +43,28 @@ export abstract class EntitySetServiceV2<
    */
   public getKeySpec() {
     return this.keySpec;
+  }
+
+  /**
+   * Create an OData path for an entity with a given id.
+   * Might be useful for routing.
+   *
+   * @example myEntity(1234)
+   * @example myEntity(id=1234,name='Test')
+   * @param id either a primitive value or an object for a composite key
+   */
+  public createKey(id: EIdType): string {
+    return compileId(this.path.startsWith("/") ? this.path.substring(1) : this.path, this.keySpec, id);
+  }
+
+  /**
+   * Parse an OData path representing the id of an entity.
+   * Might be useful for routing in combination with createKey.
+   *
+   * @param keyPath e.g. myEntity(id=1234,name='Test')
+   */
+  public parseKey(keyPath: string): ParsedKey<EIdType> {
+    return parseId<EIdType>(keyPath, this.keySpec);
   }
 
   /**

--- a/packages/odata-service/src/v4/EntitySetServiceV4.ts
+++ b/packages/odata-service/src/v4/EntitySetServiceV4.ts
@@ -5,8 +5,9 @@ import { ODataUriBuilderV4 } from "@odata2ts/odata-uri-builder";
 import { EntityTypeServiceV4 } from "./EntityTypeServiceV4";
 import { ODataCollectionResponseV4, ODataModelResponseV4 } from "./ResponseModelV4";
 import { ServiceBaseV4 } from "./ServiceBaseV4";
-import { compileId } from "../helper/UrlHelper";
-import { EntityKeySpec } from "../ServiceModel";
+import { compileId, parseId } from "../helper/UrlHelper";
+import { EntityKeySpec } from "../EntityModel";
+import { ParsedKey } from "../ServiceModel";
 
 export abstract class EntitySetServiceV4<
   T,
@@ -31,7 +32,7 @@ export abstract class EntitySetServiceV4<
     path: string,
     qModel: Q,
     protected entityTypeServiceConstructor: new (client: ODataClient, path: string) => ETS,
-    protected keySpec: Array<EntityKeySpec>
+    protected keySpec: EntityKeySpec
   ) {
     super(client, path, qModel);
   }
@@ -42,6 +43,28 @@ export abstract class EntitySetServiceV4<
    */
   public getKeySpec() {
     return this.keySpec;
+  }
+
+  /**
+   * Create an OData path for an entity with a given id.
+   * Might be useful for routing.
+   *
+   * @example myEntity(1234)
+   * @example myEntity(id=1234,name='Test')
+   * @param id either a primitive value or an object for a composite key
+   */
+  public createKey(id: EIdType): string {
+    return compileId(this.path.startsWith("/") ? this.path.substring(1) : this.path, this.keySpec, id);
+  }
+
+  /**
+   * Parse an OData path representing the id of an entity.
+   * Might be useful for routing in combination with createKey.
+   *
+   * @param keyPath e.g. myEntity(id=1234,name='Test')
+   */
+  public parseKey(keyPath: string): ParsedKey<EIdType> {
+    return parseId<EIdType>(keyPath, this.keySpec);
   }
 
   /**

--- a/packages/odata-service/src/v4/ServiceBaseV4.ts
+++ b/packages/odata-service/src/v4/ServiceBaseV4.ts
@@ -1,7 +1,7 @@
 import { QueryObject } from "@odata2ts/odata-query-objects";
 import { ODataUriBuilderV4 } from "@odata2ts/odata-uri-builder";
 
-import { ODataCollectionResponseV4, ODataModelResponseV4 } from "./ResponseModelV4";
+import { ODataModelResponseV4 } from "./ResponseModelV4";
 import { OperationBaseService } from "../OperationBaseService";
 
 export class ServiceBaseV4<T, Q extends QueryObject> extends OperationBaseService<

--- a/packages/odata-service/test/EntitySetServiceTests.ts
+++ b/packages/odata-service/test/EntitySetServiceTests.ts
@@ -8,14 +8,14 @@ import { EntitySetServiceV2, EntitySetServiceV4 } from "../src";
 export function commonEntitySetTests(
   odataClient: MockODataClient,
   serviceConstructor: new (odataClient: ODataClient, baseUrl: string) =>
-    | EntitySetServiceV4<PersonModel, EditablePersonModel, QPersonV4, any, any>
-    | EntitySetServiceV2<PersonModel, EditablePersonModel, QPersonV2, any, any>
+    | EntitySetServiceV4<PersonModel, EditablePersonModel, QPersonV4, string | { UserName: string }, any>
+    | EntitySetServiceV2<PersonModel, EditablePersonModel, QPersonV2, string | { UserName: string }, any>
 ) {
   const BASE_URL = "/test";
 
   let testService:
-    | EntitySetServiceV4<PersonModel, EditablePersonModel, QPersonV4, any, any>
-    | EntitySetServiceV2<PersonModel, EditablePersonModel, QPersonV2, any, any>;
+    | EntitySetServiceV4<PersonModel, EditablePersonModel, QPersonV4, string | { UserName: string }, any>
+    | EntitySetServiceV2<PersonModel, EditablePersonModel, QPersonV2, string | { UserName: string }, any>;
 
   beforeEach(() => {
     testService = new serviceConstructor(odataClient, BASE_URL);
@@ -24,6 +24,21 @@ export function commonEntitySetTests(
   test("entitySet: setup", async () => {
     expect(testService.getPath()).toBe(BASE_URL);
     expect(testService.getQObject()).not.toBeNull();
+  });
+
+  test("entitySet: createKey", async () => {
+    expect(testService.createKey("xxx")).toBe("test('xxx')");
+    expect(testService.createKey({ UserName: "xxx" })).toBe("test(UserName='xxx')");
+  });
+
+  test("entitySet: parseKey", async () => {
+    const expected = {
+      path: "test",
+      keys: { UserName: "xxx" },
+    };
+
+    expect(testService.parseKey("test('xxx')")).toStrictEqual(expected);
+    expect(testService.parseKey("test(UserName='xxx')")).toStrictEqual(expected);
   });
 
   test("entitySet: query", async () => {

--- a/packages/odata-service/test/UrlHelper.test.ts
+++ b/packages/odata-service/test/UrlHelper.test.ts
@@ -5,17 +5,29 @@ import {
   compileLiteralValue,
   compileQuotedValue,
   compileActionPath,
+  parseId,
 } from "../src";
+import { EntityKeySpec } from "../src/EntityModel";
 
 describe("UrlHelper Test", () => {
   const BASE_PATH = "/base";
-  const KEY_SPEC_COMPOSITE_ID = [
-    { isLiteral: false, name: "name", odataName: "NAME" },
-    { isLiteral: true, name: "age", odataName: "Age" },
-    { isLiteral: true, name: "deceased", odataName: "dead" },
+  const KEY_SPEC_COMPOSITE_ID: EntityKeySpec = [
+    { isLiteral: false, type: "string", name: "name", odataName: "NAME" },
+    { isLiteral: true, type: "number", name: "age", odataName: "Age" },
+    { isLiteral: true, type: "boolean", name: "deceased", odataName: "dead" },
   ];
-  const KEY_SPEC_STRING = [{ isLiteral: false, name: "toDo", odataName: "ToDo" }];
-  const KEY_SPEC_NUMBER = [{ isLiteral: true, name: "toDo", odataName: "ToDo" }];
+  const KEY_SPEC_STRING: EntityKeySpec = [{ isLiteral: false, type: "string", name: "toDo", odataName: "ToDo" }];
+  const KEY_SPEC_NUMBER: EntityKeySpec = [{ isLiteral: true, type: "number", name: "toDo", odataName: "ToDo" }];
+  const KEY_SPEC_BOOLEAN: EntityKeySpec = [{ isLiteral: true, type: "boolean", name: "toDo", odataName: "ToDo" }];
+  const KEY_SPEC_GUID_V2: EntityKeySpec = [
+    { isLiteral: true, type: "guid", typePrefix: "guid", name: "toDo", odataName: "ToDo" },
+  ];
+
+  const KEY_SPEC_V2: EntityKeySpec = [
+    { isLiteral: false, type: "guid", typePrefix: "guid", name: "id", odataName: "ID" },
+    { isLiteral: true, type: "datetime", typePrefix: "datetime", name: "timeStamp", odataName: "timeStamp" },
+    { isLiteral: false, type: "string", name: "test", odataName: "Test" },
+  ];
 
   test("compileFunctionPathV4", () => {
     let result = compileFunctionPathV4(BASE_PATH);
@@ -135,16 +147,21 @@ describe("UrlHelper Test", () => {
     expect(() => compileActionPath(" ")).toThrowError();
   });
 
-  test("compileId: quoted string", () => {
+  test("compileId: short form string", () => {
     const result = compileId(BASE_PATH, KEY_SPEC_STRING, "test");
 
     expect(result).toBe(BASE_PATH + "('test')");
   });
 
-  test("compileId: literal number", () => {
+  test("compileId: short form number", () => {
     const result = compileId(BASE_PATH, KEY_SPEC_NUMBER, 5);
 
     expect(result).toBe(BASE_PATH + "(5)");
+  });
+
+  test("compileId: short form boolean", () => {
+    expect(compileId(BASE_PATH, KEY_SPEC_BOOLEAN, "true")).toBe(BASE_PATH + "(true)");
+    expect(compileId(BASE_PATH, KEY_SPEC_BOOLEAN, "false")).toBe(BASE_PATH + "(false)");
   });
 
   test("compileId: without base path", () => {
@@ -155,7 +172,16 @@ describe("UrlHelper Test", () => {
 
   test("compileId: compositeId", () => {
     const result = compileId(BASE_PATH, KEY_SPEC_COMPOSITE_ID, { Age: 5, NAME: "Tester", dead: false });
+    const result2 = compileId(BASE_PATH, KEY_SPEC_COMPOSITE_ID, { Age: -1, NAME: "Tester", dead: true });
+
     expect(result).toBe(BASE_PATH + "(NAME='Tester',Age=5,dead=false)");
+    expect(result2).toBe(BASE_PATH + "(NAME='Tester',Age=-1,dead=true)");
+  });
+
+  test("compileId: compositeId", () => {
+    const result = compileId(BASE_PATH, KEY_SPEC_V2, { ID: 5, timeStamp: "2022-01-31", Test: "xxx" });
+
+    expect(result).toBe(BASE_PATH + "(ID=guid'5',timeStamp=datetime'2022-01-31',Test='xxx')");
   });
 
   test("fail compileId: compositeId and primitive", () => {
@@ -165,6 +191,100 @@ describe("UrlHelper Test", () => {
 
   test("fail compileId: non-matching keys and values", () => {
     expect(() => compileId(BASE_PATH, KEY_SPEC_COMPOSITE_ID, { name: "Heinz", age: 12, notThere: "sss" })).toThrow();
+  });
+
+  test("parseId: string", () => {
+    const expected = {
+      path: "test",
+      keys: { ToDo: "xxx" },
+    };
+
+    expect(parseId("test('xxx')", KEY_SPEC_STRING)).toStrictEqual(expected);
+    expect(parseId("test(ToDo='xxx')", KEY_SPEC_STRING)).toStrictEqual(expected);
+  });
+
+  test("parseId: number", () => {
+    const expected = {
+      path: "test",
+      keys: { ToDo: 666 },
+    };
+
+    expect(parseId("test(666)", KEY_SPEC_NUMBER)).toStrictEqual(expected);
+    expect(parseId("test(ToDo=666)", KEY_SPEC_NUMBER)).toStrictEqual(expected);
+  });
+
+  test("parseId: boolean", () => {
+    const expected = {
+      path: "test",
+      keys: { ToDo: false },
+    };
+
+    expect(parseId("test(false)", KEY_SPEC_BOOLEAN)).toStrictEqual(expected);
+    expect(parseId("test(ToDo=false)", KEY_SPEC_BOOLEAN)).toStrictEqual(expected);
+  });
+
+  test("fail parseId: boolean with wrong value", () => {
+    const errorMatcher = /Invalid value for boolean attribute "ToDo"!/;
+
+    expect(() => parseId("test('false')", KEY_SPEC_BOOLEAN)).toThrowError(errorMatcher);
+    expect(() => parseId("test(ToDo=1)", KEY_SPEC_BOOLEAN)).toThrowError(errorMatcher);
+  });
+
+  test("parseId: with type prefix (V2 only)", () => {
+    const expected = {
+      path: "test",
+      keys: { ToDo: "xxx" },
+    };
+
+    expect(parseId("test(guid'xxx')", KEY_SPEC_GUID_V2)).toStrictEqual(expected);
+    expect(parseId("test(ToDo=guid'xxx')", KEY_SPEC_GUID_V2)).toStrictEqual(expected);
+  });
+
+  test("parseId: composite key", () => {
+    expect(parseId("test(NAME='xxx',Age=22,dead=false)", KEY_SPEC_COMPOSITE_ID)).toStrictEqual({
+      path: "test",
+      keys: { NAME: "xxx", Age: 22, dead: false },
+    });
+  });
+
+  test("parseId: no base path", () => {
+    const expected = {
+      path: "",
+      keys: { ToDo: "xxx" },
+    };
+
+    expect(parseId("(ToDo='xxx')", KEY_SPEC_STRING)).toStrictEqual(expected);
+    expect(parseId("('xxx')", KEY_SPEC_STRING)).toStrictEqual(expected);
+  });
+
+  test("fail parseId: irregular ids", () => {
+    const errorMatcher = /irregular id/i;
+
+    expect(() => parseId(" ", KEY_SPEC_STRING)).toThrow(errorMatcher);
+    // @ts-ignore
+    expect(() => parseId(null, KEY_SPEC_STRING)).toThrow(errorMatcher);
+    // @ts-ignore
+    expect(() => parseId(undefined, KEY_SPEC_STRING)).toThrow(errorMatcher);
+  });
+
+  test("fail parseId: exact key match", () => {
+    const wrongKeyMatcher = /Key "wrong" is not part of the key spec!/;
+
+    expect(() => parseId("test(wrong='xxx')", KEY_SPEC_STRING)).toThrow(wrongKeyMatcher);
+    expect(() => parseId("test(ToDo='xxx',wrong='xxx')", KEY_SPEC_STRING)).toThrow(wrongKeyMatcher);
+
+    const errorMatcher = /not comply with key spec/i;
+
+    expect(() => parseId("test()", KEY_SPEC_STRING)).toThrow(errorMatcher);
+    expect(() => parseId("test(NAME='xxx')", KEY_SPEC_COMPOSITE_ID)).toThrow(errorMatcher);
+  });
+
+  test("fail parseId: key or value unspecified", () => {
+    const errorMatcher = /Key and value must be specified/i;
+
+    expect(() => parseId("test(='xxx')", KEY_SPEC_STRING)).toThrow(errorMatcher);
+    expect(() => parseId("test(ToDo=)", KEY_SPEC_STRING)).toThrow(errorMatcher);
+    expect(() => parseId("test(ToDo='')", KEY_SPEC_STRING)).toThrow(errorMatcher);
   });
 
   test("compileLiteralValue", () => {

--- a/packages/odata-service/test/fixture/PersonModel.ts
+++ b/packages/odata-service/test/fixture/PersonModel.ts
@@ -28,8 +28,7 @@ export interface PersonModel {
   BestFriend?: PersonModel;
 }
 
-export type EditablePersonModel = Pick<PersonModel, "UserName" | "Age" | "FavFeature"> &
-  Partial<Omit<PersonModel, "UserName" | "Age" | "FavFeature">>;
+export interface EditablePersonModel extends Pick<PersonModel, "UserName" | "Age" | "FavFeature" | "Features"> {}
 
 export type PersonModelServiceVersion = PMServiceV2 | PMServiceV4;
 export type PersonCollectionServiceVersion = PMCServiceV2 | PMCServiceV4;

--- a/packages/odata-service/test/fixture/v2/PersonModelService.ts
+++ b/packages/odata-service/test/fixture/v2/PersonModelService.ts
@@ -1,5 +1,5 @@
 import { ODataClient } from "@odata2ts/odata-client-api";
-import { EntityTypeServiceV2, EntitySetServiceV2, CollectionServiceV2 } from "../../../src";
+import { EntityTypeServiceV2, EntitySetServiceV2, CollectionServiceV2, compileFunctionPathV2 } from "../../../src";
 import {
   QCollectionPath,
   QEntityCollectionPath,
@@ -42,6 +42,16 @@ export class PersonModelService extends EntityTypeServiceV2<PersonModel, Editabl
 
   constructor(client: ODataClient, path: string) {
     super(client, path, new QPersonV2());
+  }
+
+  public getSomething(params: { testGuid: string; testDateTime: string; testDateTimeO: string; testTime: string }) {
+    const url = compileFunctionPathV2(this.getPath(), "GetAnything", {
+      testGuid: { isLiteral: false, typePrefix: "guid", value: params.testGuid },
+      testDateTime: { isLiteral: false, typePrefix: "datetime", value: params.testDateTime },
+      testDateTimeO: { isLiteral: false, typePrefix: "datetimeoffset", value: params.testDateTimeO },
+      testTime: { isLiteral: false, typePrefix: "time", value: params.testTime },
+    });
+    return this.client.get(url);
   }
 }
 

--- a/packages/odata-service/test/fixture/v2/PersonModelService.ts
+++ b/packages/odata-service/test/fixture/v2/PersonModelService.ts
@@ -53,6 +53,8 @@ export class PersonModelCollectionService extends EntitySetServiceV2<
   PersonModelService
 > {
   constructor(client: ODataClient, path: string) {
-    super(client, path, qPersonV2, PersonModelService, [{ isLiteral: false, name: "userName", odataName: "UserName" }]);
+    super(client, path, qPersonV2, PersonModelService, [
+      { isLiteral: false, type: "string", name: "userName", odataName: "UserName" },
+    ]);
   }
 }

--- a/packages/odata-service/test/fixture/v2/TypingModelService.ts
+++ b/packages/odata-service/test/fixture/v2/TypingModelService.ts
@@ -52,6 +52,6 @@ export class TestCollectionService extends EntitySetServiceV4<
   TestService
 > {
   constructor(client: ODataClient, path: string) {
-    super(client, path, qTest, TestService, [{ isLiteral: false, name: "id", odataName: "ID" }]);
+    super(client, path, qTest, TestService, [{ isLiteral: false, type: "guid", name: "id", odataName: "ID" }]);
   }
 }

--- a/packages/odata-service/test/fixture/v4/PersonModelService.ts
+++ b/packages/odata-service/test/fixture/v4/PersonModelService.ts
@@ -53,6 +53,8 @@ export class PersonModelCollectionService extends EntitySetServiceV4<
   PersonModelService
 > {
   constructor(client: ODataClient, path: string) {
-    super(client, path, qPersonV4, PersonModelService, [{ isLiteral: false, name: "userName", odataName: "UserName" }]);
+    super(client, path, qPersonV4, PersonModelService, [
+      { isLiteral: false, type: "string", name: "userName", odataName: "UserName" },
+    ]);
   }
 }

--- a/packages/odata-service/test/fixture/v4/TypingModelService.ts
+++ b/packages/odata-service/test/fixture/v4/TypingModelService.ts
@@ -52,6 +52,6 @@ export class TestCollectionService extends EntitySetServiceV4<
   TestService
 > {
   constructor(client: ODataClient, path: string) {
-    super(client, path, qTest, TestService, [{ isLiteral: false, name: "id", odataName: "ID" }]);
+    super(client, path, qTest, TestService, [{ isLiteral: false, type: "guid", name: "id", odataName: "ID" }]);
   }
 }

--- a/packages/odata-service/test/v2/EntityTypeServiceV2.test.ts
+++ b/packages/odata-service/test/v2/EntityTypeServiceV2.test.ts
@@ -24,11 +24,19 @@ describe("EntityTypeService V2 Test", () => {
     expect(testService.getQObject()).toMatchObject(new QPersonV2());
   });
 
-  test("entityType V4: typing of query stuff", async () => {
+  test("entityType V2: typing of query stuff", async () => {
     // typing test of result
     const result: HttpResponseModel<ODataModelResponseV2<PersonModel>> = await testService.query((builder) => {
       // typing test of builder
       const resultB: ODataUriBuilderV2<QPersonV2> = builder;
     });
+  });
+
+  test("entityType V2: function params", async () => {
+    await testService.getSomething({ testGuid: "123", testDateTime: "1", testDateTimeO: "2", testTime: "3" });
+    expect(odataClient.lastUrl).toBe(
+      BASE_URL +
+        "/GetAnything?testGuid=guid'123'&testDateTime=datetime'1'&testDateTimeO=datetimeoffset'2'&testTime=time'3'"
+    );
   });
 });

--- a/packages/odata2model/int-test/unit/TrippinService.test.ts
+++ b/packages/odata2model/int-test/unit/TrippinService.test.ts
@@ -42,7 +42,9 @@ describe("Testing Generation of TrippinService", () => {
 
     expect(testService.people.getPath()).toBe(expected);
     expect(JSON.stringify(testService.people.getQObject())).toEqual(JSON.stringify(qPerson));
-    expect(testService.people.getKeySpec()).toEqual([{ isLiteral: false, name: "userName", odataName: "UserName" }]);
+    expect(testService.people.getKeySpec()).toEqual([
+      { isLiteral: false, type: "string", name: "userName", odataName: "UserName" },
+    ]);
   });
 
   test("entitySet: create", async () => {

--- a/packages/odata2model/test/fixture/generator/service/v2/main-service-func-import-special-params.ts
+++ b/packages/odata2model/test/fixture/generator/service/v2/main-service-func-import-special-params.ts
@@ -1,0 +1,27 @@
+import { ODataClient, ODataResponse } from "@odata2ts/odata-client-api";
+import { ODataService, ODataModelResponseV2, compileFunctionPathV2 } from "@odata2ts/odata-service";
+// @ts-ignore
+import { TestEntity } from "./TesterModel";
+
+export class TesterService extends ODataService {
+  private name: string = "Tester";
+
+  constructor(client: ODataClient<any>, basePath: string) {
+    super(client, basePath);
+  }
+
+  public bestBook(params: {
+    testGuid: string;
+    testDateTime?: string;
+    testDateTimeOffset?: string;
+    testTime?: string;
+  }): ODataResponse<ODataModelResponseV2<TestEntity>> {
+    const url = compileFunctionPathV2(this.getPath(), "bestBook", {
+      testGuid: { isLiteral: false, typePrefix: "guid", value: params.testGuid },
+      testDateTime: { isLiteral: false, typePrefix: "datetime", value: params.testDateTime },
+      testDateTimeOffset: { isLiteral: false, typePrefix: "datetimeoffset", value: params.testDateTimeOffset },
+      testTime: { isLiteral: false, typePrefix: "time", value: params.testTime },
+    });
+    return this.client.get(url);
+  }
+}

--- a/packages/odata2model/test/fixture/generator/service/v2/test-entity-service-complex.ts
+++ b/packages/odata2model/test/fixture/generator/service/v2/test-entity-service-complex.ts
@@ -44,6 +44,6 @@ export class BookCollectionService extends EntitySetServiceV2<
   BookService
 > {
   constructor(client: ODataClient, path: string) {
-    super(client, path, qBook, BookService, [{ isLiteral: false, name: "id", odataName: "id" }]);
+    super(client, path, qBook, BookService, [{ isLiteral: false, type: "string", name: "id", odataName: "id" }]);
   }
 }

--- a/packages/odata2model/test/fixture/generator/service/v2/test-entity-service-enum.ts
+++ b/packages/odata2model/test/fixture/generator/service/v2/test-entity-service-enum.ts
@@ -30,6 +30,6 @@ export class BookCollectionService extends EntitySetServiceV2<
   BookService
 > {
   constructor(client: ODataClient, path: string) {
-    super(client, path, qBook, BookService, [{ isLiteral: false, name: "id", odataName: "id" }]);
+    super(client, path, qBook, BookService, [{ isLiteral: false, type: "string", name: "id", odataName: "id" }]);
   }
 }

--- a/packages/odata2model/test/fixture/generator/service/v2/test-entity-service-relationships.ts
+++ b/packages/odata2model/test/fixture/generator/service/v2/test-entity-service-relationships.ts
@@ -40,6 +40,8 @@ export class BookCollectionService extends EntitySetServiceV2<
   BookService
 > {
   constructor(client: ODataClient, path: string) {
-    super(client, path, qBook, BookService, [{ isLiteral: true, name: "id", odataName: "ID" }]);
+    super(client, path, qBook, BookService, [
+      { isLiteral: false, type: "string", typePrefix: "guid", name: "id", odataName: "ID" },
+    ]);
   }
 }

--- a/packages/odata2model/test/fixture/generator/service/v2/test-entity-service.ts
+++ b/packages/odata2model/test/fixture/generator/service/v2/test-entity-service.ts
@@ -15,10 +15,32 @@ export class TestEntityCollectionService extends EntitySetServiceV2<
   TestEntity,
   EditableTestEntity,
   QTestEntity,
-  string | { id: string },
+  {
+    id: string;
+    age: number;
+    deceased: boolean;
+    desc: string;
+    dateAndTime: string;
+    dateAndTimeAndOffset: string;
+    time: string;
+  },
   TestEntityService
 > {
   constructor(client: ODataClient, path: string) {
-    super(client, path, qTestEntity, TestEntityService, [{ isLiteral: false, name: "id", odataName: "id" }]);
+    super(client, path, qTestEntity, TestEntityService, [
+      { isLiteral: false, type: "string", typePrefix: "guid", name: "id", odataName: "id" },
+      { isLiteral: true, type: "number", name: "age", odataName: "age" },
+      { isLiteral: true, type: "boolean", name: "deceased", odataName: "deceased" },
+      { isLiteral: false, type: "string", name: "desc", odataName: "desc" },
+      { isLiteral: false, type: "string", typePrefix: "datetime", name: "dateAndTime", odataName: "dateAndTime" },
+      {
+        isLiteral: false,
+        type: "string",
+        typePrefix: "datetimeoffset",
+        name: "dateAndTimeAndOffset",
+        odataName: "dateAndTimeAndOffset",
+      },
+      { isLiteral: false, type: "string", typePrefix: "time", name: "time", odataName: "time" },
+    ]);
   }
 }

--- a/packages/odata2model/test/fixture/generator/service/v4/test-entity-service-bound-action.ts
+++ b/packages/odata2model/test/fixture/generator/service/v4/test-entity-service-bound-action.ts
@@ -34,6 +34,6 @@ export class BookCollectionService extends EntitySetServiceV4<
   BookService
 > {
   constructor(client: ODataClient, path: string) {
-    super(client, path, qBook, BookService, [{ isLiteral: false, name: "id", odataName: "id" }]);
+    super(client, path, qBook, BookService, [{ isLiteral: false, type: "string", name: "id", odataName: "id" }]);
   }
 }

--- a/packages/odata2model/test/fixture/generator/service/v4/test-entity-service-bound-func.ts
+++ b/packages/odata2model/test/fixture/generator/service/v4/test-entity-service-bound-func.ts
@@ -41,6 +41,6 @@ export class BookCollectionService extends EntitySetServiceV4<
   BookService
 > {
   constructor(client: ODataClient, path: string) {
-    super(client, path, qBook, BookService, [{ isLiteral: false, name: "id", odataName: "id" }]);
+    super(client, path, qBook, BookService, [{ isLiteral: false, type: "string", name: "id", odataName: "id" }]);
   }
 }

--- a/packages/odata2model/test/fixture/generator/service/v4/test-entity-service-complex.ts
+++ b/packages/odata2model/test/fixture/generator/service/v4/test-entity-service-complex.ts
@@ -44,6 +44,6 @@ export class BookCollectionService extends EntitySetServiceV4<
   BookService
 > {
   constructor(client: ODataClient, path: string) {
-    super(client, path, qBook, BookService, [{ isLiteral: false, name: "id", odataName: "id" }]);
+    super(client, path, qBook, BookService, [{ isLiteral: false, type: "string", name: "id", odataName: "id" }]);
   }
 }

--- a/packages/odata2model/test/fixture/generator/service/v4/test-entity-service-enum.ts
+++ b/packages/odata2model/test/fixture/generator/service/v4/test-entity-service-enum.ts
@@ -30,6 +30,6 @@ export class BookCollectionService extends EntitySetServiceV4<
   BookService
 > {
   constructor(client: ODataClient, path: string) {
-    super(client, path, qBook, BookService, [{ isLiteral: false, name: "id", odataName: "id" }]);
+    super(client, path, qBook, BookService, [{ isLiteral: false, type: "string", name: "id", odataName: "id" }]);
   }
 }

--- a/packages/odata2model/test/fixture/generator/service/v4/test-entity-service-relationships.ts
+++ b/packages/odata2model/test/fixture/generator/service/v4/test-entity-service-relationships.ts
@@ -40,6 +40,6 @@ export class BookCollectionService extends EntitySetServiceV4<
   BookService
 > {
   constructor(client: ODataClient, path: string) {
-    super(client, path, qBook, BookService, [{ isLiteral: true, name: "id", odataName: "ID" }]);
+    super(client, path, qBook, BookService, [{ isLiteral: true, type: "string", name: "id", odataName: "ID" }]);
   }
 }

--- a/packages/odata2model/test/fixture/generator/service/v4/test-entity-service.ts
+++ b/packages/odata2model/test/fixture/generator/service/v4/test-entity-service.ts
@@ -15,10 +15,15 @@ export class TestEntityCollectionService extends EntitySetServiceV4<
   TestEntity,
   EditableTestEntity,
   QTestEntity,
-  string | { id: string },
+  { id: string; age: number; deceased: boolean; desc: string },
   TestEntityService
 > {
   constructor(client: ODataClient, path: string) {
-    super(client, path, qTestEntity, TestEntityService, [{ isLiteral: false, name: "id", odataName: "id" }]);
+    super(client, path, qTestEntity, TestEntityService, [
+      { isLiteral: true, type: "string", name: "id", odataName: "id" },
+      { isLiteral: true, type: "number", name: "age", odataName: "age" },
+      { isLiteral: true, type: "boolean", name: "deceased", odataName: "deceased" },
+      { isLiteral: false, type: "string", name: "desc", odataName: "desc" },
+    ]);
   }
 }

--- a/packages/odata2model/test/generator/v2/ServiceGenerator.test.ts
+++ b/packages/odata2model/test/generator/v2/ServiceGenerator.test.ts
@@ -74,7 +74,13 @@ describe("Service Generator Tests V2", () => {
     odataBuilder
       .addEntityType("TestEntity", undefined, (builder) =>
         builder
-          .addKeyProp("id", ODataTypesV3.String)
+          .addKeyProp("id", ODataTypesV3.Guid)
+          .addKeyProp("age", ODataTypesV3.Int32)
+          .addKeyProp("deceased", ODataTypesV3.Boolean)
+          .addKeyProp("desc", ODataTypesV3.String)
+          .addKeyProp("dateAndTime", ODataTypesV3.DateTime)
+          .addKeyProp("dateAndTimeAndOffset", ODataTypesV3.DateTimeOffset)
+          .addKeyProp("time", ODataTypesV3.Time)
           // simple props don't make a difference
           .addProp("test", ODataTypesV3.String)
           .addProp("test2", ODataTypesV3.Guid)
@@ -109,6 +115,25 @@ describe("Service Generator Tests V2", () => {
 
     // then main service file encompasses unbound functions
     await compareMainService("main-service-func-import.ts", true);
+  });
+
+  test("Service Generator: Special function params", async () => {
+    // given two functions: one without and one with params
+    odataBuilder
+      .addEntityType("TestEntity", undefined, (builder) => builder.addKeyProp("id", ODataTypesV3.String))
+      .addFunctionImport("bestBook", `${SERVICE_NAME}.TestEntity`, (builder) =>
+        builder
+          .addParam("testGuid", ODataTypesV3.Guid, false)
+          .addParam("testDateTime", ODataTypesV3.DateTime)
+          .addParam("testDateTimeOffset", ODataTypesV3.DateTimeOffset)
+          .addParam("testTime", ODataTypesV3.Time)
+      );
+
+    // when generating
+    await doGenerate();
+
+    // then main service file encompasses unbound functions
+    await compareMainService("main-service-func-import-special-params.ts", true);
   });
 
   test.skip("Service Generator: one unbound action", async () => {

--- a/packages/odata2model/test/generator/v4/ServiceGenerator.test.ts
+++ b/packages/odata2model/test/generator/v4/ServiceGenerator.test.ts
@@ -73,7 +73,10 @@ describe("Service Generator Tests V4", () => {
     odataBuilder
       .addEntityType("TestEntity", undefined, (builder) =>
         builder
-          .addKeyProp("id", ODataTypesV4.String)
+          .addKeyProp("id", ODataTypesV4.Guid)
+          .addKeyProp("age", ODataTypesV4.Int32)
+          .addKeyProp("deceased", ODataTypesV4.Boolean)
+          .addKeyProp("desc", ODataTypesV4.String)
           // simple props don't make a difference
           .addProp("test", ODataTypesV4.String)
           .addProp("test2", ODataTypesV4.Guid)
@@ -105,13 +108,6 @@ describe("Service Generator Tests V4", () => {
 
     // then main service file encompasses a singleton
     await compareMainService("main-service-singleton.ts", true);
-
-    // then we get the same service file as before
-    expect(projectManager.getServiceFiles().length).toEqual(1);
-    await fixtureComparator.compareWithFixture(
-      projectManager.getServiceFiles()[0].getFullText(),
-      "v4" + path.sep + "test-entity-service.ts"
-    );
   });
 
   test("Service Generator: one unbound function", async () => {


### PR DESCRIPTION
Adds createKey and parseKey methods (cf. #36)

Fixes V2 data types in URLs (function / action params as well as keys) with prefixes. For example guid type becomes `guid'xxxx-xxxx...'` or `datetime'2022-01-31T12:15:55'. 