### PR TITLE
feat(odata-core): improved control information modelling

### DIFF
--- a/packages/odata-core/src/ODataModelPayloadV4.ts
+++ b/packages/odata-core/src/ODataModelPayloadV4.ts
@@ -1,0 +1,37 @@
+/**
+ * Response to query for an EntityType or ComplexType
+ *
+ * Result object is directly returned.
+ * Additional context attribute is merged into result object.
+ */
+export type ODataModelPayloadV4<T> = T & {
+  /**
+   * The type control information MUST appear in requests,
+   * if the type cannot be heuristically determined (see link for heuristics) and one of the following is true:
+   * - The type is derived from the type specified for the (collection of) entities or (collection of) complex type instances
+   * - The type is for a property whose type is not declared in $metadata.
+   *
+   * For built-in primitive types the value is the unqualified name of the primitive type.
+   *
+   * For payloads described by an OData-Version header with a value of 4.0,
+   * this name MUST be prefixed with the hash symbol (#);
+   * for non-OData 4.0 payloads, built-in primitive type values SHOULD be represented without the hash symbol,
+   * but consumers of 4.01 or greater payloads MUST support values with or without the hash symbol.
+   *
+   * For all other types, the URI may be absolute or relative to the type of the containing object.
+   * The root type may be absolute or relative to the root context URL.
+   *
+   * See https://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html#sec_ControlInformationtypeodatatype
+   */
+  "@odata.type"?: string;
+
+  /**
+   * The context control information MUST also be included in requests for entities
+   * whose entity set cannot be determined from the context URL of the collection.
+   *
+   * Request payloads MAY include a context URL as a base URL for relative URLs in the request payload.
+   *
+   * See: https://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html#sec_ControlInformationcontextodatacontex
+   */
+  "@odata.context"?: string;
+};

--- a/packages/odata-core/src/ResponseModelV2.ts
+++ b/packages/odata-core/src/ResponseModelV2.ts
@@ -16,6 +16,11 @@ export interface ODataCollectionResponseV2<T> {
      * @example: "__next": "https://services.odata.org/OData/OData.svc$skiptoken=12"
      */
     __next?: string;
+    __metadata?: {
+      uri: string;
+      type?: string;
+      etag?: string;
+    };
   };
 }
 
@@ -34,12 +39,53 @@ export interface ODataValueResponseV2<T> {
 }
 
 export interface EntityMetaModelV2 {
+  /**
+   *  The value of the type name/value pair MUST be the namespace qualified name of the entity’s type.
+   */
   uri: string;
-  type: string;
+  /**
+   * The value of the type name/value pair MUST be the namespace qualified name of the entity’s type.
+   */
+  type?: string;
+  /**
+   * The etag name/value pair MAY be included.
+   * When included, it MUST represent the concurrency token associated with the entity ETag.
+   * When present, this value MUST be used instead of the ETag HTTP header.
+   */
   etag?: string;
+
+  /**
+   * The id name/value pair MAY be included if the service is using OData 2.0
+   * and MUST be included if the service is using OData 3.0.
+   */
+  id?: string;
 }
 
