### PR TITLE
feat: invariant client type

### DIFF
--- a/packages/odata-service/src/ODataService.ts
+++ b/packages/odata-service/src/ODataService.ts
@@ -2,7 +2,7 @@ import { ODataHttpClient } from "@odata2ts/http-client-api";
 
 import { ServiceStateHelper } from "./ServiceStateHelper";
 
-export class ODataService<ClientType extends ODataHttpClient> {
+export class ODataService<in out ClientType extends ODataHttpClient> {
   protected readonly __base: ServiceStateHelper<any>;
 
   constructor(client: ClientType, basePath: string, bigNumbersAsString: boolean = false) {

--- a/packages/odata-service/src/ServiceStateHelper.ts
+++ b/packages/odata-service/src/ServiceStateHelper.ts
@@ -2,11 +2,11 @@ import { ODataHttpClient } from "@odata2ts/http-client-api";
 
 import { BIG_NUMBERS_HEADERS, DEFAULT_HEADERS } from "./RequestHeaders";
 
-export class ServiceStateHelper<T> {
+export class ServiceStateHelper<out ClientType extends ODataHttpClient> {
   public readonly path: string;
 
   public constructor(
-    public readonly client: ODataHttpClient,
+    public readonly client: ClientType,
     basePath: string,
     public name?: string,
     public readonly bigNumbersAsString: boolean = false

--- a/packages/odata-service/src/v2/CollectionServiceV2.ts
+++ b/packages/odata-service/src/v2/CollectionServiceV2.ts
@@ -13,14 +13,14 @@ import { ServiceStateHelperV2 } from "./ServiceStateHelperV2";
 type PrimitiveExtractor<T> = T extends PrimitiveCollectionType<infer E> ? E : T;
 
 export class CollectionServiceV2<
-  ClientType extends ODataHttpClient,
+  in out ClientType extends ODataHttpClient,
   T,
   Q extends QueryObject,
   EditableT = PrimitiveExtractor<T>
 > {
-  protected readonly __base: ServiceStateHelperV2<T, Q>;
+  protected readonly __base: ServiceStateHelperV2<ClientType, Q>;
 
-  public constructor(client: ODataHttpClient, basePath: string, name: string, qModel: Q) {
+  public constructor(client: ClientType, basePath: string, name: string, qModel: Q) {
     this.__base = new ServiceStateHelperV2(client, basePath, name, qModel);
   }
 

--- a/packages/odata-service/src/v2/EntitySetServiceV2.ts
+++ b/packages/odata-service/src/v2/EntitySetServiceV2.ts
@@ -11,23 +11,17 @@ import {
 import { ServiceStateHelperV2 } from "./ServiceStateHelperV2";
 
 export abstract class EntitySetServiceV2<
-  ClientType extends ODataHttpClient,
+  in out ClientType extends ODataHttpClient,
   T,
   EditableT,
   Q extends QueryObject,
   EIdType
 > {
-  protected readonly __base: ServiceStateHelperV2<T, Q>;
+  protected readonly __base: ServiceStateHelperV2<ClientType, Q>;
   protected readonly __idFunction: QFunction<EIdType>;
 
-  protected constructor(
-    client: ODataHttpClient,
-    basePath: string,
-    name: string,
-    qModel: Q,
-    idFunction: QFunction<EIdType>
-  ) {
-    this.__base = new ServiceStateHelperV2<T, Q>(client, basePath, name, qModel);
+  protected constructor(client: ClientType, basePath: string, name: string, qModel: Q, idFunction: QFunction<EIdType>) {
+    this.__base = new ServiceStateHelperV2(client, basePath, name, qModel);
     this.__idFunction = idFunction;
   }
 

--- a/packages/odata-service/src/v2/EntityTypeServiceV2.ts
+++ b/packages/odata-service/src/v2/EntityTypeServiceV2.ts
@@ -6,11 +6,11 @@ import { QueryObject, convertV2ModelResponse } from "@odata2ts/odata-query-objec
 import { MERGE_HEADERS } from "../RequestHeaders";
 import { ServiceStateHelperV2 } from "./ServiceStateHelperV2";
 
-export class EntityTypeServiceV2<ClientType extends ODataHttpClient, T, EditableT, Q extends QueryObject> {
-  protected readonly __base: ServiceStateHelperV2<T, Q>;
+export class EntityTypeServiceV2<in out ClientType extends ODataHttpClient, T, EditableT, Q extends QueryObject> {
+  protected readonly __base: ServiceStateHelperV2<ClientType, Q>;
 
-  protected constructor(client: ODataHttpClient, basePath: string, name: string, qModel: Q) {
-    this.__base = new ServiceStateHelperV2<T, Q>(client, basePath, name, qModel);
+  protected constructor(client: ClientType, basePath: string, name: string, qModel: Q) {
+    this.__base = new ServiceStateHelperV2(client, basePath, name, qModel);
   }
 
   public getPath() {

--- a/packages/odata-service/src/v2/PrimitiveTypeServiceV2.ts
+++ b/packages/odata-service/src/v2/PrimitiveTypeServiceV2.ts
@@ -11,12 +11,12 @@ import { ServiceStateHelper } from "../ServiceStateHelper";
 // const OPEN_ACCEPT_HEADER = { accept: "*/*" };
 // const DEFAULT_STREAM_MIME_TYPE = "application/octet-stream";
 
-export class PrimitiveTypeServiceV2<ClientType extends ODataHttpClient, T> {
-  protected readonly __base: ServiceStateHelper<T>;
+export class PrimitiveTypeServiceV2<in out ClientType extends ODataHttpClient, T> {
+  protected readonly __base: ServiceStateHelper<ClientType>;
   protected readonly __converter: ConvertibleV2;
 
   public constructor(
-    client: ODataHttpClient,
+    client: ClientType,
     basePath: string,
     name: string,
     { convertTo, convertFrom }: ValueConverter<any, any> = getIdentityConverter(),

--- a/packages/odata-service/src/v2/ServiceStateHelperV2.ts
+++ b/packages/odata-service/src/v2/ServiceStateHelperV2.ts
@@ -4,10 +4,13 @@ import { QComplexParam, QueryObject } from "@odata2ts/odata-query-objects";
 
 import { ServiceStateHelper } from "../ServiceStateHelper";
 
-export class ServiceStateHelperV2<T, Q extends QueryObject> extends ServiceStateHelper<T> {
+export class ServiceStateHelperV2<
+  in out ClientType extends ODataHttpClient,
+  Q extends QueryObject
+> extends ServiceStateHelper<ClientType> {
   public readonly qResponseType: QComplexParam<any, Q>;
 
-  public constructor(client: ODataHttpClient, basePath: string, name: string, public qModel: Q) {
+  public constructor(client: ClientType, basePath: string, name: string, public qModel: Q) {
     super(client, basePath, name);
     this.qResponseType = new QComplexParam("NONE", qModel);
   }

--- a/packages/odata-service/src/v4/CollectionServiceV4.ts
+++ b/packages/odata-service/src/v4/CollectionServiceV4.ts
@@ -13,21 +13,21 @@ import { ServiceStateHelperV4 } from "./ServiceStateHelperV4";
 type PrimitiveExtractor<T> = T extends PrimitiveCollectionType<infer E> ? E : T;
 
 export class CollectionServiceV4<
-  ClientType extends ODataHttpClient,
+  in out ClientType extends ODataHttpClient,
   T,
   Q extends QueryObject,
   EditableT = PrimitiveExtractor<T>
 > {
-  protected readonly __base: ServiceStateHelperV4<T, Q>;
+  protected readonly __base: ServiceStateHelperV4<ClientType, Q>;
 
   public constructor(
-    client: ODataHttpClient,
+    client: ClientType,
     basePath: string,
     name: string,
     qModel: Q,
     bigNumbersAsString: boolean = false
   ) {
-    this.__base = new ServiceStateHelperV4<T, Q>(client, basePath, name, qModel, bigNumbersAsString);
+    this.__base = new ServiceStateHelperV4(client, basePath, name, qModel, bigNumbersAsString);
   }
 
   public getPath() {

--- a/packages/odata-service/src/v4/EntitySetServiceV4.ts
+++ b/packages/odata-service/src/v4/EntitySetServiceV4.ts
@@ -11,13 +11,13 @@ import {
 import { ServiceStateHelperV4 } from "./ServiceStateHelperV4";
 
 export abstract class EntitySetServiceV4<
-  ClientType extends ODataHttpClient,
+  in out ClientType extends ODataHttpClient,
   T,
   EditableT,
   Q extends QueryObject,
   EIdType
 > {
-  protected readonly __base: ServiceStateHelperV4<T, Q>;
+  protected readonly __base: ServiceStateHelperV4<ClientType, Q>;
   protected readonly __idFunction: QFunction<EIdType>;
 
   /**
@@ -33,14 +33,14 @@ export abstract class EntitySetServiceV4<
    * @protected
    */
   protected constructor(
-    client: ODataHttpClient,
+    client: ClientType,
     basePath: string,
     name: string,
     qModel: Q,
     idFunction: QFunction<EIdType>,
     bigNumbersAsString: boolean = false
   ) {
-    this.__base = new ServiceStateHelperV4<T, Q>(client, basePath, name, qModel, bigNumbersAsString);
+    this.__base = new ServiceStateHelperV4(client, basePath, name, qModel, bigNumbersAsString);
     this.__idFunction = idFunction;
   }
 

--- a/packages/odata-service/src/v4/EntityTypeServiceV4.ts
+++ b/packages/odata-service/src/v4/EntityTypeServiceV4.ts
@@ -5,17 +5,17 @@ import { QueryObject, convertV4ModelResponse } from "@odata2ts/odata-query-objec
 
 import { ServiceStateHelperV4 } from "./ServiceStateHelperV4";
 
-export class EntityTypeServiceV4<ClientType extends ODataHttpClient, T, EditableT, Q extends QueryObject> {
-  protected readonly __base: ServiceStateHelperV4<T, Q>;
+export class EntityTypeServiceV4<in out ClientType extends ODataHttpClient, T, EditableT, Q extends QueryObject> {
+  protected readonly __base: ServiceStateHelperV4<ClientType, Q>;
 
   public constructor(
-    client: ODataHttpClient,
+    client: ClientType,
     basePath: string,
     name: string,
     qModel: Q,
     bigNumbersAsString: boolean = false
   ) {
-    this.__base = new ServiceStateHelperV4<T, Q>(client, basePath, name, qModel, bigNumbersAsString);
+    this.__base = new ServiceStateHelperV4(client, basePath, name, qModel, bigNumbersAsString);
   }
 
   public getPath() {

--- a/packages/odata-service/src/v4/PrimitiveTypeServiceV4.ts
+++ b/packages/odata-service/src/v4/PrimitiveTypeServiceV4.ts
@@ -8,18 +8,18 @@ import { ServiceStateHelper } from "../ServiceStateHelper";
 
 // const RAW_VALUE_SUFFIX = "/$value";
 
-export class PrimitiveTypeServiceV4<ClientType extends ODataHttpClient, T> {
-  protected readonly __base: ServiceStateHelper<T>;
+export class PrimitiveTypeServiceV4<out ClientType extends ODataHttpClient, T> {
+  protected readonly __base: ServiceStateHelper<ClientType>;
   protected readonly __converter: ValueConverter<any, any>;
 
   public constructor(
-    client: ODataHttpClient,
+    client: ClientType,
     basePath: string,
     name: string,
     converter: ValueConverter<any, any> = getIdentityConverter(),
     bigNumbersAsString: boolean = false
   ) {
-    this.__base = new ServiceStateHelper<T>(client, basePath, name, bigNumbersAsString);
+    this.__base = new ServiceStateHelper(client, basePath, name, bigNumbersAsString);
     this.__converter = converter;
   }
 

--- a/packages/odata-service/src/v4/ServiceStateHelperV4.ts
+++ b/packages/odata-service/src/v4/ServiceStateHelperV4.ts
@@ -1,14 +1,17 @@
-import { ODataHttpClient, ODataResponse } from "@odata2ts/http-client-api";
+import { ODataHttpClient } from "@odata2ts/http-client-api";
 import { ODataQueryBuilderV4, createQueryBuilderV4 } from "@odata2ts/odata-query-builder";
 import { QComplexParam, QueryObject } from "@odata2ts/odata-query-objects";
 
 import { ServiceStateHelper } from "../ServiceStateHelper";
 
-export class ServiceStateHelperV4<T, Q extends QueryObject> extends ServiceStateHelper<T> {
+export class ServiceStateHelperV4<
+  in out ClientType extends ODataHttpClient,
+  Q extends QueryObject
+> extends ServiceStateHelper<ClientType> {
   public readonly qResponseType: QComplexParam<any, Q>;
 
   public constructor(
-    client: ODataHttpClient,
+    client: ClientType,
     basePath: string,
     name: string,
     public readonly qModel: Q,

--- a/packages/odata-service/test/EntitySetServiceTests.ts
+++ b/packages/odata-service/test/EntitySetServiceTests.ts
@@ -9,7 +9,7 @@ import { MockClient } from "./mock/MockClient";
 
 export function commonEntitySetTests(
   odataClient: MockClient,
-  serviceConstructor: new (odataClient: ODataHttpClient, baseUrl: string, name: string) =>
+  serviceConstructor: new (odataClient: MockClient, baseUrl: string, name: string) =>
     | EntitySetServiceV4<MockClient, PersonModel, EditablePersonModel, QPersonV4, PersonId>
     | EntitySetServiceV2<MockClient, PersonModel, EditablePersonModel, QPersonV2, PersonId>
 ) {

--- a/packages/odata-service/test/EntityTypeServiceTests.ts
+++ b/packages/odata-service/test/EntityTypeServiceTests.ts
@@ -5,7 +5,7 @@ import { MockClient } from "./mock/MockClient";
 
 export function commonEntityTypeServiceTests(
   odataClient: MockClient,
-  serviceConstructor: new (odataClient: ODataHttpClient, basePath: string, name: string) => PersonModelServiceVersion
+  serviceConstructor: new (odataClient: MockClient, basePath: string, name: string) => PersonModelServiceVersion
 ) {
   const BASE_URL = "/test";
   const NAME = "EntityXY('tester')";

--- a/packages/odata-service/test/fixture/v2/PersonModelV2Service.ts
+++ b/packages/odata-service/test/fixture/v2/PersonModelV2Service.ts
@@ -39,7 +39,7 @@ export class PersonModelV2Service<ClientType extends ODataHttpClient> extends En
     return new PersonModelV2CollectionService(this.__base.client, this.__base.path, "Friends");
   }
 
-  constructor(client: ODataHttpClient, basePath: string, name: string) {
+  constructor(client: ClientType, basePath: string, name: string) {
     super(client, basePath, name, new QPersonV2());
   }
 
@@ -56,7 +56,7 @@ export class PersonModelV2CollectionService<ClientType extends ODataHttpClient> 
   QPersonV2,
   PersonId
 > {
-  constructor(client: ODataHttpClient, basePath: string, name: string) {
+  constructor(client: ClientType, basePath: string, name: string) {
     super(client, basePath, name, qPersonV2, new QPersonIdFunction(name));
   }
 }

--- a/packages/odata-service/test/fixture/v4/PersonModelService.ts
+++ b/packages/odata-service/test/fixture/v4/PersonModelService.ts
@@ -14,7 +14,7 @@ export class PersonModelService<ClientType extends ODataHttpClient> extends Enti
 > {
   private _qGetSomething = new QGetSomethingFunction();
 
-  constructor(client: ODataHttpClient, basePath: string, name: string, bigNumbersAsString?: boolean) {
+  constructor(client: ClientType, basePath: string, name: string, bigNumbersAsString?: boolean) {
     super(client, basePath, name, new QPersonV4(), bigNumbersAsString);
   }
 
@@ -56,7 +56,7 @@ export class PersonModelCollectionService<ClientType extends ODataHttpClient> ex
   QPersonV4,
   PersonId
 > {
-  constructor(client: ODataHttpClient, basePath: string, name: string, bigNumbersAsString?: boolean) {
+  constructor(client: ClientType, basePath: string, name: string, bigNumbersAsString?: boolean) {
     super(client, basePath, name, qPersonV4, new QPersonIdFunction(name), bigNumbersAsString);
   }
 }

--- a/packages/odata-service/test/fixture/v4/TypingModelService.ts
+++ b/packages/odata-service/test/fixture/v4/TypingModelService.ts
@@ -54,7 +54,7 @@ export class TestService<ClientType extends ODataHttpClient> extends EntityTypeS
   EditableTestModel,
   QTest
 > {
-  constructor(client: ODataHttpClient, basePath: string, name: string) {
+  constructor(client: ClientType, basePath: string, name: string) {
     super(client, basePath, name, qTest);
   }
 }
@@ -66,7 +66,7 @@ export class TestCollectionService<ClientType extends ODataHttpClient> extends E
   QTest,
   TestModelId
 > {
-  constructor(client: ODataHttpClient, basePath: string, name: string) {
+  constructor(client: ClientType, basePath: string, name: string) {
     super(client, basePath, name, qTest, new QTestIdFunction(name));
   }
 }

--- a/packages/odata2ts/src/generator/ServiceGenerator.ts
+++ b/packages/odata2ts/src/generator/ServiceGenerator.ts
@@ -258,7 +258,7 @@ class ServiceGenerator {
     file.getFile().addClass({
       isExported: true,
       name: model.serviceName,
-      typeParameters: [`ClientType extends ${httpClient}`],
+      typeParameters: [`in out ClientType extends ${httpClient}`],
       extends: entityServiceType + `<ClientType, ${modelName}, ${editableModelName}, ${qName}>`,
       ctors: [
         {
@@ -502,7 +502,7 @@ class ServiceGenerator {
     file.getFile().addClass({
       isExported: true,
       name: model.serviceCollectionName,
-      typeParameters: ["ClientType extends ODataHttpClient"],
+      typeParameters: ["in out ClientType extends ODataHttpClient"],
       extends:
         entitySetServiceType +
         `<ClientType, ${model.modelName}, ${editableModelName}, ${model.qName}, ${paramsModelName}>`,

--- a/packages/odata2ts/src/generator/ServiceGenerator.ts
+++ b/packages/odata2ts/src/generator/ServiceGenerator.ts
@@ -90,7 +90,7 @@ class ServiceGenerator {
     mainServiceFile.getFile().addClass({
       isExported: true,
       name: mainServiceName,
-      typeParameters: [`ClientType extends ${httpClient}`],
+      typeParameters: [`in out ClientType extends ${httpClient}`],
       extends: `${rootService}<ClientType>`,
       ctors: this.isV4BigNumber()
         ? [

--- a/packages/odata2ts/test/fixture/generator/service/v2/abstract-and-open-types.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/abstract-and-open-types.ts
@@ -28,7 +28,7 @@ import {
   // @ts-ignore
 } from "./TesterModel";
 
-export class TesterService<ClientType extends ODataHttpClient> extends ODataService<ClientType> {
+export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
   public fromAbstract(): ExtendedFromAbstractCollectionService<ClientType>;
   public fromAbstract(id: ExtendedFromAbstractId): ExtendedFromAbstractService<ClientType>;
   public fromAbstract(id?: ExtendedFromAbstractId | undefined) {
@@ -50,7 +50,7 @@ export class TesterService<ClientType extends ODataHttpClient> extends ODataServ
   }
 }
 
-export class AbstractEntityService<ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
+export class AbstractEntityService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
   ClientType,
   AbstractEntity,
   EditableAbstractEntity,
@@ -61,7 +61,7 @@ export class AbstractEntityService<ClientType extends ODataHttpClient> extends E
   }
 }
 
-export class OpenEntityService<ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
+export class OpenEntityService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
   ClientType,
   OpenEntity,
   EditableOpenEntity,
@@ -72,7 +72,7 @@ export class OpenEntityService<ClientType extends ODataHttpClient> extends Entit
   }
 }
 
-export class ExtendedFromAbstractService<ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
+export class ExtendedFromAbstractService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
   ClientType,
   ExtendedFromAbstract,
   EditableExtendedFromAbstract,
@@ -83,7 +83,9 @@ export class ExtendedFromAbstractService<ClientType extends ODataHttpClient> ext
   }
 }
 
-export class ExtendedFromAbstractCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV2<
+export class ExtendedFromAbstractCollectionService<
+  in out ClientType extends ODataHttpClient
+> extends EntitySetServiceV2<
   ClientType,
   ExtendedFromAbstract,
   EditableExtendedFromAbstract,
@@ -95,7 +97,7 @@ export class ExtendedFromAbstractCollectionService<ClientType extends ODataHttpC
   }
 }
 
-export class ExtendedFromOpenService<ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
+export class ExtendedFromOpenService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
   ClientType,
   ExtendedFromOpen,
   EditableExtendedFromOpen,
@@ -106,7 +108,7 @@ export class ExtendedFromOpenService<ClientType extends ODataHttpClient> extends
   }
 }
 
-export class ExtendedFromOpenCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV2<
+export class ExtendedFromOpenCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV2<
   ClientType,
   ExtendedFromOpen,
   EditableExtendedFromOpen,

--- a/packages/odata2ts/test/fixture/generator/service/v2/complex-type.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/complex-type.ts
@@ -6,9 +6,9 @@ import { QBook, QBookId, QReviewer, qBook, qReviewer } from "./QTester";
 // @ts-ignore
 import { Book, BookId, EditableBook, EditableReviewer, Reviewer } from "./TesterModel";
 
-export class TesterService<ClientType extends ODataHttpClient> extends ODataService<ClientType> {}
+export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {}
 
-export class BookService<ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
+export class BookService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
   ClientType,
   Book,
   EditableBook,
@@ -40,7 +40,7 @@ export class BookService<ClientType extends ODataHttpClient> extends EntityTypeS
   }
 }
 
-export class BookCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV2<
+export class BookCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV2<
   ClientType,
   Book,
   EditableBook,
@@ -52,7 +52,7 @@ export class BookCollectionService<ClientType extends ODataHttpClient> extends E
   }
 }
 
-export class ReviewerService<ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
+export class ReviewerService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
   ClientType,
   Reviewer,
   EditableReviewer,

--- a/packages/odata2ts/test/fixture/generator/service/v2/entity-hierarchy.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/entity-hierarchy.ts
@@ -15,9 +15,9 @@ import {
   Parent,
 } from "./TesterModel";
 
-export class TesterService<ClientType extends ODataHttpClient> extends ODataService<ClientType> {}
+export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {}
 
-export class GrandParentService<ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
+export class GrandParentService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
   ClientType,
   GrandParent,
   EditableGrandParent,
@@ -28,7 +28,7 @@ export class GrandParentService<ClientType extends ODataHttpClient> extends Enti
   }
 }
 
-export class GrandParentCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV2<
+export class GrandParentCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV2<
   ClientType,
   GrandParent,
   EditableGrandParent,
@@ -40,7 +40,7 @@ export class GrandParentCollectionService<ClientType extends ODataHttpClient> ex
   }
 }
 
-export class ParentService<ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
+export class ParentService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
   ClientType,
   Parent,
   EditableParent,
@@ -51,7 +51,7 @@ export class ParentService<ClientType extends ODataHttpClient> extends EntityTyp
   }
 }
 
-export class ParentCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV2<
+export class ParentCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV2<
   ClientType,
   Parent,
   EditableParent,
@@ -63,7 +63,7 @@ export class ParentCollectionService<ClientType extends ODataHttpClient> extends
   }
 }
 
-export class ChildService<ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
+export class ChildService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
   ClientType,
   Child,
   EditableChild,
@@ -74,7 +74,7 @@ export class ChildService<ClientType extends ODataHttpClient> extends EntityType
   }
 }
 
-export class ChildCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV2<
+export class ChildCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV2<
   ClientType,
   Child,
   EditableChild,

--- a/packages/odata2ts/test/fixture/generator/service/v2/entity-relationships.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/entity-relationships.ts
@@ -6,9 +6,9 @@ import { QAuthor, QAuthorId, QBook, QBookId, qAuthor, qBook } from "./QTester";
 // @ts-ignore
 import { Author, AuthorId, Book, BookId, EditableAuthor, EditableBook } from "./TesterModel";
 
-export class TesterService<ClientType extends ODataHttpClient> extends ODataService<ClientType> {}
+export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {}
 
-export class AuthorService<ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
+export class AuthorService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
   ClientType,
   Author,
   EditableAuthor,
@@ -40,7 +40,7 @@ export class AuthorService<ClientType extends ODataHttpClient> extends EntityTyp
   }
 }
 
-export class AuthorCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV2<
+export class AuthorCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV2<
   ClientType,
   Author,
   EditableAuthor,
@@ -52,7 +52,7 @@ export class AuthorCollectionService<ClientType extends ODataHttpClient> extends
   }
 }
 
-export class BookService<ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
+export class BookService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
   ClientType,
   Book,
   EditableBook,
@@ -94,7 +94,7 @@ export class BookService<ClientType extends ODataHttpClient> extends EntityTypeS
   }
 }
 
-export class BookCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV2<
+export class BookCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV2<
   ClientType,
   Book,
   EditableBook,

--- a/packages/odata2ts/test/fixture/generator/service/v2/enum-type.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/enum-type.ts
@@ -7,9 +7,9 @@ import { QBook, QBookId, qBook } from "./QTester";
 // @ts-ignore
 import { Book, BookId, Choice, EditableBook } from "./TesterModel";
 
-export class TesterService<ClientType extends ODataHttpClient> extends ODataService<ClientType> {}
+export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {}
 
-export class BookService<ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
+export class BookService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
   ClientType,
   Book,
   EditableBook,
@@ -31,7 +31,7 @@ export class BookService<ClientType extends ODataHttpClient> extends EntityTypeS
   }
 }
 
-export class BookCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV2<
+export class BookCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV2<
   ClientType,
   Book,
   EditableBook,

--- a/packages/odata2ts/test/fixture/generator/service/v2/function-import-special-params.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/function-import-special-params.ts
@@ -7,7 +7,7 @@ import { QBestBook, QTestEntity, QTestEntityId, qTestEntity } from "./QTester";
 // @ts-ignore
 import { BestBookParams, EditableTestEntity, TestEntity, TestEntityId } from "./TesterModel";
 
-export class TesterService<ClientType extends ODataHttpClient> extends ODataService<ClientType> {
+export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
   private _qBestBook?: QBestBook;
 
   public async bestBook(
@@ -25,7 +25,7 @@ export class TesterService<ClientType extends ODataHttpClient> extends ODataServ
   }
 }
 
-export class TestEntityService<ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
+export class TestEntityService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
   ClientType,
   TestEntity,
   EditableTestEntity,
@@ -36,7 +36,7 @@ export class TestEntityService<ClientType extends ODataHttpClient> extends Entit
   }
 }
 
-export class TestEntityCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV2<
+export class TestEntityCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV2<
   ClientType,
   TestEntity,
   EditableTestEntity,

--- a/packages/odata2ts/test/fixture/generator/service/v2/function-import.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/function-import.ts
@@ -7,7 +7,7 @@ import { QBestBook, QMostPop, QPostBestBook, QTestEntity, QTestEntityId, qTestEn
 // @ts-ignore
 import { BestBookParams, EditableTestEntity, PostBestBookParams, TestEntity, TestEntityId } from "./TesterModel";
 
-export class TesterService<ClientType extends ODataHttpClient> extends ODataService<ClientType> {
+export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
   private _qMostPop?: QMostPop;
   private _qBestBook?: QBestBook;
   private _qPostBestBook?: QPostBestBook;
@@ -54,7 +54,7 @@ export class TesterService<ClientType extends ODataHttpClient> extends ODataServ
   }
 }
 
-export class TestEntityService<ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
+export class TestEntityService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
   ClientType,
   TestEntity,
   EditableTestEntity,
@@ -65,7 +65,7 @@ export class TestEntityService<ClientType extends ODataHttpClient> extends Entit
   }
 }
 
-export class TestEntityCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV2<
+export class TestEntityCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV2<
   ClientType,
   TestEntity,
   EditableTestEntity,

--- a/packages/odata2ts/test/fixture/generator/service/v2/min.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/min.ts
@@ -1,4 +1,4 @@
 import { ODataHttpClient } from "@odata2ts/http-client-api";
 import { ODataService } from "@odata2ts/odata-service";
 
-export class TesterService<ClientType extends ODataHttpClient> extends ODataService<ClientType> {}
+export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {}

--- a/packages/odata2ts/test/fixture/generator/service/v2/one-entityset.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/one-entityset.ts
@@ -6,7 +6,7 @@ import { QTestEntity, QTestEntityId, qTestEntity } from "./QTester";
 // @ts-ignore
 import { EditableTestEntity, TestEntity, TestEntityId } from "./TesterModel";
 
-export class TesterService<ClientType extends ODataHttpClient> extends ODataService<ClientType> {
+export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
   public ents(): TestEntityCollectionService<ClientType>;
   public ents(id: TestEntityId): TestEntityService<ClientType>;
   public ents(id?: TestEntityId | undefined) {
@@ -18,7 +18,7 @@ export class TesterService<ClientType extends ODataHttpClient> extends ODataServ
   }
 }
 
-export class TestEntityService<ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
+export class TestEntityService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
   ClientType,
   TestEntity,
   EditableTestEntity,
@@ -115,7 +115,7 @@ export class TestEntityService<ClientType extends ODataHttpClient> extends Entit
   }
 }
 
-export class TestEntityCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV2<
+export class TestEntityCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV2<
   ClientType,
   TestEntity,
   EditableTestEntity,

--- a/packages/odata2ts/test/fixture/generator/service/v4/abstract-and-open-types.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/abstract-and-open-types.ts
@@ -12,7 +12,6 @@ import {
   qExtendedFromAbstract,
   qExtendedFromOpen,
   qOpenEntity,
-  // @ts-ignore
 } from "./QTester";
 import {
   AbstractEntity,
@@ -25,10 +24,9 @@ import {
   ExtendedFromOpen,
   ExtendedFromOpenId,
   OpenEntity,
-  // @ts-ignore
 } from "./TesterModel";
 
-export class TesterService<ClientType extends ODataHttpClient> extends ODataService<ClientType> {
+export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
   public fromAbstract(): ExtendedFromAbstractCollectionService<ClientType>;
   public fromAbstract(id: ExtendedFromAbstractId): ExtendedFromAbstractService<ClientType>;
   public fromAbstract(id?: ExtendedFromAbstractId | undefined) {
@@ -50,7 +48,7 @@ export class TesterService<ClientType extends ODataHttpClient> extends ODataServ
   }
 }
 
-export class AbstractEntityService<ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
+export class AbstractEntityService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
   ClientType,
   AbstractEntity,
   EditableAbstractEntity,
@@ -61,7 +59,7 @@ export class AbstractEntityService<ClientType extends ODataHttpClient> extends E
   }
 }
 
-export class OpenEntityService<ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
+export class OpenEntityService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
   ClientType,
   OpenEntity,
   EditableOpenEntity,
@@ -72,7 +70,7 @@ export class OpenEntityService<ClientType extends ODataHttpClient> extends Entit
   }
 }
 
-export class ExtendedFromAbstractService<ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
+export class ExtendedFromAbstractService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
   ClientType,
   ExtendedFromAbstract,
   EditableExtendedFromAbstract,
@@ -83,7 +81,9 @@ export class ExtendedFromAbstractService<ClientType extends ODataHttpClient> ext
   }
 }
 
-export class ExtendedFromAbstractCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV4<
+export class ExtendedFromAbstractCollectionService<
+  in out ClientType extends ODataHttpClient
+> extends EntitySetServiceV4<
   ClientType,
   ExtendedFromAbstract,
   EditableExtendedFromAbstract,
@@ -95,7 +95,7 @@ export class ExtendedFromAbstractCollectionService<ClientType extends ODataHttpC
   }
 }
 
-export class ExtendedFromOpenService<ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
+export class ExtendedFromOpenService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
   ClientType,
   ExtendedFromOpen,
   EditableExtendedFromOpen,
@@ -106,7 +106,7 @@ export class ExtendedFromOpenService<ClientType extends ODataHttpClient> extends
   }
 }
 
-export class ExtendedFromOpenCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV4<
+export class ExtendedFromOpenCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV4<
   ClientType,
   ExtendedFromOpen,
   EditableExtendedFromOpen,

--- a/packages/odata2ts/test/fixture/generator/service/v4/abstract-with-inheritance.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/abstract-with-inheritance.ts
@@ -9,10 +9,9 @@ import {
   EditableAbstractEntity,
   EditableTestEntity,
   TestEntity,
-  // @ts-ignore
 } from "./TesterModel";
 
-export class TesterService<ClientType extends ODataHttpClient> extends ODataService<ClientType> {
+export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
   public testing(): TestEntityCollectionService<ClientType>;
   public testing(id: AbstractEntityId): TestEntityService<ClientType>;
   public testing(id?: AbstractEntityId | undefined) {
@@ -24,7 +23,7 @@ export class TesterService<ClientType extends ODataHttpClient> extends ODataServ
   }
 }
 
-export class AbstractEntityService<ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
+export class AbstractEntityService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
   ClientType,
   AbstractEntity,
   EditableAbstractEntity,
@@ -35,7 +34,7 @@ export class AbstractEntityService<ClientType extends ODataHttpClient> extends E
   }
 }
 
-export class AbstractEntityCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV4<
+export class AbstractEntityCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV4<
   ClientType,
   AbstractEntity,
   EditableAbstractEntity,
@@ -47,7 +46,7 @@ export class AbstractEntityCollectionService<ClientType extends ODataHttpClient>
   }
 }
 
-export class TestEntityService<ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
+export class TestEntityService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
   ClientType,
   TestEntity,
   EditableTestEntity,
@@ -58,7 +57,7 @@ export class TestEntityService<ClientType extends ODataHttpClient> extends Entit
   }
 }
 
