### PR TITLE
fix(odata2ts): naming of main service is not configurable

### DIFF
--- a/packages/odata2ts/src/NamingModel.ts
+++ b/packages/odata2ts/src/NamingModel.ts
@@ -128,15 +128,23 @@ export interface StandardNamingOptions {
 
 /**
  * Naming options for generated service classes.
+ * These options affect the main service as well as all services generated for each entity, complex and collection type.
  *
- * By default, suffix = Service and namingStrategy = pascalCase
+ * There exists one specialty about services: The file names are not configurable.
+ * File names are determined by the name of their corresponding classes, so that service file name
+ * and service class name always correspond.
+ *
+ * By default, suffix = Service and namingStrategy = PascalCase
  */
 export interface ServiceNamingOptions extends NamingStrategyOption, StandardNamingOptions {
   /**
-   * For each service one file is generated.
-   * This option specifies the formatting of the file name.
+   * Controls the naming options for the main odata service.
+   * By default, the base service naming options are applied.
+   * But since this is the main entry point for users, it can be configured individually here.
+   *
+   * By default, applyServiceNaming = true
    */
-  fileNames?: FileNamingStrategyOption & StandardNamingOptions;
+  main?: NamingStrategyOption & StandardNamingOptions & { applyServiceNaming?: boolean };
 
   /**
    * Name of the service responsible for entity collections.

--- a/packages/odata2ts/src/data-model/NamingHelper.ts
+++ b/packages/odata2ts/src/data-model/NamingHelper.ts
@@ -67,20 +67,20 @@ export class NamingHelper {
     return this.serviceName;
   }
 
-  private getFileName(opts?: FileNamingStrategyOption & StandardNamingOptions) {
-    return this.getName(this.serviceName, this.namingFunction(opts?.namingStrategy), opts);
-  }
-
   public getFileNames() {
     return {
       model: this.getFileName(this.options.models?.fileName),
       qObject: this.getFileName(this.options.queryObjects?.fileName),
-      service: this.getFileName(this.options.services?.fileNames),
+      service: this.getMainServiceName(),
     };
   }
 
+  private getFileName(opts?: FileNamingStrategyOption & StandardNamingOptions) {
+    return this.getName(this.serviceName, this.namingFunction(opts?.namingStrategy), opts);
+  }
+
   public getFileNameService(name: string) {
-    const opts = this.options.services?.fileNames;
+    const opts = this.options.services;
     return this.getName(name, this.namingFunction(opts?.namingStrategy), opts);
   }
 
@@ -199,6 +199,16 @@ export class NamingHelper {
     const opts = this.options.queryObjects?.operations;
     const result = this.getName(name, this.getQObjectNamingStrategy(), opts?.action || opts);
     return this.getName(result, this.getQObjectNamingStrategy(), this.options.queryObjects);
+  }
+
+  public getMainServiceName() {
+    const name = this.getODataServiceName();
+    const opts = this.options.services;
+    const strategy = this.namingFunction(
+      opts?.main?.namingStrategy ?? (opts?.main?.applyServiceNaming ? opts.namingStrategy : undefined)
+    );
+    const result = this.getName(name, strategy, opts?.main);
+    return opts?.main?.applyServiceNaming ? this.getName(result, strategy, opts) : result;
   }
 
   public getServiceName = (name: string) => {

--- a/packages/odata2ts/src/defaultConfig.ts
+++ b/packages/odata2ts/src/defaultConfig.ts
@@ -54,6 +54,9 @@ const defaultConfig: Omit<RunOptions, "source" | "output"> = {
     services: {
       suffix: "Service",
       namingStrategy: NamingStrategies.PASCAL_CASE,
+      main: {
+        applyServiceNaming: true,
+      },
       collection: {
         suffix: "Collection",
         applyServiceNaming: true,
@@ -69,10 +72,6 @@ const defaultConfig: Omit<RunOptions, "source" | "output"> = {
       relatedServiceGetter: {
         namingStrategy: NamingStrategies.CAMEL_CASE,
         prefix: "navTo",
-      },
-      fileNames: {
-        namingStrategy: NamingStrategies.PASCAL_CASE,
-        suffix: "Service",
       },
       privateProps: {
         namingStrategy: NamingStrategies.CAMEL_CASE,

--- a/packages/odata2ts/src/generator/ServiceGenerator.ts
+++ b/packages/odata2ts/src/generator/ServiceGenerator.ts
@@ -48,7 +48,7 @@ class ServiceGenerator {
 
   public async generate(): Promise<void> {
     const sourceFile = await this.project.createMainServiceFile();
-    const serviceName = this.namingHelper.getFileNames().service;
+    const serviceName = this.namingHelper.getMainServiceName();
     const container = this.dataModel.getEntityContainer();
     const unboundOperations = [...Object.values(container.functions), ...Object.values(container.actions)];
 

--- a/packages/odata2ts/test/data-model/NamingHelper.test.ts
+++ b/packages/odata2ts/test/data-model/NamingHelper.test.ts
@@ -23,6 +23,7 @@ describe("NamingHelper Tests", function () {
     expect(toTest.getODataServiceName()).toBe(SERVICE_NAME);
     expect(toTest.getServicePrefix()).toBe(SERVICE_NAME + ".");
 
+    expect(toTest.getMainServiceName()).toBe("TrippinService");
     expect(toTest.getFileNames()).toStrictEqual({
       model: "TrippinModel",
       qObject: "QTrippin",
@@ -70,6 +71,7 @@ describe("NamingHelper Tests", function () {
       qObject: "QMyTrip",
       service: "MyTripService",
     });
+    expect(toTest.getMainServiceName()).toBe("MyTripService");
     expect(toTest.getFileNameService("test")).toBe("TestService");
   });
 
@@ -81,14 +83,23 @@ describe("NamingHelper Tests", function () {
     };
     options.naming!.models!.fileName = newNaming;
     options.naming!.queryObjects!.fileName = newNaming;
-    options.naming!.services!.fileNames = newNaming;
+    options.naming!.services!.namingStrategy = newNaming.namingStrategy;
+    options.naming!.services!.prefix = newNaming.prefix;
+    options.naming!.services!.suffix = newNaming.suffix;
+    options.naming!.services!.main = {
+      applyServiceNaming: false,
+      namingStrategy: NamingStrategies.SNAKE_CASE,
+      prefix: "main",
+      suffix: "service",
+    };
     createHelper();
 
     expect(toTest.getFileNames()).toStrictEqual({
       model: "PREF_TRIPPIN_SUF",
       qObject: "PREF_TRIPPIN_SUF",
-      service: "PREF_TRIPPIN_SUF",
+      service: "main_trippin_service",
     });
+    expect(toTest.getMainServiceName()).toBe("main_trippin_service");
     expect(toTest.getFileNameService("test")).toBe("PREF_TEST_SUF");
   });
 

--- a/packages/odata2ts/test/fixture/generator/service/v4/main-service-naming.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/main-service-naming.ts
@@ -4,7 +4,7 @@ import { ODataService } from "@odata2ts/odata-service";
 // @ts-ignore
 import { CREATE_TEST_ENTITY_RSLVR } from "./service/TEST_ENTITY_SRV";
 
-export class TesterService<ClientType extends ODataClient> extends ODataService<ClientType> {
+export class tester<ClientType extends ODataClient> extends ODataService<ClientType> {
   private NAME_: string = "Tester";
   public LIST = CREATE_TEST_ENTITY_RSLVR(this.client, this.getPath(), "list");
   public NAVIGATE_TO_LIST = this.LIST.get.bind(this.LIST);

--- a/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
@@ -176,6 +176,10 @@ describe("Service Generator Tests V4", () => {
       services: {
         suffix: "srv",
         namingStrategy: NamingStrategies.CONSTANT_CASE,
+        main: {
+          applyServiceNaming: false,
+          namingStrategy: NamingStrategies.SNAKE_CASE,
+        },
         privateProps: {
           namingStrategy: NamingStrategies.CONSTANT_CASE,
           prefix: "",


### PR DESCRIPTION
BREAKING CHANGE: option `service.fileNames` was removed in favour of `service.main`, so that the main service can be configured individually; the underlying bug was that file names SHOULD NOT be configurable for services