### PR TITLE
feat(generator): conversion of subtype by control info

### DIFF
--- a/examples/main/int-test/trippin/TrippinIntegration.test.ts
+++ b/examples/main/int-test/trippin/TrippinIntegration.test.ts
@@ -247,4 +247,15 @@ describe("Integration Testing of Service Generation", () => {
     expect(result).toBe(`People(UserName='${simpleResult}')`);
     expect(trippinService.people().parseKey(result)).toStrictEqual(complexInput);
   });
+
+  test("casting derived entity type", async () => {
+    const response = await trippinService
+      .people("russellwhyte")
+      .trips(0)
+      .planItems()
+      .asFlightCollectionService()
+      .query();
+
+    expect(response.data).toMatchObject({});
+  });
 });

--- a/examples/main/int-test/trippin/TrippinRwIntegration.test.ts
+++ b/examples/main/int-test/trippin/TrippinRwIntegration.test.ts
@@ -1,0 +1,74 @@
+import { AxiosClient } from "@odata2ts/http-client-axios";
+import { describe, expect, test } from "vitest";
+import { EditablePlanItemModel, PlanItemModel } from "../../build/trippin-rw/TrippinRwModel";
+import { TrippinRwService } from "../../build/trippin-rw/TrippinRwService";
+import { EditableEventModel } from "../../build/trippin/TrippinModel";
+
+describe("Integration Testing of Service Generation", () => {
+  const BASE_URL = "https://services.odata.org/V4/(S(xjqbds2oavibr01gt1fny24s))/TripPinServiceRW";
+  const odataClient = new AxiosClient();
+
+  const trippinService = new TrippinRwService(odataClient, BASE_URL);
+
+  test("casting derived entity type", async () => {
+    const response = await trippinService.people("russellwhyte").trips(0).planItems(11).asFlightService().query();
+
+    const { "@odata.context": ignore, ...result } = response.data;
+    expect(result).toStrictEqual({
+      confirmationCode: "JH58493",
+      duration: "PT0S",
+      endsAt: "2014-01-01T11:35:00Z",
+      flightNumber: "AA26",
+      planItemId: 11,
+      seatNumber: null,
+      startsAt: "2014-01-01T06:15:00Z",
+    });
+  });
+
+  test("filter & select derived entity prop", async () => {
+    const response = await trippinService
+      .people("russellwhyte")
+      .trips(0)
+      .planItems()
+      .query((builder, q) => {
+        return builder.select("QFlight_flightNumber").filter(q.QFlight_flightNumber.eq("AA26"));
+      });
+
+    expect(response.data.value).toStrictEqual([
+      {
+        "@odata.type": "#Microsoft.OData.SampleService.Models.TripPin.Flight",
+        flightNumber: "AA26",
+      },
+    ]);
+  });
+
+  test("create derived entity", async () => {
+    const model: EditableEventModel = {
+      // @ts-ignore
+      "@odata.type": "#Microsoft.OData.SampleService.Models.TripPin.Event",
+      planItemId: 33,
+      confirmationCode: "4372899DD",
+      description: "Client Meeting",
+      duration: "PT3H",
+      startsAt: "2014-05-25T23:11:17.5459178-07:00",
+      endsAt: "2014-06-01T23:11:17.5479185-07:00",
+      occursAt: {
+        address: "100 Church Street, 8th Floor, Manhattan, 10007",
+        buildingInfo: "Regus Business Center",
+        city: {
+          countryRegion: "United States",
+          name: "New York City",
+          region: "New York",
+        },
+      },
+    };
+    const response = await trippinService.people("russellwhyte").trips(0).planItems().create(model);
+    const {
+      //@ts-ignore
+      "@odata.context": ctxt,
+      ...data
+    } = response.data;
+
+    expect(data).toStrictEqual(model);
+  });
+});

--- a/examples/main/odata2ts.config.ts
+++ b/examples/main/odata2ts.config.ts
@@ -41,6 +41,22 @@ const config: ConfigFileOptions = {
         ...["createdAt", "createdBy", "modifiedAt", "modifiedBy"].map((prop) => ({ name: prop, managed: true })),
       ],
     },