-export class TestEntityCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV4<
+export class TestEntityCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV4<
   ClientType,
   TestEntity,
   EditableTestEntity,

--- a/packages/odata2ts/test/fixture/generator/service/v4/action-unbound.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/action-unbound.ts
@@ -7,7 +7,7 @@ import { QPing, QTestEntity, QTestEntityId, QVote, qTestEntity } from "./QTester
 // @ts-ignore
 import { EditableTestEntity, TestEntity, TestEntityId, VoteParams } from "./TesterModel";
 
-export class TesterService<ClientType extends ODataHttpClient> extends ODataService<ClientType> {
+export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
   private _qPing?: QPing;
   private _qVote?: QVote;
 
@@ -38,7 +38,7 @@ export class TesterService<ClientType extends ODataHttpClient> extends ODataServ
   }
 }
 
-export class TestEntityService<ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
+export class TestEntityService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
   ClientType,
   TestEntity,
   EditableTestEntity,
@@ -49,7 +49,7 @@ export class TestEntityService<ClientType extends ODataHttpClient> extends Entit
   }
 }
 
-export class TestEntityCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV4<
+export class TestEntityCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV4<
   ClientType,
   TestEntity,
   EditableTestEntity,

--- a/packages/odata2ts/test/fixture/generator/service/v4/big-number-return-types.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/big-number-return-types.ts
@@ -14,7 +14,7 @@ import {
 // @ts-ignore
 import { EditableTestEntity, TestEntity, TestEntityId } from "./TesterModel";
 
-export class TesterService<ClientType extends ODataHttpClient> extends ODataService<ClientType> {
+export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
   private _qPingBigNumber?: QPingBigNumber;
   private _qPingDecimal?: QPingDecimal;
   private _qPingDecimalCollection?: QPingDecimalCollection;
@@ -63,7 +63,7 @@ export class TesterService<ClientType extends ODataHttpClient> extends ODataServ
   }
 }
 
