### PR TITLE
feat(generator): auto detected service names are run through pascalCase to ensure valid class names

### DIFF
--- a/packages/odata2ts/test/app.test.ts
+++ b/packages/odata2ts/test/app.test.ts
@@ -65,7 +65,7 @@ describe("App Test", () => {
 
     // then the schema with entity types is used
     expect(createPmSpy.mock.calls[0][0]).toMatchObject({
-      service: "NewService",
+      service: `${newNs}Service`,
     });
   });
 
@@ -80,7 +80,21 @@ describe("App Test", () => {
 
     // then the schema with entity types is used
     expect(createPmSpy.mock.calls[0][0]).toMatchObject({
-      service: "TesterService",
+      service: `${SERVICE_NAME}Service`,
+    });
+  });
+
+  test("simple schema detection with pascal case", async () => {
+    // when multiple schemas exist
+    const newNs = "my.org.Example";
+    const expected = "MyOrgExample";
+    odataBuilder.addSchema(newNs).addEntityType("Test", undefined, (builder) => builder.addKeyProp("id", "Edm.String"));
+
+    await doRunApp();
+
+    // then the schema with entity types is used
+    expect(createPmSpy.mock.calls[0][0]).toMatchObject({
+      service: `${expected}Service`,
     });
   });
 


### PR DESCRIPTION
Due to a bad default setting, two people were confronted with an invalid class name for the main service. The name is detected automatically by virtue of the `Namespace` attribute in EDMX. It contained a dot which leads to the invalid class name.

As simple fix / feature, this auto-detected name is now run through pascal-case to ensure valid class names.

