### PR TITLE
feat: Deep Select for Complex Types

### DIFF
--- a/examples/main/test/odataV2/DeepSelect.test.ts
+++ b/examples/main/test/odataV2/DeepSelect.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest";
+import { ODataDemoService } from "../../src-generated/odataV2/ODataDemoService";
+import { MockODataClient } from "../MockODataClient";
+
+/**
+ * Integration test for deep select on complex-typed properties in V2, run against the actually generated
+ * V2 client - not a hand-written fixture. Unlike V4, V2 doesn't auto-inline complex types, so both `expand()`
+ * (now widened to accept complex properties, e.g. Supplier.Address) and `expanding()` (V2's flattening
+ * deep-select mechanism) must work correctly for a complex property, not just for navigation properties.
+ */
+describe("Unit Tests for V2 OData Demo Service: Deep Select for Complex Types", function () {
+  const BASE_URL = "test";
+  const odataClient = new MockODataClient(true);
+  const testService = new ODataDemoService(odataClient, BASE_URL, { noUrlEncoding: true });
+
+  test("expand: works for a complex prop (Supplier.address), not just navigation properties", async () => {
+    await testService
+      .suppliers(1)
+      .query((b) => b.expand("address"))
+      .execute();
+
+    expect(odataClient.lastUrl).toBe("test/Suppliers(1)?$expand=Address");
+  });
+
+  test("expanding: deep select into a complex prop (Supplier.address)", async () => {
+    await testService
+      .suppliers(1)
+      .query((b) => b.expanding("address", (addrBuilder) => addrBuilder.select("city")))
+      .execute();
+
+    expect(odataClient.lastUrl).toBe("test/Suppliers(1)?$select=Address/City&$expand=Address");
+  });
+
+  test("expanding: complex prop nested inside an entity nav prop (Product.supplier/address) flattens correctly", async () => {
+    await testService
+      .products(123)
+      .query((b) =>
+        b.expanding("supplier", (supplierBuilder) => {
+          supplierBuilder.expanding("address", (addrBuilder) => {
+            addrBuilder.select("city");
+          });
+        }),
+      )
+      .execute();
+
+    expect(odataClient.lastUrl).toBe(
+      "test/Products(123)?$select=Supplier/Address/City&$expand=Supplier,Supplier/Address",
+    );
+  });
+});

--- a/examples/main/test/trippin/DeepSelect.test.ts
+++ b/examples/main/test/trippin/DeepSelect.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "vitest";
+import { BASE_URL, ODATA_CLIENT, TRIPPIN } from "./TrippinTestConstants";
+
+/**
+ * Integration test for deep select on complex-typed properties via the unified `expanding()`, run against
+ * the actually generated Trippin client - not a hand-written fixture - to prove the generator wires complex
+ * properties (Person.HomeAddress, Person.AddressInfo, Location.City) to the same expanding() mechanism as
+ * navigation properties, with the engine dynamically choosing $select=Prop(...) instead of $expand=Prop(...).
+ */
+describe("Trippin: Deep Select for Complex Types", function () {
+  test("expanding a to-one complex prop (homeAddress) renders as $select, no $expand", async () => {
+    await TRIPPIN.people()
+      .query((b) => b.expanding("homeAddress", (addrBuilder) => addrBuilder.select("address")))
+      .execute();
+
+    expect(ODATA_CLIENT.lastUrl).toBe(`${BASE_URL}/People?$select=HomeAddress($select=Address)`);
+  });
+
+  test("expanding a complex prop nested inside another complex prop (homeAddress/city) stays inline", async () => {
+    await TRIPPIN.people()
+      .query((b) =>
+        b.expanding("homeAddress", (addrBuilder) => {
+          addrBuilder.expanding("city", (cityBuilder) => {
+            cityBuilder.select("name");
+          });
+        }),
+      )
+      .execute();
+
+    expect(ODATA_CLIENT.lastUrl).toBe(`${BASE_URL}/People?$select=HomeAddress($select=City($select=Name))`);
+  });
+
+  test("expanding a complex prop nested inside an entity nav prop (bestFriend/homeAddress) hoists nothing, stays inline", async () => {
+    await TRIPPIN.people()
+      .query((b) =>
+        b.expanding("bestFriend", (friendBuilder) => {
+          friendBuilder.expanding("homeAddress", (addrBuilder) => {
+            addrBuilder.select("address");
+          });
+        }),
+      )
+      .execute();
+
+    expect(ODATA_CLIENT.lastUrl).toBe(`${BASE_URL}/People?$expand=BestFriend($select=HomeAddress($select=Address))`);
+  });
+
+  test("expanding a to-many complex prop (addressInfo) keeps collection-only ops incl. search", async () => {
+    await TRIPPIN.people()
+      .query((b) =>
+        b.expanding("addressInfo", (nested, qLocation) => {
+          nested.select("address").filter(qLocation.address.startsWith("1")).top(1).skip(0).count().search("Seattle");
+        }),
+      )
+      .execute();
+
+    expect(ODATA_CLIENT.lastUrl).toBe(
+      `${BASE_URL}/People?$select=AddressInfo($select=Address;$filter=startswith(Address,'1');$count=true;$top=1;$skip=0;$search=Seattle)`,
+    );
+  });
+
+  test("expanding a to-one complex prop narrows the nested builder to model ops, same as a to-one nav prop", () => {
+    TRIPPIN.people().query((b) => {
+      b.expanding("homeAddress", (nested, qLocation) => {
+        nested.select("address");
+
+        // @ts-expect-error: filter is not available for a to-one expanded model, even a complex one
+        nested.filter(qLocation.address.eq("x"));
+        // @ts-expect-error: top is not available for a to-one expanded model, even a complex one
+        nested.top(1);
+      });
+    });
+  });
+
+  // plain expand() stays entity-only in V4 (already covered for homeAddress/addressInfo in Query.test.ts,
+  // "the Non-Expandables" - deep select via expanding() is the only way to reach a complex property in V4)
+});