-export class TestEntityService<ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
+export class TestEntityService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
   ClientType,
   TestEntity,
   EditableTestEntity,
@@ -74,7 +74,7 @@ export class TestEntityService<ClientType extends ODataHttpClient> extends Entit
   }
 }
 
-export class TestEntityCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV4<
+export class TestEntityCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV4<
   ClientType,
   TestEntity,
   EditableTestEntity,

--- a/packages/odata2ts/test/fixture/generator/service/v4/big-numbers.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/big-numbers.ts
@@ -7,7 +7,7 @@ import { QTestEntity, QTestEntityId, qTestEntity } from "./QTester";
 // @ts-ignore
 import { EditableTestEntity, TestEntity, TestEntityId } from "./TesterModel";
 
-export class TesterService<ClientType extends ODataHttpClient> extends ODataService<ClientType> {
+export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
   constructor(client: ClientType, basePath: string) {
     super(client, basePath, true);
   }
@@ -23,7 +23,7 @@ export class TesterService<ClientType extends ODataHttpClient> extends ODataServ
   }
 }
 
-export class TestEntityService<ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
+export class TestEntityService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
   ClientType,
   TestEntity,
   EditableTestEntity,
@@ -51,7 +51,7 @@ export class TestEntityService<ClientType extends ODataHttpClient> extends Entit
   }
 }
 
