### PR TITLE
feat(uri-builder): allow for null | undefined builder methods

### DIFF
--- a/packages/odata-uri-builder/src/ODataUriBuilderModel.ts
+++ b/packages/odata-uri-builder/src/ODataUriBuilderModel.ts
@@ -32,7 +32,24 @@ export type ExpandType<Q extends QueryObject> = ExtractPropertyNamesOfType<
   QEntityPath<any> | QEntityCollectionPath<any> | QCollectionPath<any>
 >;
 
-export type EntityPropNames<Q extends QueryObject> = Array<keyof Q | null | undefined>;
+export type Nullable = null | undefined;
+
+export type NullableParam<OptionType> = OptionType | Nullable;
+
+export type NullableParamList<OptionType> = Array<OptionType | Nullable>;
+
+/**
+ * @deprecated use NullableParamList<keyof Q> directly
+ */
+export type EntityPropNames<Q extends QueryObject> = NullableParamList<keyof Q>;
+
+export type ExpandingFunction<Prop> =
+  | ((expBuilder: ExpandingODataUriBuilderV4<EntityExtractor<Prop>>, qObject: EntityExtractor<Prop>) => void)
+  | Nullable;
+
+export type ExpandingFunctionV2<Prop> =
+  | ((expBuilder: ExpandingODataUriBuilderV2<EntityExtractor<Prop>>, qObject: EntityExtractor<Prop>) => void)
+  | Nullable;
 
 export interface ODataUriBuilderConfig {
   expandingBuilder?: boolean;
@@ -57,7 +74,7 @@ export interface ODataUriBuilderModel<Q extends QueryObject, ReturnType> {
    * @param props the property names to select as they are specified on the query object
    * @returns this query builder
    */
-  select: (...props: EntityPropNames<Q>) => ReturnType;
+  select: (...props: NullableParamList<keyof Q>) => ReturnType;
 
   /**
    * Specify as many filter expressions as you want by facilitating query objects.
@@ -74,7 +91,7 @@ export interface ODataUriBuilderModel<Q extends QueryObject, ReturnType> {
    * @param expressions possibly multiple expressions
    * @returns this query builder
    */
-  filter: (...expressions: Array<QFilterExpression>) => ReturnType;
+  filter: (...expressions: NullableParamList<QFilterExpression>) => ReturnType;
 
   /**
    * V4 search option, where the server decides how to apply the search value.
@@ -87,7 +104,7 @@ export interface ODataUriBuilderModel<Q extends QueryObject, ReturnType> {
    * @param term
    * @returns this query builder
    */
-  search: (term: string | undefined | null) => ReturnType;
+  search: (term: NullableParam<string>) => ReturnType;
 
   /**
    * Simple & plain expand of attributes which are entities or entity collections.
@@ -99,7 +116,7 @@ export interface ODataUriBuilderModel<Q extends QueryObject, ReturnType> {
    * @param props the attributes to expand
    * @returns this query builder
    */
-  expand: <Prop extends ExpandType<Q>>(...props: Array<Prop>) => ReturnType;
+  expand: <Prop extends ExpandType<Q>>(...props: NullableParamList<Prop>) => ReturnType;
 
   /**
    * Expand one property, which is an entity or entity collection.
@@ -117,13 +134,7 @@ export interface ODataUriBuilderModel<Q extends QueryObject, ReturnType> {
    * @param builderFn function which receives an entity specific builder as first & the appropriate query object as second argument
    * @returns this query builder
    */
-  expanding: <Prop extends ExpandType<Q>>(
-    prop: Prop,
-    expBuilderFn: (
-      expBuilder: ExpandingODataUriBuilderV4<EntityExtractor<Q[Prop]>>,
-      qObject: EntityExtractor<Q[Prop]>
-    ) => void
-  ) => ReturnType;
+  expanding: <Prop extends ExpandType<Q>>(prop: Prop, expBuilderFn: ExpandingFunction<Q[Prop]>) => ReturnType;
 
   /**
    * Simple group by clause for properties (no aggregate functionality yet).
@@ -136,7 +147,7 @@ export interface ODataUriBuilderModel<Q extends QueryObject, ReturnType> {
    * @param props
    * @returns this query builder
    */
-  groupBy: (...props: EntityPropNames<Q>) => ReturnType;
+  groupBy: (...props: NullableParamList<keyof Q>) => ReturnType;
 
   /**
    * Count the list of result items. The query response will have an appropriate count field.
@@ -157,7 +168,7 @@ export interface ODataUriBuilderModel<Q extends QueryObject, ReturnType> {
    * builder.top(20) // $top=20
    * @param itemsTop max amount of items to fetch
    */
-  top: (itemsTop: number) => ReturnType;
+  top: (itemsTop: NullableParam<number>) => ReturnType;
 
   /**
    * Skips a specified number of records, e.g. skip the first 20 items.
@@ -167,7 +178,7 @@ export interface ODataUriBuilderModel<Q extends QueryObject, ReturnType> {
    * @param itemsToSkip number of records to skip
    * @returns this query builder
    */
-  skip: (itemsToSkip: number) => ReturnType;
+  skip: (itemsToSkip: NullableParam<number>) => ReturnType;
 
   /**
    * Specify the sort order of the results by utilizing query objects.
@@ -177,7 +188,7 @@ export interface ODataUriBuilderModel<Q extends QueryObject, ReturnType> {
    * @param expressions
    * @returns this query builder
    */
-  orderBy: (...expressions: Array<QOrderByExpression>) => ReturnType;
+  orderBy: (...expressions: NullableParamList<QOrderByExpression>) => ReturnType;
 
   /**
    * Build the final URI string.
@@ -207,13 +218,7 @@ export interface V2ExpandingFunction<Q extends QueryObject, ReturnType> {
    * @param builderFn function which receives an entity specific builder as first & the appropriate query object as second argument
    * @returns this query builder
    */
-  expanding: <Prop extends ExpandType<Q>>(
-    prop: Prop,
-    expBuilderFn: (
-      expBuilder: ExpandingODataUriBuilderV2<EntityExtractor<Q[Prop]>>,
-      qObject: EntityExtractor<Q[Prop]>
-    ) => void
-  ) => ReturnType;
+  expanding: <Prop extends ExpandType<Q>>(prop: Prop, expBuilderFn: ExpandingFunctionV2<Q[Prop]>) => ReturnType;
 }
 
 type BuilderOp = "build";

--- a/packages/odata-uri-builder/src/v2/ODataUriBuilderV2.ts
+++ b/packages/odata-uri-builder/src/v2/ODataUriBuilderV2.ts
@@ -7,6 +7,9 @@ import {
   ODataUriBuilderConfig,
   ODataUriBuilderV2 as ODataUriBuilderV2Model,
   createExpandingUriBuilderV2,
+  NullableParamList,
+  ExpandingFunctionV2,
+  NullableParam,
 } from "../internal";
 
 /**
@@ -43,28 +46,26 @@ class ODataUriBuilderV2<Q extends QueryObject> implements ODataUriBuilderV2Model
     this.builder = new ODataUriBuilder(path, qEntity, config);
   }
 
-  public select(...props: Array<keyof Q | null | undefined>) {
+  public select(...props: NullableParamList<keyof Q>) {
     this.builder.select(props);
     return this;
   }
 
-  public filter(...expressions: Array<QFilterExpression>) {
+  public filter(...expressions: NullableParamList<QFilterExpression>) {
     this.builder.filter(expressions);
     return this;
   }
 
-  public expand<Prop extends ExpandType<Q>>(...props: Array<Prop>) {
+  public expand<Prop extends ExpandType<Q>>(...props: NullableParamList<Prop>) {
     this.builder.expand(props);
     return this;
   }
 
-  public expanding<Prop extends ExpandType<Q>>(
-    prop: Prop,
-    builderFn: (
-      builder: ExpandingODataUriBuilderV2<EntityExtractor<Q[Prop]>>,
-      qObject: EntityExtractor<Q[Prop]>
-    ) => void
-  ) {
+  public expanding<Prop extends ExpandType<Q>>(prop: Prop, builderFn: ExpandingFunctionV2<Q[Prop]>) {
+    if (!builderFn) {
+      return this;
+    }
+
     const entityProp = this.builder.getEntityProp<QComplexPath>(prop);
     const entity = entityProp.getEntity();
 
@@ -83,7 +84,7 @@ class ODataUriBuilderV2<Q extends QueryObject> implements ODataUriBuilderV2Model
     return this;
   }
 
-  public orderBy(...expressions: Array<QOrderByExpression>) {
+  public orderBy(...expressions: NullableParamList<QOrderByExpression>) {
     this.builder.orderBy(expressions);
     return this;
   }
@@ -93,12 +94,12 @@ class ODataUriBuilderV2<Q extends QueryObject> implements ODataUriBuilderV2Model
     return this;
   }
 
-  public top(itemsTop: number) {
+  public top(itemsTop: NullableParam<number>) {
     this.builder.top(itemsTop);
     return this;
   }
 
-  public skip(itemsToSkip: number) {
+  public skip(itemsToSkip: NullableParam<number>) {
     this.builder.skip(itemsToSkip);
     return this;
   }

--- a/packages/odata-uri-builder/src/v4/ExpandingODataUriBuilderV4.ts
+++ b/packages/odata-uri-builder/src/v4/ExpandingODataUriBuilderV4.ts
@@ -4,6 +4,9 @@ import {
   EntityExtractor,
   ExpandingODataUriBuilderV4 as ExpandingODataUriBuilderV4Model,
   ExpandType,
+  NullableParamList,
+  ExpandingFunction,
+  NullableParam,
 } from "../internal";
 
 export function createExpandingUriBuilderV4<Q extends QueryObject>(
@@ -24,43 +27,39 @@ class ExpandingODataUriBuilderV4<Q extends QueryObject> implements ExpandingODat
     this.builder = new ODataUriBuilder(property, qEntity, { expandingBuilder: true });
   }
 
-  public select(...props: Array<keyof Q | null | undefined>) {
+  public select(...props: NullableParamList<keyof Q>) {
     this.builder.select(props);
     return this;
   }
 
-  public expand<Prop extends ExpandType<Q>>(...props: Array<Prop>) {
+  public expand<Prop extends ExpandType<Q>>(...props: NullableParamList<Prop>) {
     this.builder.expand(props);
     return this;
   }
 
-  public expanding<Prop extends ExpandType<Q>>(
-    prop: Prop,
-    builderFn: (
-      builder: ExpandingODataUriBuilderV4<EntityExtractor<Q[Prop]>>,
-      qObject: EntityExtractor<Q[Prop]>
-    ) => void
-  ) {
-    this.builder.expanding(prop, builderFn);
+  public expanding<Prop extends ExpandType<Q>>(prop: Prop, builderFn: ExpandingFunction<Q[Prop]>) {
+    if (builderFn) {
+      this.builder.expanding(prop, builderFn);
+    }
     return this;
   }
 
-  public filter(...expressions: Array<QFilterExpression>) {
+  public filter(...expressions: NullableParamList<QFilterExpression>) {
     this.builder.filter(expressions);
     return this;
   }
 
-  public orderBy(...expressions: Array<QOrderByExpression>) {
+  public orderBy(...expressions: NullableParamList<QOrderByExpression>) {
     this.builder.orderBy(expressions);
     return this;
   }
 
-  public top(itemsTop: number) {
+  public top(itemsTop: NullableParam<number>) {
     this.builder.top(itemsTop);
     return this;
   }
 
-  public skip(itemsToSkip: number) {
+  public skip(itemsToSkip: NullableParam<number>) {
     this.builder.skip(itemsToSkip);
     return this;
   }

--- a/packages/odata-uri-builder/src/v4/ODataUriBuilderV4.ts
+++ b/packages/odata-uri-builder/src/v4/ODataUriBuilderV4.ts
@@ -1,8 +1,9 @@
 import { QFilterExpression, QOrderByExpression, QueryObject } from "@odata2ts/odata-query-objects";
 import {
-  EntityExtractor,
-  ExpandingODataUriBuilderV4,
+  ExpandingFunction,
   ExpandType,
+  NullableParam,
+  NullableParamList,
   ODataUriBuilder,
   ODataUriBuilderConfig,
   ODataUriBuilderV4 as ODataUriBuilderV4Model,
@@ -46,53 +47,49 @@ class ODataUriBuilderV4<Q extends QueryObject> implements ODataUriBuilderV4Model
     return this;
   }
 
-  public select(...props: Array<keyof Q | null | undefined>) {
+  public select(...props: NullableParamList<keyof Q>) {
     this.builder.select(props);
     return this;
   }
 
-  public filter(...expressions: Array<QFilterExpression>) {
+  public filter(...expressions: NullableParamList<QFilterExpression>) {
     this.builder.filter(expressions);
     return this;
   }
 
-  public expand<Prop extends ExpandType<Q>>(...props: Array<Prop>) {
+  public expand<Prop extends ExpandType<Q>>(...props: NullableParamList<Prop>) {
     this.builder.expand(props);
     return this;
   }
 
-  public expanding<Prop extends ExpandType<Q>>(
-    prop: Prop,
-    builderFn: (
-      builder: ExpandingODataUriBuilderV4<EntityExtractor<Q[Prop]>>,
-      qObject: EntityExtractor<Q[Prop]>
-    ) => void
-  ) {
-    this.builder.expanding(prop, builderFn);
+  public expanding<Prop extends ExpandType<Q>>(prop: Prop, builderFn: ExpandingFunction<Q[Prop]>) {
+    if (builderFn) {
+      this.builder.expanding(prop, builderFn);
+    }
     return this;
   }
 
-  public groupBy(...props: Array<keyof Q | null | undefined>) {
+  public groupBy(...props: NullableParamList<keyof Q>) {
     this.builder.groupBy(props);
     return this;
   }
 
-  public orderBy(...expressions: Array<QOrderByExpression>) {
+  public orderBy(...expressions: NullableParamList<QOrderByExpression>) {
     this.builder.orderBy(expressions);
     return this;
   }
 
-  public top(itemsTop: number) {
+  public top(itemsTop: NullableParam<number>) {
     this.builder.top(itemsTop);
     return this;
   }
 
-  public skip(itemsToSkip: number) {
+  public skip(itemsToSkip: NullableParam<number>) {
     this.builder.skip(itemsToSkip);
     return this;
   }
 
-  public search(term: string | undefined | null) {
+  public search(term: NullableParam<string>) {
     this.builder.search(term);
     return this;
   }

--- a/packages/odata-uri-builder/test/ODataUriBuilderV2.test.ts
+++ b/packages/odata-uri-builder/test/ODataUriBuilderV2.test.ts
@@ -9,7 +9,7 @@ import { createUriBuilderV2, ODataUriBuilderV2 } from "../src/";
  * @returns
  */
 function addBase(urlPart: string) {
-  return `/Persons?${urlPart}`;
+  return `/Persons${urlPart ? `?${urlPart}` : ""}`;
 }
 
 describe("ODataUriBuilderV2 Test", () => {
@@ -25,12 +25,10 @@ describe("ODataUriBuilderV2 Test", () => {
   });
 
   test("count: true", () => {
-    const candidate = toTest.count(true).build();
-    const candidate2 = toTest.count().build();
     const expected = addBase("$inlinecount=allpages");
 
-    expect(candidate).toBe(expected);
-    expect(candidate).toBe(candidate2);
+    expect(toTest.count().build()).toBe(expected);
+    expect(toTest.count(true).build()).toBe(expected);
   });
 
   test("count: false", () => {
@@ -38,6 +36,20 @@ describe("ODataUriBuilderV2 Test", () => {
     const expected = "/Persons";
 
     expect(candidate).toBe(expected);
+  });
+
+  test("expanding: simple", () => {
+    const candidate = toTest.expanding("address", () => {}).build();
+    const expected = addBase("$expand=Address");
+
+    expect(candidate).toBe(expected);
+  });
+
+  test("expanding: ignore null function", () => {
+    const expected = addBase("");
+
+    expect(toTest.expanding("address", null).build()).toBe(expected);
+    expect(toTest.expanding("address", undefined).build()).toBe(expected);
   });
 
   test("expanding: selecting nested prop", () => {
@@ -73,11 +85,4 @@ describe("ODataUriBuilderV2 Test", () => {
 
     expect(candidate).toBe(expected);
   });
-
-  /*test("expanding: nested expand", () => {
-      const candidate = toTest.expanding("address", (q) => q.responsible).build();
-      const expected = addBase("$expand=Address/responsible");
-
-      expect(candidate).toBe(expected);
-    });*/
 });

--- a/test/v2/odata.http
+++ b/test/v2/odata.http
@@ -6,6 +6,12 @@ GET {{baseUrl}}/$metadata
 GET {{rootUrl}}
 
 
+# --- Data Types
+### @name DateTime
+GET {{baseUrl}}/Products?$inlinecount=allpages&$select=ReleaseDate
+Accept: {{contentType}}
+
+
 # --- Queries ---
 ### @name list products
 GET {{baseUrl}}/Products?$inlinecount=allpages
@@ -48,7 +54,6 @@ Accept: {{contentType}}
 GET {{baseUrl}}/Products(0)?$select=ID,Name,Category/Name,Category/Products/Name&$expand=Category,Category/Products
 Accept: {{contentType}}
 
-
 # --- Create Entity ---
 ### @name create new product
 POST {{baseUrl}}/Products
@@ -64,16 +69,24 @@ Content-Type: {{contentType}}
   "ReleaseDate": "2022-01-01T00:00:00"
 }
 
-# PATCH doesn't work and merge is not supported by HTTPClient
-### @name update new product
-PATCH {{baseUrl}}/Products(999)
+### @name merge new product
+POST {{baseUrl}}/Products(999)
 Accept: {{contentType}}
 Content-Type: {{contentType}}
+X-Http-Method: MERGE
 
 {
   "Description": "Test Descriptioning!!!",
   "Rating": 3
 }
+
+### PATCH doesn't work and merge is not supported by HTTPClient
+### @name update new product
+PATCH {{baseUrl}}/Products(999)
+Accept: {{contentType}}
+Content-Type: {{contentType}}
+
+
 
 ### @name update category association
 PATCH {{baseUrl}}/Products(999)


### PR DESCRIPTION
Allow to pass nullable values in select, filter, orderby, skip, top, etc.
Nullables are automatically filtered.

This allows for an entirely fluent style.