### PR TITLE
feat(service): subtype services

### DIFF
--- a/examples/main/int-test/trippin/TrippinRwIntegration.test.ts
+++ b/examples/main/int-test/trippin/TrippinRwIntegration.test.ts
@@ -1,12 +1,11 @@
-import { AxiosClient } from "@odata2ts/http-client-axios";
+import { FetchClient } from "@odata2ts/http-client-fetch";
 import { describe, expect, test } from "vitest";
-import { EditablePlanItemModel, PlanItemModel } from "../../build/trippin-rw/TrippinRwModel";
 import { TrippinRwService } from "../../build/trippin-rw/TrippinRwService";
 import { EditableEventModel } from "../../build/trippin/TrippinModel";
 
 describe("Integration Testing of Service Generation", () => {
   const BASE_URL = "https://services.odata.org/V4/(S(xjqbds2oavibr01gt1fny24s))/TripPinServiceRW";
-  const odataClient = new AxiosClient();
+  const odataClient = new FetchClient();
 
   const trippinService = new TrippinRwService(odataClient, BASE_URL);
 

--- a/examples/main/int-test/trippin/TrippinRwIntegration.test.ts
+++ b/examples/main/int-test/trippin/TrippinRwIntegration.test.ts
@@ -43,8 +43,7 @@ describe("Integration Testing of Service Generation", () => {
   });
 
   test("create derived entity", async () => {
-    const model: EditableEventModel = {
-      // @ts-ignore
+    const model: EditableEventModel & { "@odata.type"?: string } = {
       "@odata.type": "#Microsoft.OData.SampleService.Models.TripPin.Event",
       planItemId: 33,
       confirmationCode: "4372899DD",
@@ -63,11 +62,7 @@ describe("Integration Testing of Service Generation", () => {
       },
     };
     const response = await trippinService.people("russellwhyte").trips(0).planItems().create(model);
-    const {
-      //@ts-ignore
-      "@odata.context": ctxt,
-      ...data
-    } = response.data;
+    const { "@odata.context": ctxt, ...data } = response.data;
 
     expect(data).toStrictEqual(model);
   });

--- a/examples/main/odata2ts.config.ts
+++ b/examples/main/odata2ts.config.ts
@@ -49,8 +49,6 @@ const config: ConfigFileOptions = {
       // TrippinService does not generate IDs on the server, but the client side => demo service
       disableAutoManagedKey: true,
       allowRenaming: true,
-      // for the fun of it
-      enablePrimitivePropertyServices: true,
       naming: {
         models: {
           suffix: "Model",

--- a/examples/main/package.json
+++ b/examples/main/package.json
@@ -21,6 +21,7 @@
     "@odata2ts/converter-luxon": "^0.2.3",
     "@odata2ts/converter-v2-to-v4": "^0.5.3",
     "@odata2ts/http-client-axios": "^0.11.3",
+    "@odata2ts/http-client-fetch": "^0.8.0",
     "@odata2ts/odata-service": "^0.21.0",
     "axios": "^1.7.3",
     "bignumber.js": "^9.1.2",

--- a/packages/odata-service/src/ODataServiceOptions.ts
+++ b/packages/odata-service/src/ODataServiceOptions.ts
@@ -7,12 +7,14 @@ export interface ODataServiceOptions {
   noUrlEncoding?: boolean;
 }
 
-/**
- * Extra interface for the bigNumbersAsString option.
- * On the one hand it is only needed for v4. On the other hand this must be set internally
- * as it plays together with converters, which are handled by the generator, not at runtime.
- */
 export interface ODataServiceOptionsInternal extends ODataServiceOptions {
+  /**
+   * On the one hand it is only needed for v4. On the other hand this must be set internally
+   * as it plays together with converters, which are handled by the generator, not at runtime.
+   */
   bigNumbersAsString?: boolean;
+  /**
+   * Marks service as subtype service.
+   */
   subtype?: boolean;
 }

--- a/packages/odata-service/src/ServiceStateHelper.ts
+++ b/packages/odata-service/src/ServiceStateHelper.ts
@@ -7,7 +7,7 @@ export class ServiceStateHelper<out ClientType extends ODataHttpClient> {
 
   public constructor(
     public readonly client: ClientType,
-    basePath: string,
+    public basePath: string,
     public name?: string,
     public options: ODataServiceOptionsInternal = {},
   ) {

--- a/packages/odata-service/src/v4/EntitySetServiceV4.ts
+++ b/packages/odata-service/src/v4/EntitySetServiceV4.ts
@@ -8,7 +8,7 @@ import {
   QueryObjectModel,
 } from "@odata2ts/odata-query-objects";
 import { ODataServiceOptionsInternal } from "../ODataServiceOptions";
-import { ServiceStateHelperV4 } from "./ServiceStateHelperV4.js";
+import { ServiceStateHelperV4, SubtypeOptions } from "./ServiceStateHelperV4.js";
 
 export abstract class EntitySetServiceV4<
   in out ClientType extends ODataHttpClient,
@@ -88,17 +88,20 @@ export abstract class EntitySetServiceV4<
    *
    * @param model
    * @param requestConfig
+   * @param createOptions
    * @return
    */
   public async create<ReturnType extends Partial<T> | void = T>(
-    model: EditableT,
+    model: ODataModelPayloadV4<EditableT>,
     requestConfig?: ODataHttpClientConfig<ClientType>,
-  ): ODataResponse<ReturnType> {
-    const { client, qModel, path, getDefaultHeaders, qResponseType } = this.__base;
+    createOptions?: SubtypeOptions,
+  ): ODataResponse<ODataModelResponseV4<ReturnType>> {
+    const { client, qModel, basePath, path, getDefaultHeaders, qResponseType } = this.__base;
+    const { dontUseCastPathSegment, useTypeCi } = this.__base.evaluateSubtypeOptions(createOptions);
 
     const result = await client.post<ODataModelResponseV4<T> | void>(
-      path,
-      qModel.convertToOData(model),
+      dontUseCastPathSegment ? basePath : path,
+      qModel.convertToOData(useTypeCi ? this.__base.addTypeControlInfo(model) : model),
       requestConfig,
       getDefaultHeaders(),
     );

--- a/packages/odata-service/src/v4/EntityTypeServiceV4.ts
+++ b/packages/odata-service/src/v4/EntityTypeServiceV4.ts
@@ -3,7 +3,7 @@ import { ODataModelPayloadV4, ODataModelResponseV4 } from "@odata2ts/odata-core"
 import { ODataQueryBuilderV4 } from "@odata2ts/odata-query-builder";
 import { convertV4ModelResponse, QueryObjectModel } from "@odata2ts/odata-query-objects";
 import { ODataServiceOptionsInternal } from "../ODataServiceOptions";
-import { ServiceStateHelperV4 } from "./ServiceStateHelperV4.js";
+import { ServiceStateHelperV4, SubtypeOptions } from "./ServiceStateHelperV4.js";
 
 export class EntityTypeServiceV4<in out ClientType extends ODataHttpClient, T, EditableT, Q extends QueryObjectModel> {
   protected readonly __base: ServiceStateHelperV4<ClientType, Q>;
@@ -25,12 +25,14 @@ export class EntityTypeServiceV4<in out ClientType extends ODataHttpClient, T, E
   public async patch(
     model: ODataModelPayloadV4<Partial<EditableT>>,
     requestConfig?: ODataHttpClientConfig<ClientType>,
+    patchOptions?: SubtypeOptions,
   ): ODataResponse<void | ODataModelResponseV4<T>> {
-    const { client, qModel, path, getDefaultHeaders, qResponseType } = this.__base;
+    const { client, qModel, basePath, path, getDefaultHeaders, qResponseType } = this.__base;
+    const { dontUseCastPathSegment, useTypeCi } = this.__base.evaluateSubtypeOptions(patchOptions);
 
     const result = await client.patch<void | ODataModelResponseV4<T>>(
-      path,
-      qModel.convertToOData(model),
+      dontUseCastPathSegment ? basePath : path,
+      qModel.convertToOData(useTypeCi ? this.__base.addTypeControlInfo(model) : model),
       requestConfig,
       getDefaultHeaders(),
     );
@@ -40,12 +42,14 @@ export class EntityTypeServiceV4<in out ClientType extends ODataHttpClient, T, E
   public async update(
     model: ODataModelPayloadV4<EditableT>,
     requestConfig?: ODataHttpClientConfig<ClientType>,
+    updateOptions?: SubtypeOptions,
   ): ODataResponse<void | ODataModelResponseV4<T>> {
-    const { client, qModel, path, getDefaultHeaders, qResponseType } = this.__base;
+    const { client, qModel, basePath, path, getDefaultHeaders, qResponseType } = this.__base;
+    const { dontUseCastPathSegment, useTypeCi } = this.__base.evaluateSubtypeOptions(updateOptions);
 
     const result = await client.put<void | ODataModelResponseV4<T>>(
-      path,
-      qModel.convertToOData(model),
+      dontUseCastPathSegment ? basePath : path,
+      qModel.convertToOData(useTypeCi ? this.__base.addTypeControlInfo(model) : model),
       requestConfig,
       getDefaultHeaders(),
     );

--- a/packages/odata-service/src/v4/ServiceStateHelperV4.ts
+++ b/packages/odata-service/src/v4/ServiceStateHelperV4.ts
@@ -1,8 +1,14 @@
 import { ODataHttpClient } from "@odata2ts/http-client-api";
+import { ODataModelPayloadV4 } from "@odata2ts/odata-core";
 import { createQueryBuilderV4, ODataQueryBuilderV4 } from "@odata2ts/odata-query-builder";
 import { QComplexParam, QueryObjectModel } from "@odata2ts/odata-query-objects";
 import { ODataServiceOptionsInternal } from "../ODataServiceOptions";
 import { ServiceStateHelper } from "../ServiceStateHelper.js";
+
+export interface SubtypeOptions {
+  withCastPathSegment?: boolean;
+  withTypeControlInfo?: boolean;
+}
 
 export class ServiceStateHelperV4<
   in out ClientType extends ODataHttpClient,
@@ -30,4 +36,22 @@ export class ServiceStateHelperV4<
 
     return this.path;
   };
+
+  public evaluateSubtypeOptions(options: SubtypeOptions | undefined) {
+    const isSubtype = !!this.options.subtype;
+    const dontUseCastPathSegment = isSubtype && !options?.withCastPathSegment;
+    return {
+      dontUseCastPathSegment,
+      useTypeCi:
+        (isSubtype && dontUseCastPathSegment && options?.withTypeControlInfo !== false) ||
+        (isSubtype && options?.withTypeControlInfo),
+    };
+  }
+
+  public addTypeControlInfo<T>(model: ODataModelPayloadV4<T>) {
+    return {
+      "@odata.type": `#${this.name}`,
+      ...model,
+    };
+  }
 }

--- a/packages/odata-service/test/fixture/v4/BaseTypeModel.ts
+++ b/packages/odata-service/test/fixture/v4/BaseTypeModel.ts
@@ -1,0 +1,177 @@
+import { ODataHttpClient } from "@odata2ts/http-client-api";
+import {
+  ENUMERABLE_PROP_DEFINITION,
+  QId,
+  QNumberParam,
+  QNumberPath,
+  QStringPath,
+  QueryObject,
+} from "@odata2ts/odata-query-objects";
+import { EntitySetServiceV4, EntityTypeServiceV4, ODataServiceOptionsInternal } from "../../../src";
+
+export interface PlanItemModel {
+  "@odata.type"?: "#Tester.PlanItem" | "#Tester.Event" | "#Tester.Flight";
+  id: number;
+  name: string | null;
+}
+
+export interface EditablePlanItemModel
+  extends Pick<PlanItemModel, "id" | "@odata.type">,
+    Partial<Pick<PlanItemModel, "name">> {}
+
+export type PlanItemIdModel = string | { id: number };
+
+export interface EventModel extends PlanItemModel {
+  "@odata.type"?: "#Tester.Event";
+  description: string | null;
+}
+
+export interface EditableEventModel
+  extends Pick<EventModel, "id" | "@odata.type">,
+    Partial<Pick<EventModel, "name" | "description">> {}
+
+export interface FlightModel extends PlanItemModel {
+  "@odata.type"?: "#Tester.Flight";
+  flightNumber: string;
+}
+
+export interface EditableFlightModel
+  extends Pick<FlightModel, "id" | "@odata.type" | "flightNumber">,
+    Partial<Pick<EventModel, "name">> {}
+
+export class QPlanItemBaseType<Model extends PlanItemModel> extends QueryObject<Model> {
+  public readonly id = new QNumberPath(this.withPrefix("Id"));
+  public readonly name = new QStringPath(this.withPrefix("Name"));
+}
+
+export class QPlanItem extends QPlanItemBaseType<PlanItemModel> {
+  protected readonly __subtypeMapping = { "Tester.Event": "QEvent", "Tester.Flight": "QFlight" };
+
+  protected get __asQEvent() {
+    return new QEvent(this.withPrefix("Tester.Event"));
+  }
+
+  protected get __asQFlight() {
+    return new QFlight(this.withPrefix("Tester.Flight"));
+  }
+
+  public get QEvent_description() {
+    return this.__asQEvent.description;
+  }
+
+  public get QFlight_flightNumber() {
+    return this.__asQFlight.flightNumber;
+  }
+}
+
+Object.defineProperties(QPlanItem.prototype, {
+  QEvent_description: ENUMERABLE_PROP_DEFINITION,
+  QFlight_flightNumber: ENUMERABLE_PROP_DEFINITION,
+});
+
+export class QPlanItemId extends QId<PlanItemIdModel> {
+  getParams() {
+    return [new QNumberParam("Id", "id")];
+  }
+}
+
+export class QEvent extends QPlanItemBaseType<EventModel> {
+  public readonly description = new QStringPath(this.withPrefix("Description"));
+}
+
+export class QFlight extends QPlanItemBaseType<FlightModel> {
+  public readonly flightNumber = new QStringPath(this.withPrefix("FlightNumber"));
+}
+
+export class PlanItemService<ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
+  ClientType,
+  PlanItemModel,
+  EditablePlanItemModel,
+  QPlanItem
+> {
+  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal) {
+    super(client, basePath, name, new QPlanItem(), options);
+  }
+
+  public asFlightService() {
+    const { client, path, options } = this.__base;
+    options.subtype = true;
+    return new FlightService(client, path, "Tester.Flight", options);
+  }
+
+  public asEventService() {
+    const { client, path, options } = this.__base;
+    options.subtype = true;
+    return new EventService(client, path, "Tester.Event", options);
+  }
+}
+
+export class PlanItemCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV4<
+  ClientType,
+  PlanItemModel,
+  EditablePlanItemModel,
+  QPlanItem,
+  PlanItemIdModel
+> {
+  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal) {
+    super(client, basePath, name, new QPlanItem(), new QPlanItemId(name), options);
+  }
+
+  public asFlightCollectionService() {
+    const { client, path, options } = this.__base;
+    options.subtype = true;
+    return new FlightCollectionService(client, path, "Tester.Flight", options);
+  }
+
+  public asEventCollectionService() {
+    const { client, path, options } = this.__base;
+    options.subtype = true;
+    return new EventCollectionService(client, path, "Tester.Event", options);
+  }
+}
+
+export class FlightService<ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
+  ClientType,
+  FlightModel,
+  EditableFlightModel,
+  QFlight
+> {
+  constructor(client: ClientType, basePath: string, name: string, options: ODataServiceOptionsInternal) {
+    super(client, basePath, name, new QFlight(), options);
+  }
+}
+
+export class FlightCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV4<
+  ClientType,
+  FlightModel,
+  EditableFlightModel,
+  QFlight,
+  PlanItemIdModel
+> {
+  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal) {
+    super(client, basePath, name, new QFlight(), new QPlanItemId(name), options);
+  }
+}
+
+export class EventService<ClientType extends ODataHttpClient> extends EntityTypeServiceV4<
+  ClientType,
+  EventModel,
+  EditableEventModel,
+  QEvent
+> {
+  constructor(client: ClientType, basePath: string, name: string, options: ODataServiceOptionsInternal) {
+    super(client, basePath, name, new QEvent(), options);
+  }
+}
+
+export class EventCollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV4<
+  ClientType,
+  EventModel,
+  EditableEventModel,
+  QEvent,
+  PlanItemIdModel
+> {
+  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal) {
+    super(client, basePath, name, new QEvent(), new QPlanItemId(name), options);
+  }
+}

--- a/packages/odata-service/test/v4/EntityTypeServiceV4.test.ts
+++ b/packages/odata-service/test/v4/EntityTypeServiceV4.test.ts
@@ -5,8 +5,9 @@ import { beforeEach, describe, expect, test } from "vitest";
 import { DEFAULT_HEADERS } from "../../src";
 import { commonEntityTypeServiceTests } from "../EntityTypeServiceTests";
 import { PersonModel } from "../fixture/PersonModel";
+import { EditableFlightModel, PlanItemService } from "../fixture/v4/BaseTypeModel";
 import { PersonModelService } from "../fixture/v4/PersonModelService";
-import { QPersonV4, qPersonV4 } from "../fixture/v4/QPersonV4";
+import { QPersonV4 } from "../fixture/v4/QPersonV4";
 import { MockClient } from "../mock/MockClient";
 
 describe("EntityTypeService V4 Tests", () => {
@@ -26,9 +27,9 @@ describe("EntityTypeService V4 Tests", () => {
 
   test("entityType V4: patch", async () => {
     const model: Partial<PersonModel> = { Age: "45" };
-    const requestModel = { Age: 45, "@odata.type": `#Trippin.Person` };
+    const requestModel = { Age: 45 };
 
-    await testService.patch({ ...model, "@odata.type": `#Trippin.Person` });
+    await testService.patch(model);
 
     expect(odataClient.lastUrl).toBe(EXPECTED_PATH);
     expect(odataClient.lastOperation).toBe("PATCH");
@@ -38,6 +39,82 @@ describe("EntityTypeService V4 Tests", () => {
 
     await testService.patch(model, REQUEST_CONFIG);
     expect(odataClient.lastRequestConfig).toStrictEqual(REQUEST_CONFIG);
+
+    // subtype options won't take effect
+    await testService.patch(model, REQUEST_CONFIG, { withCastPathSegment: true, withTypeControlInfo: true });
+    expect(odataClient.lastUrl).toBe(EXPECTED_PATH);
+    expect(odataClient.lastData).toEqual(requestModel);
+  });
+
+  test("entityType V4: patch & update subtype", async () => {
+    const serviceToTest = new PlanItemService(odataClient, BASE_URL, NAME).asFlightService();
+    const inputModel: EditableFlightModel = {
+      id: 123,
+      name: "Optional",
+      flightNumber: "F123",
+    };
+    const expectedModel = { ...inputModel, "@odata.type": "#Tester.Flight" };
+    const odataModel = {
+      "@odata.type": "#Tester.Flight",
+      Id: inputModel.id,
+      Name: inputModel.name,
+      FlightNumber: inputModel.flightNumber,
+    };
+
+    // patch
+    odataClient.setModelResponse(odataModel);
+    let result = await serviceToTest.patch(inputModel);
+    expect(odataClient.lastUrl).toBe(EXPECTED_PATH);
+    expect(odataClient.lastOperation).toBe("PATCH");
+    expect(odataClient.lastData).toEqual(odataModel);
+    expect(result.data).toStrictEqual(expectedModel);
+
+    // update
+    odataClient.setModelResponse(odataModel);
+    result = await serviceToTest.update(inputModel);
+    expect(odataClient.lastUrl).toBe(EXPECTED_PATH);
+    expect(odataClient.lastOperation).toBe("PUT");
+    expect(odataClient.lastData).toEqual(odataModel);
+    expect(result.data).toStrictEqual(expectedModel);
+  });
+
+  test("entityType V4: patch & update subtype with options", async () => {
+    const serviceToTest = new PlanItemService(odataClient, BASE_URL, NAME).asFlightService();
+    const inputModel: EditableFlightModel = {
+      id: 123,
+      name: "Optional",
+      flightNumber: "F123",
+    };
+    const odataModel = {
+      Id: inputModel.id,
+      Name: inputModel.name,
+      FlightNumber: inputModel.flightNumber,
+    };
+    const odataModelWithType = { ...odataModel, "@odata.type": "#Tester.Flight" };
+
+    await serviceToTest.patch(inputModel, undefined, { withTypeControlInfo: false });
+    expect(odataClient.lastUrl).toBe(EXPECTED_PATH);
+    expect(odataClient.lastData).toEqual(odataModel);
+
+    await serviceToTest.update(inputModel, undefined, { withTypeControlInfo: false });
+    expect(odataClient.lastUrl).toBe(EXPECTED_PATH);
+    expect(odataClient.lastData).toEqual(odataModel);
+
+    await serviceToTest.patch(inputModel, undefined, { withCastPathSegment: true });
+    expect(odataClient.lastUrl).toBe(EXPECTED_PATH + "/Tester.Flight");
+    expect(odataClient.lastData).toEqual(odataModel);
+
+    await serviceToTest.update(inputModel, undefined, { withCastPathSegment: true });
+    expect(odataClient.lastUrl).toBe(EXPECTED_PATH + "/Tester.Flight");
+    expect(odataClient.lastData).toEqual(odataModel);
+
+    await serviceToTest.patch(inputModel, undefined, { withCastPathSegment: true, withTypeControlInfo: true });
+    expect(odataClient.lastUrl).toBe(EXPECTED_PATH + "/Tester.Flight");
+    expect(odataClient.lastData).toEqual(odataModelWithType);
+
+    await serviceToTest.update(inputModel, undefined, { withCastPathSegment: true, withTypeControlInfo: true });
+    expect(odataClient.lastUrl).toBe(EXPECTED_PATH + "/Tester.Flight");
+    expect(odataClient.lastData).toEqual(odataModelWithType);
   });
 
   test("entityType V4: big number", async () => {

--- a/packages/odata2ts/src/generator/ServiceGenerator.ts
+++ b/packages/odata2ts/src/generator/ServiceGenerator.ts
@@ -665,20 +665,21 @@ class ServiceGenerator {
   ): PropsAndOps {
     const result: PropsAndOps = { properties: [], methods: [] };
 
-    model.subtypes.forEach((subtype) => {
-      const subClass = this.dataModel.getModel(subtype) as ComplexType;
-      const serviceName = isCollection ? subClass.serviceCollectionName : subClass.serviceName;
-      const serviceType = importContainer.addGeneratedService(subClass.fqName, serviceName);
-      result.methods.push({
-        name: `as${upperCaseFirst(serviceName)}`,
-        scope: Scope.Public,
-        statements: [
-          "const { client, path, options } = this.__base;",
-          "options.subtype = true;",
-          `return new ${serviceType}(client, path, "${subClass.fqName}", options);`,
-        ],
+    if (this.version === ODataVersions.V4) {
+      model.subtypes.forEach((subtype) => {
+        const subClass = this.dataModel.getModel(subtype) as ComplexType;
+        const serviceName = isCollection ? subClass.serviceCollectionName : subClass.serviceName;
+        const serviceType = importContainer.addGeneratedService(subClass.fqName, serviceName);
+        result.methods.push({
+          name: `as${upperCaseFirst(serviceName)}`,
+          scope: Scope.Public,
+          statements: [
+            "const { client, path, options } = this.__base;",
+            `return new ${serviceType}(client, path, "${subClass.fqName}", { ...options, subtype: true });`,
+          ],
+        });
       });
-    });
+    }
 
     return result;
   }

--- a/packages/odata2ts/src/generator/ServiceGenerator.ts
+++ b/packages/odata2ts/src/generator/ServiceGenerator.ts
@@ -674,6 +674,7 @@ class ServiceGenerator {
         scope: Scope.Public,
         statements: [
           "const { client, path, options } = this.__base;",
+          "options.subtype = true;",
           `return new ${serviceType}(client, path, "${subClass.fqName}", options);`,
         ],
       });

--- a/packages/odata2ts/test/fixture/generator/service/v2/abstract-and-open-types.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/abstract-and-open-types.ts
@@ -69,16 +69,19 @@ export class AbstractEntityService<in out ClientType extends ODataHttpClient> ex
 
   public asOpenEntityService() {
     const { client, path, options } = this.__base;
+    options.subtype = true;
     return new OpenEntityService(client, path, "Tester.OpenEntity", options);
   }
 
   public asExtendedFromAbstractService() {
     const { client, path, options } = this.__base;
+    options.subtype = true;
     return new ExtendedFromAbstractService(client, path, "Tester.ExtendedFromAbstract", options);
   }
 
   public asExtendedFromOpenService() {
     const { client, path, options } = this.__base;
+    options.subtype = true;
     return new ExtendedFromOpenService(client, path, "Tester.ExtendedFromOpen", options);
   }
 }
@@ -95,6 +98,7 @@ export class OpenEntityService<in out ClientType extends ODataHttpClient> extend
 
   public asExtendedFromOpenService() {
     const { client, path, options } = this.__base;
+    options.subtype = true;
     return new ExtendedFromOpenService(client, path, "Tester.ExtendedFromOpen", options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v2/abstract-and-open-types.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/abstract-and-open-types.ts
@@ -66,24 +66,6 @@ export class AbstractEntityService<in out ClientType extends ODataHttpClient> ex
   constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qAbstractEntity, options);
   }
-
-  public asOpenEntityService() {
-    const { client, path, options } = this.__base;
-    options.subtype = true;
-    return new OpenEntityService(client, path, "Tester.OpenEntity", options);
-  }
-
-  public asExtendedFromAbstractService() {
-    const { client, path, options } = this.__base;
-    options.subtype = true;
-    return new ExtendedFromAbstractService(client, path, "Tester.ExtendedFromAbstract", options);
-  }
-
-  public asExtendedFromOpenService() {
-    const { client, path, options } = this.__base;
-    options.subtype = true;
-    return new ExtendedFromOpenService(client, path, "Tester.ExtendedFromOpen", options);
-  }
 }
 
 export class OpenEntityService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
@@ -94,12 +76,6 @@ export class OpenEntityService<in out ClientType extends ODataHttpClient> extend
 > {
   constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qOpenEntity, options);
-  }
-
-  public asExtendedFromOpenService() {
-    const { client, path, options } = this.__base;
-    options.subtype = true;
-    return new ExtendedFromOpenService(client, path, "Tester.ExtendedFromOpen", options);
   }
 }
 

--- a/packages/odata2ts/test/fixture/generator/service/v2/entity-hierarchy.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/entity-hierarchy.ts
@@ -40,11 +40,13 @@ export class GrandParentService<in out ClientType extends ODataHttpClient> exten
 
   public asParentService() {
     const { client, path, options } = this.__base;
+    options.subtype = true;
     return new ParentService(client, path, "Tester.Parent", options);
   }
 
   public asChildService() {
     const { client, path, options } = this.__base;
+    options.subtype = true;
     return new ChildService(client, path, "Tester.Child", options);
   }
 }
@@ -62,11 +64,13 @@ export class GrandParentCollectionService<in out ClientType extends ODataHttpCli
 
   public asParentCollectionService() {
     const { client, path, options } = this.__base;
+    options.subtype = true;
     return new ParentCollectionService(client, path, "Tester.Parent", options);
   }
 
   public asChildCollectionService() {
     const { client, path, options } = this.__base;
+    options.subtype = true;
     return new ChildCollectionService(client, path, "Tester.Child", options);
   }
 }
@@ -83,6 +87,7 @@ export class ParentService<in out ClientType extends ODataHttpClient> extends En
 
   public asChildService() {
     const { client, path, options } = this.__base;
+    options.subtype = true;
     return new ChildService(client, path, "Tester.Child", options);
   }
 }
@@ -100,6 +105,7 @@ export class ParentCollectionService<in out ClientType extends ODataHttpClient> 
 
   public asChildCollectionService() {
     const { client, path, options } = this.__base;
+    options.subtype = true;
     return new ChildCollectionService(client, path, "Tester.Child", options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v2/entity-hierarchy.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/entity-hierarchy.ts
@@ -37,18 +37,6 @@ export class GrandParentService<in out ClientType extends ODataHttpClient> exten
   constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qGrandParent, options);
   }
-
-  public asParentService() {
-    const { client, path, options } = this.__base;
-    options.subtype = true;
-    return new ParentService(client, path, "Tester.Parent", options);
-  }
-
-  public asChildService() {
-    const { client, path, options } = this.__base;
-    options.subtype = true;
-    return new ChildService(client, path, "Tester.Child", options);
-  }
 }
 
 export class GrandParentCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV2<
@@ -61,18 +49,6 @@ export class GrandParentCollectionService<in out ClientType extends ODataHttpCli
   constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qGrandParent, new QGrandParentId(name), options);
   }
-
-  public asParentCollectionService() {
-    const { client, path, options } = this.__base;
-    options.subtype = true;
-    return new ParentCollectionService(client, path, "Tester.Parent", options);
-  }
-
-  public asChildCollectionService() {
-    const { client, path, options } = this.__base;
-    options.subtype = true;
-    return new ChildCollectionService(client, path, "Tester.Child", options);
-  }
 }
 
 export class ParentService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
@@ -83,12 +59,6 @@ export class ParentService<in out ClientType extends ODataHttpClient> extends En
 > {
   constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qParent, options);
-  }
-
-  public asChildService() {
-    const { client, path, options } = this.__base;
-    options.subtype = true;
-    return new ChildService(client, path, "Tester.Child", options);
   }
 }
 
@@ -101,12 +71,6 @@ export class ParentCollectionService<in out ClientType extends ODataHttpClient> 
 > {
   constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qParent, new QGrandParentId(name), options);
-  }
-
-  public asChildCollectionService() {
-    const { client, path, options } = this.__base;
-    options.subtype = true;
-    return new ChildCollectionService(client, path, "Tester.Child", options);
   }
 }
 

--- a/packages/odata2ts/test/fixture/generator/service/v4/abstract-and-open-types.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/abstract-and-open-types.ts
@@ -74,16 +74,19 @@ export class AbstractEntityService<in out ClientType extends ODataHttpClient> ex
 
   public asOpenEntityService() {
     const { client, path, options } = this.__base;
+    options.subtype = true;
     return new OpenEntityService(client, path, "Tester.OpenEntity", options);
   }
 
   public asExtendedFromAbstractService() {
     const { client, path, options } = this.__base;
+    options.subtype = true;
     return new ExtendedFromAbstractService(client, path, "Tester.ExtendedFromAbstract", options);
   }
 
   public asExtendedFromOpenService() {
     const { client, path, options } = this.__base;
+    options.subtype = true;
     return new ExtendedFromOpenService(client, path, "Tester.ExtendedFromOpen", options);
   }
 }