-export class TestEntityCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV4<
+export class TestEntityCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV4<
   ClientType,
   TestEntity,
   EditableTestEntity,

--- a/packages/odata2ts/test/fixture/generator/service/v4/bound-action.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/bound-action.ts
@@ -7,9 +7,9 @@ import { Book_QLike, Book_QRate, Book_QRatings, QBook, QBookId, qBook } from "./
 // @ts-ignore
 import { Book, BookId, Book_RateParams, Book_RatingsParams, EditableBook, Rating } from "./TesterModel";
 
-export class TesterService<ClientType extends ODataHttpClient> extends ODataService<ClientType> {}
+export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {}
 
-export class BookService<ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
+export class BookService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
   ClientType,
   Book,
   EditableBook,
@@ -54,7 +54,7 @@ export class BookService<ClientType extends ODataHttpClient> extends EntityTypeS
   }
 }
 
-export class BookCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV4<
+export class BookCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV4<
   ClientType,
   Book,
   EditableBook,

--- a/packages/odata2ts/test/fixture/generator/service/v4/bound-function.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/bound-function.ts
@@ -7,9 +7,9 @@ import { Book_QBestReview, Book_QFilterReviews, QBook, QBookId, QReview, qBook, 
 // @ts-ignore
 import { Book, BookId, Book_FilterReviewsParams, EditableBook, EditableReview, Review } from "./TesterModel";
 
-export class TesterService<ClientType extends ODataHttpClient> extends ODataService<ClientType> {}
+export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {}
 
-export class BookService<ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
+export class BookService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
   ClientType,
   Book,
   EditableBook,
@@ -35,7 +35,7 @@ export class BookService<ClientType extends ODataHttpClient> extends EntityTypeS
   }
 }
 
