### PR TITLE
feat(qobjects): allow arrays for in-filter

### DIFF
--- a/examples/main/test/odataV2/Query.test.ts
+++ b/examples/main/test/odataV2/Query.test.ts
@@ -33,4 +33,12 @@ describe("Unit Tests for V2 OData Demo Service", function () {
       "Content-Type": "application/json",
     });
   });
+
+  test("in filter", async () => {
+    await testService.products().query((builder, qProduct) => builder.filter(qProduct.name.in(["x", "y"], "z")));
+    expect(odataClient.lastUrl).toBe("test/Products?$filter=(Name eq 'x' or Name eq 'y' or Name eq 'z')");
+
+    await testService.products().query((builder, qProduct) => builder.filter(qProduct.name.in("x", "y", "z")));
+    expect(odataClient.lastUrl).toBe("test/Products?$filter=(Name eq 'x' or Name eq 'y' or Name eq 'z')");
+  });
 });

--- a/packages/odata-query-objects/test/path/StringBaseTests.ts
+++ b/packages/odata-query-objects/test/path/StringBaseTests.ts
@@ -144,6 +144,10 @@ export function createStringTests<T extends QStringPath | QStringV2Path>(toTest:
     const result = toTest.in("X", "y", "z").toString();
 
     expect(result).toBe(`(Country eq 'X' or Country eq 'y' or Country eq 'z')`);
+    expect(result).toBe(toTest.in(["X", "y"], "z").toString());
+    expect(result).toBe(toTest.in(["X", "y", "z"]).toString());
+    expect(result).toBe(toTest.in("X", ["y", "z"]).toString());
+    expect(result).toBe(toTest.in(["X"], ["y", "z"]).toString());
   });
 
   test("concat prefix", () => {

--- a/packages/odata-query-objects/test/path/v4/QStringPath.test.ts
+++ b/packages/odata-query-objects/test/path/v4/QStringPath.test.ts
@@ -1,7 +1,6 @@
 import { stringToPrefixModelConverter } from "@odata2ts/test-converters";
 import { describe, expect, test } from "vitest";
-import { QStringPath } from "../../../src";
-import { getIdentityConverter } from "../../../src/IdentityConverter";
+import { getIdentityConverter, QStringPath } from "../../../src";
 import { createStringTests } from "../StringBaseTests";
 
 describe("QStringPath test", () => {


### PR DESCRIPTION
allow arrays as well as spread: 
* old and still working: `qX.in(...list)`
* new: `qX.in(list)`
* crazy: `qX.in(x, list, [y,z])`