--- a/packages/odata-query-builder/src/ODataQueryBuilder.ts
+++ b/packages/odata-query-builder/src/ODataQueryBuilder.ts
@@ -1,4 +1,6 @@
 import {
+  QComplexCollectionPath,
+  QComplexPath,
   QEntityPathModel,
   QFilterExpression,
   QOrderByExpression,
@@ -11,7 +13,7 @@ import {
 import { ODataOperators } from "./ODataModel";
 import {
   ExpandingCollectionQueryBuilderV4,
-  ExpandType,
+  NestingType,
   NullableParam,
   NullableParamList,
   ODataQueryBuilderConfig,
@@ -37,6 +39,13 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
   private expands: Array<string> | undefined;
   private groupBys: Array<string> | undefined;
   private searchTerms: Array<QSearchTerm> | undefined;
+
+  /**
+   * Expand fragments that were reached via a complex-typed property and therefore cannot be embedded inline
+   * (a `$select=Prop(...)` clause cannot contain `$expand`) - they are relayed here, already path-prefixed by
+   * the complex hop, until they reach a context that can embed them (see `expanding()` / `buildNested()`).
+   */
+  private hoistedExpandsBucket: Array<string> | undefined;
 
   constructor(path: string, qEntity: Q, config?: ODataQueryBuilderConfig) {
     if (!qEntity || !path || !path.trim()) {
@@ -80,6 +89,13 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
       this.expands = [];
     }
     return this.expands;
+  }
+
+  private getHoistedExpandsBucket() {
+    if (!this.hoistedExpandsBucket) {
+      this.hoistedExpandsBucket = [];
+    }
+    return this.hoistedExpandsBucket;
   }
 
   public addSelects = (...paths: NullableParamList<string>) => {
@@ -147,7 +163,7 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
     );
   } */
 
-  public expand<Prop extends ExpandType<Q>>(props: NullableParamList<Prop | QSelectExpression>) {
+  public expand(props: NullableParamList<keyof Q | QSelectExpression>) {
     const filteredPaths = this.filterSelectAndMapPath(props);
     if (filteredPaths.length) {
       this.getExpands().push(...filteredPaths);
@@ -158,24 +174,43 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
    * V4 only method used by regular and expanding builder.
    * The regular V2 builder has an own and quite special implementation.
    *
+   * Whether `prop` is an entity/entity-collection navigation property or a complex/complex-collection property
+   * is resolved dynamically here (via `instanceof`), which decides whether the nested builder's content is
+   * embedded as `$expand=prop(...)` or `$select=prop(...)`. In the complex case, any `expand`/`expanding` calls
+   * made inside the nested builder cannot be embedded inline (a `$select=...` clause cannot contain `$expand`,
+   * per real-world OData server behavior even though the spec grammar technically allows it) - they are instead
+   * relayed up (path-prefixed) via `hoistedExpandsBucket` until they reach a context that can embed them
+   * (either an ancestor `expanding()` call reached via a navigation property, or the top-level builder).
+   *
    * @param creator
    * @param prop
    * @param builderFn
    */
-  public expanding<Prop extends ExpandType<Q>>(
-    creator: (property: string, qEntity: Q) => ExpandingCollectionQueryBuilderV4<Q>,
+  public expanding<Prop extends NestingType<Q>>(
+    creator: (property: string, qEntity: Q) => ExpandingCollectionQueryBuilderV4<Q> & { getEngine(): unknown },
     prop: Prop,
     builderFn: (builder: any, qObject: any) => void,
   ) {
     const entityProp = this.getEntityProp<QEntityPathModel<Q>>(prop);
     const path = entityProp.getPath();
     const entity = entityProp.getEntity();
+    const isComplex = entityProp instanceof QComplexPath || entityProp instanceof QComplexCollectionPath;
 
-    const expander = creator(path, entity);
+    const facade = creator(path, entity);
 
-    builderFn(expander, entity);
+    builderFn(facade, entity);
 
-    this.getExpands().push(expander.build());
+    const nestedEngine = facade.getEngine() as ODataQueryBuilder<any>;
+    const { content, hoistedExpands } = nestedEngine.buildNested(isComplex);
+
+    if (isComplex) {
+      this.getSelects().push(content);
+    } else {
+      this.getExpands().push(content);
+    }
+    if (hoistedExpands.length) {
+      this.getHoistedExpandsBucket().push(...hoistedExpands.map((fragment) => `${path}/${fragment}`));
+    }
   }
 
   /**
@@ -248,7 +283,10 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
     return `${encodeURIComponent(operator)}=${encodeURIComponent(value)}`;
   }
 
-  private buildQuery(param: (operator: string, value: string) => string): Array<string> {
+  private buildQuery(
+    param: (operator: string, value: string) => string,
+    opts?: { excludeExpands?: boolean },
+  ): Array<string> {
     const params: Array<string> = [];
     const add = (operator: string, value: string) => params.push(param(operator, value));
 
@@ -257,7 +295,7 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
     if (this.selects?.length) {
       add(ODataOperators.SELECT, this.selects.join(","));
     }
-    if (this.expands?.length) {
+    if (this.expands?.length && !opts?.excludeExpands) {
       add(ODataOperators.EXPAND, this.expands.join(","));
     }
     if (cleanedFilters?.length) {
@@ -291,6 +329,12 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
   }
 
   public build(): string {
+    // fold anything relayed up from complex-typed descendants into this (entity-context) builder's own $expand
+    if (this.hoistedExpandsBucket?.length) {
+      this.getExpands().push(...this.hoistedExpandsBucket);
+      this.hoistedExpandsBucket = undefined;
+    }
+
     const paramFn = this.unencoded || this.config?.expandingBuilder ? this.param : this.paramEncoded;
     const params = this.buildQuery(paramFn);
 
@@ -298,5 +342,28 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
       this.path +
       (!params.length ? "" : !this.config?.expandingBuilder ? `?${params.join("&")}` : `(${params.join(";")})`)
     );
+  }
+
+  /**
+   * Internal-only: used exclusively by `expanding()` to decide `$expand` vs `$select` placement for this
+   * builder's own content, and to compute anything that must be hoisted past this context.
+   *
+   * - Entity context (`isComplexContext === false`, "sink"): behaves exactly like `build()` - embeds `$expand`
+   *   inline and folds in anything relayed up from complex-typed descendants.
+   * - Complex context (`isComplexContext === true`, "relay"): excludes `$expand` from its own rendered content
+   *   entirely (a `$select=Prop(...)` clause cannot contain `$expand`) and instead returns its own `expands`
+   *   plus anything already relayed from its own descendants, unprefixed, for the caller to prefix and forward.
+   */
+  public buildNested(isComplexContext: boolean): { content: string; hoistedExpands: Array<string> } {
+    if (!isComplexContext) {
+      return { content: this.build(), hoistedExpands: [] };
+    }
+
+    const paramFn = this.unencoded || this.config?.expandingBuilder ? this.param : this.paramEncoded;
+    const params = this.buildQuery(paramFn, { excludeExpands: true });
+    const content = this.path + (params.length ? `(${params.join(";")})` : "");
+    const hoistedExpands = [...(this.expands ?? []), ...(this.hoistedExpandsBucket ?? [])];
+
+    return { content, hoistedExpands };
   }
 }

--- a/packages/odata-query-builder/src/ODataQueryBuilderModel.ts
+++ b/packages/odata-query-builder/src/ODataQueryBuilderModel.ts
@@ -1,4 +1,6 @@
 import {
+  QComplexCollectionPath,
+  QComplexPath,
   QEntityCollectionPath,
   QEntityPath,
   QFilterExpression,
@@ -9,10 +11,18 @@ import {
 } from "@odata2ts/odata-query-objects";
 
 /**
- * Extracts the wrapped entity from QEntityPath or QEntityCollectionPath
+ * Extracts the wrapped entity from QEntityPath, QEntityCollectionPath, QComplexPath or QComplexCollectionPath
  */
 export type EntityExtractor<QProp> =
-  QProp extends QEntityPath<infer ET> ? ET : QProp extends QEntityCollectionPath<infer ET> ? ET : never;
+  QProp extends QEntityPath<infer ET>
+    ? ET
+    : QProp extends QEntityCollectionPath<infer ET>
+      ? ET
+      : QProp extends QComplexPath<infer ET>
+        ? ET
+        : QProp extends QComplexCollectionPath<infer ET>
+          ? ET
+          : never;
 
 /**
  * Extracts all keys from a property (Q*Path), but only for the given types
@@ -22,12 +32,26 @@ export type ExtractPropertyNamesOfType<QPath, QPathTypes> = {
 }[keyof QPath];
 
 /**
- * Retrieves all property names which are expandable,
- * i.e. props of type QEntityPath and QEntityCollectionPath
+ * Retrieves all property names which are expandable via a plain `$expand`,
+ * i.e. props of type QEntityPath and QEntityCollectionPath.
+ *
+ * Complex-typed properties are deliberately excluded: per the OData V4 ABNF, an `expandPath` can never terminate
+ * on a bare complex property (only `*`, a stream property, or a navigation property are valid terminal segments),
+ * so a plain `$expand=ComplexProp` is not valid V4 syntax. Use `expanding()` instead (see NestingType).
  */
 export type ExpandType<Q extends QueryObjectModel> = ExtractPropertyNamesOfType<
   Q,
   QEntityPath<any> | QEntityCollectionPath<any>
+>;
+
+/**
+ * Retrieves all property names which are valid `expanding()` targets, i.e. entity/entity-collection navigation
+ * properties (rendered as `$expand=Prop(...)`) as well as complex/complex-collection properties (rendered as
+ * `$select=Prop(...)`, since complex types are always inline and never need `$expand` in V4).
+ */
+export type NestingType<Q extends QueryObjectModel> = ExtractPropertyNamesOfType<
+  Q,
+  QEntityPath<any> | QEntityCollectionPath<any> | QComplexPath<any> | QComplexCollectionPath<any>
 >;
 
 export type Nullable = null | undefined;
@@ -38,11 +62,14 @@ export type NullableParamList<OptionType> = Array<OptionType | Nullable>;
 
 /**
  * The nested builder type passed into an `expanding()` callback depends on whether the expanded property
- * is a to-one (single model) or to-many (collection) navigation property: a to-one target only allows
- * select/expand/expanding, while a to-many target keeps the full set of system query options.
+ * is a to-one (single model) or to-many (collection) property — entity or complex, it doesn't matter which:
+ * a to-one target only allows select/expand/expanding, while a to-many target keeps the full set of system
+ * query options. Whether the property itself is an entity/entity-collection (rendered as `$expand=Prop(...)`)
+ * or a complex/complex-collection type (rendered as `$select=Prop(...)`) is resolved dynamically at runtime
+ * by the engine — the nested builder's shape only depends on cardinality.
  */
 export type ExpandingFunction<Prop> =
-  | (Prop extends QEntityCollectionPath<any>
+  | (Prop extends QEntityCollectionPath<any> | QComplexCollectionPath<any>
       ? (expBuilder: ExpandingCollectionQueryBuilderV4<EntityExtractor<Prop>>, qObject: EntityExtractor<Prop>) => void
       : (expBuilder: ExpandingModelQueryBuilderV4<EntityExtractor<Prop>>, qObject: EntityExtractor<Prop>) => void)
   | Nullable;
@@ -134,11 +161,16 @@ export interface ODataQueryBuilderModel<Q extends QueryObjectModel, ReturnType> 
    *     .select("city")
    *     .filter(qAddress.country.eq("IT"))
    * })} // $expand=address($select=City;$filter=Country eq 'IT')
-   * @param prop the name of the property which should be expanded (must be an entity or entity collection)
+   * @example
+   * builder.expanding("homeAddress", (addressBuilder) => {
+   *   addressBuilder.select("city")
+   * })} // $select=homeAddress($select=city) -- homeAddress is a complex type, not a navigation property
+   * @param prop the name of the property which should be expanded (an entity, entity collection, complex type
+   * or complex type collection)
    * @param builderFn function which receives an entity specific builder as first & the appropriate query object as second argument
    * @returns this query builder
    */
-  expanding: <Prop extends ExpandType<Q>>(prop: Prop, expBuilderFn: ExpandingFunction<Q[Prop]>) => ReturnType;
+  expanding: <Prop extends NestingType<Q>>(prop: Prop, expBuilderFn: ExpandingFunction<Q[Prop]>) => ReturnType;
 
   /**
    * Simple group by clause for properties (no aggregate functionality yet).
@@ -206,7 +238,7 @@ export interface ODataQueryBuilderModel<Q extends QueryObjectModel, ReturnType> 
 
 export interface V2ExpandingFunction<Q extends QueryObjectModel, ReturnType> {
   /**
-   * Expand one property, which is an entity or entity collection.
+   * Expand one property, which is an entity, entity collection, complex type or complex type collection.
    * The second parameter is a callback function which receives a specialized URI builder and the proper query object
    * for the expanded entity.
    * With the help of the builder you can further select, filter, expand, etc.
@@ -218,27 +250,37 @@ export interface V2ExpandingFunction<Q extends QueryObjectModel, ReturnType> {
    * builder.expanding("address", (expBuilder) => expBuilder.select("street", "city")) // $select=address/street,address/city&$expand=address
    * @example
    * builder.expanding("address", (expBuilder) => expBuilder.expand("country")) // $expand=address,address/country
-   * @param prop the name of the property which should be expanded (must be an entity or entity collection)
+   * @param prop the name of the property which should be expanded (an entity, entity collection, complex type
+   * or complex type collection)
    * @param builderFn function which receives an entity specific builder as first & the appropriate query object as second argument
    * @returns this query builder
    */
-  expanding: <Prop extends ExpandType<Q>>(prop: Prop, expBuilderFn: ExpandingFunctionV2<Q[Prop]>) => ReturnType;
+  expanding: <Prop extends NestingType<Q>>(prop: Prop, expBuilderFn: ExpandingFunctionV2<Q[Prop]>) => ReturnType;
+}
+
+/**
+ * V2 only: `expand` is widened to also accept complex/complex-collection properties, since (unlike V4, where
+ * complex types are always inline) V2 requires `$expand=ComplexProp` alongside `$select=ComplexProp/Sub` for a
+ * complex-typed property to appear in the response at all.
+ */
+export interface V2ExpandFunction<Q extends QueryObjectModel, ReturnType> {
+  expand: <Prop extends NestingType<Q>>(...props: NullableParamList<Prop | QSelectExpression>) => ReturnType;
 }
 
 type BuilderOp = "build";
 type ModelOps = "select" | "expand" | BuilderOp;
 type CollectionOnlyOps = "filter" | "orderBy" | "count" | "skip" | "top";
 
-// custom `expanding` method implementation not listed here
-type V2ModelOps = ModelOps;
-type V2CollectionOps = ModelOps | CollectionOnlyOps;
+// `expand`/`expanding` method implementations not listed here, provided via V2ExpandFunction/V2ExpandingFunction
+type V2ModelOps = "select" | BuilderOp;
+type V2CollectionOps = "select" | BuilderOp | CollectionOnlyOps;
 // custom expanding & build method
-type V2ExpandingOps = "select" | "expand";
+type V2ExpandingOps = "select";
 
 type V4ModelOps = ModelOps | "expanding";
 type V4CollectionOps = V4ModelOps | CollectionOnlyOps | "groupBy" | "search";
 type V4ModelExpandingOps = V4ModelOps;
-type V4CollectionExpandingOps = V4ModelOps | CollectionOnlyOps;
+type V4CollectionExpandingOps = V4ModelOps | CollectionOnlyOps | "search";
 
 export type V2ExpandResult = { selects: Array<string>; expands: Array<string> };
 
@@ -248,7 +290,8 @@ export type V2ExpandResult = { selects: Array<string>; expands: Array<string> };
  */
 export interface CollectionQueryBuilderV2<Q extends QueryObjectModel>
   extends Pick<ODataQueryBuilderModel<Q, CollectionQueryBuilderV2<Q>>, V2CollectionOps>,
-    V2ExpandingFunction<Q, CollectionQueryBuilderV2<Q>> {
+    V2ExpandingFunction<Q, CollectionQueryBuilderV2<Q>>,
+    V2ExpandFunction<Q, CollectionQueryBuilderV2<Q>> {
   /**
    * Creates a new builder with the identical state (deep copy).
    */
@@ -261,7 +304,8 @@ export interface CollectionQueryBuilderV2<Q extends QueryObjectModel>
  */
 export interface ModelQueryBuilderV2<Q extends QueryObjectModel>
   extends Pick<ODataQueryBuilderModel<Q, ModelQueryBuilderV2<Q>>, V2ModelOps>,
-    V2ExpandingFunction<Q, ModelQueryBuilderV2<Q>> {
+    V2ExpandingFunction<Q, ModelQueryBuilderV2<Q>>,
+    V2ExpandFunction<Q, ModelQueryBuilderV2<Q>> {
   /**
    * Creates a new builder with the identical state (deep copy).
    */
@@ -270,7 +314,8 @@ export interface ModelQueryBuilderV2<Q extends QueryObjectModel>
 
 export interface ExpandingQueryBuilderV2<Q extends QueryObjectModel>
   extends Pick<ODataQueryBuilderModel<Q, ExpandingQueryBuilderV2<Q>>, V2ExpandingOps>,
-    V2ExpandingFunction<Q, ExpandingQueryBuilderV2<Q>> {
+    V2ExpandingFunction<Q, ExpandingQueryBuilderV2<Q>>,
+    V2ExpandFunction<Q, ExpandingQueryBuilderV2<Q>> {
   /**
    * Build result is actually a list of select and expand strings, which must be consumed manually by the
    * caller of the build function.

--- a/packages/odata-query-builder/src/v2/ExpandingODataQueryBuilderV2.ts
+++ b/packages/odata-query-builder/src/v2/ExpandingODataQueryBuilderV2.ts
@@ -1,10 +1,10 @@
-import { QEntityPath, QSelectExpression, QueryObjectModel } from "@odata2ts/odata-query-objects";
+import { QEntityPathModel, QSelectExpression, QueryObjectModel } from "@odata2ts/odata-query-objects";
 import { ODataQueryBuilder } from "../ODataQueryBuilder";
 import {
   EntityExtractor,
   ExpandingFunctionV2,
   ExpandingQueryBuilderV2 as ExpandingODataQueryBuilderV2Model,
-  ExpandType,
+  NestingType,
   NullableParamList,
 } from "../ODataQueryBuilderModel";
 
@@ -43,7 +43,7 @@ class ExpandingODataQueryBuilderV2<Q extends QueryObjectModel> implements Expand
     return this;
   }
 
-  public expand<Prop extends ExpandType<Q>>(...props: NullableParamList<Prop | QSelectExpression>) {
+  public expand<Prop extends NestingType<Q>>(...props: NullableParamList<Prop | QSelectExpression>) {
     const filtered = this.builder.filterSelectAndMapPath(props);
     if (filtered.length) {
       filtered.forEach((path) => {
@@ -54,12 +54,12 @@ class ExpandingODataQueryBuilderV2<Q extends QueryObjectModel> implements Expand
     return this;
   }
 
-  public expanding<Prop extends ExpandType<Q>>(prop: Prop, builderFn: ExpandingFunctionV2<Q[Prop]>) {
+  public expanding<Prop extends NestingType<Q>>(prop: Prop, builderFn: ExpandingFunctionV2<Q[Prop]>) {
     if (!builderFn) {
       return this;
     }
 
-    const entityProp = this.builder.getEntityProp<QEntityPath<any>>(prop);
+    const entityProp = this.builder.getEntityProp<QEntityPathModel<any>>(prop);
     const entity = entityProp.getEntity();
     const expander = new ExpandingODataQueryBuilderV2<EntityExtractor<Q[Prop]>>(entityProp.getPath(), entity);
 

--- a/packages/odata-query-builder/src/v2/ODataQueryBuilderV2.ts
+++ b/packages/odata-query-builder/src/v2/ODataQueryBuilderV2.ts
@@ -1,5 +1,5 @@
 import {
-  QEntityPath,
+  QEntityPathModel,
   QFilterExpression,
   QOrderByExpression,
   QSelectExpression,
@@ -7,12 +7,12 @@ import {
 } from "@odata2ts/odata-query-objects";
 import { ODataQueryBuilder } from "../ODataQueryBuilder";
 import {
-  CollectionQueryBuilderV2 as ODataQueryBuilderV2Model,
   ExpandingFunctionV2,
-  ExpandType,
+  NestingType,
   NullableParam,
   NullableParamList,
   ODataQueryBuilderConfig,
+  CollectionQueryBuilderV2 as ODataQueryBuilderV2Model,
 } from "../ODataQueryBuilderModel.js";
 import { createExpandingQueryBuilderV2 } from "./ExpandingODataQueryBuilderV2";
 
@@ -70,12 +70,12 @@ class ODataQueryBuilderV2<Q extends QueryObjectModel> implements ODataQueryBuild
     return this;
   }
 
-  public expand<Prop extends ExpandType<Q>>(...props: NullableParamList<Prop | QSelectExpression>) {
+  public expand<Prop extends NestingType<Q>>(...props: NullableParamList<Prop | QSelectExpression>) {
     this.builder.expand(props);
     return this;
   }
 
-  public expanding<Prop extends ExpandType<Q>>(prop: Prop, builderFn: ExpandingFunctionV2<Q[Prop]>) {
+  public expanding<Prop extends NestingType<Q>>(prop: Prop, builderFn: ExpandingFunctionV2<Q[Prop]>) {
     if (!prop) {
       throw new Error("Expanding prop must be defined!");
     }
@@ -83,7 +83,7 @@ class ODataQueryBuilderV2<Q extends QueryObjectModel> implements ODataQueryBuild
       return this;
     }
 
-    const entityProp = this.builder.getEntityProp<QEntityPath<any>>(prop);
+    const entityProp = this.builder.getEntityProp<QEntityPathModel<any>>(prop);
     const entity = entityProp.getEntity();
 
     const expander = createExpandingQueryBuilderV2(entityProp.getPath(), entity);

--- a/packages/odata-query-builder/src/v4/ExpandingODataQueryBuilderV4.ts
+++ b/packages/odata-query-builder/src/v4/ExpandingODataQueryBuilderV4.ts
@@ -1,14 +1,16 @@
 import {
   QFilterExpression,
   QOrderByExpression,
+  QSearchTerm,
   QSelectExpression,
   QueryObjectModel,
 } from "@odata2ts/odata-query-objects";
 import { ODataQueryBuilder } from "../ODataQueryBuilder";
 import {
-  ExpandingCollectionQueryBuilderV4 as ExpandingODataQueryBuilderV4Model,
   ExpandingFunction,
+  ExpandingCollectionQueryBuilderV4 as ExpandingODataQueryBuilderV4Model,
   ExpandType,
+  NestingType,
   NullableParam,
   NullableParamList,
 } from "../ODataQueryBuilderModel";
@@ -16,19 +18,30 @@ import {
 export function createExpandingQueryBuilderV4<Q extends QueryObjectModel>(
   property: string,
   qEntity: Q,
-): ExpandingODataQueryBuilderV4Model<Q> {
+): ExpandingODataQueryBuilderV4Model<Q> & { getEngine(): unknown } {
   return new ExpandingODataQueryBuilderV4<Q>(property, qEntity);
 }
 
 /**
- * Builder for expanded entities or entity collections.
+ * Builder for expanded entities/entity collections and, via `expanding()`, deep-selected complex/complex
+ * collection properties (the engine decides dynamically which one applies per property, see
+ * `ODataQueryBuilder.expanding()`).
  */
 class ExpandingODataQueryBuilderV4<Q extends QueryObjectModel> implements ExpandingODataQueryBuilderV4Model<Q> {
   private builder: ODataQueryBuilder<Q>;
 
   public constructor(property: string, qEntity: Q) {
-    // must never be encoded, since it is part of $expand
+    // must never be encoded, since it is part of $expand/$select
     this.builder = new ODataQueryBuilder(property, qEntity, { expandingBuilder: true });
+  }
+
+  /**
+   * Internal-only accessor used by `ODataQueryBuilder.expanding()` to resolve `$expand` vs `$select` placement
+   * and to hoist any `expand`/`expanding` calls made from within a complex-typed context. Not part of the
+   * public `ExpandingCollectionQueryBuilderV4`/`ExpandingModelQueryBuilderV4` contract.
+   */
+  public getEngine(): unknown {
+    return this.builder;
   }
 
   public select(...props: NullableParamList<keyof Q | QSelectExpression>) {
@@ -41,7 +54,7 @@ class ExpandingODataQueryBuilderV4<Q extends QueryObjectModel> implements Expand
     return this;
   }
 
-  public expanding<Prop extends ExpandType<Q>>(prop: Prop, builderFn: ExpandingFunction<Q[Prop]>) {
+  public expanding<Prop extends NestingType<Q>>(prop: Prop, builderFn: ExpandingFunction<Q[Prop]>) {
     if (builderFn) {
       this.builder.expanding(createExpandingQueryBuilderV4, prop, builderFn);
     }
@@ -70,6 +83,11 @@ class ExpandingODataQueryBuilderV4<Q extends QueryObjectModel> implements Expand
 
   public count(doCount = true) {
     this.builder.count(doCount);
+    return this;
+  }
+
+  public search(...terms: NullableParamList<string | QSearchTerm>) {
+    this.builder.search(terms);
     return this;
   }
 

--- a/packages/odata-query-builder/src/v4/ODataQueryBuilderV4.ts
+++ b/packages/odata-query-builder/src/v4/ODataQueryBuilderV4.ts
@@ -7,12 +7,13 @@ import {
 } from "@odata2ts/odata-query-objects";
 import { ODataQueryBuilder } from "../ODataQueryBuilder";
 import {
-  CollectionQueryBuilderV4 as ODataQueryBuilderV4Model,
   ExpandingFunction,
   ExpandType,
+  NestingType,
   NullableParam,
   NullableParamList,
   ODataQueryBuilderConfig,
+  CollectionQueryBuilderV4 as ODataQueryBuilderV4Model,
 } from "../ODataQueryBuilderModel";
 import { createExpandingQueryBuilderV4 } from "./ExpandingODataQueryBuilderV4";
 
@@ -79,7 +80,7 @@ class ODataQueryBuilderV4<Q extends QueryObjectModel> implements ODataQueryBuild
     return this;
   }
 
-  public expanding<Prop extends ExpandType<Q>>(prop: Prop, builderFn: ExpandingFunction<Q[Prop]>) {
+  public expanding<Prop extends NestingType<Q>>(prop: Prop, builderFn: ExpandingFunction<Q[Prop]>) {
     if (!prop) {
       throw new Error("Expanding prop must be defined!");
     }

--- a/packages/odata-query-builder/test/ODataQueryBuilderBaseTests.ts
+++ b/packages/odata-query-builder/test/ODataQueryBuilderBaseTests.ts
@@ -14,8 +14,8 @@ function addBase(urlPart: string) {
 }
 
 type QueryBuilder =
-  | Omit<CollectionQueryBuilderV2<QPerson>, "expanding" | "count">
-  | Omit<CollectionQueryBuilderV4<QPerson>, "expanding" | "count" | "groupBy">;
+  | Omit<CollectionQueryBuilderV2<QPerson>, "expanding" | "count" | "expand">
+  | Omit<CollectionQueryBuilderV4<QPerson>, "expanding" | "count" | "groupBy" | "expand">;
 
 export type BuilderFactoryFunction<Q extends QueryObject> = (
   path: string,
@@ -215,78 +215,6 @@ export function createBaseTests(createBuilder: BuilderFactoryFunction<QPerson>) 
     const expected = addBase(`$filter=${raw}`);
 
     expect(candidate).toBe(expected);
-  });
-
-  /*
-  test("filterOr: simple", () => {
-    const candidate = toTest.filterOr(qPerson.name.eq("Heinz")).build();
-    const expected = addBase("$filter=name eq 'Heinz'");
-
-    expect(candidate).toBe(expected);
-  });
-
-  test("filterOr: 2 filters", () => {
-    const candidate = toTest.filterOr(qPerson.name.eq("Heinz"), qPerson.age.ge(12)).build();
-    const expected = addBase("$filter=name eq 'Heinz' or age ge 12");
-
-    expect(candidate).toBe(expected);
-  });
-
-  test("filterOr: multiple times", () => {
-    const candidate = toTest
-      .filterOr(qPerson.name.eq("Heinz"), qPerson.age.ge(12))
-      .filterOr(QPerson.deceased.isTrue(), QPerson.age.gt(50))
-      .build();
-    const expected = addBase("$filter=(name eq 'Heinz' or age ge 8) and (deceased eq true or age gt 50)");
-
-    expect(candidate).toBe(expected);
-  });
-  */
-
-  test("expand: simple", () => {
-    const candidate = toTest.expand("bestFriend").build();
-    const expected = addBase("$expand=bestFriend");
-
-    expect(candidate).toBe(expected);
-  });
-
-  test("expand: two simple ones", () => {
-    const candidate = toTest.expand("bestFriend", "friends").build();
-    const expected = addBase("$expand=bestFriend,friends");
-
-    expect(candidate).toBe(expected);
-  });
-
-  test("expand: custom prop", () => {
-    const candidate = toTest.expand(new QSelectExpression("XXX")).build();
-    const expected = addBase("$expand=XXX");
-
-    expect(candidate).toBe(expected);
-  });
-
-  test("expand: mixed with custom prop", () => {
-    const candidate = toTest.expand(new QSelectExpression("x_yz"), "bestFriend").build();
-    const expected = addBase("$expand=x_yz,bestFriend");
-
-    expect(candidate).toBe(expected);
-  });
-
-  test("expand: ignore nullables", () => {
-    const expectedNull = addBase("");
-    const expected = addBase("$expand=bestFriend");
-
-    expect(toTest.expand(null).build()).toBe(expectedNull);
-    expect(toTest.expand(undefined).build()).toBe(expectedNull);
-    expect(toTest.expand("bestFriend", undefined, null).build()).toBe(expected);
-  });
-
-  test("expand: won't work for complex types or collections", () => {
-    // @ts-expect-error
-    toTest.expand("likedFeatures");
-    // @ts-expect-error
-    toTest.expand("address");
-    // @ts-expect-error
-    toTest.expand("altAddresses");
   });
 
   test("clone", () => {

--- a/packages/odata-query-builder/test/ODataQueryBuilderV2.test.ts
+++ b/packages/odata-query-builder/test/ODataQueryBuilderV2.test.ts
@@ -40,6 +40,51 @@ describe("ODataQueryBuilderV2 Test", () => {
     expect(candidate).toBe(expected);
   });
 
+  test("expand: simple", () => {
+    const candidate = toTest.expand("bestFriend").build();
+    const expected = addBase("$expand=bestFriend");
+
+    expect(candidate).toBe(expected);
+  });
+
+  test("expand: two simple ones", () => {
+    const candidate = toTest.expand("bestFriend", "friends").build();
+    const expected = addBase("$expand=bestFriend,friends");
+
+    expect(candidate).toBe(expected);
+  });
+
+  test("expand: custom prop", () => {
+    const candidate = toTest.expand(new QSelectExpression("XXX")).build();
+    const expected = addBase("$expand=XXX");
+
+    expect(candidate).toBe(expected);
+  });
+
+  test("expand: mixed with custom prop", () => {
+    const candidate = toTest.expand(new QSelectExpression("x_yz"), "bestFriend").build();
+    const expected = addBase("$expand=x_yz,bestFriend");
+
+    expect(candidate).toBe(expected);
+  });
+
+  test("expand: ignore nullables", () => {
+    const expectedNull = addBase("");
+    const expected = addBase("$expand=bestFriend");
+
+    expect(toTest.expand(null).build()).toBe(expectedNull);
+    expect(toTest.expand(undefined).build()).toBe(expectedNull);
+    expect(toTest.expand("bestFriend", undefined, null).build()).toBe(expected);
+  });
+
+  test("expand: also works for complex types and collections in V2", () => {
+    // unlike V4, V2 doesn't auto-inline complex types - $expand is required for them to appear at all
+    const candidate = toTest.expand("address", "altAddresses").build();
+    const expected = addBase("$expand=Address,AltAdresses");
+
+    expect(candidate).toBe(expected);
+  });
+
   test("expanding: simple", () => {
     const candidate = toTest.expanding("bestFriend", () => {}).build();
     const expected = addBase("$expand=bestFriend");
@@ -84,6 +129,52 @@ describe("ODataQueryBuilderV2 Test", () => {
       .expanding("bestFriend", (builder) => builder.select("age"))
       .build();
     const expected = addBase("$select=name,bestFriend/age&$expand=friends,bestFriend");
+
+    expect(candidate).toBe(expected);
+  });
+
+  test("expanding: complex prop - flattened like an entity nav prop", () => {
+    const candidate = toTest.expanding("address", (builder) => builder.select("street")).build();
+    const expected = addBase("$select=Address/street&$expand=Address");
+
+    expect(candidate).toBe(expected);
+  });
+
+  test("expanding: entity nested inside complex prop", () => {
+    const candidate = toTest
+      .expanding("address", (builder) => {
+        builder.expanding("responsible", (respBuilder) => {
+          respBuilder.select("name");
+        });
+      })
+      .build();
+    const expected = addBase("$select=Address/responsible/name&$expand=Address,Address/responsible");
+
+    expect(candidate).toBe(expected);
+  });
+
+  test("expanding: complex prop nested inside entity", () => {
+    const candidate = toTest
+      .expanding("bestFriend", (builder) => {
+        builder.expanding("address", (addrBuilder) => {
+          addrBuilder.select("street");
+        });
+      })
+      .build();
+    const expected = addBase("$select=bestFriend/Address/street&$expand=bestFriend,bestFriend/Address");
+
+    expect(candidate).toBe(expected);
+  });
+
+  test("expanding: complex prop nested inside complex prop", () => {
+    const candidate = toTest
+      .expanding("address", (builder) => {
+        builder.expanding("geo", (geoBuilder) => {
+          geoBuilder.select("lat");
+        });
+      })
+      .build();
+    const expected = addBase("$select=Address/geo/lat&$expand=Address,Address/geo");
 
     expect(candidate).toBe(expected);
   });

--- a/packages/odata-query-builder/test/ODataQueryBuilderV4.test.ts
+++ b/packages/odata-query-builder/test/ODataQueryBuilderV4.test.ts
@@ -63,6 +63,52 @@ describe("ODataQueryBuilderV4 Test", () => {
     expect(candidate).toBe(expected);
   });
 
+  test("expand: simple", () => {
+    const candidate = toTest.expand("bestFriend").build();
+    const expected = addBase("$expand=bestFriend");
+
+    expect(candidate).toBe(expected);
+  });
+
+  test("expand: two simple ones", () => {
+    const candidate = toTest.expand("bestFriend", "friends").build();
+    const expected = addBase("$expand=bestFriend,friends");
+
+    expect(candidate).toBe(expected);
+  });
+
+  test("expand: custom prop", () => {
+    const candidate = toTest.expand(new QSelectExpression("XXX")).build();
+    const expected = addBase("$expand=XXX");
+
+    expect(candidate).toBe(expected);
+  });
+
+  test("expand: mixed with custom prop", () => {
+    const candidate = toTest.expand(new QSelectExpression("x_yz"), "bestFriend").build();
+    const expected = addBase("$expand=x_yz,bestFriend");
+
+    expect(candidate).toBe(expected);
+  });
+
+  test("expand: ignore nullables", () => {
+    const expectedNull = addBase("");
+    const expected = addBase("$expand=bestFriend");
+
+    expect(toTest.expand(null).build()).toBe(expectedNull);
+    expect(toTest.expand(undefined).build()).toBe(expectedNull);
+    expect(toTest.expand("bestFriend", undefined, null).build()).toBe(expected);
+  });
+
+  test("expand: won't work for complex types or collections", () => {
+    // @ts-expect-error - an expandPath can never terminate on a bare complex property, use expanding() instead
+    toTest.expand("likedFeatures");
+    // @ts-expect-error
+    toTest.expand("address");
+    // @ts-expect-error
+    toTest.expand("altAddresses");
+  });
+
   test("expanding: simple", () => {
     const candidate = toTest.expanding("bestFriend", () => {}).build();
     const expected = addBase("$expand=bestFriend");
@@ -133,7 +179,7 @@ describe("ODataQueryBuilderV4 Test", () => {
 
   test("expanding: nested expand", () => {
     const candidate = toTest
-      .expanding("bestFriend", (builder, qAddress) => {
+      .expanding("bestFriend", (builder) => {
         builder.expand("bestFriend");
       })
       .build();
@@ -144,7 +190,7 @@ describe("ODataQueryBuilderV4 Test", () => {
 
   test("expanding: with custom prop", () => {
     const candidate = toTest
-      .expanding("bestFriend", (builder, qAddress) => {
+      .expanding("bestFriend", (builder) => {
         builder.select(new QSelectExpression("THE1")).expand(new QSelectExpression("xxx"));
       })
       .build();
@@ -172,6 +218,65 @@ describe("ODataQueryBuilderV4 Test", () => {
       })
       .build();
     const expected = addBase("$expand=friends($orderby=name asc)");
+
+    expect(candidate).toBe(expected);
+  });
+
+  test("expanding: single complex prop renders as $select, no $expand", () => {
+    const candidate = toTest.expanding("address", (builder) => builder.select("street")).build();
+    const expected = addBase("$select=Address($select=street)");
+
+    expect(candidate).toBe(expected);
+  });
+
+  test("expanding: complex collection prop keeps collection-only ops incl. search", () => {
+    const candidate = toTest
+      .expanding("altAddresses", (builder, qAddr) => {
+        builder.select("street").filter(qAddr.street.startsWith("H")).count().top(1).skip(0).search("berlin");
+      })
+      .build();
+    const expected = addBase(
+      "$select=AltAdresses($select=street;$filter=startswith(street,'H');$count=true;$top=1;$skip=0;$search=berlin)",
+    );
+
+    expect(candidate).toBe(expected);
+  });
+
+  test("expanding: entity nested inside complex prop gets hoisted to the nearest $expand", () => {
+    const candidate = toTest
+      .expanding("address", (builder) => {
+        builder.select("street").expanding("responsible", (respBuilder) => {
+          respBuilder.select("name");
+        });
+      })
+      .build();
+    const expected = addBase("$select=Address($select=street)&$expand=Address/responsible($select=name)");
+
+    expect(candidate).toBe(expected);
+  });
+
+  test("expanding: complex prop nested inside entity stays inline", () => {
+    const candidate = toTest
+      .expanding("bestFriend", (builder) => {
+        builder.expanding("address", (addrBuilder) => {
+          addrBuilder.select("street");
+        });
+      })
+      .build();
+    const expected = addBase("$expand=bestFriend($select=Address($select=street))");
+
+    expect(candidate).toBe(expected);
+  });
+
+  test("expanding: complex prop nested inside complex prop stays inline", () => {
+    const candidate = toTest
+      .expanding("address", (builder) => {
+        builder.expanding("geo", (geoBuilder) => {
+          geoBuilder.select("lat");
+        });
+      })
+      .build();
+    const expected = addBase("$select=Address($select=geo($select=lat))");
 
     expect(candidate).toBe(expected);
   });

--- a/packages/odata-query-builder/test/QueryBuilderCardinality.test.ts
+++ b/packages/odata-query-builder/test/QueryBuilderCardinality.test.ts
@@ -74,6 +74,37 @@ describe("Query Builder Cardinality", () => {
         "/Persons?$expand=friends($select=name;$filter=name eq 'Horst';$orderby=name asc;$count=true;$top=1;$skip=0)",
       );
     });
+
+    test("expanding a to-one complex prop narrows the nested builder to model ops", () => {
+      createQueryBuilderV4("/Persons", qPerson).expanding("address", (nested, qAddress) => {
+        nested.select("street").expanding("responsible", (respNested) => {
+          respNested.select("name");
+        });
+
+        // @ts-expect-error: filter is not available for a to-one expanded model, even a complex one
+        nested.filter(qAddress.street.eq("Horststr."));
+        // @ts-expect-error: top is not available for a to-one expanded model, even a complex one
+        nested.top(1);
+        // @ts-expect-error: skip is not available for a to-one expanded model, even a complex one
+        nested.skip(1);
+        // @ts-expect-error: count is not available for a to-one expanded model, even a complex one
+        nested.count();
+        // @ts-expect-error: orderBy is not available for a to-one expanded model, even a complex one
+        nested.orderBy(qAddress.street.asc());
+      });
+    });
+
+    test("expanding a to-many complex prop keeps the nested builder at full (collection) ops incl. search", () => {
+      const candidate = createQueryBuilderV4("/Persons", qPerson, { unencoded: true })
+        .expanding("altAddresses", (nested, qAddress) => {
+          nested.select("street").filter(qAddress.street.eq("Horststr.")).top(1).skip(0).count().search("berlin");
+        })
+        .build();
+
+      expect(candidate).toBe(
+        "/Persons?$select=AltAdresses($select=street;$filter=street eq 'Horststr.';$count=true;$top=1;$skip=0;$search=berlin)",
+      );
+    });
   });
 
   describe("V2", () => {

--- a/packages/odata-query-builder/test/fixture/types/QSimplePersonModel.ts
+++ b/packages/odata-query-builder/test/fixture/types/QSimplePersonModel.ts
@@ -36,6 +36,7 @@ export const qPerson = new QPerson();
 export class QAddress extends QueryObject {
   public readonly street = new QStringPath(this.withPrefix("street"));
   public readonly responsible = new QEntityPath<QPerson>(this.withPrefix("responsible"), () => QPerson);
+  public readonly geo = new QComplexPath<QGeoPosition>(this.withPrefix("geo"), () => QGeoPosition);
 
   constructor(path?: string) {
     super(path);
@@ -43,3 +44,14 @@ export class QAddress extends QueryObject {
 }
 
 export const qAddress = new QAddress();
+
+export class QGeoPosition extends QueryObject {
+  public readonly lat = new QNumberPath(this.withPrefix("lat"));
+  public readonly lng = new QNumberPath(this.withPrefix("lng"));
+
+  constructor(path?: string) {
+    super(path);
+  }
+}
+
+export const qGeoPosition = new QGeoPosition();


### PR DESCRIPTION
via `expanding` complex types can be deeply selected: results in deep select path, e.g. `Address/Street`. Complex collections can also be filtered, skipped, etc., which results in complex select paths, e.g `$select=Adresses($filter=startswith(Street,'H');$top=1)`.

Additionally, complex types can also expand entities / navigations properties. In the background this is then added to the proper `expand` clause.