-export class BookCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV4<
+export class BookCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV4<
   ClientType,
   Book,
   EditableBook,
@@ -63,7 +63,7 @@ export class BookCollectionService<ClientType extends ODataHttpClient> extends E
   }
 }
 
-export class ReviewService<ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
+export class ReviewService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
   ClientType,
   Review,
   EditableReview,

--- a/packages/odata2ts/test/fixture/generator/service/v4/complex-type.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/complex-type.ts
@@ -6,9 +6,9 @@ import { QBook, QBookId, QReviewer, qBook, qReviewer } from "./QTester";
 // @ts-ignore
 import { Book, BookId, EditableBook, EditableReviewer, Reviewer } from "./TesterModel";
 
-export class TesterService<ClientType extends ODataHttpClient> extends ODataService<ClientType> {}
+export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {}
 
-export class BookService<ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
+export class BookService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
   ClientType,
   Book,
   EditableBook,
@@ -40,7 +40,7 @@ export class BookService<ClientType extends ODataHttpClient> extends EntityTypeS
   }
 }
 
-export class BookCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV4<
+export class BookCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV4<
   ClientType,
   Book,
   EditableBook,
@@ -52,7 +52,7 @@ export class BookCollectionService<ClientType extends ODataHttpClient> extends E
   }
 }
 
