### PR TITLE
fix(odata2ts): add Accept header for metadata downloads

### DIFF
--- a/packages/odata2ts/test/download/downloadMetadata.test.ts
+++ b/packages/odata2ts/test/download/downloadMetadata.test.ts
@@ -12,6 +12,7 @@ describe("Download Test", () => {
   const DEFAULT_REQUEST_CONFIG: AxiosRequestConfig = {
     url: DEFAULT_URL + "/$metadata",
     method: "GET",
+    headers: { Accept: "application/xml" },
   };
   const AJAX_RESULT = "ajdfoaifjj";
 
@@ -84,6 +85,7 @@ describe("Download Test", () => {
       auth: { password: "xxx hidden xxx", username: "user" },
       method: "GET",
       url: "http://localhost:3000/api/$metadata",
+      headers: { Accept: "application/xml" },
     });
   });
 
@@ -99,7 +101,7 @@ describe("Download Test", () => {
 
   test("custom request config overwrites defaults", async () => {
     const config: UrlSourceConfiguration = {
-      custom: { method: "POST", url: "hey" },
+      custom: { method: "POST", url: "hey", headers: { Accept: "something/else" } },
     };
 
     await downloadMetadata(DEFAULT_URL, config);


### PR DESCRIPTION
**Problem**: Axios defaults the `Accept` header to `application/json`, which can cause OData API servers to return metadata in JSON format. For example, when the endpoint `https://api.channeladvisor.com/v1/$metadata` is accessed with the default Accept header, it returns metadata in JSON format.

**Impact**: This leads to errors because the generator expects the metadata in XML format, not JSON.

**Solution**: Added a default `Accept: "application/xml"` header to ensure that the OData API returns metadata in the correct XML format, preventing errors.