@@ -100,6 +103,7 @@ export class OpenEntityService<in out ClientType extends ODataHttpClient> extend
 
   public asExtendedFromOpenService() {
     const { client, path, options } = this.__base;
+    options.subtype = true;
     return new ExtendedFromOpenService(client, path, "Tester.ExtendedFromOpen", options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/abstract-and-open-types.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/abstract-and-open-types.ts
@@ -74,20 +74,17 @@ export class AbstractEntityService<in out ClientType extends ODataHttpClient> ex
 
   public asOpenEntityService() {
     const { client, path, options } = this.__base;
-    options.subtype = true;
-    return new OpenEntityService(client, path, "Tester.OpenEntity", options);
+    return new OpenEntityService(client, path, "Tester.OpenEntity", { ...options, subtype: true });
   }
 
   public asExtendedFromAbstractService() {
     const { client, path, options } = this.__base;
-    options.subtype = true;
-    return new ExtendedFromAbstractService(client, path, "Tester.ExtendedFromAbstract", options);
+    return new ExtendedFromAbstractService(client, path, "Tester.ExtendedFromAbstract", { ...options, subtype: true });
   }
 
   public asExtendedFromOpenService() {
     const { client, path, options } = this.__base;
-    options.subtype = true;
-    return new ExtendedFromOpenService(client, path, "Tester.ExtendedFromOpen", options);
+    return new ExtendedFromOpenService(client, path, "Tester.ExtendedFromOpen", { ...options, subtype: true });
   }
 }
 
@@ -103,8 +100,7 @@ export class OpenEntityService<in out ClientType extends ODataHttpClient> extend
 
   public asExtendedFromOpenService() {
     const { client, path, options } = this.__base;
-    options.subtype = true;
-    return new ExtendedFromOpenService(client, path, "Tester.ExtendedFromOpen", options);
+    return new ExtendedFromOpenService(client, path, "Tester.ExtendedFromOpen", { ...options, subtype: true });
   }
 }
 