-export interface ComplexMetaModelV2 extends Omit<EntityMetaModelV2, "uri" | "etag"> {}
+export interface EnityMetaModelV3 extends EntityMetaModelV2 {
+  /**
+   * The value of the properties name/value pair MUST be a JSON object.
+   * It SHOULD contain a name/value pair for each navigation property.
+   *
+   * See https://www.odata.org/documentation/odata-version-3-0/json-verbose-format/#representingnavigationpropertymetadata
+   */
+  properties?: Record<string, { associationuri: string }>;
+  /**
+   * Advertisment for actions.
+   * Since V3
+   *
+   * See https://www.odata.org/documentation/odata-version-3-0/json-verbose-format/#advertisementforafunctionoraction
+   */
+  actions?: Array<{ title: string; target: string }>;
+  /**
+   * Advertisement for functions.
+   * Since v3
+   *
+   * See https://www.odata.org/documentation/odata-version-3-0/json-verbose-format/#advertisementforafunctionoraction
+   */
+  functions?: Array<{ title: string; target: string }>;
+}
+
+export interface ComplexMetaModelV2 extends Omit<EntityMetaModelV2, "uri" | "etag" | "id"> {}
 
 export type EntityModelV2<T> = T & {
   __metadata: EntityMetaModelV2;
@@ -47,6 +93,28 @@ export type EntityModelV2<T> = T & {
 
 export type ComplexModelV2<T> = T & {
   __metadata: ComplexMetaModelV2;
+};
+
+export type MediaEntityModelV2<T> = T & {
+  __metadata: {
+    /**
+     * The value of the media_src name/value pair MUST be the source URI for the data corresponding to this MLE.
+     */
+    media_src: string;
+    /**
+     * The value of the media_etag name/value pair MUST be the concurrency token for the data corresponding to this MLE.
+     */
+    media_etag?: string;
+    /**
+     * The value of the edit_media name/value pair MUST be the edit URI for the data corresponding to this MLE.
+     */
+    edit_media?: string;
+    /**
+     * The value of the content_type name/value pair SHOULD be the MIME type of the data corresponding to this MLE.
+     * This is only a hint. The actual content type will be included in a header when the resource is requested.
+     */
+    content_type?: string;
+  };
 };
 
 /**

--- a/packages/odata-core/src/ResponseModelV4.ts
+++ b/packages/odata-core/src/ResponseModelV4.ts
@@ -2,8 +2,61 @@
  * Response to a collection query.
  */
 export interface ODataCollectionResponseV4<T> {
-  "@odata.context": string;
+  /**
+   * The context control information returns the context URL for the payload. This URL can be absolute or relative.
+   *
+   * The context control information is not returned if metadata=none is requested.
+   * Otherwise, it MUST be the first property of any JSON response.
+   *
+   * The context control information MUST also be included in responses for entities
+   * whose entity set cannot be determined from the context URL of the collection.
+   */
+  "@odata.context"?: string;
+  /**
+   * The type control information MUST appear in responses,
+   * if the type cannot be heuristically determined (see link for heuristics) and one of the following is true:
+   * - The type is derived from the type specified for the (collection of) entities or (collection of) complex type instances
+   *
+   * For payloads described by an OData-Version header with a value of 4.0,
+   * this name MUST be prefixed with the hash symbol (#);
+   * for non-OData 4.0 payloads, built-in primitive type values SHOULD be represented without the hash symbol,
+   * but consumers of 4.01 or greater payloads MUST support values with or without the hash symbol.
+   *
+   * For all other types, the URI may be absolute or relative to the type of the containing object.
+   * The root type may be absolute or relative to the root context URL.
+   *
+   * See https://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html#sec_ControlInformationtypeodatatype
+   */
+  "@odata.type"?: string;
+  /**
+   * The metadataEtag control information MAY appear in a response in order to specify the entity tag (ETag)
+   * that can be used to determine the version of the metadata of the response.
+   * If an ETag is returned when requesting the metadata document, then the service SHOULD set the metadataEtag
+   * control information to the metadata document's ETag in all responses when using metadata=minimal or metadata=full.
+   *
+   * If no ETag is returned when requesting the metadata document, then the service SHOULD NOT
+   * set the metadataEtag control information in any responses.
+   */
+  "@odata.metadataEtag"?: string;
+  /**
+   * The etag control information MAY be applied to an entity or collection in a response.
+   * The value of the control information is an entity tag (ETag) which is an opaque string value
+   * that can be used in a subsequent request to determine if the value of the entity or collection has changed.
+   */
+  "@odata.etag"?: string;
+  /**
+   * The count control information occurs when system query option $count has been used.
+   * Its value is an Edm.Int64 value corresponding to the total count of members in the collection represented by the request.
+   */
   "@odata.count"?: number;
+  /**
+   * The nextLink control information indicates that a response is only a subset of the requested collection.
+   * It contains a URL that allows retrieving the next subset of the requested collection.
+   */
+  "@odata.nextLink"?: string;
+  /**
+   * The requested collection value.
+   */
   value: Array<T>;
 }
 
@@ -14,14 +67,74 @@ export interface ODataCollectionResponseV4<T> {
  * Additional context attribute is merged into result object.
  */
 export type ODataModelResponseV4<T> = T & {
-  "@odata.context": string;
+  /**
+   * The context control information returns the context URL for the payload. This URL can be absolute or relative.
+   *
+   * The context control information is not returned if metadata=none is requested.
+   * Otherwise, it MUST be the first property of any JSON response.
+   *
+   * The context control information MUST also be included in responses for entities
+   * whose entity set cannot be determined from the context URL of the collection.
+   */
+  "@odata.context"?: string;
+  /**
+   * The type control information MUST appear in responses,
+   * if the type cannot be heuristically determined (see link for heuristics) and the following is true:
+   * The type is derived from the type specified for the (collection of) entities or (collection of) complex type instances
+   *
+   * For payloads described by an OData-Version header with a value of 4.0,
+   * this name MUST be prefixed with the hash symbol (#);
+   * for non-OData 4.0 payloads, built-in primitive type values SHOULD be represented without the hash symbol,
+   * but consumers of 4.01 or greater payloads MUST support values with or without the hash symbol.
+   *
+   * For all other types, the URI may be absolute or relative to the type of the containing object.
+   * The root type may be absolute or relative to the root context URL.
+   *
+   * See https://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html#sec_ControlInformationtypeodatatype
+   */
+  "@odata.type"?: string;
+  /**
+   * The etag control information MAY be applied to an entity or collection in a response.
+   * The value of the control information is an entity tag (ETag) which is an opaque string value
+   * that can be used in a subsequent request to determine if the value of the entity or collection has changed.
+   */
+  "@odata.etag"?: string;
+  /**
+   * The metadataEtag control information MAY appear in a response in order to specify the entity tag (ETag)
+   * that can be used to determine the version of the metadata of the response.
+   * If an ETag is returned when requesting the metadata document, then the service SHOULD set the metadataEtag
+   * control information to the metadata document's ETag in all responses when using metadata=minimal or metadata=full.
+   *
+   * If no ETag is returned when requesting the metadata document, then the service SHOULD NOT
+   * set the metadataEtag control information in any responses.
+   */
+  "@odata.metadataEtag"?: string;
+  /**
+   * The id control information contains the entity-id.
+   * By convention the entity-id is identical to the canonical URL of the entity.
+   *
+   * The id control information MUST appear in responses if metadata=full is requested, or if metadata=minimal
+   * is requested and any of a non-transient entity's key fields are omitted from the response
+   * or the entity-id is not identical to the canonical URL.
+   */
+  "@odata.id"?: string;
+
+  /**
+   * The readLink control information contains the read URL of the entity or collection.
+   */
+  "@odata.readLink"?: string;
+  /**
+   * The editLink control information contains the edit URL of the entity.
+   */
+  "@odata.editLink"?: string;
 };
 
 /**
  * Response to a value query on a property.
  */
 export interface ODataValueResponseV4<T> {
-  "@odata.context": string;
+  "@odata.context"?: string;
+  "@odata.type"?: string;
   value: T;
 }
 

--- a/packages/odata-core/src/index.ts
+++ b/packages/odata-core/src/index.ts
@@ -3,3 +3,4 @@ export * from "./ODataTypesV4";
 export * from "./ODataTypesV2";
 export * from "./ResponseModelV4";
 export * from "./ResponseModelV2";
+export * from "./ODataModelPayloadV4";


### PR DESCRIPTION
Added ODataModelPayloadV4 type to allow "@odata.type" and "@odata.context" to request payloads representing an entity; improved typing and quite some documentation for most control infos.