### PR TITLE
refactor: use proper getMethods for services

### DIFF
--- a/packages/odata2model/int-test/integration/v2/ODataV2ServiceIntegration.test.ts
+++ b/packages/odata2model/int-test/integration/v2/ODataV2ServiceIntegration.test.ts
@@ -28,7 +28,7 @@ describe("Integration Testing of generated stuff for Sample V2 OData Service", (
   };
 
   test("list products with count", async () => {
-    const result = await testService.products.query((b) => b.count());
+    const result = await testService.getProductsSrv().query((b) => b.count());
     expect(result.status).toBe(200);
     expect(result.data).toBeDefined();
     expect(result.data.d).toBeDefined();
@@ -40,7 +40,7 @@ describe("Integration Testing of generated stuff for Sample V2 OData Service", (
   });
 
   test("get product zero", async () => {
-    const result = await testService.products.get(0).query();
+    const result = await testService.getProductsSrv().get(0).query();
     expect(result.status).toBe(200);
     expect(result.data).toBeDefined();
     expect(result.data.d).toBeDefined();
@@ -51,7 +51,7 @@ describe("Integration Testing of generated stuff for Sample V2 OData Service", (
 
   test("get unknown product", async () => {
     try {
-      await testService.products.get(666).query();
+      await testService.getProductsSrv().get(666).query();
       // we expect an error and no success
       expect(1).toBe(2);
     } catch (error) {
@@ -78,12 +78,12 @@ describe("Integration Testing of generated stuff for Sample V2 OData Service", (
     };
 
     // when creating the product
-    let result = await editableService.products.create(product);
+    let result = await editableService.getProductsSrv().create(product);
     // then return object matches our product
     expect(result.data.d).toMatchObject({ ...product, ReleaseDate: "/Date(1672488959000)/" });
 
     // given a service for the new product
-    const productService = editableService.products.get(product.ID);
+    const productService = editableService.getProductsSrv().get(product.ID);
     // when updating the description, we expect no error
     await productService.patch({ Description: "Updated Desc" });
 
@@ -102,7 +102,7 @@ describe("Integration Testing of generated stuff for Sample V2 OData Service", (
   });
 
   test("deep select query", async () => {
-    const result = await testService.products.query((b, qProduct) => {
+    const result = await testService.getProductsSrv().query((b, qProduct) => {
       b.count()
         .select("id", "name", qProduct.category.props.name)
         .select(qProduct.category.props.id) // just for the fun of it

--- a/packages/odata2model/int-test/integration/v4/TrippinIntegration.test.ts
+++ b/packages/odata2model/int-test/integration/v4/TrippinIntegration.test.ts
@@ -24,7 +24,7 @@ describe("Integration Testing of Service Generation", () => {
   });
 
   test("entityType query", async () => {
-    const result = await testService.people.get("russellwhyte").query();
+    const result = await testService.getPeopleSrv().get("russellwhyte").query();
     expect(result.status).toBe(200);
     expect(result.data).toBeDefined();
     expect(result.data.FirstName).toBe("Russell");
@@ -32,14 +32,14 @@ describe("Integration Testing of Service Generation", () => {
   });
 
   test("entitySet query", async () => {
-    const result = await testService.people.query();
+    const result = await testService.getPeopleSrv().query();
     expect(result.status).toBe(200);
     expect(result.data).toBeDefined();
     expect(result.data.value.length).toBe(20);
   });
 
   test("entitySet query people with any Feature 1", async () => {
-    const result = await testService.people.query((builder, qPerson) => {
+    const result = await testService.getPeopleSrv().query((builder, qPerson) => {
       return builder
         .count()
         .top(10)
@@ -112,7 +112,7 @@ describe("Integration Testing of Service Generation", () => {
   });
 
   test("collection of strings", async () => {
-    const result = await testService.people.get("russellwhyte").addressInfo.query();
+    const result = await testService.getPeopleSrv().get("russellwhyte").getAddressInfoSrv().query();
 
     expect(result.status).toBe(200);
     expect(result.data).toBeDefined();

--- a/packages/odata2model/int-test/unit/TrippinService.test.ts
+++ b/packages/odata2model/int-test/unit/TrippinService.test.ts
@@ -40,9 +40,9 @@ describe("Testing Generation of TrippinService", () => {
   test("entitySet", async () => {
     const expected = `${BASE_URL}/People`;
 
-    expect(testService.people.getPath()).toBe(expected);
-    expect(JSON.stringify(testService.people.getQObject())).toEqual(JSON.stringify(qPerson));
-    expect(testService.people.getKeySpec()).toEqual([
+    expect(testService.getPeopleSrv().getPath()).toBe(expected);
+    expect(JSON.stringify(testService.getPeopleSrv().getQObject())).toEqual(JSON.stringify(qPerson));
+    expect(testService.getPeopleSrv().getKeySpec()).toEqual([
       { isLiteral: false, type: "string", name: "userName", odataName: "UserName" },
     ]);
   });
@@ -50,7 +50,7 @@ describe("Testing Generation of TrippinService", () => {
   test("entitySet: create", async () => {
     const expectedUrl = `${BASE_URL}/People`;
 
-    await testService.people.create(editModel);
+    await testService.getPeopleSrv().create(editModel);
 
     expect(odataClient.lastOperation).toBe("POST");
     expect(odataClient.lastUrl).toBe(expectedUrl);
@@ -61,7 +61,7 @@ describe("Testing Generation of TrippinService", () => {
     const testId = "test";
     const expected = `${BASE_URL}/People('${testId}')`;
 
-    const etService = testService.people.get(testId);
+    const etService = testService.getPeopleSrv().get(testId);
 
     expect(etService.getPath()).toBe(expected);
     expect(JSON.stringify(etService.getQObject())).toEqual(JSON.stringify(qPerson));
@@ -71,8 +71,8 @@ describe("Testing Generation of TrippinService", () => {
     const testId = { UserName: "williams" };
     const expected = `${BASE_URL}/People(UserName='williams')`;
 
-    expect(testService.people.get(testId).getPath()).toBe(expected);
-    expect(testService.people.get(editModel).getPath()).toBe(expected);
+    expect(testService.getPeopleSrv().get(testId).getPath()).toBe(expected);
+    expect(testService.getPeopleSrv().get(editModel).getPath()).toBe(expected);
   });
 
   test("entityType: update", async () => {
@@ -87,7 +87,7 @@ describe("Testing Generation of TrippinService", () => {
       Age: 33,
     };
 
-    await testService.people.get(id).update(model);
+    await testService.getPeopleSrv().get(id).update(model);
 
     expect(odataClient.lastOperation).toBe("PUT");
     expect(odataClient.lastUrl).toBe(expectedUrl);
@@ -101,7 +101,7 @@ describe("Testing Generation of TrippinService", () => {
       Age: 44,
     };
 
-    await testService.people.get(id).patch(model);
+    await testService.getPeopleSrv().get(id).patch(model);
 
     expect(odataClient.lastOperation).toBe("PATCH");
     expect(odataClient.lastUrl).toBe(expectedUrl);
@@ -112,7 +112,7 @@ describe("Testing Generation of TrippinService", () => {
     const id = "williams";
     const expectedUrl = `${BASE_URL}/People('${id}')`;
 
-    await testService.people.get(id).delete();
+    await testService.getPeopleSrv().get(id).delete();
 
     expect(odataClient.lastOperation).toBe("DELETE");
     expect(odataClient.lastUrl).toBe(expectedUrl);
@@ -120,14 +120,14 @@ describe("Testing Generation of TrippinService", () => {
   });
 
   test("complex type", async () => {
-    const complex = testService.people.get("tester").homeAddress;
+    const complex = testService.getPeopleSrv().get("tester").getHomeAddressSrv();
 
     expect(complex.getPath()).toBe(`${BASE_URL}/People('tester')/HomeAddress`);
     expect(JSON.stringify(complex.getQObject())).toEqual(JSON.stringify(qLocation));
   });
 
   test("complex type: query", async () => {
-    await testService.people.get("tester").homeAddress.query();
+    await testService.getPeopleSrv().get("tester").getHomeAddressSrv().query();
 
     expect(odataClient.lastUrl).toBe(`${BASE_URL}/People('tester')/HomeAddress`);
     expect(odataClient.lastOperation).toBe("GET");
@@ -135,7 +135,7 @@ describe("Testing Generation of TrippinService", () => {
   });
 
   test("complex type: update", async () => {
-    const complex = testService.people.get("tester").homeAddress;
+    const complex = testService.getPeopleSrv().get("tester").getHomeAddressSrv();
 
     const model: EditableLocationModel = {
       Address: "Test Address",
@@ -149,14 +149,14 @@ describe("Testing Generation of TrippinService", () => {
   });
 
   test("complex collection", async () => {
-    const complex = testService.people.get("tester").addressInfo;
+    const complex = testService.getPeopleSrv().get("tester").getAddressInfoSrv();
 
     expect(complex.getPath()).toBe(`${BASE_URL}/People('tester')/AddressInfo`);
     expect(JSON.stringify(complex.getQObject())).toEqual(JSON.stringify(qLocation));
   });
 
   test("complex collection: query", async () => {
-    await testService.people.get("tester").addressInfo.query();
+    await testService.getPeopleSrv().get("tester").getAddressInfoSrv().query();
 
     expect(odataClient.lastUrl).toBe(`${BASE_URL}/People('tester')/AddressInfo`);
     expect(odataClient.lastOperation).toBe("GET");
@@ -165,7 +165,7 @@ describe("Testing Generation of TrippinService", () => {
 
   test("complex collection: create", async () => {
     const model: EditableLocationModel = { Address: "TestAdress" };
-    await testService.people.get("tester").addressInfo.add(model);
+    await testService.getPeopleSrv().get("tester").getAddressInfoSrv().add(model);
 
     expect(odataClient.lastUrl).toBe(`${BASE_URL}/People('tester')/AddressInfo`);
     expect(odataClient.lastOperation).toBe("POST");
@@ -174,7 +174,7 @@ describe("Testing Generation of TrippinService", () => {
 
   test("complex collection: update", async () => {
     const models = [{ Address: "TestAddress 1" }, { Address: "test 2" }];
-    await testService.people.get("tester").addressInfo.update(models);
+    await testService.getPeopleSrv().get("tester").getAddressInfoSrv().update(models);
 
     expect(odataClient.lastUrl).toBe(`${BASE_URL}/People('tester')/AddressInfo`);
     expect(odataClient.lastOperation).toBe("PUT");
@@ -182,7 +182,7 @@ describe("Testing Generation of TrippinService", () => {
   });
 
   test("complex collection: delete", async () => {
-    await testService.people.get("tester").addressInfo.delete();
+    await testService.getPeopleSrv().get("tester").getAddressInfoSrv().delete();
 
     expect(odataClient.lastUrl).toBe(`${BASE_URL}/People('tester')/AddressInfo`);
     expect(odataClient.lastOperation).toBe("DELETE");
@@ -190,13 +190,20 @@ describe("Testing Generation of TrippinService", () => {
   });
 
   test("navigation", async () => {
-    const result = testService.people.get("tester").bestFriend.bestFriend.bestFriend.homeAddress.city;
+    const result = testService
+      .getPeopleSrv()
+      .get("tester")
+      .getBestFriendSrv()
+      .getBestFriendSrv()
+      .getBestFriendSrv()
+      .getHomeAddressSrv()
+      .getCitySrv();
 
     expect(result.getPath()).toBe(`${BASE_URL}/People('tester')/BestFriend/BestFriend/BestFriend/HomeAddress/City`);
   });
 
   test("singleton", async () => {
-    const result = testService.me;
+    const result = testService.getMeSrv();
 
     expect(result.getPath()).toBe(`${BASE_URL}/Me`);
     expect(JSON.stringify(result.getQObject())).toEqual(JSON.stringify(qPerson));

--- a/packages/odata2model/src/generator/ServiceGenerator.ts
+++ b/packages/odata2model/src/generator/ServiceGenerator.ts
@@ -70,7 +70,8 @@ class ServiceGenerator {
             scope: Scope.Private,
             name: this.getPropNameForService(name),
             type,
-          };
+            hasQuestionToken: true,
+          } as PropertyDeclarationStructure;
         }),
         ...Object.values(container.singletons).map(({ name, type: entityType }) => {
           const type = this.getServiceName(entityType.name);
@@ -81,6 +82,7 @@ class ServiceGenerator {
             scope: Scope.Private,
             name: this.getPropNameForService(name),
             type,
+            hasQuestionToken: true,
           };
         }),
       ],

--- a/packages/odata2model/src/generator/ServiceGenerator.ts
+++ b/packages/odata2model/src/generator/ServiceGenerator.ts
@@ -1,11 +1,4 @@
-import {
-  GetAccessorDeclarationStructure,
-  MethodDeclarationStructure,
-  OptionalKind,
-  PropertyDeclarationStructure,
-  Scope,
-  SourceFile,
-} from "ts-morph";
+import { MethodDeclarationStructure, OptionalKind, PropertyDeclarationStructure, Scope, SourceFile } from "ts-morph";
 import { firstCharLowerCase } from "xml2js/lib/processors";
 import { upperCaseFirst } from "upper-case-first";
 
@@ -63,30 +56,19 @@ class ServiceGenerator {
             { name: "client", type: "ODataClient<any>" },
             { name: "basePath", type: "string" },
           ],
-          statements: [
-            "super(client, basePath);",
-            ...Object.values(container.entitySets).map(({ name, odataName, entityType }) => {
-              const serviceType = this.getCollectionServiceName(entityType.name);
-              return `this.${name} = new ${serviceType}(this.client, this.getPath() + "/${odataName}")`;
-            }),
-            ...Object.values(container.singletons).map(({ name, odataName, type }) => {
-              const serviceType = this.getServiceName(type.name);
-              return `this.${name} = new ${serviceType}(this.client, this.getPath() + "/${odataName}")`;
-            }),
-          ],
+          statements: ["super(client, basePath);"],
         },
       ],
       properties: [
-        // the name of the service is part of any URL: basePath/name/*
-        { scope: Scope.Private, name: "name", type: "string", initializer: `"${this.dataModel.getServiceName()}"` },
+        { scope: Scope.Private, name: "_name", type: "string", initializer: `"${this.dataModel.getServiceName()}"` },
         ...Object.values(container.entitySets).map(({ name, entityType }) => {
           const type = this.getCollectionServiceName(entityType.name);
 
           importContainer.addGeneratedService(this.getServiceName(entityType.name), type);
 
           return {
-            scope: Scope.Public,
-            name,
+            scope: Scope.Private,
+            name: this.getPropNameForService(name),
             type,
           };
         }),
@@ -96,13 +78,43 @@ class ServiceGenerator {
           importContainer.addGeneratedService(this.getServiceName(entityType.name), type);
 
           return {
-            scope: Scope.Public,
-            name,
+            scope: Scope.Private,
+            name: this.getPropNameForService(name),
             type,
           };
         }),
       ],
       methods: [
+        ...Object.values(container.entitySets).map(({ name, odataName, entityType }) => {
+          const propName = this.getPropNameForService(name);
+          const serviceType = this.getCollectionServiceName(entityType.name);
+          return {
+            scope: Scope.Public,
+            name: this.getGetterNameForService(name),
+            statements: [
+              `if(!this.${propName}) {`,
+              // prettier-ignore
+              `  this.${propName} = new ${serviceType}(this.client, this.getPath() + "/${odataName}")`,
+              "}",
+              `return this.${propName}`,
+            ],
+          };
+        }),
+        ...Object.values(container.singletons).map(({ name, odataName, type }) => {
+          const propName = this.getPropNameForService(name);
+          const serviceType = this.getServiceName(type.name);
+          return {
+            scope: Scope.Public,
+            name: this.getGetterNameForService(name),
+            statements: [
+              `if(!this.${propName}) {`,
+              // prettier-ignore
+              `  this.${propName} = new ${serviceType}(this.client, this.getPath() + "/${odataName}")`,
+              "}",
+              `return this.${propName}`,
+            ],
+          };
+        }),
         ...this.generateUnboundOperations(
           [...Object.values(container.functions), ...Object.values(container.actions)],
           importContainer
@@ -152,12 +164,7 @@ class ServiceGenerator {
             { name: "client", type: "ODataClient" },
             { name: "path", type: "string" },
           ],
-          statements: [
-            `super(client, path, ${firstCharLowerCase(model.qName)});`,
-            /* ...Object.values(container.entitySets).map(({ name, entityType }) => {
-            return `this.${name} = new EntitySetService(this.client, this.getPath(), ${entityType.qName})`;
-          }), */
-          ],
+          statements: [`super(client, path, ${firstCharLowerCase(model.qName)});`],
         },
       ],
       properties: [
@@ -179,7 +186,7 @@ class ServiceGenerator {
 
           return {
             scope: Scope.Private,
-            name: "_" + prop.name,
+            name: this.getPropNameForService(prop.name),
             type: `${propModelType}`,
             hasQuestionToken: true,
           } as PropertyDeclarationStructure;
@@ -207,14 +214,15 @@ class ServiceGenerator {
 
           return {
             scope: Scope.Private,
-            name: "_" + prop.name,
+            name: this.getPropNameForService(prop.name),
             type: `${collectionType}`,
             hasQuestionToken: true,
           };
         }),
       ],
-      getAccessors: [
+      methods: [
         ...modelProps.map((prop) => {
+          const propName = this.getPropNameForService(prop.name);
           const complexType = this.dataModel.getComplexType(prop.type);
           const isComplexCollection = prop.isCollection && complexType;
           const type = isComplexCollection
@@ -225,32 +233,33 @@ class ServiceGenerator {
 
           return {
             scope: Scope.Public,
-            name: prop.name,
+            name: this.getGetterNameForService(prop.name),
             returnType: type,
             statements: [
-              `if(!this._${prop.name}) {`,
+              `if(!this.${propName}) {`,
               // prettier-ignore
-              `  this._${prop.name} = new ${type}(this.client, this.path + "/${prop.odataName}"${isComplexCollection ? `, ${firstCharLowerCase(complexType.qName)}`: ""})`,
+              `  this.${propName} = new ${type}(this.client, this.path + "/${prop.odataName}"${isComplexCollection ? `, ${firstCharLowerCase(complexType.qName)}`: ""})`,
               "}",
-              `return this._${prop.name}`,
+              `return this.${propName}`,
             ],
-          } as GetAccessorDeclarationStructure;
+          };
         }),
         ...primColProps.map((prop) => {
+          const propName = this.getPropNameForService(prop.name);
           return {
             scope: Scope.Public,
-            name: prop.name,
+            name: this.getGetterNameForService(prop.name),
             statements: [
-              `if(!this._${prop.name}) {`,
+              `if(!this.${propName}) {`,
               // prettier-ignore
-              `  this._${prop.name} = new ${collectionServiceType}(this.client, this.path + "/${prop.odataName}", ${firstCharLowerCase(prop.qObject!)})`,
+              `  this.${propName} = new ${collectionServiceType}(this.client, this.path + "/${prop.odataName}", ${firstCharLowerCase(prop.qObject!)})`,
               "}",
-              `return this._${prop.name}`,
+              `return this.${propName}`,
             ],
-          } as GetAccessorDeclarationStructure;
+          };
         }),
+        ...this.generateBoundOperations(operations, importContainer),
       ],
-      methods: [...this.generateBoundOperations(operations, importContainer)],
     });
   }
 
@@ -327,6 +336,14 @@ class ServiceGenerator {
 
   private getServiceName(name: string) {
     return name + "Service";
+  }
+
+  private getPropNameForService(name: string) {
+    return `_${firstCharLowerCase(name)}Srv`;
+  }
+
+  private getGetterNameForService(name: string) {
+    return `get${upperCaseFirst(name)}Srv`;
   }
 
   private getCollectionServiceName(name: string) {

--- a/packages/odata2model/test/fixture/generator/service/main-service-entityset.ts
+++ b/packages/odata2model/test/fixture/generator/service/main-service-entityset.ts
@@ -5,7 +5,7 @@ import { TestEntityCollectionService } from "./service/TestEntityService";
 
 export class TesterService extends ODataService {
   private _name: string = "Tester";
-  private _listSrv: TestEntityCollectionService;
+  private _listSrv?: TestEntityCollectionService;
 
   constructor(client: ODataClient<any>, basePath: string) {
     super(client, basePath);

--- a/packages/odata2model/test/fixture/generator/service/main-service-entityset.ts
+++ b/packages/odata2model/test/fixture/generator/service/main-service-entityset.ts
@@ -4,11 +4,18 @@ import { ODataService } from "@odata2ts/odata-service";
 import { TestEntityCollectionService } from "./service/TestEntityService";
 
 export class TesterService extends ODataService {
-  private name: string = "Tester";
-  public list: TestEntityCollectionService;
+  private _name: string = "Tester";
+  private _listSrv: TestEntityCollectionService;
 
   constructor(client: ODataClient<any>, basePath: string) {
     super(client, basePath);
-    this.list = new TestEntityCollectionService(this.client, this.getPath() + "/list");
+  }
+
+  public getListSrv() {
+    if (!this._listSrv) {
+      this._listSrv = new TestEntityCollectionService(this.client, this.getPath() + "/list");
+    }
+
+    return this._listSrv;
   }
 }

--- a/packages/odata2model/test/fixture/generator/service/main-service-min.ts
+++ b/packages/odata2model/test/fixture/generator/service/main-service-min.ts
@@ -2,7 +2,7 @@ import { ODataClient } from "@odata2ts/odata-client-api";
 import { ODataService } from "@odata2ts/odata-service";
 
 export class TesterService extends ODataService {
-  private name: string = "Tester";
+  private _name: string = "Tester";
 
   constructor(client: ODataClient<any>, basePath: string) {
     super(client, basePath);

--- a/packages/odata2model/test/fixture/generator/service/v2/main-service-func-import-special-params.ts
+++ b/packages/odata2model/test/fixture/generator/service/v2/main-service-func-import-special-params.ts
@@ -4,7 +4,7 @@ import { ODataService, ODataModelResponseV2, compileFunctionPathV2 } from "@odat
 import { TestEntity } from "./TesterModel";
 
 export class TesterService extends ODataService {
-  private name: string = "Tester";
+  private _name: string = "Tester";
 
   constructor(client: ODataClient<any>, basePath: string) {
     super(client, basePath);

--- a/packages/odata2model/test/fixture/generator/service/v2/main-service-func-import.ts
+++ b/packages/odata2model/test/fixture/generator/service/v2/main-service-func-import.ts
@@ -9,7 +9,7 @@ import {
 import { TestEntity } from "./TesterModel";
 
 export class TesterService extends ODataService {
-  private name: string = "Tester";
+  private _name: string = "Tester";
 
   constructor(client: ODataClient<any>, basePath: string) {
     super(client, basePath);

--- a/packages/odata2model/test/fixture/generator/service/v2/test-entity-service-complex.ts
+++ b/packages/odata2model/test/fixture/generator/service/v2/test-entity-service-complex.ts
@@ -8,31 +8,31 @@ import { QBook, qBook, QReviewer, qReviewer } from "../QTester";
 import { ReviewerService } from "./ReviewerService";
 
 export class BookService extends EntityTypeServiceV2<Book, EditableBook, QBook> {
-  private _lector?: ReviewerService;
-  private _reviewers?: CollectionServiceV2<Reviewer, QReviewer, EditableReviewer>;
+  private _lectorSrv?: ReviewerService;
+  private _reviewersSrv?: CollectionServiceV2<Reviewer, QReviewer, EditableReviewer>;
 
   constructor(client: ODataClient, path: string) {
     super(client, path, qBook);
   }
 
-  public get lector(): ReviewerService {
-    if (!this._lector) {
-      this._lector = new ReviewerService(this.client, this.path + "/lector");
+  public getLectorSrv(): ReviewerService {
+    if (!this._lectorSrv) {
+      this._lectorSrv = new ReviewerService(this.client, this.path + "/lector");
     }
 
-    return this._lector;
+    return this._lectorSrv;
   }
 
-  public get reviewers(): CollectionServiceV2<Reviewer, QReviewer, EditableReviewer> {
-    if (!this._reviewers) {
-      this._reviewers = new CollectionServiceV2<Reviewer, QReviewer, EditableReviewer>(
+  public getReviewersSrv(): CollectionServiceV2<Reviewer, QReviewer, EditableReviewer> {
+    if (!this._reviewersSrv) {
+      this._reviewersSrv = new CollectionServiceV2<Reviewer, QReviewer, EditableReviewer>(
         this.client,
         this.path + "/reviewers",
         qReviewer
       );
     }
 
-    return this._reviewers;
+    return this._reviewersSrv;
   }
 }
 

--- a/packages/odata2model/test/fixture/generator/service/v2/test-entity-service-enum.ts
+++ b/packages/odata2model/test/fixture/generator/service/v2/test-entity-service-enum.ts
@@ -7,18 +7,18 @@ import { Book, EditableBook, Choice } from "../TesterModel";
 import { QBook, qBook } from "../QTester";
 
 export class BookService extends EntityTypeServiceV2<Book, EditableBook, QBook> {
-  private _altChoices?: CollectionServiceV2<EnumCollection<Choice>, QEnumCollection>;
+  private _altChoicesSrv?: CollectionServiceV2<EnumCollection<Choice>, QEnumCollection>;
 
   constructor(client: ODataClient, path: string) {
     super(client, path, qBook);
   }
 
-  public get altChoices() {
-    if (!this._altChoices) {
-      this._altChoices = new CollectionServiceV2(this.client, this.path + "/altChoices", qEnumCollection);
+  public getAltChoicesSrv() {
+    if (!this._altChoicesSrv) {
+      this._altChoicesSrv = new CollectionServiceV2(this.client, this.path + "/altChoices", qEnumCollection);
     }
 
-    return this._altChoices;
+    return this._altChoicesSrv;
   }
 }
 

--- a/packages/odata2model/test/fixture/generator/service/v2/test-entity-service-relationships.ts
+++ b/packages/odata2model/test/fixture/generator/service/v2/test-entity-service-relationships.ts
@@ -8,27 +8,27 @@ import { QBook, qBook } from "../QTester";
 import { AuthorService, AuthorCollectionService } from "./AuthorService";
 
 export class BookService extends EntityTypeServiceV2<Book, EditableBook, QBook> {
-  private _author?: AuthorService;
-  private _relatedAuthors?: AuthorCollectionService;
+  private _authorSrv?: AuthorService;
+  private _relatedAuthorsSrv?: AuthorCollectionService;
 
   constructor(client: ODataClient, path: string) {
     super(client, path, qBook);
   }
 
-  public get author(): AuthorService {
-    if (!this._author) {
-      this._author = new AuthorService(this.client, this.path + "/author");
+  public getAuthorSrv(): AuthorService {
+    if (!this._authorSrv) {
+      this._authorSrv = new AuthorService(this.client, this.path + "/author");
     }
 
-    return this._author;
+    return this._authorSrv;
   }
 
-  public get relatedAuthors(): AuthorCollectionService {
-    if (!this._relatedAuthors) {
-      this._relatedAuthors = new AuthorCollectionService(this.client, this.path + "/relatedAuthors");
+  public getRelatedAuthorsSrv(): AuthorCollectionService {
+    if (!this._relatedAuthorsSrv) {
+      this._relatedAuthorsSrv = new AuthorCollectionService(this.client, this.path + "/relatedAuthors");
     }
 
-    return this._relatedAuthors;
+    return this._relatedAuthorsSrv;
   }
 }
 

--- a/packages/odata2model/test/fixture/generator/service/v4/main-service-action-unbound.ts
+++ b/packages/odata2model/test/fixture/generator/service/v4/main-service-action-unbound.ts
@@ -4,7 +4,7 @@ import { ODataService, ODataModelResponseV4, compileActionPath } from "@odata2ts
 import { TestEntity } from "./TesterModel";
 
 export class TesterService extends ODataService {
-  private name: string = "Tester";
+  private _name: string = "Tester";
 
   constructor(client: ODataClient<any>, basePath: string) {
     super(client, basePath);

--- a/packages/odata2model/test/fixture/generator/service/v4/main-service-func-unbound.ts
+++ b/packages/odata2model/test/fixture/generator/service/v4/main-service-func-unbound.ts
@@ -9,7 +9,7 @@ import {
 import { TestEntity } from "./TesterModel";
 
 export class TesterService extends ODataService {
-  private name: string = "Tester";
+  private _name: string = "Tester";
 
   constructor(client: ODataClient<any>, basePath: string) {
     super(client, basePath);

--- a/packages/odata2model/test/fixture/generator/service/v4/main-service-singleton.ts
+++ b/packages/odata2model/test/fixture/generator/service/v4/main-service-singleton.ts
@@ -5,7 +5,7 @@ import { TestEntityService } from "./service/TestEntityService";
 
 export class TesterService extends ODataService {
   private _name: string = "Tester";
-  private _currentUserSrv: TestEntityService;
+  private _currentUserSrv?: TestEntityService;
 
   constructor(client: ODataClient<any>, basePath: string) {
     super(client, basePath);
@@ -13,8 +13,9 @@ export class TesterService extends ODataService {
 
   public getCurrentUserSrv() {
     if (!this._currentUserSrv) {
-      this._currentUserSrv = new TestEntityService(this.client, this.getPath() + "/current");
+      this._currentUserSrv = new TestEntityService(this.client, this.getPath() + "/CURRENT_USER");
     }
+
     return this._currentUserSrv;
   }
 }

--- a/packages/odata2model/test/fixture/generator/service/v4/main-service-singleton.ts
+++ b/packages/odata2model/test/fixture/generator/service/v4/main-service-singleton.ts
@@ -4,11 +4,17 @@ import { ODataService } from "@odata2ts/odata-service";
 import { TestEntityService } from "./service/TestEntityService";
 
 export class TesterService extends ODataService {
-  private name: string = "Tester";
-  public current: TestEntityService;
+  private _name: string = "Tester";
+  private _currentUserSrv: TestEntityService;
 
   constructor(client: ODataClient<any>, basePath: string) {
     super(client, basePath);
-    this.current = new TestEntityService(this.client, this.getPath() + "/current");
+  }
+
+  public getCurrentUserSrv() {
+    if (!this._currentUserSrv) {
+      this._currentUserSrv = new TestEntityService(this.client, this.getPath() + "/current");
+    }
+    return this._currentUserSrv;
   }
 }

--- a/packages/odata2model/test/fixture/generator/service/v4/test-entity-service-complex.ts
+++ b/packages/odata2model/test/fixture/generator/service/v4/test-entity-service-complex.ts
@@ -8,31 +8,31 @@ import { QBook, qBook, QReviewer, qReviewer } from "../QTester";
 import { ReviewerService } from "./ReviewerService";
 
 export class BookService extends EntityTypeServiceV4<Book, EditableBook, QBook> {
-  private _lector?: ReviewerService;
-  private _reviewers?: CollectionServiceV4<Reviewer, QReviewer, EditableReviewer>;
+  private _lectorSrv?: ReviewerService;
+  private _reviewersSrv?: CollectionServiceV4<Reviewer, QReviewer, EditableReviewer>;
 
   constructor(client: ODataClient, path: string) {
     super(client, path, qBook);
   }
 
-  public get lector(): ReviewerService {
-    if (!this._lector) {
-      this._lector = new ReviewerService(this.client, this.path + "/lector");
+  public getLectorSrv(): ReviewerService {
+    if (!this._lectorSrv) {
+      this._lectorSrv = new ReviewerService(this.client, this.path + "/lector");
     }
 
-    return this._lector;
+    return this._lectorSrv;
   }
 
-  public get reviewers(): CollectionServiceV4<Reviewer, QReviewer, EditableReviewer> {
-    if (!this._reviewers) {
-      this._reviewers = new CollectionServiceV4<Reviewer, QReviewer, EditableReviewer>(
+  public getReviewersSrv(): CollectionServiceV4<Reviewer, QReviewer, EditableReviewer> {
+    if (!this._reviewersSrv) {
+      this._reviewersSrv = new CollectionServiceV4<Reviewer, QReviewer, EditableReviewer>(
         this.client,
         this.path + "/reviewers",
         qReviewer
       );
     }
 
-    return this._reviewers;
+    return this._reviewersSrv;
   }
 }
 

--- a/packages/odata2model/test/fixture/generator/service/v4/test-entity-service-enum.ts
+++ b/packages/odata2model/test/fixture/generator/service/v4/test-entity-service-enum.ts
@@ -7,18 +7,18 @@ import { Book, EditableBook, Choice } from "../TesterModel";
 import { QBook, qBook } from "../QTester";
 
 export class BookService extends EntityTypeServiceV4<Book, EditableBook, QBook> {
-  private _altChoices?: CollectionServiceV4<EnumCollection<Choice>, QEnumCollection>;
+  private _altChoicesSrv?: CollectionServiceV4<EnumCollection<Choice>, QEnumCollection>;
 
   constructor(client: ODataClient, path: string) {
     super(client, path, qBook);
   }
 
-  public get altChoices() {
-    if (!this._altChoices) {
-      this._altChoices = new CollectionServiceV4(this.client, this.path + "/altChoices", qEnumCollection);
+  public getAltChoicesSrv() {
+    if (!this._altChoicesSrv) {
+      this._altChoicesSrv = new CollectionServiceV4(this.client, this.path + "/altChoices", qEnumCollection);
     }
 
-    return this._altChoices;
+    return this._altChoicesSrv;
   }
 }
 

--- a/packages/odata2model/test/fixture/generator/service/v4/test-entity-service-relationships.ts
+++ b/packages/odata2model/test/fixture/generator/service/v4/test-entity-service-relationships.ts
@@ -8,27 +8,27 @@ import { QBook, qBook } from "../QTester";
 import { AuthorService, AuthorCollectionService } from "./AuthorService";
 
 export class BookService extends EntityTypeServiceV4<Book, EditableBook, QBook> {
-  private _author?: AuthorService;
-  private _relatedAuthors?: AuthorCollectionService;
+  private _authorSrv?: AuthorService;
+  private _relatedAuthorsSrv?: AuthorCollectionService;
 
   constructor(client: ODataClient, path: string) {
     super(client, path, qBook);
   }
 
-  public get author(): AuthorService {
-    if (!this._author) {
-      this._author = new AuthorService(this.client, this.path + "/author");
+  public getAuthorSrv(): AuthorService {
+    if (!this._authorSrv) {
+      this._authorSrv = new AuthorService(this.client, this.path + "/author");
     }
 
-    return this._author;
+    return this._authorSrv;
   }
 
-  public get relatedAuthors(): AuthorCollectionService {
-    if (!this._relatedAuthors) {
-      this._relatedAuthors = new AuthorCollectionService(this.client, this.path + "/relatedAuthors");
+  public getRelatedAuthorsSrv(): AuthorCollectionService {
+    if (!this._relatedAuthorsSrv) {
+      this._relatedAuthorsSrv = new AuthorCollectionService(this.client, this.path + "/relatedAuthors");
     }
 
-    return this._relatedAuthors;
+    return this._relatedAuthorsSrv;
   }
 }
 

--- a/packages/odata2model/test/generator/v4/ServiceGenerator.test.ts
+++ b/packages/odata2model/test/generator/v4/ServiceGenerator.test.ts
@@ -101,7 +101,7 @@ describe("Service Generator Tests V4", () => {
     // given one singleton
     odataBuilder
       .addEntityType("TestEntity", undefined, (builder) => builder.addKeyProp("id", ODataTypesV4.String))
-      .addSingleton("current", `${SERVICE_NAME}.TestEntity`);
+      .addSingleton("CURRENT_USER", `${SERVICE_NAME}.TestEntity`);
 
     // when generating
     await doGenerate();


### PR DESCRIPTION
BREAKING CHANGE: changed API to get from service to individual services => use "getXxxSrv()" instead of get accessors "xxx"