### PR TITLE
test: improve main tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ gen/
 target/
 _out
 coverage
+src-generated
 
 # Typescript
 tsconfig.build.tsbuildinfo

--- a/examples/main/int-test/odataV2/CrudIntegration.test.ts
+++ b/examples/main/int-test/odataV2/CrudIntegration.test.ts
@@ -1,8 +1,8 @@
 import { AxiosClient } from "@odata2ts/http-client-axios";
 import { BigNumber } from "bignumber.js";
 import { describe, expect, test } from "vitest";
-import { EditableProductModel } from "../../build/odataV2/ODataDemoModel";
-import { ODataDemoService } from "../../build/odataV2/ODataDemoService";
+import { EditableProductModel } from "../../src-generated/odataV2/ODataDemoModel";
+import { ODataDemoService } from "../../src-generated/odataV2/ODataDemoService";
 
 /**
  * This sample service is buggy:

--- a/examples/main/int-test/odataV2/ODataV2ServiceIntegration.test.ts
+++ b/examples/main/int-test/odataV2/ODataV2ServiceIntegration.test.ts
@@ -1,8 +1,8 @@
 import { AxiosClient, AxiosClientError } from "@odata2ts/http-client-axios";
 import { BigNumber } from "bignumber.js";
 import { describe, expect, test } from "vitest";
-import { ProductModel } from "../../build/odataV2/ODataDemoModel";
-import { ODataDemoService } from "../../build/odataV2/ODataDemoService";
+import { ProductModel } from "../../src-generated/odataV2/ODataDemoModel";
+import { ODataDemoService } from "../../src-generated/odataV2/ODataDemoService";
 
 /**
  * This sample service is buggy:

--- a/examples/main/int-test/trippin/CrudIntegration.test.ts
+++ b/examples/main/int-test/trippin/CrudIntegration.test.ts
@@ -1,8 +1,8 @@
 import { AxiosClient } from "@odata2ts/http-client-axios";
 import { describe, expect, test, vi } from "vitest";
-import type { EditablePersonModel, LocationModel } from "../../build/trippin/TrippinModel";
-import { FeatureModel, PersonGenderModel } from "../../build/trippin/TrippinModel";
-import { TrippinService } from "../../build/trippin/TrippinService";
+import type { EditablePersonModel, LocationModel } from "../../src-generated/trippin/TrippinModel";
+import { FeatureModel, PersonGenderModel } from "../../src-generated/trippin/TrippinModel";
+import { TrippinService } from "../../src-generated/trippin/TrippinService";
 
 describe.skip("Trippin: CRUD Integration Tests", function () {
   const homeBase: LocationModel = {

--- a/examples/main/int-test/trippin/TrippinIntegration.test.ts
+++ b/examples/main/int-test/trippin/TrippinIntegration.test.ts
@@ -1,8 +1,8 @@
 import { AxiosClient, AxiosClientError } from "@odata2ts/http-client-axios";
 import { describe, expect, test } from "vitest";
-import type { PersonIdModel, PersonModel } from "../../build/trippin/TrippinModel";
-import { FeatureModel, PersonGenderModel } from "../../build/trippin/TrippinModel";
-import { TrippinService } from "../../build/trippin/TrippinService";
+import type { PersonIdModel, PersonModel } from "../../src-generated/trippin/TrippinModel";
+import { FeatureModel, PersonGenderModel } from "../../src-generated/trippin/TrippinModel";
+import { TrippinService } from "../../src-generated/trippin/TrippinService";
 
 describe("Integration Testing of Service Generation", () => {
   const BASE_URL = "https://services.odata.org/TripPinRESTierService/(S(sivik5crfo3qvprrreziudlp))";

--- a/examples/main/int-test/trippin/TrippinRwIntegration.test.ts
+++ b/examples/main/int-test/trippin/TrippinRwIntegration.test.ts
@@ -1,7 +1,7 @@
 import { FetchClient } from "@odata2ts/http-client-fetch";
 import { describe, expect, test } from "vitest";
-import { TrippinRwService } from "../../build/trippin-rw/TrippinRwService";
-import { EditableEventModel } from "../../build/trippin/TrippinModel";
+import { TrippinRwService } from "../../src-generated/trippin-rw/TrippinRwService";
+import { EditableEventModel } from "../../src-generated/trippin/TrippinModel";
 
 describe("Integration Testing of Service Generation", () => {
   const BASE_URL = "https://services.odata.org/V4/(S(xjqbds2oavibr01gt1fny24s))/TripPinServiceRW";

--- a/examples/main/odata2ts.config.ts
+++ b/examples/main/odata2ts.config.ts
@@ -5,7 +5,7 @@ function srcFolder(name: string, isSpecial = false) {
 }
 
 function outputFolder(name: string, isSpecial = false) {
-  return `build/${isSpecial ? "specials/" : ""}${name}`;
+  return `src-generated/${isSpecial ? "specials/" : ""}${name}`;
 }
 
 const config: ConfigFileOptions = {
@@ -135,15 +135,22 @@ const config: ConfigFileOptions = {
         { type: TypeModel.OperationImportType, name: "ResetDataSource", mappedName: "DoReset" },
       ],
     },
-    // using all data types for v2 and converters
+    // using all data types for v2
     dataTypesV2: {
       source: srcFolder("data-types-v2.xml"),
       output: outputFolder("data-types-v2"),
-      enablePrimitivePropertyServices: true,
+      disableAutoManagedKey: true,
+      allowRenaming: true,
+    },
+    // using all data types for v2 and applying converters
+    dataTypesV2Converted: {
+      source: srcFolder("data-types-v2.xml"),
+      output: outputFolder("data-types-v2-converted"),
       disableAutoManagedKey: true,
       allowRenaming: true,
       converters: [
         "@odata2ts/converter-v2-to-v4",
+        "@odata2ts/converter-luxon",
         "@odata2ts/converter-big-number",
         {
           module: "@odata2ts/converter-common",

--- a/examples/main/package.json
+++ b/examples/main/package.json
@@ -9,7 +9,7 @@
   "type": "module",
   "scripts": {
     "build": "yarn clean && yarn generate",
-    "clean": "rimraf build",
+    "clean": "rimraf build src-generated",
     "generate": "odata2ts",
     "int-test": "vitest run --dir int-test",
     "test": "tsc && vitest run --dir test",

--- a/examples/main/test/TestConstants.ts
+++ b/examples/main/test/TestConstants.ts
@@ -1,7 +1,0 @@
-import { TrippinService } from "../build/trippin/TrippinService";
-import { MockODataClient } from "./MockODataClient";
-
-export const BASE_URL = "/test";
-export const ODATA_CLIENT = new MockODataClient();
-export const TRIPPIN = new TrippinService(ODATA_CLIENT, BASE_URL);
-export const TRIPPIN_NE = new TrippinService(ODATA_CLIENT, BASE_URL, { noUrlEncoding: true });

--- a/examples/main/test/dataTypes/DataTypeV2Converted.test.ts
+++ b/examples/main/test/dataTypes/DataTypeV2Converted.test.ts
@@ -1,7 +1,8 @@
 import { BigNumber } from "bignumber.js";
+import { DateTime } from "luxon";
 import { describe, expect, test } from "vitest";
-import { EditableOneOfEverything } from "../../src-generated/data-types-v2/DataTypeExampleModel";
-import { DataTypeExampleService } from "../../src-generated/data-types-v2/DataTypeExampleService";
+import { EditableOneOfEverything } from "../../src-generated/data-types-v2-converted/DataTypeExampleModel";
+import { DataTypeExampleService } from "../../src-generated/data-types-v2-converted/DataTypeExampleService";
 import { MockODataClient } from "../MockODataClient";
 
 describe("V2 Data Types & Converter Tests", function () {
@@ -22,33 +23,34 @@ describe("V2 Data Types & Converter Tests", function () {
     const subject: EditableOneOfEverything = {
       stringType: "Tester",
       booleanType: true,
-      byteType: "1",
-      sByteType: "-1",
+      byteType: 1,
+      sByteType: -1,
       int16Type: 16,
       int32Type: 32,
-      int64Type: "123",
-      singleType: "1.1",
-      doubleType: "2.2",
-      decimalType: "9.9",
-      timeType: "PT12H59S59S",
-      dateTimeType: "2006-11-05T00:00:00.000Z",
-      dateTimeOffsetType: "2022-12-31T12:59:59Z",
+      int64Type: BigInt("123"),
+      singleType: 1.1,
+      doubleType: 2.2,
+      decimalType: BigNumber("9.9"),
+      // timeType: DateTime.fromISO("12:59:59"),
+      dateTimeType: DateTime.fromISO("2006-11-05T00:00:00.000Z"),
+      dateTimeOffsetType: DateTime.fromISO("2022-12-31T12:59:59Z"),
     };
 
     const expectedResult = {
-      StringType: subject.stringType,
-      BooleanType: subject.booleanType,
-      ByteType: subject.byteType,
-      SByteType: subject.sByteType,
-      Int16Type: subject.int16Type,
-      Int32Type: subject.int32Type,
-      Int64Type: subject.int64Type,
-      SingleType: subject.singleType,
-      DoubleType: subject.doubleType,
-      DecimalType: subject.decimalType,
-      TimeType: subject.timeType,
-      DateTimeType: subject.dateTimeType,
-      DateTimeOffsetType: subject.dateTimeOffsetType,
+      StringType: "Tester",
+      BooleanType: true,
+      ByteType: "1",
+      SByteType: "-1",
+      Int16Type: 16,
+      Int32Type: 32,
+      Int64Type: "123",
+      SingleType: "1.1",
+      DoubleType: "2.2",
+      DecimalType: "9.9",
+      // TODO: Edm.Time gives undefined
+      // TimeType: "PT1H2M3S",
+      DateTimeType: "/Date(1162684800000)/",
+      DateTimeOffsetType: "2022-12-31T12:59:59Z",
     };
 
     await DATA_TYPE_SERVICE.oneOfEverything().create(subject);
@@ -63,7 +65,7 @@ describe("V2 Data Types & Converter Tests", function () {
     const expected = "2006-11-05T00:00:00.000Z";
 
     await DATA_TYPE_SERVICE.oneOfEverything().query((builder, qOoe) => {
-      return builder.filter(qOoe.dateTimeType.eq(expected));
+      return builder.filter(qOoe.dateTimeType.eq(DateTime.fromISO(expected)));
     });
 
     expect(ODATA_CLIENT.lastUrl).toBe(`${ONE_OF_EVERYTHING_URL}?$filter=DateTimeType eq datetime'${expected}'`);

--- a/examples/main/test/dataTypes/DataTypeV2Converted.test.ts
+++ b/examples/main/test/dataTypes/DataTypeV2Converted.test.ts
@@ -50,7 +50,7 @@ describe("V2 Data Types & Converter Tests", function () {
       // TODO: Edm.Time gives undefined
       // TimeType: "PT1H2M3S",
       DateTimeType: "/Date(1162684800000)/",
-      DateTimeOffsetType: "2022-12-31T12:59:59Z",
+      DateTimeOffsetType: "2022-12-31T12:59:59.000Z",
     };
 
     await DATA_TYPE_SERVICE.oneOfEverything().create(subject);

--- a/examples/main/test/dataTypes/DataTypeV2Converted.test.ts
+++ b/examples/main/test/dataTypes/DataTypeV2Converted.test.ts
@@ -62,12 +62,12 @@ describe("V2 Data Types & Converter Tests", function () {
   });
 
   test("v2: DateTime in URL", async () => {
-    const expected = "2006-11-05T00:00:00.000Z";
+    const exampleDate = "2006-11-05T00:00:00.000Z";
 
     await DATA_TYPE_SERVICE.oneOfEverything().query((builder, qOoe) => {
-      return builder.filter(qOoe.dateTimeType.eq(DateTime.fromISO(expected)));
+      return builder.filter(qOoe.dateTimeType.eq(DateTime.fromISO(exampleDate)));
     });
 
-    expect(ODATA_CLIENT.lastUrl).toBe(`${ONE_OF_EVERYTHING_URL}?$filter=DateTimeType eq datetime'${expected}'`);
+    expect(ODATA_CLIENT.lastUrl).toBe(`${ONE_OF_EVERYTHING_URL}?$filter=DateTimeType eq datetime'${exampleDate}'`);
   });
 });

--- a/examples/main/test/dataTypes/DataTypeV4.test.ts
+++ b/examples/main/test/dataTypes/DataTypeV4.test.ts
@@ -1,8 +1,8 @@
 import { BigNumber } from "bignumber.js";
 import { DateTime } from "luxon";
 import { describe, expect, test } from "vitest";
-import type { EditableOneOfEverything } from "../../build/data-types-v4/DataTypeExampleModel";
-import { DataTypeExampleService } from "../../build/data-types-v4/DataTypeExampleService";
+import type { EditableOneOfEverything } from "../../src-generated/data-types-v4/DataTypeExampleModel";
+import { DataTypeExampleService } from "../../src-generated/data-types-v4/DataTypeExampleService";
 import { MockODataClient } from "../MockODataClient";
 
 describe("V4 Data Types & Converter Tests", function () {

--- a/examples/main/test/odataV2/CrudOperation.test.ts
+++ b/examples/main/test/odataV2/CrudOperation.test.ts
@@ -1,13 +1,13 @@
 import { BigNumber } from "bignumber.js";
 import { describe, expect, test } from "vitest";
-import { EditableProductModel } from "../../build/odataV2/ODataDemoModel";
-import { ODataDemoService } from "../../build/odataV2/ODataDemoService";
+import { EditableProductModel } from "../../src-generated/odataV2/ODataDemoModel";
+import { ODataDemoService } from "../../src-generated/odataV2/ODataDemoService";
 import { MockODataClient } from "../MockODataClient";
 
 describe("V2 CRUD Functionality Tests", function () {
   const BASE_URL = "test";
   const odataClient = new MockODataClient(true);
-  const testService = new ODataDemoService(odataClient, BASE_URL);
+  const testService = new ODataDemoService(odataClient, BASE_URL, { noUrlEncoding: true });
 
   test("create", () => {
     const model: EditableProductModel = {

--- a/examples/main/test/odataV2/Operation.test.ts
+++ b/examples/main/test/odataV2/Operation.test.ts
@@ -1,14 +1,14 @@
 import type { HttpResponseModel } from "@odata2ts/http-client-api";
 import type { ODataCollectionResponseV2 } from "@odata2ts/odata-core";
 import { describe, expect, test } from "vitest";
-import { ProductModel } from "../../build/odataV2/ODataDemoModel";
-import { ODataDemoService } from "../../build/odataV2/ODataDemoService";
+import { ProductModel } from "../../src-generated/odataV2/ODataDemoModel";
+import { ODataDemoService } from "../../src-generated/odataV2/ODataDemoService";
 import { MockODataClient } from "../MockODataClient";
 
 describe("V2 Operation (FunctionImport) Tests", function () {
   const BASE_URL = "test";
   const odataClient = new MockODataClient(true);
-  const testService = new ODataDemoService(odataClient, BASE_URL);
+  const testService = new ODataDemoService(odataClient, BASE_URL, { noUrlEncoding: true });
 
   test("productsByRating", async () => {
     const result: HttpResponseModel<ODataCollectionResponseV2<ProductModel>> = await testService.getProductsByRating({

--- a/examples/main/test/odataV2/Query.test.ts
+++ b/examples/main/test/odataV2/Query.test.ts
@@ -1,15 +1,14 @@
 import type { HttpResponseModel } from "@odata2ts/http-client-api";
 import type { ODataCollectionResponseV2, ODataModelResponseV2 } from "@odata2ts/odata-core";
 import { describe, expect, test } from "vitest";
-import { ProductModel } from "../../build/odataV2/ODataDemoModel";
-import { ODataDemoService } from "../../build/odataV2/ODataDemoService";
+import { ProductModel } from "../../src-generated/odataV2/ODataDemoModel";
+import { ODataDemoService } from "../../src-generated/odataV2/ODataDemoService";
 import { MockODataClient } from "../MockODataClient";
 
 describe("Unit Tests for V2 OData Demo Service", function () {
   const BASE_URL = "test";
   const odataClient = new MockODataClient(true);
-  const testService = new ODataDemoService(odataClient, BASE_URL);
-  const ENC = encodeURIComponent;
+  const testService = new ODataDemoService(odataClient, BASE_URL, { noUrlEncoding: true });
 
   test("get by id", async () => {
     const result: HttpResponseModel<ODataModelResponseV2<ProductModel>> = await testService.products(123).query();
@@ -27,10 +26,8 @@ describe("Unit Tests for V2 OData Demo Service", function () {
       .products()
       .query((builder, qProduct) => builder.select("id", "name").filter(qProduct.price.plus("1").gt("1000")));
 
-    expect(odataClient.lastUrl).toBe(
-      `test/Products?%24select=${ENC("ID,Name")}&%24filter=${ENC("Price add 1 gt 1000")}`,
-    );
     expect(result.status).toBe(200);
+    expect(odataClient.lastUrl).toBe("test/Products?$select=ID,Name&$filter=Price add 1 gt 1000");
     expect(odataClient.additionalHeaders).toStrictEqual({
       Accept: "application/json",
       "Content-Type": "application/json",

--- a/examples/main/test/renaming/MaxRenaming.test.ts
+++ b/examples/main/test/renaming/MaxRenaming.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, test } from "vitest";
-import { servicexxx_Trippin_xxxs } from "../../build/trippin-max-renaming/servicexxx_Trippin_xxxs";
+import { servicexxx_Trippin_xxxs } from "../../src-generated/trippin-max-renaming/servicexxx_Trippin_xxxs";
 import type {
   EDITABLE_LOCATION,
   EDITABLE_THE_PERSON,
   THE_PERSON_ID,
-} from "../../build/trippin-max-renaming/TRIPPIN_TYPES";
-import { FEATURE, PERSON_GENDER } from "../../build/trippin-max-renaming/TRIPPIN_TYPES";
+} from "../../src-generated/trippin-max-renaming/TRIPPIN_TYPES";
+import { FEATURE, PERSON_GENDER } from "../../src-generated/trippin-max-renaming/TRIPPIN_TYPES";
 import { MockODataClient } from "../MockODataClient";
 
 describe("Testing Generation With Max Renaming Options", () => {
@@ -13,7 +13,7 @@ describe("Testing Generation With Max Renaming Options", () => {
   const odataClient = new MockODataClient();
 
   // noinspection JSPotentiallyInvalidConstructorUsage
-  const testService = new servicexxx_Trippin_xxxs(odataClient, BASE_URL);
+  const testService = new servicexxx_Trippin_xxxs(odataClient, BASE_URL, { noUrlEncoding: true });
 
   let editModel: EDITABLE_THE_PERSON;
 

--- a/examples/main/test/renaming/MinRenaming.test.ts
+++ b/examples/main/test/renaming/MinRenaming.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test } from "vitest";
-import type { EditableLocation, EditablePerson, PersonId } from "../../build/trippin-min-naming/TrippinModel";
-import { Feature, PersonGender } from "../../build/trippin-min-naming/TrippinModel";
-import { TrippinService } from "../../build/trippin-min-naming/TrippinService";
+import type { EditableLocation, EditablePerson, PersonId } from "../../src-generated/trippin-min-naming/TrippinModel";
+import { Feature, PersonGender } from "../../src-generated/trippin-min-naming/TrippinModel";
+import { TrippinService } from "../../src-generated/trippin-min-naming/TrippinService";
 import { MockODataClient } from "../MockODataClient";
 
 describe("Testing Generation with min renaming options", () => {
@@ -9,7 +9,7 @@ describe("Testing Generation with min renaming options", () => {
   const odataClient = new MockODataClient();
 
   // noinspection JSPotentiallyInvalidConstructorUsAge
-  const testService = new TrippinService(odataClient, BASE_URL);
+  const testService = new TrippinService(odataClient, BASE_URL, { noUrlEncoding: true });
 
   let editModel: EditablePerson;
 

--- a/examples/main/test/trippin/CrudOperation.test.ts
+++ b/examples/main/test/trippin/CrudOperation.test.ts
@@ -4,8 +4,8 @@ import {
   EditablePersonModel,
   FeatureModel,
   PersonGenderModel,
-} from "../../build/trippin/TrippinModel";
-import { BASE_URL, ODATA_CLIENT, TRIPPIN } from "../TestConstants";
+} from "../../src-generated/trippin/TrippinModel";
+import { BASE_URL, ODATA_CLIENT, TRIPPIN } from "./TrippinTestConstants";
 
 describe("Testing Generation of TrippinService", () => {
   let editModel: EditablePersonModel;

--- a/examples/main/test/trippin/Operation.test.ts
+++ b/examples/main/test/trippin/Operation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { BASE_URL, ODATA_CLIENT, TRIPPIN } from "../TestConstants";
+import { BASE_URL, ODATA_CLIENT, TRIPPIN } from "./TrippinTestConstants";
 
 describe("Trippin: Operation Test", function () {
   test("unbound function", async () => {

--- a/examples/main/test/trippin/Query.test.ts
+++ b/examples/main/test/trippin/Query.test.ts
@@ -1,9 +1,8 @@
 import { HttpResponseModel } from "@odata2ts/http-client-api";
 import { ODataCollectionResponseV4, ODataModelResponseV4 } from "@odata2ts/odata-core";
 import { describe, expect, test } from "vitest";
-import { PersonIdModel, PersonModel } from "../../build/trippin/TrippinModel";
-import { TrippinService } from "../../build/trippin/TrippinService";
-import { BASE_URL, ODATA_CLIENT, TRIPPIN, TRIPPIN_NE } from "../TestConstants";
+import { PersonIdModel, PersonModel } from "../../src-generated/trippin/TrippinModel";
+import { BASE_URL, ODATA_CLIENT, TRIPPIN } from "./TrippinTestConstants";
 
 type SelectedPersonShape = Pick<PersonModel, "user" | "lastName" | "addressInfo">;
 
@@ -30,7 +29,7 @@ describe("Trippin: Testing Query Functionality", function () {
   });
 
   test("entitySet: query with select", async () => {
-    const expected = `${BASE_URL}/People?%24select=UserName%2CLastName%2CAddressInfo`;
+    const expected = `${BASE_URL}/People?$select=UserName,LastName,AddressInfo`;
 
     // const response = await TRIPPIN.people().query((builder) => builder.select("user", "lastName", "addressInfo"));
 
@@ -69,7 +68,7 @@ describe("Trippin: Testing Query Functionality", function () {
       return builder.filter(qPerson.trips.any());
     });
 
-    expect(ODATA_CLIENT.lastUrl).toBe(`${BASE_URL}/People?%24filter=Trips%2Fany()`);
+    expect(ODATA_CLIENT.lastUrl).toBe(`${BASE_URL}/People?$filter=Trips/any()`);
   });
 
   test("any: without return type", async () => {
@@ -77,29 +76,29 @@ describe("Trippin: Testing Query Functionality", function () {
       return builder.filter(qPerson.trips.any(() => {}));
     });
 
-    expect(ODATA_CLIENT.lastUrl).toBe(`${BASE_URL}/People?%24filter=Trips%2Fany()`);
+    expect(ODATA_CLIENT.lastUrl).toBe(`${BASE_URL}/People?$filter=Trips/any()`);
   });
 
   test("no url encoding", async () => {
-    await TRIPPIN_NE.people("hei/ner").query((b, q) => b.filter(q.age.gt(18)));
+    await TRIPPIN.people("hei/ner").query((b, q) => b.filter(q.age.gt(18)));
 
     expect(ODATA_CLIENT.lastUrl).toBe(`${BASE_URL}/People('hei/ner')?$filter=Age gt 18`);
   });
 
   test("function without url encoding", async () => {
-    await TRIPPIN_NE.people("heiner").getFriendsTrips({ userName: "hei/ner" });
+    await TRIPPIN.people("heiner").getFriendsTrips({ userName: "hei/ner" });
 
     expect(ODATA_CLIENT.lastUrl).toBe(`${BASE_URL}/People('heiner')/Trippin.GetFriendsTrips(userName='hei/ner')`);
   });
 
   test("casting derived entity type", async () => {
-    await TRIPPIN_NE.people("russellwhyte").trips(0).planItems().asFlightCollectionService().query();
+    await TRIPPIN.people("russellwhyte").trips(0).planItems().asFlightCollectionService().query();
 
     expect(ODATA_CLIENT.lastUrl).toBe(`${BASE_URL}/People('russellwhyte')/Trips(0)/PlanItems/Trippin.Flight`);
   });
 
   test("select & expand casted prop of derived entity type", async () => {
-    await TRIPPIN_NE.people("russellwhyte")
+    await TRIPPIN.people("russellwhyte")
       .trips(0)
       .planItems()
       .query((b, q) => {
@@ -112,7 +111,7 @@ describe("Trippin: Testing Query Functionality", function () {
   });
 
   test("filter casted prop of derived entity type", async () => {
-    await TRIPPIN_NE.people("russellwhyte")
+    await TRIPPIN.people("russellwhyte")
       .trips(0)
       .planItems()
       .query((b, q) => {

--- a/examples/main/test/trippin/Smoke.test.ts
+++ b/examples/main/test/trippin/Smoke.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
-import { PersonIdModel } from "../../build/trippin/TrippinModel";
-import { BASE_URL, TRIPPIN } from "../TestConstants";
+import { PersonIdModel } from "../../src-generated/trippin/TrippinModel";
+import { BASE_URL, TRIPPIN } from "./TrippinTestConstants";
 
 describe("Trippin: Smoke Test", function () {
   test("entitySet", async () => {

--- a/examples/main/test/trippin/TrippinTestConstants.ts
+++ b/examples/main/test/trippin/TrippinTestConstants.ts
@@ -1,0 +1,6 @@
+import { TrippinService } from "../../src-generated/trippin/TrippinService";
+import { MockODataClient } from "../MockODataClient";
+
+export const BASE_URL = "/test";
+export const ODATA_CLIENT = new MockODataClient();
+export const TRIPPIN = new TrippinService(ODATA_CLIENT, BASE_URL, { noUrlEncoding: true });

--- a/examples/main/tsconfig.json
+++ b/examples/main/tsconfig.json
@@ -5,5 +5,5 @@
     "noEmit": true,
     "lib": ["DOM"]
   },
-  "include": ["build", "test", "int-test"]
+  "include": ["src-generated", "test", "int-test"]
 }

--- a/packages/odata2ts/package.json
+++ b/packages/odata2ts/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@odata2ts/converter-api": "^0.2.5",
-    "@odata2ts/converter-runtime": "^0.5.0",
+    "@odata2ts/converter-runtime": "^0.5.5",
     "@odata2ts/http-client-api": "^0.6.2",
     "@odata2ts/odata-core": "^0.6.0",
     "@prettier/plugin-xml": "^3.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -639,12 +639,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@odata2ts/converter-runtime@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "@odata2ts/converter-runtime@npm:0.5.0"
+"@odata2ts/converter-runtime@npm:^0.5.5":
+  version: 0.5.5
+  resolution: "@odata2ts/converter-runtime@npm:0.5.5"
   dependencies:
-    "@odata2ts/converter-api": "npm:^0.2.2"
-  checksum: 10/b46a3839abf20065eb5029d0a2962bfd3f47800c4f7f1b2695e3bc8acddde4467e3e30bdc3b3d58cc8945d5fd888e16e89e625c598f4f862bffb821339c770d7
+    "@odata2ts/converter-api": "npm:^0.2.6"
+  checksum: 10/798e65e65b6db0eb04e5fa3e642bfd3ac6ad9e2a2d217b65599abe10e084d90b89e0f88a36de044283b8f9c249c230fb7b594708e79bfcb3d0659aea261bf7b5
   languageName: node
   linkType: hard
 
@@ -788,7 +788,7 @@ __metadata:
   resolution: "@odata2ts/odata2ts@workspace:packages/odata2ts"
   dependencies:
     "@odata2ts/converter-api": "npm:^0.2.5"
-    "@odata2ts/converter-runtime": "npm:^0.5.0"
+    "@odata2ts/converter-runtime": "npm:^0.5.5"
     "@odata2ts/converter-v2-to-v4": "npm:^0.5.1"
     "@odata2ts/http-client-api": "npm:^0.6.2"
     "@odata2ts/odata-core": "npm:^0.6.0"


### PR DESCRIPTION
generate to src-generated instead of build (no code assistance otherwise); use the newly introduced noUrlEncoding flag to simplify tests; tests for v2 data types in raw and converted form