### PR TITLE
feat: keep enum values from $metadata

### DIFF
--- a/packages/odata2ts/src/FactoryFunctionModel.ts
+++ b/packages/odata2ts/src/FactoryFunctionModel.ts
@@ -18,6 +18,7 @@ export type DigestionOptions = Pick<
   | "skipComments"
   | "disableAutomaticNameClashResolution"
   | "bundledFileGeneration"
+  | "retainEnumValues"
 >;
 
 /**

--- a/packages/odata2ts/src/OptionModel.ts
+++ b/packages/odata2ts/src/OptionModel.ts
@@ -262,6 +262,12 @@ export interface ConfigFileOptions extends Omit<CliOptions, "sourceUrl" | "sourc
    * To enable this behaviour set this option to true.
    */
   bundledFileGeneration?: boolean;
+
+  /**
+   * By default, odata2ts generates enums with a string value, matching the enum name.
+   * This option retains the value specified in the metadata file.
+   */
+  retainEnumValues?: boolean;
 }
 
 /**

--- a/packages/odata2ts/src/data-model/DataModelDigestion.ts
+++ b/packages/odata2ts/src/data-model/DataModelDigestion.ts
@@ -229,7 +229,11 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
         name: enumName,
         modelName: this.namingHelper.getEnumName(enumName),
         folderPath: filePath,
-        members: et.Member?.length ? et.Member.map((m) => m.$.Name) : [],
+        members: et.Member?.length
+          ? !this.options.retainEnumValues
+            ? et.Member.map((m) => m.$.Name)
+            : et.Member.map((m) => ({ name: m.$.Name, value: m.$.Value }))
+          : [],
       });
     }
   }

--- a/packages/odata2ts/src/data-model/DataTypeModel.ts
+++ b/packages/odata2ts/src/data-model/DataTypeModel.ts
@@ -80,7 +80,7 @@ export interface EnumType {
   name: string;
   modelName: string;
   folderPath: string;
-  members: Array<string>;
+  members: Array<string> | Array<{ name: string, value: number | string }>;
 }
 
 export interface OperationType {

--- a/packages/odata2ts/src/defaultConfig.ts
+++ b/packages/odata2ts/src/defaultConfig.ts
@@ -27,6 +27,7 @@ const defaultConfig: DefaultConfiguration = {
   v4BigNumberAsString: false,
   disableAutomaticNameClashResolution: false,
   bundledFileGeneration: true,
+  retainEnumValues: false,
   naming: {
     models: {
       namingStrategy: NamingStrategies.PASCAL_CASE,

--- a/packages/odata2ts/src/generator/ModelGenerator.ts
+++ b/packages/odata2ts/src/generator/ModelGenerator.ts
@@ -55,7 +55,15 @@ class ModelGenerator {
       file.getFile().addEnum({
         name: et.modelName,
         isExported: true,
-        members: et.members.map((mem) => ({ name: mem, initializer: `"${mem}"` })),
+        members: et.members.map((mem) => {
+          if (typeof mem === 'string') {
+            return ({ name: mem, initializer: `"${mem}"` })
+          }
+          return {
+            name: mem.name,
+            initializer: typeof mem.value === 'number' ? `${mem.value}` : `"${mem.value}"`
+          };
+        }),
       });
 
       return this.project.finalizeFile(file);
@@ -244,14 +252,14 @@ class ModelGenerator {
       properties: !complexProps
         ? undefined
         : complexProps.map((p) => {
-            return {
-              name: p.name,
-              type: this.getEditablePropType(file.getImports(), p),
-              // optional props don't need to be specified in editable model
-              // also, entities would require deep insert func => we make it optional for now
-              hasQuestionToken: !p.required || p.dataType === DataTypes.ModelType,
-            };
-          }),
+          return {
+            name: p.name,
+            type: this.getEditablePropType(file.getImports(), p),
+            // optional props don't need to be specified in editable model
+            // also, entities would require deep insert func => we make it optional for now
+            hasQuestionToken: !p.required || p.dataType === DataTypes.ModelType,
+          };
+        }),
     });
   }
 


### PR DESCRIPTION
when generating typescript model
- add config setting `retainEnumValues`
- if retainEnumValues is true:
  - digest the enums into an array of name/value objects
  - in the generator, handle string/object type
  - if object, provide correct initializer based on value type (string/number)


Example, `$metadata` file:
```
<EnumType Name="DecisionTypeEnum">
  <Member Name="Favorable" Value="1"/>
  <Member Name="Unfavorable" Value="2"/>
</EnumType>
```
Existing code results in:
```
export enum DecisionTypeEnum {
    Favorable = "Favorable",
    Unfavorable = "Unfavorable"
}
```
Proposed modification, with `retainEnumValues: true` results in:
```
export enum DecisionTypeEnum {
    Favorable = 1,
    Unfavorable = 2
}
```