-export class ReviewerService<ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
+export class ReviewerService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
   ClientType,
   Reviewer,
   EditableReviewer,

--- a/packages/odata2ts/test/fixture/generator/service/v4/entity-relationships.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/entity-relationships.ts
@@ -6,9 +6,9 @@ import { QAuthor, QAuthorId, QBook, QBookId, qAuthor, qBook } from "./QTester";
 // @ts-ignore
 import { Author, AuthorId, Book, BookId, EditableAuthor, EditableBook } from "./TesterModel";
 
-export class TesterService<ClientType extends ODataHttpClient> extends ODataService<ClientType> {}
+export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {}
 
-export class AuthorService<ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
+export class AuthorService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
   ClientType,
   Author,
   EditableAuthor,
@@ -40,7 +40,7 @@ export class AuthorService<ClientType extends ODataHttpClient> extends EntityTyp
   }
 }
 
-export class AuthorCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV4<
+export class AuthorCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV4<
   ClientType,
   Author,
   EditableAuthor,
@@ -52,7 +52,7 @@ export class AuthorCollectionService<ClientType extends ODataHttpClient> extends
   }
 }
 
-export class BookService<ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
+export class BookService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
   ClientType,
   Book,
   EditableBook,
@@ -94,7 +94,7 @@ export class BookService<ClientType extends ODataHttpClient> extends EntityTypeS
   }
 }
 