+    // Just the Trippin service with a bit of mapping
+    trippinRw: {
+      serviceName: "TrippinRw",
+      source: srcFolder("trippin-rw.xml"),
+      output: outputFolder("trippin-rw"),
+      // TrippinService does not generate IDs on the server, but the client side => demo service
+      disableAutoManagedKey: true,
+      allowRenaming: true,
+      // for the fun of it
+      enablePrimitivePropertyServices: true,
+      naming: {
+        models: {
+          suffix: "Model",
+        },
+      },
+    },
     // Starting renaming from scratch: minimal defaults
     minimalDefaults: {
       source: srcFolder("trippin.xml"),

--- a/examples/main/resource/trippin-rw.xml
+++ b/examples/main/resource/trippin-rw.xml
@@ -1,0 +1,384 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="Microsoft.OData.SampleService.Models.TripPin" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EnumType Name="PersonGender">
+        <Member Name="Male" Value="0" />
+        <Member Name="Female" Value="1" />
+        <Member Name="Unknown" Value="2" />
+      </EnumType>
+      <ComplexType Name="City">
+        <Property Name="CountryRegion" Type="Edm.String" Nullable="false" />
+        <Property Name="Name" Type="Edm.String" Nullable="false" />
+        <Property Name="Region" Type="Edm.String" Nullable="false" />
+      </ComplexType>
+      <ComplexType Name="Location" OpenType="true">
+        <Property Name="Address" Type="Edm.String" Nullable="false" />
+        <Property Name="City" Type="Microsoft.OData.SampleService.Models.TripPin.City" Nullable="false" />
+      </ComplexType>
+      <ComplexType
+        Name="EventLocation"
+        BaseType="Microsoft.OData.SampleService.Models.TripPin.Location"
+        OpenType="true"
+      >
+        <Property Name="BuildingInfo" Type="Edm.String" />
+      </ComplexType>
+      <ComplexType
+        Name="AirportLocation"
+        BaseType="Microsoft.OData.SampleService.Models.TripPin.Location"
+        OpenType="true"
+      >
+        <Property Name="Loc" Type="Edm.GeographyPoint" Nullable="false" SRID="4326" />
+      </ComplexType>
+      <EntityType Name="Photo" HasStream="true">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property Name="Id" Type="Edm.Int64" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Permissions">
+            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+          </Annotation>
+        </Property>
+        <Property Name="Name" Type="Edm.String" />
+        <Annotation Term="Org.OData.Core.V1.AcceptableMediaTypes">
+          <Collection>
+            <String>image/jpeg</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+      <EntityType Name="Person" OpenType="true">
+        <Key>
+          <PropertyRef Name="UserName" />
+        </Key>
+        <Property Name="UserName" Type="Edm.String" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Permissions">
+            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+          </Annotation>
+        </Property>
+        <Property Name="FirstName" Type="Edm.String" Nullable="false" />
+        <Property Name="LastName" Type="Edm.String" Nullable="false" />
+        <Property Name="Emails" Type="Collection(Edm.String)" />
+        <Property Name="AddressInfo" Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Location)" />
+        <Property Name="Gender" Type="Microsoft.OData.SampleService.Models.TripPin.PersonGender" />
+        <Property Name="Concurrency" Type="Edm.Int64" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
+        </Property>
+        <NavigationProperty Name="Friends" Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Person)" />
+        <NavigationProperty
+          Name="Trips"
+          Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Trip)"
+          ContainsTarget="true"
+        />
+        <NavigationProperty Name="Photo" Type="Microsoft.OData.SampleService.Models.TripPin.Photo" />
+      </EntityType>
+      <EntityType Name="Airline">
+        <Key>
+          <PropertyRef Name="AirlineCode" />
+        </Key>
+        <Property Name="AirlineCode" Type="Edm.String" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Permissions">
+            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+          </Annotation>
+        </Property>
+        <Property Name="Name" Type="Edm.String" Nullable="false" />
+      </EntityType>
+      <EntityType Name="Airport">
+        <Key>
+          <PropertyRef Name="IcaoCode" />
+        </Key>
+        <Property Name="IcaoCode" Type="Edm.String" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Permissions">
+            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+          </Annotation>
+        </Property>
+        <Property Name="Name" Type="Edm.String" Nullable="false" />
+        <Property Name="IataCode" Type="Edm.String" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Immutable" Bool="true" />
+        </Property>
+        <Property
+          Name="Location"
+          Type="Microsoft.OData.SampleService.Models.TripPin.AirportLocation"
+          Nullable="false"
+        />
+      </EntityType>
+      <EntityType Name="PlanItem">
+        <Key>
+          <PropertyRef Name="PlanItemId" />
+        </Key>
+        <Property Name="PlanItemId" Type="Edm.Int32" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Permissions">
+            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+          </Annotation>
+        </Property>
+        <Property Name="ConfirmationCode" Type="Edm.String" />
+        <Property Name="StartsAt" Type="Edm.DateTimeOffset" />
+        <Property Name="EndsAt" Type="Edm.DateTimeOffset" />
+        <Property Name="Duration" Type="Edm.Duration" />
+      </EntityType>
+      <EntityType Name="PublicTransportation" BaseType="Microsoft.OData.SampleService.Models.TripPin.PlanItem">
+        <Property Name="SeatNumber" Type="Edm.String" />
+      </EntityType>
+      <EntityType Name="Flight" BaseType="Microsoft.OData.SampleService.Models.TripPin.PublicTransportation">
+        <Property Name="FlightNumber" Type="Edm.String" Nullable="false" />
+        <NavigationProperty Name="From" Type="Microsoft.OData.SampleService.Models.TripPin.Airport" Nullable="false" />
+        <NavigationProperty Name="To" Type="Microsoft.OData.SampleService.Models.TripPin.Airport" Nullable="false" />
+        <NavigationProperty
+          Name="Airline"
+          Type="Microsoft.OData.SampleService.Models.TripPin.Airline"
+          Nullable="false"
+        />
+      </EntityType>
+      <EntityType Name="Event" BaseType="Microsoft.OData.SampleService.Models.TripPin.PlanItem" OpenType="true">
+        <Property Name="Description" Type="Edm.String" />
+        <Property Name="OccursAt" Type="Microsoft.OData.SampleService.Models.TripPin.EventLocation" Nullable="false" />
+      </EntityType>
+      <EntityType Name="Trip">
+        <Key>
+          <PropertyRef Name="TripId" />
+        </Key>
+        <Property Name="TripId" Type="Edm.Int32" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Permissions">
+            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+          </Annotation>
+        </Property>
+        <Property Name="ShareId" Type="Edm.Guid" />
+        <Property Name="Description" Type="Edm.String" />
+        <Property Name="Name" Type="Edm.String" Nullable="false" />
+        <Property Name="Budget" Type="Edm.Single" Nullable="false">
+          <Annotation Term="Org.OData.Measures.V1.ISOCurrency" String="USD" />
+          <Annotation Term="Org.OData.Measures.V1.Scale" Int="2" />
+        </Property>
+        <Property Name="StartsAt" Type="Edm.DateTimeOffset" Nullable="false" />
+        <Property Name="EndsAt" Type="Edm.DateTimeOffset" Nullable="false" />
+        <Property Name="Tags" Type="Collection(Edm.String)" Nullable="false" />
+        <NavigationProperty Name="Photos" Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Photo)" />
+        <NavigationProperty
+          Name="PlanItems"
+          Type="Collection(Microsoft.OData.SampleService.Models.TripPin.PlanItem)"
+          ContainsTarget="true"
+        />
+      </EntityType>
+      <Function
+        Name="GetFavoriteAirline"
+        IsBound="true"
+        EntitySetPath="person/Trips/PlanItems/Microsoft.OData.SampleService.Models.TripPin.Flight/Airline"
+        IsComposable="true"
+      >
+        <Parameter Name="person" Type="Microsoft.OData.SampleService.Models.TripPin.Person" Nullable="false" />
+        <ReturnType Type="Microsoft.OData.SampleService.Models.TripPin.Airline" Nullable="false" />
+      </Function>
+      <Function Name="GetInvolvedPeople" IsBound="true" IsComposable="true">
+        <Parameter Name="trip" Type="Microsoft.OData.SampleService.Models.TripPin.Trip" Nullable="false" />
+        <ReturnType Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Person)" Nullable="false" />
+      </Function>
+      <Function Name="GetFriendsTrips" IsBound="true" EntitySetPath="person/Friends/Trips" IsComposable="true">
+        <Parameter Name="person" Type="Microsoft.OData.SampleService.Models.TripPin.Person" Nullable="false" />
+        <Parameter Name="userName" Type="Edm.String" Nullable="false" />
+        <ReturnType Type="Collection(Microsoft.OData.SampleService.Models.TripPin.Trip)" Nullable="false" />
+      </Function>
+      <Function Name="GetNearestAirport" IsComposable="true">
+        <Parameter Name="lat" Type="Edm.Double" Nullable="false" />
+        <Parameter Name="lon" Type="Edm.Double" Nullable="false" />
+        <ReturnType Type="Microsoft.OData.SampleService.Models.TripPin.Airport" Nullable="false" />
+      </Function>
+      <Action Name="ResetDataSource" />
+      <Action Name="ShareTrip" IsBound="true">
+        <Parameter Name="person" Type="Microsoft.OData.SampleService.Models.TripPin.Person" Nullable="false" />
+        <Parameter Name="userName" Type="Edm.String" Nullable="false" />
+        <Parameter Name="tripId" Type="Edm.Int32" Nullable="false" />
+      </Action>
+      <EntityContainer Name="DefaultContainer">
+        <EntitySet Name="Photos" EntityType="Microsoft.OData.SampleService.Models.TripPin.Photo">
+          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="Photos" />
+          <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
+            <Record>
+              <PropertyValue Property="Searchable" Bool="true" />
+              <PropertyValue Property="UnsupportedExpressions">
+                <EnumMember>Org.OData.Capabilities.V1.SearchExpressions/none</EnumMember>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+            <Record>
+              <PropertyValue Property="Insertable" Bool="true" />
+              <PropertyValue Property="NonInsertableNavigationProperties">
+                <Collection />
+              </PropertyValue>
+            </Record>
+          </Annotation>
+        </EntitySet>
+        <EntitySet Name="People" EntityType="Microsoft.OData.SampleService.Models.TripPin.Person">
+          <NavigationPropertyBinding Path="Friends" Target="People" />
+          <NavigationPropertyBinding
+            Path="Microsoft.OData.SampleService.Models.TripPin.Flight/Airline"
+            Target="Airlines"
+          />
+          <NavigationPropertyBinding
+            Path="Microsoft.OData.SampleService.Models.TripPin.Flight/From"
+            Target="Airports"
+          />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Flight/To" Target="Airports" />
+          <NavigationPropertyBinding Path="Photo" Target="Photos" />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Trip/Photos" Target="Photos" />
+          <Annotation Term="Org.OData.Core.V1.OptimisticConcurrency">
+            <Collection>
+              <PropertyPath>Concurrency</PropertyPath>
+            </Collection>
+          </Annotation>
+          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="People" />
+          <Annotation Term="Org.OData.Capabilities.V1.NavigationRestrictions">
+            <Record>
+              <PropertyValue Property="Navigability">
+                <EnumMember>Org.OData.Capabilities.V1.NavigationType/None</EnumMember>
+              </PropertyValue>
+              <PropertyValue Property="RestrictedProperties">
+                <Collection>
+                  <Record>
+                    <PropertyValue Property="NavigationProperty" NavigationPropertyPath="Friends" />
+                    <PropertyValue Property="Navigability">
+                      <EnumMember>Org.OData.Capabilities.V1.NavigationType/Recursive</EnumMember>
+                    </PropertyValue>
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
+            <Record>
+              <PropertyValue Property="Searchable" Bool="true" />
+              <PropertyValue Property="UnsupportedExpressions">
+                <EnumMember>Org.OData.Capabilities.V1.SearchExpressions/none</EnumMember>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+            <Record>
+              <PropertyValue Property="Insertable" Bool="true" />
+              <PropertyValue Property="NonInsertableNavigationProperties">
+                <Collection>
+                  <NavigationPropertyPath>Trips</NavigationPropertyPath>
+                  <NavigationPropertyPath>Friends</NavigationPropertyPath>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+        </EntitySet>
+        <EntitySet Name="Airlines" EntityType="Microsoft.OData.SampleService.Models.TripPin.Airline">
+          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="Airlines" />
+          <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
+            <Record>
+              <PropertyValue Property="Searchable" Bool="true" />
+              <PropertyValue Property="UnsupportedExpressions">
+                <EnumMember>Org.OData.Capabilities.V1.SearchExpressions/none</EnumMember>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+            <Record>
+              <PropertyValue Property="Insertable" Bool="true" />
+              <PropertyValue Property="NonInsertableNavigationProperties">
+                <Collection />
+              </PropertyValue>
+            </Record>
+          </Annotation>
+        </EntitySet>
+        <EntitySet Name="Airports" EntityType="Microsoft.OData.SampleService.Models.TripPin.Airport">
+          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="Airports" />
+          <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
+            <Record>
+              <PropertyValue Property="Searchable" Bool="true" />
+              <PropertyValue Property="UnsupportedExpressions">
+                <EnumMember>Org.OData.Capabilities.V1.SearchExpressions/none</EnumMember>
+              </PropertyValue>
+            </Record>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.InsertRestrictions">
+            <Record>
+              <PropertyValue Property="Insertable" Bool="false" />
+              <PropertyValue Property="NonInsertableNavigationProperties">
+                <Collection />
+              </PropertyValue>
+            </Record>
+          </Annotation>
+          <Annotation Term="Org.OData.Capabilities.V1.DeleteRestrictions">
+            <Record>
+              <PropertyValue Property="Deletable" Bool="false" />
+              <PropertyValue Property="NonDeletableNavigationProperties">
+                <Collection />
+              </PropertyValue>
+            </Record>
+          </Annotation>
+        </EntitySet>
+        <Singleton Name="Me" Type="Microsoft.OData.SampleService.Models.TripPin.Person">
+          <NavigationPropertyBinding Path="Friends" Target="People" />
+          <NavigationPropertyBinding
+            Path="Microsoft.OData.SampleService.Models.TripPin.Flight/Airline"
+            Target="Airlines"
+          />
+          <NavigationPropertyBinding
+            Path="Microsoft.OData.SampleService.Models.TripPin.Flight/From"
+            Target="Airports"
+          />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Flight/To" Target="Airports" />
+          <NavigationPropertyBinding Path="Photo" Target="Photos" />
+          <NavigationPropertyBinding Path="Microsoft.OData.SampleService.Models.TripPin.Trip/Photos" Target="Photos" />
+          <Annotation Term="Org.OData.Core.V1.ResourcePath" String="Me" />
+        </Singleton>
+        <FunctionImport
+          Name="GetNearestAirport"
+          Function="Microsoft.OData.SampleService.Models.TripPin.GetNearestAirport"
+          EntitySet="Airports"
+          IncludeInServiceDocument="true"
+        >
+          <Annotation
+            Term="Org.OData.Core.V1.ResourcePath"
+            String="Microsoft.OData.SampleService.Models.TripPin.GetNearestAirport"
+          />
+        </FunctionImport>
+        <ActionImport Name="ResetDataSource" Action="Microsoft.OData.SampleService.Models.TripPin.ResetDataSource" />
+        <Annotation Term="Org.OData.Core.V1.Description" String="TripPin service is a sample service for OData V4." />
+      </EntityContainer>
+      <Annotations Target="Microsoft.OData.SampleService.Models.TripPin.DefaultContainer">
+        <Annotation Term="Org.OData.Core.V1.DereferenceableIDs" Bool="true" />
+        <Annotation Term="Org.OData.Core.V1.ConventionalIDs" Bool="true" />
+        <Annotation Term="Org.OData.Capabilities.V1.ConformanceLevel">
+          <EnumMember>Org.OData.Capabilities.V1.ConformanceLevelType/Advanced</EnumMember>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.SupportedFormats">
+          <Collection>
+            <String>application/json;odata.metadata=full;IEEE754Compatible=false;odata.streaming=true</String>
+            <String>application/json;odata.metadata=minimal;IEEE754Compatible=false;odata.streaming=true</String>
+            <String>application/json;odata.metadata=none;IEEE754Compatible=false;odata.streaming=true</String>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.AsynchronousRequestsSupported" Bool="true" />
+        <Annotation Term="Org.OData.Capabilities.V1.BatchContinueOnErrorSupported" Bool="false" />
+        <Annotation Term="Org.OData.Capabilities.V1.FilterFunctions">
+          <Collection>
+            <String>contains</String>
+            <String>endswith</String>
+            <String>startswith</String>
+            <String>length</String>
+            <String>indexof</String>
+            <String>substring</String>
+            <String>tolower</String>
+            <String>toupper</String>
+            <String>trim</String>
+            <String>concat</String>
+            <String>year</String>
+            <String>month</String>
+            <String>day</String>
+            <String>hour</String>
+            <String>minute</String>
+            <String>second</String>
+            <String>round</String>
+            <String>floor</String>
+            <String>ceiling</String>
+            <String>cast</String>
+            <String>isof</String>
+          </Collection>
+        </Annotation>
+      </Annotations>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/packages/odata-query-objects/src/index.ts
+++ b/packages/odata-query-objects/src/index.ts
@@ -3,7 +3,7 @@ export * from "./QueryObjectModel";
 export { QFilterExpression } from "./QFilterExpression";
 export { QOrderByExpression } from "./QOrderByExpression";
 export { QSearchTerm, searchTerm } from "./QSearchTerm";
