### PR TITLE
fix(odata2model): prettier as peer dep only

### DIFF
--- a/packages/odata2model/package.json
+++ b/packages/odata2model/package.json
@@ -36,7 +36,8 @@
   "peerDependencies": {
     "@odata2ts/odata-client-api": "*",
     "@odata2ts/odata-query-objects": "*",
-    "@odata2ts/odata-service": "*"
+    "@odata2ts/odata-service": "*",
+    "prettier": "*"
   },
   "dependencies": {
     "camel-case": "^4.1.2",
@@ -44,7 +45,6 @@
     "cosmiconfig": "^7.0.1",
     "fs-extra": "^10.0.1",
     "pascal-case": "^3.1.2",
-    "prettier": "^2.6.2",
     "ts-morph": "^14.0.0",
     "upper-case-first": "^2.0.2",
     "xml2js": "^0.4.23"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2075,6 +2075,7 @@ __metadata:
     "@odata2ts/odata-client-api": "*"
     "@odata2ts/odata-query-objects": "*"
     "@odata2ts/odata-service": "*"
+    prettier: "*"
   bin:
     odata2model: lib/run-cli.js
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -2064,7 +2064,6 @@ __metadata:
     fs-extra: ^10.0.1
     jest: ^27.5.1
     pascal-case: ^3.1.2
-    prettier: ^2.6.2
     rimraf: ^3.0.2
     ts-jest: ^27.1.4
     ts-morph: ^14.0.0


### PR DESCRIPTION
OData2Model shouldn't export it's own version of prettier.
However, OData2Model imports prettier, but only needs it in certain circumstances (transforming to typescript and prettier is enabled).

This PR redeclares prettier as peer dependency, quite lenient with `*` for its version.

Otherwise prettier is completely removed (not even as dev dep), since root already uses prettier.