-export class BookCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV4<
+export class BookCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV4<
   ClientType,
   Book,
   EditableBook,

--- a/packages/odata2ts/test/fixture/generator/service/v4/enum-type.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/enum-type.ts
@@ -7,9 +7,9 @@ import { QBook, QBookId, qBook } from "./QTester";
 // @ts-ignore
 import { Book, BookId, Choice, EditableBook } from "./TesterModel";
 
-export class TesterService<ClientType extends ODataHttpClient> extends ODataService<ClientType> {}
+export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {}
 
-export class BookService<ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
+export class BookService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
   ClientType,
   Book,
   EditableBook,
@@ -31,7 +31,7 @@ export class BookService<ClientType extends ODataHttpClient> extends EntityTypeS
   }
 }
 
-export class BookCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV4<
+export class BookCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV4<
   ClientType,
   Book,
   EditableBook,

--- a/packages/odata2ts/test/fixture/generator/service/v4/function-unbound.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/function-unbound.ts
@@ -7,7 +7,7 @@ import { QFirstBook, QGetBestsellers, QTestEntity, QTestEntityId, qTestEntity } 
 // @ts-ignore
 import { EditableTestEntity, FirstBookParams, TestEntity, TestEntityId } from "./TesterModel";
 
-export class TesterService<ClientType extends ODataHttpClient> extends ODataService<ClientType> {
+export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
   private _qGetBestsellers?: QGetBestsellers;
   private _qFirstBook?: QFirstBook;
 
@@ -39,7 +39,7 @@ export class TesterService<ClientType extends ODataHttpClient> extends ODataServ
   }
 }
 
-export class TestEntityService<ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
+export class TestEntityService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
   ClientType,
   TestEntity,
   EditableTestEntity,
@@ -50,7 +50,7 @@ export class TestEntityService<ClientType extends ODataHttpClient> extends Entit
   }
 }
 
