### PR TITLE
feat(odata2ts): config by prop name

### DIFF
--- a/packages/odata2model/int-test/integration/v2/ODataV2ServiceIntegration.test.ts
+++ b/packages/odata2model/int-test/integration/v2/ODataV2ServiceIntegration.test.ts
@@ -19,14 +19,14 @@ describe("Integration Testing of generated stuff for Sample V2 OData Service", (
 
   const testService = new ODataDemoService(odataClient, BASE_URL);
 
-  const PRODUCT_ZERO: Omit<ProductModel, "Category" | "Supplier"> = {
-    ID: 0,
-    Name: "Bread",
-    Description: "Whole grain bread",
-    ReleaseDate: "/Date(694224000000)/",
-    DiscontinuedDate: null,
-    Rating: 4,
-    Price: "2.5",
+  const PRODUCT_ZERO: Omit<ProductModel, "category" | "supplier"> = {
+    id: 0,
+    name: "Bread",
+    description: "Whole grain bread",
+    releaseDate: "/Date(694224000000)/",
+    discontinuedDate: null,
+    rating: 4,
+    price: "2.5",
   };
 
   test("list products with count", async () => {
@@ -71,12 +71,12 @@ describe("Integration Testing of generated stuff for Sample V2 OData Service", (
 
     // given
     const product: EditableProductModel = {
-      ID: 999,
-      Description: "Test Description",
-      Name: "TestName",
-      Price: "12.88",
-      Rating: 1,
-      ReleaseDate: "2022-12-31T12:15:59", //WTF?! => this should be "/Date(...)"
+      id: 999,
+      description: "Test Description",
+      name: "TestName",
+      price: "12.88",
+      rating: 1,
+      releaseDate: "2022-12-31T12:15:59", //WTF?! => this should be "/Date(...)"
     };
 
     // when creating the product
@@ -85,9 +85,9 @@ describe("Integration Testing of generated stuff for Sample V2 OData Service", (
     expect(result.data.d).toMatchObject({ ...product, ReleaseDate: "/Date(1672488959000)/" });
 
     // given a service for the new product
-    const productService = editableService.getProductsSrv().get(product.ID);
+    const productService = editableService.getProductsSrv().get(product.id);
     // when updating the description, we expect no error
-    await productService.patch({ Description: "Updated Desc" });
+    await productService.patch({ description: "Updated Desc" });
 
     // when deleting this new product, we expect no error
     await new Promise((res) => setTimeout(res, 1000));
@@ -128,7 +128,7 @@ describe("Integration Testing of generated stuff for Sample V2 OData Service", (
 
   test("create key and parse key", async () => {
     const expectedSimple = 333;
-    const expectedComplex = { ID: expectedSimple };
+    const expectedComplex = { id: expectedSimple };
 
     // simple version
     let result = testService.getProductsSrv().createKey(expectedSimple);

--- a/packages/odata2model/int-test/integration/v4/TrippinIntegration.test.ts
+++ b/packages/odata2model/int-test/integration/v4/TrippinIntegration.test.ts
@@ -3,33 +3,35 @@ import { TrippinService } from "../../../build/v4/trippin/TrippinService";
 import { TestODataClient } from "../../TestODataClient";
 
 describe("Integration Testing of Service Generation", () => {
-  const BASE_URL = "https://services.odata.org/TripPinRESTierService/(S(sivik5crfo3qvprrreziudlp))";
+  const BASE_URL = "https://services.odata.org/TripPinRESTierService/(S(0i1abrnxnvfig05jk1s4yxpi))";
   const odataClient = new TestODataClient();
 
   const testService = new TrippinService(odataClient, BASE_URL);
 
-  test("unbound action", async () => {
+  // skipped, because it breaks the session state
+  test.skip("unbound action", async () => {
     const result = await testService.resetDataSource();
     expect(result.data).toBe("");
   });
 
   test("unbound function", async () => {
     const result = await testService.getPersonWithMostFriends();
-    expect(result.data.FirstName).toBe("Russell");
-    expect(result.data.LastName).toBe("Whyte");
+    expect(result.data.firstName).toBe("Russell");
+    expect(result.data.lastName).toBe("Whyte");
   });
 
   test("unbound function with params", async () => {
     const result = await testService.getNearestAirport({ lat: 123, lon: 345 });
-    expect(result.data.IcaoCode).toBe("ZBAA");
+    expect(result.data.icaoCode).toBe("ZBAA");
   });
 
   test("entityType query", async () => {
     const result = await testService.getPeopleSrv().get("russellwhyte").query();
     expect(result.status).toBe(200);
-    expect(result.data).toBeDefined();
-    expect(result.data.FirstName).toBe("Russell");
-    expect(result.data.LastName).toBe("Whyte");
+    expect(result.data).toMatchObject({
+      firstName: "Russell",
+      lastName: "Whyte",
+    });
   });
 
   test("entitySet query", async () => {
@@ -118,12 +120,12 @@ describe("Integration Testing of Service Generation", () => {
     expect(result.status).toBe(200);
     expect(result.data).toBeDefined();
     expect(result.data.value.length).toBe(1);
-    expect(result.data.value[0].Address).toBe("187 Suffolk Ln.");
+    expect(result.data.value[0].address).toBe("187 Suffolk Ln.");
   });
 
   test("create key and parse key", async () => {
     const expectedSimple = "test@testing.de";
-    const expectedComplex: PersonIdModel = { UserName: expectedSimple };
+    const expectedComplex: PersonIdModel = { user: expectedSimple };
 
     // simple version
     let result = testService.getPeopleSrv().createKey(expectedSimple);

--- a/packages/odata2model/int-test/unit/TrippinService.test.ts
+++ b/packages/odata2model/int-test/unit/TrippinService.test.ts
@@ -19,11 +19,11 @@ describe("Testing Generation of TrippinService", () => {
 
   beforeEach(() => {
     editModel = {
-      UserName: "williams",
-      FavoriteFeature: FeatureModel.Feature1,
-      Features: [],
-      FirstName: "Heinz",
-      Gender: PersonGenderModel.Unknown,
+      user: "williams",
+      favoriteFeature: FeatureModel.Feature1,
+      features: [],
+      firstName: "Heinz",
+      traditionalGenderCategories: PersonGenderModel.Unknown,
     };
   });
 
@@ -73,7 +73,7 @@ describe("Testing Generation of TrippinService", () => {
   });
 
   test("entitySet: get with complex id", async () => {
-    const testId: PersonIdModel = { UserName: "williams" };
+    const testId: PersonIdModel = { user: "williams" };
     const expected = `${BASE_URL}/People(UserName='williams')`;
 
     expect(testService.getPeopleSrv().get(testId).getPath()).toBe(expected);
@@ -83,12 +83,12 @@ describe("Testing Generation of TrippinService", () => {
     const id = "williams";
     const expectedUrl = `${BASE_URL}/People('${id}')`;
     const model: EditablePersonModel = {
-      UserName: "williams",
-      FavoriteFeature: FeatureModel.Feature1,
-      Features: [],
-      FirstName: "Heinz",
-      Gender: PersonGenderModel.Unknown,
-      Age: 33,
+      user: "williams",
+      favoriteFeature: FeatureModel.Feature1,
+      features: [],
+      firstName: "Heinz",
+      traditionalGenderCategories: PersonGenderModel.Unknown,
+      age: 33,
     };
 
     await testService.getPeopleSrv().get(id).update(model);
@@ -102,7 +102,7 @@ describe("Testing Generation of TrippinService", () => {
     const id = "williams";
     const expectedUrl = `${BASE_URL}/People('${id}')`;
     const model = {
-      Age: 44,
+      age: 44,
     };
 
     await testService.getPeopleSrv().get(id).patch(model);
@@ -142,8 +142,8 @@ describe("Testing Generation of TrippinService", () => {
     const complex = testService.getPeopleSrv().get("tester").getHomeAddressSrv();
 
     const model: EditableLocationModel = {
-      Address: "Test Address",
-      City: { Name: "Test City" },
+      address: "Test Address",
+      city: { name: "Test City" },
     };
     await complex.update(model);
 
@@ -168,7 +168,7 @@ describe("Testing Generation of TrippinService", () => {
   });
 
   test("complex collection: create", async () => {
-    const model: EditableLocationModel = { Address: "TestAdress" };
+    const model: EditableLocationModel = { address: "TestAdress" };
     await testService.getPeopleSrv().get("tester").getAddressInfoSrv().add(model);
 
     expect(odataClient.lastUrl).toBe(`${BASE_URL}/People('tester')/AddressInfo`);
@@ -177,7 +177,7 @@ describe("Testing Generation of TrippinService", () => {
   });
 
   test("complex collection: update", async () => {
-    const models = [{ Address: "TestAddress 1" }, { Address: "test 2" }];
+    const models = [{ address: "TestAddress 1" }, { address: "test 2" }];
     await testService.getPeopleSrv().get("tester").getAddressInfoSrv().update(models);
 
     expect(odataClient.lastUrl).toBe(`${BASE_URL}/People('tester')/AddressInfo`);

--- a/packages/odata2model/odata2ts.config.ts
+++ b/packages/odata2model/odata2ts.config.ts
@@ -1,4 +1,4 @@
-import { ConfigFileOptions, EmitModes, Modes, NamingStrategies } from "@odata2ts/odata2model";
+import { ConfigFileOptions, EmitModes, Modes } from "@odata2ts/odata2model";
 
 const config: ConfigFileOptions = {
   debug: false,
@@ -14,18 +14,15 @@ const config: ConfigFileOptions = {
       // serviceName: "TrippinService",
       source: "int-test/fixture/v4/trippin.xml",
       output: "build/v4/trippin",
-      propertyTypes: [
+      propertiesByName: [
         {
-          name: "ID",
+          name: "UserName",
           mappedName: "id",
           managed: true,
         },
-        ...["createdAt", "createdBy", "modifiedAt", "modifiedBy"].map((prop) => ({
-          name: prop,
-          managed: true,
-        })),
+        ...["createdAt", "createdBy", "modifiedAt", "modifiedBy"].map((prop) => ({ name: prop, managed: true })),
       ],
-      modelTypes: [
+      entitiesByName: [
         {
           name: "Product",
           mappedName: "prod666uct",

--- a/packages/odata2model/odata2ts.config.ts
+++ b/packages/odata2model/odata2ts.config.ts
@@ -5,19 +5,43 @@ const config: ConfigFileOptions = {
   mode: Modes.service,
   emitMode: EmitModes.ts,
   prettier: true,
+  naming: {
+    models: {
+      suffix: "Model",
+    },
+  },
   services: {
     odata: {
       source: "int-test/fixture/v2/odata.xml",
       output: "build/v2/odata",
+      propertiesByName: [
+        {
+          name: "ID",
+          mappedName: "id",
+        },
+      ],
     },
     trippin: {
       // serviceName: "TrippinService",
       source: "int-test/fixture/v4/trippin.xml",
       output: "build/v4/trippin",
+      naming: {
+        queryObjects: {
+          operations: {
+            function: { suffix: "Function" },
+            action: { suffix: "Action" },
+          },
+        },
+      },
       propertiesByName: [
         {
           name: "UserName",
-          mappedName: "id",
+          mappedName: "user",
+          managed: true,
+        },
+        {
+          name: "Gender",
+          mappedName: "TraditionalGenderCategories",
           managed: true,
         },
         ...["createdAt", "createdBy", "modifiedAt", "modifiedBy"].map((prop) => ({ name: prop, managed: true })),
@@ -42,11 +66,6 @@ const config: ConfigFileOptions = {
     nw4: {
       source: "int-test/fixture/v4/northwind.xml",
       output: "build/v4/northwind",
-    },
-  },
-  naming: {
-    models: {
-      suffix: "Model",
     },
   },
 };

--- a/packages/odata2model/src/FactoryFunctionModel.ts
+++ b/packages/odata2model/src/FactoryFunctionModel.ts
@@ -1,4 +1,3 @@
-import { MappedConverterChains } from "@odata2ts/converter-runtime";
 import { ODataVersions } from "@odata2ts/odata-core";
 import { SourceFile } from "ts-morph";
 
@@ -7,7 +6,7 @@ import { Schema } from "./data-model/edmx/ODataEdmxModelBase";
 import { NamingHelper } from "./data-model/NamingHelper";
 import { RunOptions } from "./OptionModel";
 
-export type DigestionOptions = Pick<RunOptions, "converters">;
+export type DigestionOptions = Pick<RunOptions, "converters" | "propertiesByName" | "entitiesByName">;
 
 /**
  * Takes an EdmxSchema plus the run options and creates a DataModel.

--- a/packages/odata2model/src/OptionModel.ts
+++ b/packages/odata2model/src/OptionModel.ts
@@ -129,79 +129,90 @@ export interface ConfigFileOptions extends Omit<CliOptions, "source" | "output" 
    */
   skipOperations?: boolean;
 
+  /**
+   * The naming options regarding the generated artefacts.
+   */
   naming?: NamingOptions;
 }
 
 /**
  * Custom generation options which are dependent on a specific odata service.
  */
-interface ServiceGenerationOptions
+export interface ServiceGenerationOptions
   extends Required<Pick<CliOptions, "source" | "output">>,
     Omit<ConfigFileOptions, "services"> {
   /**
    * Configure generation process for EntityTypes and ComplexTypes including their properties.
    */
-  modelTypes?: Array<ModelTypeGenerationOptions>;
+  entitiesByName?: Array<EntityGenerationOptions>;
   /**
    * Configure generation process for individual properties based on their name.
    */
-  propertyTypes?: Array<PropertyGenerationOptions>;
+  propertiesByName?: Array<PropertyGenerationOptions>;
 }
 
 /**
- * All configurations for EntityTypes and ComplexTypes.
+ * Configuration options for EntityTypes and ComplexTypes.
+ * This config applies if the name matches the name of an EntityType or ComplexType as it is specified
+ * in the metadata (e.g. in EDMX <EntityType name="Test" ....)
  */
-interface ModelTypeGenerationOptions {
+export interface EntityGenerationOptions {
   /**
    * Name of the EntityType or ComplexType, e.g. "Person".
+   * Must match exactly or can be a regular expression.
    */
-  name: string;
+  name: string | RegExp;
   /**
-   * Map the name to a different name.
+   * Use a different name.
+   * If name is a regular expression, mappedName allows to specify captured groups (via $1, $2, ...).
    */
   mappedName?: string;
-  /**
-   * Whether the generated service should allow for querying this model.
-   * True by default.
-   */
-  queryable?: boolean;
-  /**
-   * Whether the generated service should allow for creating new models (POST).
-   * True by default.
-   */
-  creatable?: boolean;
-  /**
-   * Whether the generated service should allow for updates (PUT).
-   * True by default.
-   */
-  updatable?: boolean;
-  /**
-   * Whether the generated service should allow for partial updates (PATCH).
-   * True by default.
-   */
-  patchable?: boolean;
-  /**
-   * Whether the generated service should allow for deletion.
-   * True by default.
-   */
-  deletable?: boolean;
-  // converter: string | Array<string>
   /**
    * Configuration of individual properties.
    */
   properties?: Array<PropertyGenerationOptions>;
+
+  // converter: string | Array<string>
+
+  /**
+   * Whether the generated service should allow for querying this model.
+   * True by default.
+   */
+  // queryable?: boolean;
+  /**
+   * Whether the generated service should allow for creating new models (POST).
+   * True by default.
+   */
+  // creatable?: boolean;
+  /**
+   * Whether the generated service should allow for updates (PUT).
+   * True by default.
+   */
+  // updatable?: boolean;
+  /**
+   * Whether the generated service should allow for partial updates (PATCH).
+   * True by default.
+   */
+  // patchable?: boolean;
+  /**
+   * Whether the generated service should allow for deletion.
+   * True by default.
+   */
+  // deletable?: boolean;
 }
 
 /**
  * All configuration options for properties of models.
  */
-interface PropertyGenerationOptions {
+export interface PropertyGenerationOptions {
   /**
-   * Name of the property to match. Must match exactly.
+   * Name of the property to match.
+   * Must match exactly or can be a regular expression.
    */
-  name: string;
+  name: string | RegExp;
   /**
-   * Map the name to a different name.
+   * Use a different name.
+   * If name is a regular expression, mappedName allows to specify captured groups (via $1, $2, ...).
    */
   mappedName?: string;
   /**

--- a/packages/odata2model/src/data-model/DataModelDigestion.ts
+++ b/packages/odata2model/src/data-model/DataModelDigestion.ts
@@ -5,6 +5,7 @@ import { DataModel } from "./DataModel";
 import { ComplexType as ComplexModelType, DataTypes, ODataVersion, PropertyModel } from "./DataTypeModel";
 import { ComplexType, EntityType, Property, Schema } from "./edmx/ODataEdmxModelBase";
 import { NamingHelper } from "./NamingHelper";
+import { ServiceConfigHelper } from "./ServiceConfigHelper";
 
 export interface TypeModel {
   outputType: string;
@@ -18,6 +19,7 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
   protected static ROOT_OPERATION = "/";
 
   protected readonly dataModel: DataModel;
+  protected readonly serviceConfigHelper: ServiceConfigHelper;
 
   private model2Type: Map<string, DataTypes> = new Map<string, DataTypes>();
 
@@ -29,6 +31,7 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
     converters?: MappedConverterChains
   ) {
     this.dataModel = new DataModel(version, converters);
+    this.serviceConfigHelper = new ServiceConfigHelper(options);
     this.collectModelTypes(this.schema);
   }
 
@@ -130,14 +133,13 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
     for (const model of models) {
       const baseModel = this.getBaseModel(model);
 
-      // key support
-      // we cannot add keys now stemming from base classes
-      // => postprocess required
-      const keys: Array<string> = [];
+      // key support: we add keys from this entity,
+      // but not keys stemming from base classes (postprocess required)
+      const keyNames: Array<string> = [];
       const entity = model as EntityType;
       if (entity.Key && entity.Key.length && entity.Key[0].PropertyRef.length) {
         const propNames = entity.Key[0].PropertyRef.map((key) => key.$.Name);
-        keys.push(...propNames);
+        keyNames.push(...propNames);
       }
 
       this.dataModel.addModel(baseModel.name, {
@@ -145,9 +147,9 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
         idModelName: this.namingHelper.getIdModelName(model.$.Name),
         qIdFunctionName: this.namingHelper.getQIdFunctionName(model.$.Name),
         generateId: true,
-        keyNames: keys, // postprocess required to include key specs from base classes
+        keyNames: keyNames, // postprocess required to include key specs from base classes
         keys: [], // postprocess required to include props from base classes
-        getKeyUnion: () => keys.join(" | "),
+        getKeyUnion: () => keyNames.join(" | "),
       });
     }
   }
@@ -275,15 +277,16 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
       );
     }
 
-    const name = this.namingHelper.getModelPropName(p.$.Name);
-    const odataName = p.$.Name;
+    const configProp = this.serviceConfigHelper.findConfigPropByName(p.$.Name);
+    const name = this.namingHelper.getModelPropName(configProp?.mappedName || p.$.Name);
 
     return {
-      odataName,
+      odataName: p.$.Name,
       name,
       odataType: p.$.Type,
       required: p.$.Nullable === "false",
       isCollection: isCollection,
+      managed: !!configProp?.managed,
       ...result,
     };
   };

--- a/packages/odata2model/src/data-model/DataTypeModel.ts
+++ b/packages/odata2model/src/data-model/DataTypeModel.ts
@@ -30,6 +30,7 @@ export interface PropertyModel {
   isCollection: boolean;
   dataType: DataTypes;
   converters?: Array<ValueConverterImport>;
+  managed?: boolean;
 }
 
 export interface ModelType extends ComplexType {

--- a/packages/odata2model/src/data-model/ServiceConfigHelper.ts
+++ b/packages/odata2model/src/data-model/ServiceConfigHelper.ts
@@ -1,0 +1,71 @@
+import { DigestionOptions } from "../FactoryFunctionModel";
+import { PropertyGenerationOptions } from "../OptionModel";
+
+export interface ConfiguredProp extends Omit<PropertyGenerationOptions, "name"> {}
+
+const EXCEPTION_NO_NAME = "PropertiesByName: No value for required attribute [name] specified!";
+const EXCEPTION_WRONG_NAME_TYPE =
+  "PropertiesByName: Wrong type for attribute [name]! You have to supply either a plain string or a RegExp.";
+
+export class ServiceConfigHelper {
+  private propMapping = new Map<string, PropertyGenerationOptions>();
+  private propRegExps: Array<[RegExp, PropertyGenerationOptions]> = [];
+
+  constructor(options: DigestionOptions) {
+    this.evaluateProps(options);
+  }
+
+  private evaluateProps(options: DigestionOptions) {
+    options.propertiesByName.forEach((prop) => {
+      if (!prop.name) {
+        throw new Error(EXCEPTION_NO_NAME);
+      }
+      switch (typeof prop.name) {
+        case "string":
+          // TODO: check for existing prop.name and throw?
+          this.propMapping.set(prop.name, prop);
+          break;
+        case "object":
+          const { source, ignoreCase } = prop.name as RegExp;
+          if (!source) {
+            throw new Error(EXCEPTION_WRONG_NAME_TYPE);
+          }
+          this.propRegExps.push([new RegExp(`^${source}$`, ignoreCase ? "i" : ""), prop]);
+          break;
+        default:
+          throw new Error(EXCEPTION_WRONG_NAME_TYPE);
+      }
+    });
+  }
+
+  private getPropByName(nameToMap: string): ConfiguredProp | undefined {
+    const stringProp = this.propMapping.get(nameToMap);
+    if (!stringProp) {
+      return;
+    }
+    const { name, ...attrs } = stringProp;
+    return { ...attrs };
+  }
+
+  private getPropByRegExp(nameToMap: string): ConfiguredProp | undefined {
+    const resultList = this.propRegExps
+      .filter(([regExp]) => regExp.test(nameToMap))
+      .map(([regExp, { name, mappedName, ...attrs }]) => ({
+        mappedName: mappedName ? nameToMap.replace(regExp, mappedName) : undefined,
+        ...attrs,
+      }));
+
+    return !resultList.length
+      ? undefined
+      : resultList.reduce<ConfiguredProp>((result, prop) => {
+          return { ...result, ...prop };
+        }, {});
+  }
+
+  public findConfigPropByName = (name: string): ConfiguredProp | undefined => {
+    const stringProp = this.getPropByName(name);
+    const reProp = this.getPropByRegExp(name);
+
+    return stringProp && reProp ? { ...reProp, ...stringProp } : stringProp || reProp;
+  };
+}

--- a/packages/odata2model/src/defaultConfig.ts
+++ b/packages/odata2model/src/defaultConfig.ts
@@ -73,8 +73,8 @@ const defaultConfig: Omit<RunOptions, "source" | "output"> = {
       },
     },
   },
-  propertyTypes: [],
-  modelTypes: [],
+  propertiesByName: [],
+  entitiesByName: [],
 };
 
 /**

--- a/packages/odata2model/src/generator/ModelGenerator.ts
+++ b/packages/odata2model/src/generator/ModelGenerator.ts
@@ -75,7 +75,7 @@ class ModelGenerator {
       properties: model.props.map((p) => {
         const isEntity = p.dataType == DataTypes.ModelType;
         return {
-          name: p.odataName, // todo: map to lowercase
+          name: p.name,
           type: this.getPropType(p),
           // props for entities or entity collections are not added in V4 if not explicitly expanded
           hasQuestionToken: this.dataModel.isV4() && isEntity,
@@ -113,7 +113,7 @@ class ModelGenerator {
       return;
     }
     const singleType = model.keys.length === 1 ? `${model.keys[0].type} | ` : "";
-    const keyTypes = model.keys.map((keyProp) => `${keyProp.odataName}: ${this.getPropType(keyProp)}`).join(",");
+    const keyTypes = model.keys.map((keyProp) => `${keyProp.name}: ${this.getPropType(keyProp)}`).join(",");
     const type = `${singleType}{${keyTypes}}`;
 
     this.sourceFile.addTypeAlias({
@@ -129,11 +129,11 @@ class ModelGenerator {
 
     const requiredProps = allProps
       .filter((p) => p.required && !entityTypes.includes(p.dataType))
-      .map((p) => `"${p.odataName}"`)
+      .map((p) => `"${p.name}"`)
       .join(" | ");
     const optionalProps = allProps
       .filter((p) => !p.required && !entityTypes.includes(p.dataType))
-      .map((p) => `"${p.odataName}"`)
+      .map((p) => `"${p.name}"`)
       .join(" | ");
     const complexProps = allProps.filter((p) => p.dataType === DataTypes.ComplexType);
 
@@ -150,7 +150,7 @@ class ModelGenerator {
         ? undefined
         : complexProps.map((p) => {
             return {
-              name: p.odataName,
+              name: p.name,
               type: this.getEditablePropType(p),
               // optional props don't need to be specified in editable model
               // also, entities would require deep insert func => we make it optional for now
@@ -198,7 +198,7 @@ class ModelGenerator {
       isExported: true,
       properties: operation.parameters.map((p) => {
         return {
-          name: p.odataName, //TODO: mappedName
+          name: p.name,
           type: this.getPropType(p),
           hasQuestionToken: !p.required,
         };

--- a/packages/odata2model/src/generator/QueryObjectGenerator.ts
+++ b/packages/odata2model/src/generator/QueryObjectGenerator.ts
@@ -196,7 +196,7 @@ class QueryObjectGenerator {
         if (prop.qParam) {
           importContainer.addFromQObject(prop.qParam);
         }
-        const isMappedNameNecessary = false; //TODO prop.odataName !== prop.name;
+        const isMappedNameNecessary = prop.odataName !== prop.name;
         const mappedName = isMappedNameNecessary ? `"${prop.name}"` : prop.converters?.length ? "undefined" : undefined;
         const converterStmt = this.generateConverterStmt(prop.converters, importContainer);
         return `new ${prop.qParam}("${prop.odataName}"${mappedName ? `, ${mappedName}` : ""}${

--- a/packages/odata2model/src/generator/QueryObjectGenerator.ts
+++ b/packages/odata2model/src/generator/QueryObjectGenerator.ts
@@ -98,7 +98,8 @@ class QueryObjectGenerator {
     importContainer: ImportContainer
   ): Array<OptionalKind<PropertyDeclarationStructure>> {
     return props.map((prop) => {
-      const { name, odataName } = prop;
+      const { odataName } = prop;
+      const name = this.namingHelper.getQPropName(odataName);
       const isModelType = prop.dataType === DataTypes.ModelType || prop.dataType === DataTypes.ComplexType;
       let qPathInit: string;
 

--- a/packages/odata2model/test/data-model/ComplexTypeAndEnumDigestionTests.ts
+++ b/packages/odata2model/test/data-model/ComplexTypeAndEnumDigestionTests.ts
@@ -40,6 +40,7 @@ export function createComplexAndEnumTests() {
     expect(model.props[1]).toEqual({
       dataType: DataTypes.EnumType,
       isCollection: false,
+      managed: false,
       name: "myChoice",
       odataName: "myChoice",
       odataType: `${SERVICE_NAME}.Choice`,
@@ -66,6 +67,7 @@ export function createComplexAndEnumTests() {
     expect(model.props[1]).toEqual({
       dataType: DataTypes.EnumType,
       isCollection: true,
+      managed: false,
       name: "myChoices",
       odataName: "myChoices",
       odataType: `Collection(${SERVICE_NAME}.Choice)`,
@@ -90,6 +92,7 @@ export function createComplexAndEnumTests() {
     expect(model.props[1]).toEqual({
       dataType: DataTypes.ComplexType,
       isCollection: false,
+      managed: false,
       name: "branding",
       odataName: "branding",
       odataType: `${SERVICE_NAME}.Brand`,

--- a/packages/odata2model/test/data-model/ServiceConfigHelper.test.ts
+++ b/packages/odata2model/test/data-model/ServiceConfigHelper.test.ts
@@ -1,0 +1,111 @@
+import { PropertyGenerationOptions } from "../../src";
+import { ServiceConfigHelper } from "../../src/data-model/ServiceConfigHelper";
+
+describe("ServiceConfigHelper Tests", function () {
+  let toTest: ServiceConfigHelper;
+
+  function createHelperWithProps(...propsSetting: Array<PropertyGenerationOptions>) {
+    toTest = new ServiceConfigHelper({
+      converters: [],
+      entitiesByName: [],
+      propertiesByName: propsSetting || [],
+    });
+  }
+
+  test("propByName: empty options", () => {
+    createHelperWithProps();
+
+    expect(toTest.findConfigPropByName("test")).toBeUndefined();
+  });
+
+  test("propByName: matching, but empty config", () => {
+    const name = "test";
+    createHelperWithProps({ name });
+
+    expect(toTest.findConfigPropByName(name)).toStrictEqual({});
+    expect(toTest.findConfigPropByName("xxx")).toBeUndefined();
+  });
+
+  test("propByName: simple name mapping", () => {
+    const name = "test";
+    const mappedName = "xyz";
+
+    // by string
+    createHelperWithProps({ name, mappedName });
+    let result = toTest.findConfigPropByName(name);
+
+    expect(result).toStrictEqual({ mappedName });
+
+    // by RegExp
+    const nameRegExp = /test/;
+    createHelperWithProps({ name: nameRegExp, mappedName });
+    result = toTest.findConfigPropByName(name);
+
+    expect(result).toStrictEqual({ mappedName });
+  });
+
+  test("propByName: wrong name option", () => {
+    const exceptionNoName = "No value for required attribute [name] specified!";
+    const exceptionWrongType = "Wrong type for attribute [name]!";
+
+    // @ts-ignore
+    expect(() => createHelperWithProps({ name: undefined })).toThrow(exceptionNoName);
+    // @ts-ignore
+    expect(() => createHelperWithProps({ name: null })).toThrow(exceptionNoName);
+    expect(() => createHelperWithProps({ name: "" })).toThrow(exceptionNoName);
+    // @ts-ignore
+    expect(() => createHelperWithProps({ name: {} })).toThrow(exceptionWrongType);
+  });
+
+  test("propByName: case insensitive regexp", () => {
+    const name = /test/i;
+    const mappedName = "xyz";
+    const expectedResult = { mappedName };
+
+    createHelperWithProps({ name, mappedName });
+
+    expect(toTest.findConfigPropByName("test")).toStrictEqual(expectedResult);
+    expect(toTest.findConfigPropByName("Test")).toStrictEqual(expectedResult);
+    expect(toTest.findConfigPropByName("TeST")).toStrictEqual(expectedResult);
+    expect(toTest.findConfigPropByName("xxx")).toBeUndefined();
+  });
+
+  test("propByName: regexp replacing", () => {
+    const name = /(\d+)test(\d+)/;
+    const mappedName = "xyz$1_$2";
+
+    createHelperWithProps({ name, mappedName });
+
+    expect(toTest.findConfigPropByName("test")).toBeUndefined();
+    expect(toTest.findConfigPropByName("123test456")).toStrictEqual({ mappedName: "xyz123_456" });
+  });
+
+  test("propByName: managed", () => {
+    const name = "test";
+
+    let managed = true;
+    createHelperWithProps({ name, managed });
+    expect(toTest.findConfigPropByName(name)).toStrictEqual({ managed });
+
+    managed = false;
+    createHelperWithProps({ name, managed });
+    expect(toTest.findConfigPropByName(name)).toStrictEqual({ managed });
+  });
+
+  test("propByName: multiple matching regexps", () => {
+    const name = /(\d+)test(\d+)/;
+    const mappedName = "xyz$1_$2";
+
+    const name2 = /(\d+)test.*/i;
+    const mappedName2 = "xyz$1";
+    const result2 = "xyz123";
+
+    createHelperWithProps({ name, mappedName, managed: true }, { name: name2, mappedName: mappedName2 });
+
+    // only mapping2 applies
+    expect(toTest.findConfigPropByName("123test")).toStrictEqual({ mappedName: result2 });
+    expect(toTest.findConfigPropByName("123Test456")).toStrictEqual({ mappedName: result2 });
+    // combined mappings apply => merged, but last one wins the name mapping
+    expect(toTest.findConfigPropByName("123test456")).toStrictEqual({ mappedName: result2, managed: true });
+  });
+});

--- a/packages/odata2model/test/data-model/v2/EntityTypeDigestion.test.ts
+++ b/packages/odata2model/test/data-model/v2/EntityTypeDigestion.test.ts
@@ -439,6 +439,7 @@ describe("V2: EntityTypeDigestion Test", () => {
       odataType: `${SERVICE_NAME}.Category`,
       isCollection: false,
       dataType: DataTypes.ModelType,
+      managed: false,
       required: true,
     } as PropertyModel);
     expect(product.props[2]).toEqual({
@@ -450,6 +451,7 @@ describe("V2: EntityTypeDigestion Test", () => {
       odataType: `${SERVICE_NAME}.Supplier`,
       isCollection: false,
       dataType: DataTypes.ModelType,
+      managed: false,
       required: false,
     } as PropertyModel);
 
@@ -464,6 +466,7 @@ describe("V2: EntityTypeDigestion Test", () => {
       odataType: `Collection(${SERVICE_NAME}.Product)`,
       isCollection: true,
       dataType: DataTypes.ModelType,
+      managed: false,
       required: false,
     } as PropertyModel);
   });

--- a/packages/odata2model/test/data-model/v4/EntityTypeDigestion.test.ts
+++ b/packages/odata2model/test/data-model/v4/EntityTypeDigestion.test.ts
@@ -8,7 +8,7 @@ import { ODataModelBuilderV4 } from "../builder/v4/ODataModelBuilderV4";
 
 const NOOP_FN = () => {};
 
-describe("V2: EntityTypeDigestion Test", () => {
+describe("V4: EntityTypeDigestion Test", () => {
   const SERVICE_NAME = "Tester";
   const CONFIG = getDefaultConfig();
   const NAMING_HELPER = new NamingHelper(CONFIG.naming, SERVICE_NAME);
@@ -48,6 +48,7 @@ describe("V2: EntityTypeDigestion Test", () => {
     const expectedProp = {
       dataType: DataTypes.PrimitiveType,
       isCollection: false,
+      managed: false,
       name: "id",
       odataName: "id",
       odataType: ODataTypesV4.String,

--- a/packages/odata2model/test/fixture/generator/model/entity-hierarchy.ts
+++ b/packages/odata2model/test/fixture/generator/model/entity-hierarchy.ts
@@ -14,11 +14,11 @@ export interface EditableParent extends Pick<Parent, "id">, Partial<Pick<Parent,
 
 export interface Child extends Parent {
   id2: boolean;
-  Ch1ld1shF4n: boolean | null;
+  ch1ld1shF4n: boolean | null;
 }
 
 export type ChildId = { id: boolean; id2: boolean };
 
 export interface EditableChild
   extends Pick<Child, "id" | "id2">,
-    Partial<Pick<Child, "parentalAdvice" | "Ch1ld1shF4n">> {}
+    Partial<Pick<Child, "parentalAdvice" | "ch1ld1shF4n">> {}

--- a/packages/odata2model/test/fixture/generator/model/entity-max-v2.ts
+++ b/packages/odata2model/test/fixture/generator/model/entity-max-v2.ts
@@ -13,7 +13,7 @@ export interface Book {
   testInt64: string | null;
   testSingle: string | null;
   testDouble: string | null;
-  TestDecimal: string | null;
+  testDecimal: string | null;
   testBinary: string | null;
   testAny: string | null;
   multipleIds: Array<string>;
@@ -44,7 +44,7 @@ export interface EditableBook
         | "testInt64"
         | "testSingle"
         | "testDouble"
-        | "TestDecimal"
+        | "testDecimal"
         | "testBinary"
         | "testAny"
         | "multipleIds"

--- a/packages/odata2model/test/fixture/generator/model/entity-max.ts
+++ b/packages/odata2model/test/fixture/generator/model/entity-max.ts
@@ -6,7 +6,7 @@ export interface Book {
   time: string | null;
   optionalDate: string | null;
   dateTimeOffset: string | null;
-  TestDecimal: number | null;
+  testDecimal: number | null;
   testBinary: string | null;
   testAny: string | null;
   multipleStrings: Array<string>;
@@ -29,7 +29,7 @@ export interface EditableBook
         | "time"
         | "optionalDate"
         | "dateTimeOffset"
-        | "TestDecimal"
+        | "testDecimal"
         | "testBinary"
         | "testAny"
         | "multipleStrings"

--- a/packages/odata2model/test/fixture/generator/model/model-naming.ts
+++ b/packages/odata2model/test/fixture/generator/model/model-naming.ts
@@ -4,23 +4,23 @@ export enum CHOICE_MODEL {
 }
 
 export interface PARENT_MODEL {
-  parentId: boolean;
+  PARENT_ID: boolean;
 }
 
-export type PARENT_KEY = boolean | { parentId: boolean };
+export type PARENT_KEY = boolean | { PARENT_ID: boolean };
 
-export interface EDIT_PARENT_MODEL extends Pick<PARENT_MODEL, "parentId"> {}
+export interface EDIT_PARENT_MODEL extends Pick<PARENT_MODEL, "PARENT_ID"> {}
 
 export interface BOOK_MODEL extends PARENT_MODEL {
-  id: boolean;
-  myChoice: CHOICE_MODEL;
-  address: LOCATION_MODEL | null;
+  ID: boolean;
+  MY_CHOICE: CHOICE_MODEL;
+  ADDRESS: LOCATION_MODEL | null;
 }
 
-export type BOOK_KEY = { parentId: boolean; id: boolean };
+export type BOOK_KEY = { PARENT_ID: boolean; ID: boolean };
 
-export interface EDIT_BOOK_MODEL extends Pick<BOOK_MODEL, "parentId" | "id" | "myChoice"> {
-  address?: EDIT_LOCATION_MODEL | null;
+export interface EDIT_BOOK_MODEL extends Pick<BOOK_MODEL, "PARENT_ID" | "ID" | "MY_CHOICE"> {
+  ADDRESS?: EDIT_LOCATION_MODEL | null;
 }
 
 export interface LOCATION_MODEL {

--- a/packages/odata2model/test/fixture/generator/qobject/action-min.ts
+++ b/packages/odata2model/test/fixture/generator/qobject/action-min.ts
@@ -4,7 +4,7 @@ import { QAction, QStringParam } from "@odata2ts/odata-query-objects";
 import { MinActionParams } from "./TesterModel";
 
 export class QMinAction extends QAction<MinActionParams> {
-  private readonly params = [new QStringParam("test"), new QStringParam("optTest")];
+  private readonly params = [new QStringParam("test"), new QStringParam("opt_Test", "optTest")];
 
   constructor() {
     super("MinAction");

--- a/packages/odata2model/test/fixture/generator/qobject/function-max-v2.ts
+++ b/packages/odata2model/test/fixture/generator/qobject/function-max-v2.ts
@@ -15,7 +15,7 @@ import { MaxFunctionParams } from "./TesterModel";
 
 export class QMaxFunction extends QFunction<MaxFunctionParams> {
   private readonly params = [
-    new QStringParam("TEST_STRING"),
+    new QStringParam("TEST_STRING", "testString"),
     new QNumberParam("testNumber"),
     new QBooleanParam("testBoolean", undefined, booleanToNumberConverter),
     new QGuidV2Param("testGuid"),

--- a/packages/odata2model/test/fixture/generator/qobject/function-max.ts
+++ b/packages/odata2model/test/fixture/generator/qobject/function-max.ts
@@ -15,7 +15,7 @@ import { MaxFunctionParams } from "./TesterModel";
 
 export class QMaxFunction extends QFunction<MaxFunctionParams> {
   private readonly params = [
-    new QStringParam("TEST_STRING"),
+    new QStringParam("TEST_STRING", "testString"),
     new QNumberParam("testNumber"),
     new QBooleanParam("testBoolean", undefined, booleanToNumberConverter),
     new QGuidParam("testGuid"),

--- a/packages/odata2model/test/fixture/generator/qobject/model-naming.ts
+++ b/packages/odata2model/test/fixture/generator/qobject/model-naming.ts
@@ -10,7 +10,7 @@ export class PARENT_Q_OBJ extends QueryObject {
 export const pARENT_Q_OBJ = new PARENT_Q_OBJ();
 
 export class PARENT_ID_Q_OBJ extends QId<PARENT_KEY> {
-  private readonly params = [new QBooleanParam("parentId")];
+  private readonly params = [new QBooleanParam("parentId", "PARENT_ID")];
 
   getParams() {
     return this.params;
@@ -19,14 +19,14 @@ export class PARENT_ID_Q_OBJ extends QId<PARENT_KEY> {
 
 export class BOOK_Q_OBJ extends PARENT_Q_OBJ {
   public readonly id = new QBooleanPath(this.withPrefix("id"));
-  public readonly myChoice = new QEnumPath(this.withPrefix("myChoice"));
-  public readonly address = new QEntityPath(this.withPrefix("address"), () => LOCATION_Q_OBJ);
+  public readonly myChoice = new QEnumPath(this.withPrefix("my_Choice"));
+  public readonly address = new QEntityPath(this.withPrefix("Address"), () => LOCATION_Q_OBJ);
 }
 
 export const bOOK_Q_OBJ = new BOOK_Q_OBJ();
 
 export class BOOK_ID_Q_OBJ extends QId<BOOK_KEY> {
-  private readonly params = [new QBooleanParam("parentId"), new QBooleanParam("id")];
+  private readonly params = [new QBooleanParam("parentId", "PARENT_ID"), new QBooleanParam("id", "ID")];
 
   getParams() {
     return this.params;

--- a/packages/odata2model/test/generator/v4/EntityBasedGenerationTests.ts
+++ b/packages/odata2model/test/generator/v4/EntityBasedGenerationTests.ts
@@ -256,6 +256,7 @@ export function createEntityBasedGenerationTests(
         models: {
           suffix: "model",
           namingStrategy: NamingStrategies.CONSTANT_CASE,
+          propNamingStrategy: NamingStrategies.CONSTANT_CASE,
           idModels: {
             suffix: "Key",
             applyModelNaming: false,

--- a/packages/odata2model/test/generator/v4/EntityBasedGenerationTests.ts
+++ b/packages/odata2model/test/generator/v4/EntityBasedGenerationTests.ts
@@ -234,12 +234,14 @@ export function createEntityBasedGenerationTests(
   test(`${testSuiteName}: model naming`, async () => {
     // given an entity with enum props
     odataBuilder
-      .addEntityType("parent", undefined, (builder) => builder.addKeyProp("parentId", ODataTypesV4.Boolean))
+      .addEntityType("parent", undefined, (builder) => {
+        return builder.addKeyProp("parentId", ODataTypesV4.Boolean);
+      })
       .addEntityType(ENTITY_NAME, SERVICE_NAME + ".parent", (builder) =>
         builder
           .addKeyProp("id", ODataTypesV4.Boolean)
-          .addProp("myChoice", `${SERVICE_NAME}.Choice`, false)
-          .addProp("address", `${SERVICE_NAME}.LOCATION`)
+          .addProp("my_Choice", `${SERVICE_NAME}.Choice`, false)
+          .addProp("Address", `${SERVICE_NAME}.LOCATION`)
       )
       .addEnumType("Choice", [
         { name: "A", value: 1 },

--- a/packages/odata2model/test/generator/v4/QueryObjectGenerator.test.ts
+++ b/packages/odata2model/test/generator/v4/QueryObjectGenerator.test.ts
@@ -89,7 +89,7 @@ describe("Query Object Generator Tests V4", () => {
   test(`${TEST_SUITE_NAME}: min QAction`, async () => {
     // given a simple function
     odataBuilder.addAction("MinAction", ODataTypesV4.String, false, (builder) =>
-      builder.addParam("test", ODataTypesV4.String, false).addParam("optTest", ODataTypesV4.String, true)
+      builder.addParam("test", ODataTypesV4.String, false).addParam("opt_Test", ODataTypesV4.String, true)
     );
 
     // when generating model


### PR DESCRIPTION
add service specific configuration option `propertiesByName` to allow for property configuration by matching the name (exact string or RegExp)