### PR TITLE
feat(generator): add ts-nocheck to each generated file by default

### DIFF
--- a/packages/odata2ts/src/app.ts
+++ b/packages/odata2ts/src/app.ts
@@ -80,6 +80,7 @@ export async function runApp(metadataJson: ODataEdmxModelBase<any>, options: Run
     usePrettier: options.prettier,
     tsConfigPath: options.tsconfig,
     bundledFileGeneration: options.bundledFileGeneration,
+    allowTypeChecking: options.debug,
   });
 
   // const promises: Array<Promise<void>> = [

--- a/packages/odata2ts/test/app.test.ts
+++ b/packages/odata2ts/test/app.test.ts
@@ -161,6 +161,7 @@ describe("App Test", () => {
       usePrettier: false,
       bundledFileGeneration: true,
       tsConfigPath: "tsconfig.json",
+      allowTypeChecking: false,
     });
 
     // then only generateModels was called
@@ -188,6 +189,7 @@ describe("App Test", () => {
       usePrettier: true,
       bundledFileGeneration: false,
       tsConfigPath: "test.json",
+      allowTypeChecking: false,
     });
 
     // then generateModels & generateQObjects was called

--- a/packages/odata2ts/test/generator/comparator/FixtureComparator.ts
+++ b/packages/odata2ts/test/generator/comparator/FixtureComparator.ts
@@ -1,6 +1,6 @@
 import path from "path";
 
-import { pathExistsSync, readFileSync } from "fs-extra";
+import { pathExistsSync, readFile } from "fs-extra";
 import prettier, { Options } from "prettier";
 
 /**
@@ -34,7 +34,7 @@ export class FixtureComparator {
       throw new Error("Unable to load fixture: " + fullPath);
     }
 
-    const fixture = this.loadFixture(fullPath);
+    const fixture = await this.loadFixture(fullPath);
     const cleanedFixture = fixture
       .replace(/\r\n/g, "\n")
       .replace(new RegExp("^//( )*@ts-nocheck( )*\n"), "")
@@ -50,6 +50,6 @@ export class FixtureComparator {
   }
 
   public loadFixture(path: string) {
-    return readFileSync(path, "utf-8");
+    return readFile(path, "utf-8");
   }
 }

--- a/packages/odata2ts/test/generator/v2/ModelGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v2/ModelGenerator.test.ts
@@ -22,6 +22,7 @@ describe("Model Generator Tests V2", () => {
     const projectManager = await createProjectManager("build/unitTest", EmitModes.ts, namingHelper, dataModel, {
       noOutput: true,
       bundledFileGeneration: true,
+      allowTypeChecking: true,
     });
     await generateModels(projectManager, dataModel, ODataVersions.V2, genOptions, namingHelper);
     return projectManager;

--- a/packages/odata2ts/test/generator/v2/QueryObjectGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v2/QueryObjectGenerator.test.ts
@@ -21,6 +21,7 @@ describe("Query Object Generator Tests V2", () => {
     const projectManager = await createProjectManager("build/unitTest", EmitModes.ts, namingHelper, dataModel, {
       bundledFileGeneration: true,
       noOutput: true,
+      allowTypeChecking: true,
     });
     await generateQueryObjects(projectManager, dataModel, ODataVersions.V2, genOptions, namingHelper);
     return projectManager;

--- a/packages/odata2ts/test/generator/v2/ServiceGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v2/ServiceGenerator.test.ts
@@ -39,6 +39,7 @@ describe("Service Generator Tests V2", () => {
     projectManager = await createProjectManager("build/unitTest", EmitModes.ts, namingHelper, dataModel, {
       noOutput: true,
       bundledFileGeneration: true,
+      allowTypeChecking: true,
     });
 
     await generateServices(projectManager, dataModel, ODataVersions.V2, namingHelper, runOptions);

--- a/packages/odata2ts/test/generator/v4/ModelGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/ModelGenerator.test.ts
@@ -22,6 +22,7 @@ describe("Model Generator Tests V4", () => {
     const projectManager = await createProjectManager("build/unitTest", EmitModes.ts, namingHelper, dataModel, {
       noOutput: true,
       bundledFileGeneration: true,
+      allowTypeChecking: true,
     });
     await generateModels(projectManager, dataModel, ODataVersions.V4, genOptions, namingHelper);
     return projectManager;

--- a/packages/odata2ts/test/generator/v4/QueryObjectGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/QueryObjectGenerator.test.ts
@@ -23,6 +23,7 @@ describe("Query Object Generator Tests V4", () => {
     const projectManager = await createProjectManager("build/unitTest", EmitModes.ts, namingHelper, dataModel, {
       noOutput: true,
       bundledFileGeneration: true,
+      allowTypeChecking: true,
     });
     await generateQueryObjects(projectManager, dataModel, ODataVersions.V4, options, namingHelper);
     return projectManager;

--- a/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
@@ -45,6 +45,7 @@ describe("Service Generator Tests V4", () => {
     projectManager = await createProjectManager("build", EmitModes.ts, namingHelper, dataModel, {
       bundledFileGeneration: true,
       noOutput: true,
+      allowTypeChecking: true,
     });
 
     await fixtureComparatorHelper.generateService(projectManager, namingHelper, runOptions);

--- a/packages/odata2ts/test/project/ProjectManager.test.ts
+++ b/packages/odata2ts/test/project/ProjectManager.test.ts
@@ -121,14 +121,11 @@ describe("ProjectManager Test", () => {
       fileName,
       // we don't check the SourceFile from ts-morph
       expect.anything(),
-      usedDataModel,
-      // main file names must have been passed
-      MAIN_FILE_NAMES,
-      // bundled file generation
-      false,
+      // todo: import container
+      expect.anything(),
       // we don't want to check the formatter
       expect.anything(),
-      reservedNames
+      false
     );
   }
 
@@ -139,14 +136,11 @@ describe("ProjectManager Test", () => {
       fileName,
       // we don't check the SourceFile from ts-morph
       expect.anything(),
-      usedDataModel,
-      // main file names must have been passed
-      MAIN_FILE_NAMES,
-      // bundled file generation
-      true,
+      // todo: import container
+      expect.anything(),
       // we don't want to check the formatter
       expect.anything(),
-      reservedNames
+      false
     );
   }
 


### PR DESCRIPTION
BREAKING CHANGE: generated code won't be type checked anymore. Use `debug: true` to get type checking back.