-export class TestEntityCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV4<
+export class TestEntityCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV4<
   ClientType,
   TestEntity,
   EditableTestEntity,

--- a/packages/odata2ts/test/fixture/generator/service/v4/min-big-numbers.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/min-big-numbers.ts
@@ -1,7 +1,7 @@
 import { ODataHttpClient } from "@odata2ts/http-client-api";
 import { ODataService } from "@odata2ts/odata-service";
 
-export class TesterService<ClientType extends ODataHttpClient> extends ODataService<ClientType> {
+export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
   constructor(client: ClientType, basePath: string) {
     super(client, basePath, true);
   }

--- a/packages/odata2ts/test/fixture/generator/service/v4/min.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/min.ts
@@ -1,4 +1,4 @@
 import { ODataHttpClient } from "@odata2ts/http-client-api";
 import { ODataService } from "@odata2ts/odata-service";
 
-export class TesterService<ClientType extends ODataHttpClient> extends ODataService<ClientType> {}
+export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {}

--- a/packages/odata2ts/test/fixture/generator/service/v4/naming.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/naming.ts
@@ -6,7 +6,7 @@ import { Q_TEST_ENTITY, Q_TEST_ENTITY_ID, q_TEST_ENTITY } from "./QTester";
 // @ts-ignore
 import { EDITABLE_TEST_ENTITY, TEST_ENTITY, TEST_ENTITY_ID } from "./TesterModel";
 
-export class tester<ClientType extends ODataHttpClient> extends ODataService<ClientType> {
+export class tester<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
   public NAVIGATE_TO_LIST(): TEST_ENTITY_COLLECTION_SRV<ClientType>;
   public NAVIGATE_TO_LIST(id: TEST_ENTITY_ID): TEST_ENTITY_SRV<ClientType>;
   public NAVIGATE_TO_LIST(id?: TEST_ENTITY_ID | undefined) {
@@ -18,7 +18,7 @@ export class tester<ClientType extends ODataHttpClient> extends ODataService<Cli
   }
 }
 
-export class TEST_ENTITY_SRV<ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
+export class TEST_ENTITY_SRV<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
   ClientType,
   TEST_ENTITY,
   EDITABLE_TEST_ENTITY,
@@ -29,7 +29,7 @@ export class TEST_ENTITY_SRV<ClientType extends ODataHttpClient> extends EntityT
   }
 }
 
-export class TEST_ENTITY_COLLECTION_SRV<ClientType extends ODataHttpClient> extends EntitySetServiceV4<
+export class TEST_ENTITY_COLLECTION_SRV<in out ClientType extends ODataHttpClient> extends EntitySetServiceV4<
   ClientType,
   TEST_ENTITY,
   EDITABLE_TEST_ENTITY,

--- a/packages/odata2ts/test/fixture/generator/service/v4/one-entityset.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/one-entityset.ts
@@ -6,7 +6,7 @@ import { QTestEntity, QTestEntityId, qTestEntity } from "./QTester";
 // @ts-ignore
 import { EditableTestEntity, TestEntity, TestEntityId } from "./TesterModel";
 
-export class TesterService<ClientType extends ODataHttpClient> extends ODataService<ClientType> {
+export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
   public ents(): TestEntityCollectionService<ClientType>;
   public ents(id: TestEntityId): TestEntityService<ClientType>;
   public ents(id?: TestEntityId | undefined) {
@@ -18,7 +18,7 @@ export class TesterService<ClientType extends ODataHttpClient> extends ODataServ
   }
 }
 
-export class TestEntityService<ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
+export class TestEntityService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
   ClientType,
   TestEntity,
   EditableTestEntity,
@@ -70,7 +70,7 @@ export class TestEntityService<ClientType extends ODataHttpClient> extends Entit
   }
 }
 
-export class TestEntityCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV4<
+export class TestEntityCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV4<
   ClientType,
   TestEntity,
   EditableTestEntity,

--- a/packages/odata2ts/test/fixture/generator/service/v4/primitive-return-types.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/primitive-return-types.ts
@@ -7,7 +7,7 @@ import { QPingCollection, QPingNumber, QPingString, QTestEntity, QTestEntityId, 
 // @ts-ignore
 import { EditableTestEntity, TestEntity, TestEntityId } from "./TesterModel";
 
-export class TesterService<ClientType extends ODataHttpClient> extends ODataService<ClientType> {
+export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
   private _qPingString?: QPingString;
   private _qPingNumber?: QPingNumber;
   private _qPingCollection?: QPingCollection;
@@ -52,7 +52,7 @@ export class TesterService<ClientType extends ODataHttpClient> extends ODataServ
   }
 }
 
-export class TestEntityService<ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
+export class TestEntityService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
   ClientType,
   TestEntity,
   EditableTestEntity,
@@ -63,7 +63,7 @@ export class TestEntityService<ClientType extends ODataHttpClient> extends Entit
   }
 }
 
-export class TestEntityCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV4<
+export class TestEntityCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV4<
   ClientType,
   TestEntity,
   EditableTestEntity,

--- a/packages/odata2ts/test/fixture/generator/service/v4/singleton.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/singleton.ts
@@ -6,7 +6,7 @@ import { QTestEntity, QTestEntityId, qTestEntity } from "./QTester";
 // @ts-ignore
 import { EditableTestEntity, TestEntity, TestEntityId } from "./TesterModel";
 
-export class TesterService<ClientType extends ODataHttpClient> extends ODataService<ClientType> {
+export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
   private _currentUser?: TestEntityService<ClientType>;
 
   public currentUser() {
@@ -19,7 +19,7 @@ export class TesterService<ClientType extends ODataHttpClient> extends ODataServ
   }
 }
 
-export class TestEntityService<ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
+export class TestEntityService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
   ClientType,
   TestEntity,
   EditableTestEntity,
@@ -30,7 +30,7 @@ export class TestEntityService<ClientType extends ODataHttpClient> extends Entit
   }
 }
 
-export class TestEntityCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV4<
+export class TestEntityCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV4<
   ClientType,
   TestEntity,
   EditableTestEntity,


### PR DESCRIPTION
Explicit variance annotation for each service regarding the `ClientType` type parameter.
This prevents TS to calculate variance in recursive fashion, which breaks with larger data models (max call stack size exceeded).