-export { QueryObject } from "./QueryObject";
+export { QueryObject, ENUMERABLE_PROP_DEFINITION } from "./QueryObject";
 export { getIdentityConverter } from "./IdentityConverter";
 
 export * from "./enum/EnumModel";

--- a/packages/odata-query-objects/test/QueryObject.test.ts
+++ b/packages/odata-query-objects/test/QueryObject.test.ts
@@ -1,6 +1,7 @@
 import { FIXED_DATE, FIXED_STRING } from "@odata2ts/test-converters";
 import { describe, expect, test } from "vitest";
 import { QEntityCollectionPath, QEntityPath, QStringV2Path, QueryObject } from "../src";
+import { EventModel, PlanItemModel, QPlanItem } from "./fixture/BaseTypeModel";
 import { QSimpleEntityWithConverter, QTestEntity } from "./fixture/SimpleEntityWithConverter";
 
 describe("QueryObject tests", () => {
@@ -221,5 +222,27 @@ describe("QueryObject tests", () => {
     // @ts-expect-error
     expect(qToTestWithAssoc.convertToOData({ options: null })).toStrictEqual({ options: null });
     expect(qToTestWithAssoc.convertToOData({ options: undefined })).toStrictEqual({ options: undefined });
+  });
+
+  test("subtype casting", () => {
+    const qBaseType = new QPlanItem();
+    const rawModel = {
+      "@odata.type": "Tester.Event",
+      Id: 123,
+      Name: "Test",
+      Description: "Desc",
+    };
+    const finalModel: EventModel = {
+      "@odata.type": "Tester.Event",
+      id: 123,
+      name: "Test",
+      description: "Desc",
+    };
+
+    const result = qBaseType.convertFromOData(rawModel);
+    expect(result).toStrictEqual(finalModel);
+
+    const result2 = qBaseType.convertToOData(finalModel);
+    expect(result2).toStrictEqual(rawModel);
   });
 });