--- a/packages/odata2ts/test/fixture/generator/service/v4/abstract-with-inheritance.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/abstract-with-inheritance.ts
@@ -42,6 +42,7 @@ export class AbstractEntityService<in out ClientType extends ODataHttpClient> ex
 
   public asTestEntityService() {
     const { client, path, options } = this.__base;
+    options.subtype = true;
     return new TestEntityService(client, path, "Tester.TestEntity", options);
   }
 }
@@ -59,6 +60,7 @@ export class AbstractEntityCollectionService<in out ClientType extends ODataHttp
 
   public asTestEntityCollectionService() {
     const { client, path, options } = this.__base;
+    options.subtype = true;
     return new TestEntityCollectionService(client, path, "Tester.TestEntity", options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/abstract-with-inheritance.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/abstract-with-inheritance.ts
@@ -42,8 +42,7 @@ export class AbstractEntityService<in out ClientType extends ODataHttpClient> ex
 
   public asTestEntityService() {
     const { client, path, options } = this.__base;
-    options.subtype = true;
-    return new TestEntityService(client, path, "Tester.TestEntity", options);
+    return new TestEntityService(client, path, "Tester.TestEntity", { ...options, subtype: true });
   }
 }
 
@@ -60,8 +59,7 @@ export class AbstractEntityCollectionService<in out ClientType extends ODataHttp
 
   public asTestEntityCollectionService() {
     const { client, path, options } = this.__base;
-    options.subtype = true;
-    return new TestEntityCollectionService(client, path, "Tester.TestEntity", options);
+    return new TestEntityCollectionService(client, path, "Tester.TestEntity", { ...options, subtype: true });
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1220,6 +1220,7 @@ __metadata:
     "@odata2ts/converter-luxon": ^0.2.3
     "@odata2ts/converter-v2-to-v4": ^0.5.3
     "@odata2ts/http-client-axios": ^0.11.3
+    "@odata2ts/http-client-fetch": ^0.8.0
     "@odata2ts/odata-service": ^0.21.0
     "@odata2ts/odata2ts": ^0.38.1
     "@types/luxon": ^3.4.2
@@ -1253,6 +1254,15 @@ __metadata:
   dependencies:
     "@odata2ts/http-client-api": ^0.6.2
   checksum: 979a36f9022032914712342d7f16f079a1a6e4c048da6540c66a7f8ed5a33e5ad8647b0173d21631845e7d179cb93326b900accde9864eb9f90bf8a4ac32030e
+  languageName: node
+  linkType: hard
+
+"@odata2ts/http-client-fetch@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "@odata2ts/http-client-fetch@npm:0.8.0"
+  dependencies:
+    "@odata2ts/http-client-base": ^0.5.3
+  checksum: d9dfed350f3da1fd04a626ff1eb48931dc9e29f6734231008a5a93a61db54ef2037bcbcca9502c35dc9ff53db789098c2c652ca45f4f5815cba9defedbd6c02b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
For queries the cast path segment is added (as before), but for modifying actions (create, put, patch) the odata.type control info is added by default (can be configured).