### PR TITLE
refactor(qobjects): parentheses only via `group`

### DIFF
--- a/packages/odata-query-objects/src/QFilterExpression.ts
+++ b/packages/odata-query-objects/src/QFilterExpression.ts
@@ -5,22 +5,25 @@ export class QFilterExpression {
     return this.expression?.trim() || "";
   }
 
-  public not(): QFilterExpression {
+  public group(): QFilterExpression {
     if (this.expression?.trim()) {
-      return new QFilterExpression(`not(${this.expression})`);
+      return new QFilterExpression(`(${this.expression})`);
     }
     return this;
   }
 
-  private combine(
-    expression: QFilterExpression | null | undefined,
-    isOrOperation: boolean,
-    withoutParentheses = false,
-  ) {
+  public not(): QFilterExpression {
+    if (this.expression?.trim()) {
+      return new QFilterExpression(`not ${this.expression}`);
+    }
+    return this;
+  }
+
+  private combine(expression: QFilterExpression | null | undefined, isOrOperation: boolean) {
     if (expression?.toString()) {
       if (this.expression) {
         const newExpr = `${this.expression} ${isOrOperation ? "or" : "and"} ${expression.toString()}`;
-        return new QFilterExpression(isOrOperation && !withoutParentheses ? `(${newExpr})` : newExpr);
+        return new QFilterExpression(newExpr);
       } else {
         return expression;
       }
@@ -32,7 +35,7 @@ export class QFilterExpression {
     return this.combine(expression, false);
   }
 
-  public or(expression: QFilterExpression | null | undefined, withoutParentheses = false): QFilterExpression {
-    return this.combine(expression, true, withoutParentheses);
+  public or(expression: QFilterExpression | null | undefined): QFilterExpression {
+    return this.combine(expression, true);
   }
 }

--- a/packages/odata-query-objects/src/path/base/BaseFunctions.ts
+++ b/packages/odata-query-objects/src/path/base/BaseFunctions.ts
@@ -100,10 +100,11 @@ export function filterInEmulated<T>(path: string, mapValue: MapValue<T>) {
    * The in-statement is actually emulated by using an or-concatenation of equals-statements.
    */
   return (...values: Array<T | Array<T>>) => {
-    return flattenList(values).reduce<QFilterExpression>((expression, value, idx, coll) => {
-      const expr = buildQFilterOperation(path, StandardFilterOperators.EQUALS, mapValue(value));
-      return expression.or(expr, idx < coll.length - 1);
+    const flatVals = flattenList(values);
+    const result = flatVals.reduce<QFilterExpression>((expression, value) => {
+      return expression.or(buildQFilterOperation(path, StandardFilterOperators.EQUALS, mapValue(value)));
     }, new QFilterExpression());
+    return flatVals.length > 1 ? result.group() : result;
   };
 }
 

--- a/packages/odata-query-objects/test/QFilterExpression.test.ts
+++ b/packages/odata-query-objects/test/QFilterExpression.test.ts
@@ -15,10 +15,28 @@ describe("QFilterExpression test", () => {
     expect(new QFilterExpression("").toString()).toBe("");
   });
 
+  test("group operator", () => {
+    const toTest = exampleExpression.group().toString();
+
+    expect(toTest).toBe(`(${exampleResult})`);
+  });
+
+  test("group operator with empty filter", () => {
+    const toTest = new QFilterExpression().group().toString();
+
+    expect(toTest).toBe("");
+  });
+
+  test("group operator multiple times", () => {
+    const toTest = exampleExpression.group().group().group().toString();
+
+    expect(toTest).toBe(`(((${exampleResult})))`);
+  });
+
   test("not operator", () => {
     const toTest = exampleExpression.not().toString();
 
-    expect(toTest).toBe(`not(${exampleResult})`);
+    expect(toTest).toBe(`not ${exampleResult}`);
   });
 
   test("not operator with empty filter", () => {
@@ -30,7 +48,7 @@ describe("QFilterExpression test", () => {
   test("not operator multiple times", () => {
     const toTest = exampleExpression.not().not().not().toString();
 
-    expect(toTest).toBe(`not(not(not(${exampleResult})))`);
+    expect(toTest).toBe(`not not not ${exampleResult}`);
   });
 
   test("and operator", () => {
@@ -58,7 +76,7 @@ describe("QFilterExpression test", () => {
   test("or operator", () => {
     const toTest = exampleExpression.or(exampleNumberExpr).toString();
 
-    expect(toTest).toBe(`(${exampleResult} or ${exampleNumberResult})`);
+    expect(toTest).toBe(`${exampleResult} or ${exampleNumberResult}`);
   });
 
   test("or operator with empty filter", () => {
@@ -74,31 +92,24 @@ describe("QFilterExpression test", () => {
   test("or operator multiple times", () => {
     const toTest = exampleExpression.or(exampleNumberExpr).or(exampleNumberExpr).or(exampleExpression).toString();
 
-    expect(toTest).toBe(
-      `(((${exampleResult} or ${exampleNumberResult}) or ${exampleNumberResult}) or ${exampleResult})`,
-    );
+    expect(toTest).toBe(`${exampleResult} or ${exampleNumberResult} or ${exampleNumberResult} or ${exampleResult}`);
   });
 
   test("combination", () => {
-    const toTest = exampleExpression.not().or(exampleNumberExpr).and(exampleNumberExpr).toString();
+    const toTest = exampleNumberExpr.and(exampleExpression.not().or(exampleNumberExpr).group()).toString();
 
-    expect(toTest).toBe(`(not(${exampleResult}) or ${exampleNumberResult}) and ${exampleNumberResult}`);
+    expect(toTest).toBe(`${exampleNumberResult} and (not ${exampleResult} or ${exampleNumberResult})`);
   });
 
   test("or with parentheses", () => {
-    const toTest = exampleExpression.or(exampleNumberExpr).and(exampleExpression.or(exampleNumberExpr)).toString();
+    const toTest = exampleExpression
+      .or(exampleNumberExpr)
+      .group()
+      .and(exampleExpression.or(exampleNumberExpr).group())
+      .toString();
 
     expect(toTest).toBe(
       `(${exampleResult} or ${exampleNumberResult}) and (${exampleResult} or ${exampleNumberResult})`,
     );
-  });
-
-  test("or without parentheses", () => {
-    const toTest = exampleExpression
-      .or(exampleNumberExpr, true)
-      .or(exampleExpression.or(exampleNumberExpr, true), true)
-      .toString();
-
-    expect(toTest).toBe(`${exampleResult} or ${exampleNumberResult} or ${exampleResult} or ${exampleNumberResult}`);
   });
 });

--- a/packages/odata-service/test/v2/CollectionServiceV2.test.ts
+++ b/packages/odata-service/test/v2/CollectionServiceV2.test.ts
@@ -7,11 +7,9 @@ import {
   StringCollection,
 } from "@odata2ts/odata-query-objects";
 import { describe, expect, test } from "vitest";
-import { CollectionServiceV2, ODataServiceOptions } from "../../src";
-import { DEFAULT_HEADERS } from "../../src/RequestHeaders";
+import { CollectionServiceV2, DEFAULT_HEADERS, ODataServiceOptions } from "../../src";
 import { commonCollectionTests, getParams } from "../CollectionServiceTests";
 import { MockClient } from "../mock/MockClient";
-import { StringTestEnum } from "../v4/CollectionServiceV4.test";
 
 export enum NumericTestEnum {
   A,
@@ -60,7 +58,7 @@ describe("CollectionService V2 Tests", () => {
   });
 
   test("numeric enum collection: filter", async () => {
-    const params = getParams({ $filter: "($it eq 'A' or $it eq 'B')" });
+    const params = getParams({ $filter: "$it eq 'A' or $it eq 'B'" });
 
     const enumService = enumConstructor(BASE_PATH, NAME_ENUM);
 

--- a/packages/odata-service/test/v4/CollectionServiceV4.test.ts
+++ b/packages/odata-service/test/v4/CollectionServiceV4.test.ts
@@ -50,7 +50,7 @@ describe("CollectionService V4 Tests", () => {
   });
 
   test("string enum collection: filter", async () => {
-    const params = getParams({ $filter: "($it eq 'A' or $it eq 'B')" });
+    const params = getParams({ $filter: "$it eq 'A' or $it eq 'B'" });
 
     const enumService = enumConstructor(BASE_PATH, NAME_ENUM);
 


### PR DESCRIPTION
BREAKING CHANGE: Previously parentheses were set automatically for or-expressions and erroneously for not-expressions; now users have to set parenthesis explicitly via `.group()`