--- a/packages/odata-query-objects/test/fixture/BaseTypeModel.ts
+++ b/packages/odata-query-objects/test/fixture/BaseTypeModel.ts
@@ -1,0 +1,56 @@
+import { QBook } from "@odata2ts/odata2ts/test/fixture/generator/qobject/abstract";
+import { ENUMERABLE_PROP_DEFINITION, QNumberPath, QStringPath, QueryObject } from "../../src";
+
+export interface PlanItemModel {
+  "@odata.type": "Tester.PlanItem" | "Tester.Event" | "Tester.Flight";
+  id: number;
+  name: string | null;
+}
+
+export interface EventModel extends PlanItemModel {
+  "@odata.type": "Tester.Event";
+  description: string | null;
+}
+
+export interface FlightModel extends PlanItemModel {
+  "@odata.type": "Tester.Flight";
+  flightNumber: string;
+}
+
+export class QPlanItemBaseType<Model extends PlanItemModel> extends QueryObject<Model> {
+  public readonly id = new QNumberPath(this.withPrefix("Id"));
+  public readonly name = new QStringPath(this.withPrefix("Name"));
+}
+
+export class QPlanItem extends QPlanItemBaseType<PlanItemModel> {
+  protected readonly __subtypeMapping = { "Tester.Event": "QEvent", "Tester.Flight": "QFlight" };
+
+  protected get __asQEvent() {
+    return new QEvent(this.withPrefix("Tester.Event"));
+  }
+
+  protected get __asQFlight() {
+    return new QFlight(this.withPrefix("Tester.Flight"));
+  }
+
+  public get QEvent_description() {
+    return this.__asQEvent.description;
+  }
+
+  public get QFlight_flightNumber() {
+    return this.__asQFlight.flightNumber;
+  }
+}
+
+Object.defineProperties(QPlanItem.prototype, {
+  QEvent_description: ENUMERABLE_PROP_DEFINITION,
+  QFlight_flightNumber: ENUMERABLE_PROP_DEFINITION,
+});
+
+export class QEvent extends QPlanItemBaseType<EventModel> {
+  public readonly description = new QStringPath(this.withPrefix("Description"));
+}
+
+export class QFlight extends QPlanItemBaseType<FlightModel> {
+  public readonly flightNumber = new QStringPath(this.withPrefix("FlightNumber"));
+}

--- a/packages/odata-service/src/ODataServiceOptions.ts
+++ b/packages/odata-service/src/ODataServiceOptions.ts
@@ -14,4 +14,5 @@ export interface ODataServiceOptions {
  */
 export interface ODataServiceOptionsInternal extends ODataServiceOptions {
   bigNumbersAsString?: boolean;
+  subtype?: boolean;
 }

--- a/packages/odata-service/src/v4/EntitySetServiceV4.ts
+++ b/packages/odata-service/src/v4/EntitySetServiceV4.ts
@@ -91,7 +91,7 @@ export abstract class EntitySetServiceV4<
    * @return
    */
   public async create<ReturnType extends Partial<T> | void = T>(
-    model: ODataModelPayloadV4<EditableT>,
+    model: EditableT,
     requestConfig?: ODataHttpClientConfig<ClientType>,
   ): ODataResponse<ReturnType> {
     const { client, qModel, path, getDefaultHeaders, qResponseType } = this.__base;

--- a/packages/odata2ts/src/generator/import/ImportObjects.ts
+++ b/packages/odata2ts/src/generator/import/ImportObjects.ts
@@ -35,6 +35,7 @@ export const VERSIONED_CORE_IMPORTS = [
  */
 export enum QueryObjectImports {
   QueryObject = "QueryObject",
+  ENUMERABLE_PROP_DEFINITION = "ENUMERABLE_PROP_DEFINITION",
   QId = "QId",
   QFunction = "QFunction",
   QAction = "QAction",

--- a/packages/odata2ts/test/fixture/generator/qobject/abstract-with-inheritance.ts
+++ b/packages/odata2ts/test/fixture/generator/qobject/abstract-with-inheritance.ts
@@ -1,4 +1,10 @@
-import { QBooleanParam, QBooleanPath, QId, QueryObject } from "@odata2ts/odata-query-objects";
+import {
+  ENUMERABLE_PROP_DEFINITION,
+  QBooleanParam,
+  QBooleanPath,
+  QId,
+  QueryObject,
+} from "@odata2ts/odata-query-objects";
 // @ts-ignore
 import type { BookId, WithOwnStuffId } from "./TesterModel";
 
@@ -8,6 +14,11 @@ export class QBookBaseType extends QueryObject {
 }
 
 export class QBook extends QBookBaseType {
+  protected readonly __subtypeMapping = {
+    "Tester.NothingToAdd": "QNothingToAdd",
+    "Tester.WithOwnStuff": "QWithOwnStuff",
+  };
+
   public get QWithOwnStuff_id2() {
     return this.__asQWithOwnStuff().id2;
   }
@@ -24,6 +35,10 @@ export class QBook extends QBookBaseType {
     return new QWithOwnStuff(this.withPrefix("Tester.WithOwnStuff"));
   }
 }
+Object.defineProperties(QBook.prototype, {
+  QWithOwnStuff_id2: ENUMERABLE_PROP_DEFINITION,
+  QWithOwnStuff_test2: ENUMERABLE_PROP_DEFINITION,
+});
 
 export const qBook = new QBook();
 

--- a/packages/odata2ts/test/fixture/generator/qobject/abstract.ts
+++ b/packages/odata2ts/test/fixture/generator/qobject/abstract.ts
@@ -1,10 +1,18 @@
-import { QBooleanParam, QBooleanPath, QId, QueryObject } from "@odata2ts/odata-query-objects";
+import {
+  ENUMERABLE_PROP_DEFINITION,
+  QBooleanParam,
+  QBooleanPath,
+  QId,
+  QueryObject,
+} from "@odata2ts/odata-query-objects";
 // @ts-ignore
 import type { ExtendsFromEntityId } from "./TesterModel";
 
 export class QBookBaseType extends QueryObject {}
 
 export class QBook extends QBookBaseType {
+  protected readonly __subtypeMapping = { "Tester.ExtendsFromEntity": "QExtendsFromEntity" };
+
   public get QExtendsFromEntity_id() {
     return this.__asQExtendsFromEntity().id;
   }
@@ -13,6 +21,7 @@ export class QBook extends QBookBaseType {
     return new QExtendsFromEntity(this.withPrefix("Tester.ExtendsFromEntity"));
   }
 }
+Object.defineProperties(QBook.prototype, { QExtendsFromEntity_id: ENUMERABLE_PROP_DEFINITION });
 
 export const qBook = new QBook();
 
@@ -33,6 +42,8 @@ export class QExtendsFromEntityId extends QId<ExtendsFromEntityId> {
 export class QComplexBaseType extends QueryObject {}
 
 export class QComplex extends QComplexBaseType {
+  protected readonly __subtypeMapping = { "Tester.ExtendsFromComplex": "QExtendsFromComplex" };
+
   public get QExtendsFromComplex_test() {
     return this.__asQExtendsFromComplex().test;
   }
@@ -41,6 +52,7 @@ export class QComplex extends QComplexBaseType {
     return new QExtendsFromComplex(this.withPrefix("Tester.ExtendsFromComplex"));
   }
 }
+Object.defineProperties(QComplex.prototype, { QExtendsFromComplex_test: ENUMERABLE_PROP_DEFINITION });
 
 export const qComplex = new QComplex();
 

--- a/packages/odata2ts/test/fixture/generator/qobject/entity-hierarchy.ts
+++ b/packages/odata2ts/test/fixture/generator/qobject/entity-hierarchy.ts
@@ -1,4 +1,10 @@
-import { QBooleanParam, QBooleanPath, QId, QueryObject } from "@odata2ts/odata-query-objects";
+import {
+  ENUMERABLE_PROP_DEFINITION,
+  QBooleanParam,
+  QBooleanPath,
+  QId,
+  QueryObject,
+} from "@odata2ts/odata-query-objects";
 // @ts-ignore
 import type { ChildId, GrandParentId } from "./TesterModel";
 
@@ -7,6 +13,8 @@ export class QGrandParentBaseType extends QueryObject {
 }
 
 export class QGrandParent extends QGrandParentBaseType {
+  protected readonly __subtypeMapping = { "Tester.Parent": "QParent", "Tester.Child": "QChild" };
+
   public get QParent_parentalAdvice() {
     return this.__asQParent().parentalAdvice;
   }
@@ -27,6 +35,11 @@ export class QGrandParent extends QGrandParentBaseType {
     return new QChild(this.withPrefix("Tester.Child"));
   }
 }
+Object.defineProperties(QGrandParent.prototype, {
+  QParent_parentalAdvice: ENUMERABLE_PROP_DEFINITION,
+  QChild_id2: ENUMERABLE_PROP_DEFINITION,
+  QChild_ch1ld1shF4n: ENUMERABLE_PROP_DEFINITION,
+});
 
 export const qGrandParent = new QGrandParent();
 
@@ -43,6 +56,8 @@ export class QParentBaseType extends QGrandParentBaseType {
 }
 
 export class QParent extends QParentBaseType {
+  protected readonly __subtypeMapping = { "Tester.Child": "QChild" };
+
   public get QChild_id2() {
     return this.__asQChild().id2;
   }
@@ -55,6 +70,10 @@ export class QParent extends QParentBaseType {
     return new QChild(this.withPrefix("Tester.Child"));
   }
 }
+Object.defineProperties(QParent.prototype, {
+  QChild_id2: ENUMERABLE_PROP_DEFINITION,
+  QChild_ch1ld1shF4n: ENUMERABLE_PROP_DEFINITION,
+});
 
 export const qParent = new QParent();
 

--- a/packages/odata2ts/test/fixture/generator/qobject/model-naming-min.ts
+++ b/packages/odata2ts/test/fixture/generator/qobject/model-naming-min.ts
@@ -1,4 +1,12 @@
-import { QBooleanParam, QBooleanPath, QEntityPath, QEnumPath, QId, QueryObject } from "@odata2ts/odata-query-objects";
+import {
+  ENUMERABLE_PROP_DEFINITION,
+  QBooleanParam,
+  QBooleanPath,
+  QEntityPath,
+  QEnumPath,
+  QId,
+  QueryObject,
+} from "@odata2ts/odata-query-objects";
 // @ts-ignore
 import type { BookId, parentId } from "./TesterModel";
 // @ts-ignore
@@ -9,6 +17,8 @@ export class parentBaseType extends QueryObject {
 }
 
 export class Qparent extends parentBaseType {
+  protected readonly __subtypeMapping = { "Tester.Book": "QBook" };
+
   public get QBook_id() {
     return this.__asQBook().id;
   }
@@ -25,6 +35,11 @@ export class Qparent extends parentBaseType {
     return new QBook(this.withPrefix("Tester.Book"));
   }
 }
+Object.defineProperties(Qparent.prototype, {
+  QBook_id: ENUMERABLE_PROP_DEFINITION,
+  QBook_my_Choice: ENUMERABLE_PROP_DEFINITION,
+  QBook_Address: ENUMERABLE_PROP_DEFINITION,
+});
 
 export const qparent = new Qparent();
 

--- a/packages/odata2ts/test/fixture/generator/qobject/model-naming.ts
+++ b/packages/odata2ts/test/fixture/generator/qobject/model-naming.ts
@@ -1,4 +1,12 @@
-import { QBooleanParam, QBooleanPath, QEntityPath, QEnumPath, QId, QueryObject } from "@odata2ts/odata-query-objects";
+import {
+  ENUMERABLE_PROP_DEFINITION,
+  QBooleanParam,
+  QBooleanPath,
+  QEntityPath,
+  QEnumPath,
+  QId,
+  QueryObject,
+} from "@odata2ts/odata-query-objects";
 // @ts-ignore
 import type { BOOK_KEY, PARENT_KEY } from "./TesterModel";
 // @ts-ignore
@@ -9,6 +17,8 @@ export class PARENT_BASE_TYPE_Q_OBJ extends QueryObject {
 }
 
 export class PARENT_Q_OBJ extends PARENT_BASE_TYPE_Q_OBJ {
+  protected readonly __subtypeMapping = { "Tester.Book": "BOOK_Q_OBJ" };
+
   public get BOOK_Q_OBJ_ID() {
     return this.__asBOOK_Q_OBJ().ID;
   }
@@ -25,6 +35,11 @@ export class PARENT_Q_OBJ extends PARENT_BASE_TYPE_Q_OBJ {
     return new BOOK_Q_OBJ(this.withPrefix("Tester.Book"));
   }
 }
+Object.defineProperties(PARENT_Q_OBJ.prototype, {
+  BOOK_Q_OBJ_ID: ENUMERABLE_PROP_DEFINITION,
+  BOOK_Q_OBJ_MY_CHOICE: ENUMERABLE_PROP_DEFINITION,
+  BOOK_Q_OBJ_ADDRESS: ENUMERABLE_PROP_DEFINITION,
+});
 
 export const pARENT_Q_OBJ = new PARENT_Q_OBJ();
 

--- a/test/v4/trippinRw.http
+++ b/test/v4/trippinRw.http
@@ -22,3 +22,27 @@ GET {{baseUrl}}/People('russellwhyte')/Trips(0)?$expand=PlanItems($expand=Micros
 
 ### filter on casted prop of subtype
 GET {{baseUrl}}/People('russellwhyte')/Trips(0)/PlanItems?$filter=Microsoft.OData.SampleService.Models.TripPin.Flight/FlightNumber eq 'AA26'
+
+### create derived entity type
+POST {{baseUrl}}/People('russellwhyte')/Trips(0)/PlanItems
+Content-Type: application/json
+Accept: application/json
+
+{
+  "@odata.type": "#Microsoft.OData.SampleService.Models.TripPin.Event",
+  "PlanItemId": 33,
+  "ConfirmationCode": "4372899DD",
+  "Description": "Client Meeting",
+  "Duration": "PT3H",
+  "StartsAt": "2014-05-25T23:11:17.5459178-07:00",
+  "EndsAt": "2014-06-01T23:11:17.5479185-07:00",
+  "OccursAt": {
+    "Address": "100 Church Street, 8th Floor, Manhattan, 10007",
+    "BuildingInfo": "Regus Business Center",
+    "City": {
+      "CountryRegion": "United States",
+      "Name": "New York City",
+      "Region": "New York"
+    }
+  }
+}


### PR DESCRIPTION
With this the Q-object representing any base type, will handle subtype conversion properly when supplied with the correct control information, i.e. "@odata.type".