### PR TITLE
feat(odata-service): support select/expand on create/update/patch/add

### DIFF
--- a/examples/main/test/odataV2/CrudOperation.test.ts
+++ b/examples/main/test/odataV2/CrudOperation.test.ts
@@ -38,6 +38,44 @@ describe("V2 CRUD Functionality Tests", function () {
     });
   });
 
+  test("create with select/expand", () => {
+    const model: EditableProductModel = {
+      id: 123,
+      name: "test",
+      price: new BigNumber("12.03"),
+      rating: 5,
+      releaseDate: "xyz",
+      description: "Description",
+      discontinuedDate: null,
+    };
+    testService
+      .products()
+      .create(model, (b) => b.select("name"))
+      .execute();
+
+    expect(odataClient.lastOperation).toBe("POST");
+    expect(odataClient.lastUrl).toBe("test/Products?$select=Name");
+  });
+
+  test("update returns a builder-backed Cmd, addToQuery works", () => {
+    const model = {
+      id: 123,
+      name: "test",
+      price: new BigNumber("12.03"),
+      rating: 5,
+      releaseDate: "xyz",
+      discontinuedDate: null,
+    };
+    testService
+      .products(123)
+      .update(model)
+      .addToQuery((b) => b.select("name"))
+      .execute();
+
+    expect(odataClient.lastOperation).toBe("PUT");
+    expect(odataClient.lastUrl).toBe("test/Products(123)?$select=Name");
+  });
+
   test("update", () => {
     const model = {
       id: 123,

--- a/examples/main/test/trippin/CrudOperation.test.ts
+++ b/examples/main/test/trippin/CrudOperation.test.ts
@@ -55,6 +55,44 @@ describe("Testing Generation of TrippinService", () => {
     expectTypeOf(response).toEqualTypeOf<HttpResponseModel<undefined>>();
   });
 
+  test("entitySet: create with select/expand", async () => {
+    const expectedUrl = `${BASE_URL}/People?$select=FirstName`;
+
+    ODATA_CLIENT.setModelResponse(odataModel);
+    const response = await TRIPPIN.people()
+      .create(userModel, undefined, (b) => b.select("firstName"))
+      .execute();
+
+    expect(ODATA_CLIENT.lastOperation).toBe("POST");
+    expect(ODATA_CLIENT.lastUrl).toBe(expectedUrl);
+    expectTypeOf(response).toEqualTypeOf<HttpResponseModel<ODataModelResponseV4<PersonModel>>>();
+  });
+
+  test("entityType: update with select/expand", async () => {
+    const id = userModel.user;
+    const expectedUrl = `${BASE_URL}/People('${id}')?$expand=BestFriend`;
+
+    const response = await TRIPPIN.people(id)
+      .update(userModel, undefined, (b) => b.expand("bestFriend"))
+      .execute();
+
+    expect(ODATA_CLIENT.lastOperation).toBe("PUT");
+    expect(ODATA_CLIENT.lastUrl).toBe(expectedUrl);
+    expectTypeOf(response).toEqualTypeOf<HttpResponseModel<undefined>>();
+  });
+
+  test("entityType: update returns a builder-backed Cmd, addToQuery works", async () => {
+    const id = userModel.user;
+    const expectedUrl = `${BASE_URL}/People('${id}')?$select=FirstName`;
+
+    await TRIPPIN.people(id)
+      .update(userModel)
+      .addToQuery((b) => b.select("firstName"))
+      .execute();
+
+    expect(ODATA_CLIENT.lastUrl).toBe(expectedUrl);
+  });
+
   test("entityType: patch", async () => {
     const id = "williams";
     const expectedUrl = `${BASE_URL}/People('${id}')`;
@@ -103,6 +141,18 @@ describe("Testing Generation of TrippinService", () => {
     await TRIPPIN.people("tester").addressInfo().add(model).execute();
 
     expect(ODATA_CLIENT.lastUrl).toBe(`${BASE_URL}/People('tester')/AddressInfo`);
+    expect(ODATA_CLIENT.lastOperation).toBe("POST");
+    expect(ODATA_CLIENT.lastData).toStrictEqual({ Address: "TestAdress" });
+  });
+
+  test("complex collection: create with select/expand", async () => {
+    const model: EditableLocationModel = { address: "TestAdress" };
+    await TRIPPIN.people("tester")
+      .addressInfo()
+      .add(model, (b) => b.select("address"))
+      .execute();
+
+    expect(ODATA_CLIENT.lastUrl).toBe(`${BASE_URL}/People('tester')/AddressInfo?$select=Address`);
     expect(ODATA_CLIENT.lastOperation).toBe("POST");
     expect(ODATA_CLIENT.lastData).toStrictEqual({ Address: "TestAdress" });
   });

--- a/packages/odata-service/src/request/UrlBuilderRequestCmdV2.ts
+++ b/packages/odata-service/src/request/UrlBuilderRequestCmdV2.ts
@@ -3,19 +3,34 @@ import { CollectionQueryBuilderV2, ModelQueryBuilderV2 } from "@odata2ts/odata-q
 import { QueryObjectModel } from "@odata2ts/odata-query-objects";
 import { RequestCmd, RequestCmdOptions } from "./RequestCmd";
 
+export interface UrlBuilderRequestCmdOptionsV2<ResponseStructure, DataStructure = undefined>
+  extends RequestCmdOptions<ResponseStructure, DataStructure> {
+  /**
+   * HTTP method for this request. Defaults to GET, the only method relevant for plain `.query()` use.
+   * Write operations (create/update/patch/add) that also shape their response via $select/$expand
+   * supply PUT/PATCH/POST here.
+   */
+  method?: ODataHttpMethods;
+  /**
+   * Request payload, e.g. the entity being created or updated. Irrelevant for GET.
+   */
+  data?: DataStructure;
+}
+
 export class UrlBuilderRequestCmdV2<
   ClientType extends ODataHttpClient,
   ResponseStructure,
   Q extends QueryObjectModel,
   Builder extends ModelQueryBuilderV2<Q> = CollectionQueryBuilderV2<Q>,
-> extends RequestCmd<ClientType, ResponseStructure> {
+  DataStructure = undefined,
+> extends RequestCmd<ClientType, ResponseStructure, DataStructure> {
   constructor(
     protected client: ClientType,
     protected urlBuilder: Builder,
     protected q: Q,
-    protected options: RequestCmdOptions<ResponseStructure, undefined> = {},
+    protected options: UrlBuilderRequestCmdOptionsV2<ResponseStructure, DataStructure> = {},
   ) {
-    super(client, ODataHttpMethods.Get, undefined, options);
+    super(client, options.method ?? ODataHttpMethods.Get, options.data, options);
   }
 
   public getUrl(): string {
@@ -33,7 +48,7 @@ export class UrlBuilderRequestCmdV2<
     }
     const builder = modFunction(this.urlBuilder.clone() as Builder, this.q);
 
-    return new UrlBuilderRequestCmdV2<ClientType, ResponseStructure, Q, Builder>(
+    return new UrlBuilderRequestCmdV2<ClientType, ResponseStructure, Q, Builder, DataStructure>(
       this.client,
       builder,
       this.q,

--- a/packages/odata-service/src/request/UrlBuilderRequestCmdV2.ts
+++ b/packages/odata-service/src/request/UrlBuilderRequestCmdV2.ts
@@ -3,20 +3,6 @@ import { CollectionQueryBuilderV2, ModelQueryBuilderV2 } from "@odata2ts/odata-q
 import { QueryObjectModel } from "@odata2ts/odata-query-objects";
 import { RequestCmd, RequestCmdOptions } from "./RequestCmd";
 
-export interface UrlBuilderRequestCmdOptionsV2<ResponseStructure, DataStructure = undefined>
-  extends RequestCmdOptions<ResponseStructure, DataStructure> {
-  /**
-   * HTTP method for this request. Defaults to GET, the only method relevant for plain `.query()` use.
-   * Write operations (create/update/patch/add) that also shape their response via $select/$expand
-   * supply PUT/PATCH/POST here.
-   */
-  method?: ODataHttpMethods;
-  /**
-   * Request payload, e.g. the entity being created or updated. Irrelevant for GET.
-   */
-  data?: DataStructure;
-}
-
 export class UrlBuilderRequestCmdV2<
   ClientType extends ODataHttpClient,
   ResponseStructure,
@@ -26,11 +12,13 @@ export class UrlBuilderRequestCmdV2<
 > extends RequestCmd<ClientType, ResponseStructure, DataStructure> {
   constructor(
     protected client: ClientType,
+    method: ODataHttpMethods,
     protected urlBuilder: Builder,
     protected q: Q,
-    protected options: UrlBuilderRequestCmdOptionsV2<ResponseStructure, DataStructure> = {},
+    data?: DataStructure,
+    protected options: RequestCmdOptions<ResponseStructure, DataStructure> = {},
   ) {
-    super(client, options.method ?? ODataHttpMethods.Get, options.data, options);
+    super(client, method, data, options);
   }
 
   public getUrl(): string {
@@ -50,8 +38,10 @@ export class UrlBuilderRequestCmdV2<
 
     return new UrlBuilderRequestCmdV2<ClientType, ResponseStructure, Q, Builder, DataStructure>(
       this.client,
+      this.method,
       builder,
       this.q,
+      this.data,
       this.options,
     );
   }

--- a/packages/odata-service/src/request/UrlBuilderRequestCmdV4.ts
+++ b/packages/odata-service/src/request/UrlBuilderRequestCmdV4.ts
@@ -4,24 +4,34 @@ import { QueryObjectModel } from "@odata2ts/odata-query-objects";
 import { RequestCmd, RequestCmdOptions } from "./RequestCmd";
 import { GetToPostConverter } from "./RequestHelper";
 
-export type UrlBuilderRequestCmdOptions<ResponseStructure> = Omit<
-  RequestCmdOptions<ResponseStructure, undefined>,
-  "mainRequestConverter"
->;
+export interface UrlBuilderRequestCmdOptions<ResponseStructure, DataStructure = undefined>
+  extends RequestCmdOptions<ResponseStructure, DataStructure> {
+  /**
+   * HTTP method for this request. Defaults to GET, the only method relevant for plain `.query()` use.
+   * Write operations (create/update/patch/add) that also shape their response via $select/$expand
+   * supply PUT/PATCH/POST here.
+   */
+  method?: ODataHttpMethods;
+  /**
+   * Request payload, e.g. the entity being created or updated. Irrelevant for GET.
+   */
+  data?: DataStructure;
+}
 
 export class UrlBuilderRequestCmdV4<
   ClientType extends ODataHttpClient,
   ResponseStructure,
   Q extends QueryObjectModel,
   Builder extends ModelQueryBuilderV4<Q> = CollectionQueryBuilderV4<Q>,
-> extends RequestCmd<ClientType, ResponseStructure> {
+  DataStructure = undefined,
+> extends RequestCmd<ClientType, ResponseStructure, DataStructure> {
   constructor(
     protected client: ClientType,
     protected urlBuilder: Builder,
     protected q: Q,
-    protected options: UrlBuilderRequestCmdOptions<ResponseStructure> = {},
+    protected options: UrlBuilderRequestCmdOptions<ResponseStructure, DataStructure> = {},
   ) {
-    super(client, ODataHttpMethods.Get, undefined, options);
+    super(client, options.method ?? ODataHttpMethods.Get, options.data, options);
   }
 
   public getUrl(): string {
@@ -40,7 +50,7 @@ export class UrlBuilderRequestCmdV4<
     }
     const builder = modFunction(this.urlBuilder.clone() as Builder, this.q);
 
-    return new UrlBuilderRequestCmdV4<ClientType, ResponseStructure, Q, Builder>(
+    return new UrlBuilderRequestCmdV4<ClientType, ResponseStructure, Q, Builder, DataStructure>(
       this.client,
       builder,
       this.q,

--- a/packages/odata-service/src/request/UrlBuilderRequestCmdV4.ts
+++ b/packages/odata-service/src/request/UrlBuilderRequestCmdV4.ts
@@ -4,20 +4,6 @@ import { QueryObjectModel } from "@odata2ts/odata-query-objects";
 import { RequestCmd, RequestCmdOptions } from "./RequestCmd";
 import { GetToPostConverter } from "./RequestHelper";
 
-export interface UrlBuilderRequestCmdOptions<ResponseStructure, DataStructure = undefined>
-  extends RequestCmdOptions<ResponseStructure, DataStructure> {
-  /**
-   * HTTP method for this request. Defaults to GET, the only method relevant for plain `.query()` use.
-   * Write operations (create/update/patch/add) that also shape their response via $select/$expand
-   * supply PUT/PATCH/POST here.
-   */
-  method?: ODataHttpMethods;
-  /**
-   * Request payload, e.g. the entity being created or updated. Irrelevant for GET.
-   */
-  data?: DataStructure;
-}
-
 export class UrlBuilderRequestCmdV4<
   ClientType extends ODataHttpClient,
   ResponseStructure,
@@ -27,11 +13,13 @@ export class UrlBuilderRequestCmdV4<
 > extends RequestCmd<ClientType, ResponseStructure, DataStructure> {
   constructor(
     protected client: ClientType,
+    method: ODataHttpMethods,
     protected urlBuilder: Builder,
     protected q: Q,
-    protected options: UrlBuilderRequestCmdOptions<ResponseStructure, DataStructure> = {},
+    data?: DataStructure,
+    protected options: RequestCmdOptions<ResponseStructure, DataStructure> = {},
   ) {
-    super(client, options.method ?? ODataHttpMethods.Get, options.data, options);
+    super(client, method, data, options);
   }
 
   public getUrl(): string {
@@ -52,8 +40,10 @@ export class UrlBuilderRequestCmdV4<
 
     return new UrlBuilderRequestCmdV4<ClientType, ResponseStructure, Q, Builder, DataStructure>(
       this.client,
+      this.method,
       builder,
       this.q,
+      this.data,
       this.options,
     );
   }

--- a/packages/odata-service/src/v2/CollectionServiceV2.ts
+++ b/packages/odata-service/src/v2/CollectionServiceV2.ts
@@ -56,9 +56,7 @@ export class CollectionServiceV2<
       Q,
       ModelQueryBuilderV2<Q>,
       PrimitiveT
-    >(client, createModelQueryBuilder(queryFn), qModel, {
-      method: ODataHttpMethods.Post,
-      data: model,
+    >(client, ODataHttpMethods.Post, createModelQueryBuilder(queryFn), qModel, model, {
       headers: getDefaultHeaders(),
       mainRequestConverter: qModel,
       mainResponseConverter: new CollectionResponseConverterV2(qModel) as MainResponseConverter<
@@ -94,9 +92,7 @@ export class CollectionServiceV2<
       Q,
       ModelQueryBuilderV2<Q>,
       Array<PrimitiveT>
-    >(client, createModelQueryBuilder(queryFn), qModel, {
-      method: ODataHttpMethods.Put,
-      data: models,
+    >(client, ODataHttpMethods.Put, createModelQueryBuilder(queryFn), qModel, models, {
       headers: getDefaultHeaders(),
       mainRequestConverter: qModel,
       mainResponseConverter: new CollectionResponseConverterV2(qModel) as MainResponseConverter<
@@ -123,8 +119,10 @@ export class CollectionServiceV2<
 
     return new UrlBuilderRequestCmdV2<ClientType, ODataCollectionResponseV2<ReturnType>, Q>(
       client,
+      ODataHttpMethods.Get,
       createQueryBuilder(queryFn),
       qModel,
+      undefined,
       {
         headers: getDefaultHeaders(),
         mainResponseConverter: new CollectionResponseConverterV2(qModel),

--- a/packages/odata-service/src/v2/CollectionServiceV2.ts
+++ b/packages/odata-service/src/v2/CollectionServiceV2.ts
@@ -1,6 +1,6 @@
 import { ODataHttpClient, ODataHttpMethods } from "@odata2ts/http-client-api";
 import { ODataCollectionResponseV2 } from "@odata2ts/odata-core";
-import { CollectionQueryBuilderV2 } from "@odata2ts/odata-query-builder";
+import { CollectionQueryBuilderV2, ModelQueryBuilderV2 } from "@odata2ts/odata-query-builder";
 import {
   CollectionResponseConverterV2,
   MainResponseConverter,
@@ -44,23 +44,28 @@ export class CollectionServiceV2<
    *
    * @param model primitive value
    */
-  public add<Response extends boolean = false>(model: PrimitiveT) {
-    const { path, client, qModel, getDefaultHeaders } = this.__base;
+  public add<Response extends boolean = false>(
+    model: PrimitiveT,
+    queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void,
+  ) {
+    const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
 
-    return new UrlRequestCmd<ClientType, CollectionModificationResponseV2<Response, PrimitiveT>, PrimitiveT>(
-      client,
-      ODataHttpMethods.Post,
-      path,
-      model,
-      {
-        headers: getDefaultHeaders(),
-        mainRequestConverter: qModel,
-        mainResponseConverter: new CollectionResponseConverterV2(qModel) as MainResponseConverter<
-          CollectionModificationResponseV2<Response, PrimitiveT>,
-          T
-        >,
-      },
-    );
+    return new UrlBuilderRequestCmdV2<
+      ClientType,
+      CollectionModificationResponseV2<Response, PrimitiveT>,
+      Q,
+      ModelQueryBuilderV2<Q>,
+      PrimitiveT
+    >(client, createModelQueryBuilder(queryFn), qModel, {
+      method: ODataHttpMethods.Post,
+      data: model,
+      headers: getDefaultHeaders(),
+      mainRequestConverter: qModel,
+      mainResponseConverter: new CollectionResponseConverterV2(qModel) as MainResponseConverter<
+        CollectionModificationResponseV2<Response, PrimitiveT>,
+        T
+      >,
+    });
   }
 
   /**
@@ -77,23 +82,28 @@ export class CollectionServiceV2<
    *
    * @param models set of primitive values
    */
-  public update<Response extends boolean = false>(models: Array<PrimitiveT>) {
-    const { client, path, qModel, getDefaultHeaders } = this.__base;
+  public update<Response extends boolean = false>(
+    models: Array<PrimitiveT>,
+    queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void,
+  ) {
+    const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
 
-    return new UrlRequestCmd<ClientType, CollectionModificationResponseV2<Response, PrimitiveT>, Array<PrimitiveT>>(
-      client,
-      ODataHttpMethods.Put,
-      path,
-      models,
-      {
-        headers: getDefaultHeaders(),
-        mainRequestConverter: qModel,
-        mainResponseConverter: new CollectionResponseConverterV2(qModel) as MainResponseConverter<
-          CollectionModificationResponseV2<Response, PrimitiveT>,
-          T
-        >,
-      },
-    );
+    return new UrlBuilderRequestCmdV2<
+      ClientType,
+      CollectionModificationResponseV2<Response, PrimitiveT>,
+      Q,
+      ModelQueryBuilderV2<Q>,
+      Array<PrimitiveT>
+    >(client, createModelQueryBuilder(queryFn), qModel, {
+      method: ODataHttpMethods.Put,
+      data: models,
+      headers: getDefaultHeaders(),
+      mainRequestConverter: qModel,
+      mainResponseConverter: new CollectionResponseConverterV2(qModel) as MainResponseConverter<
+        CollectionModificationResponseV2<Response, PrimitiveT>,
+        T
+      >,
+    });
   }
 
   /**

--- a/packages/odata-service/src/v2/ComplexTypeServiceV2.ts
+++ b/packages/odata-service/src/v2/ComplexTypeServiceV2.ts
@@ -24,11 +24,11 @@ export class ComplexTypeServiceV2<in out ClientType extends ODataHttpClient, T, 
 
     return new UrlBuilderRequestCmdV2<ClientType, undefined, Q, ModelQueryBuilderV2<Q>, Partial<EditableT>>(
       client,
+      ODataHttpMethods.Post,
       createModelQueryBuilder(queryFn),
       qModel,
+      model,
       {
-        method: ODataHttpMethods.Post,
-        data: model,
         headers,
         mainRequestConverter: qModel,
       },
@@ -40,11 +40,11 @@ export class ComplexTypeServiceV2<in out ClientType extends ODataHttpClient, T, 
 
     return new UrlBuilderRequestCmdV2<ClientType, undefined, Q, ModelQueryBuilderV2<Q>, EditableT>(
       client,
+      ODataHttpMethods.Put,
       createModelQueryBuilder(queryFn),
       qModel,
+      model,
       {
-        method: ODataHttpMethods.Put,
-        data: model,
         headers: getDefaultHeaders(),
         mainRequestConverter: qModel,
       },
@@ -62,8 +62,10 @@ export class ComplexTypeServiceV2<in out ClientType extends ODataHttpClient, T, 
 
     return new UrlBuilderRequestCmdV2<ClientType, ODataComplexModelResponseV2<ReturnType>, Q, ModelQueryBuilderV2<Q>>(
       client,
+      ODataHttpMethods.Get,
       createModelQueryBuilder(queryFn),
       qModel,
+      undefined,
       {
         headers: getDefaultHeaders(),
         mainResponseConverter: new ComplexResponseConverterV2(qModel),

--- a/packages/odata-service/src/v2/ComplexTypeServiceV2.ts
+++ b/packages/odata-service/src/v2/ComplexTypeServiceV2.ts
@@ -18,23 +18,37 @@ export class ComplexTypeServiceV2<in out ClientType extends ODataHttpClient, T, 
     return this.__base.path;
   }
 
-  public patch(model: Partial<EditableT>) {
-    const { client, qModel, path, getDefaultHeaders } = this.__base;
+  public patch(model: Partial<EditableT>, queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void) {
+    const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
     const headers = { ...getDefaultHeaders(), ...MERGE_HEADERS };
 
-    return new UrlRequestCmd<ClientType, undefined, Partial<EditableT>>(client, ODataHttpMethods.Post, path, model, {
-      headers,
-      mainRequestConverter: qModel,
-    });
+    return new UrlBuilderRequestCmdV2<ClientType, undefined, Q, ModelQueryBuilderV2<Q>, Partial<EditableT>>(
+      client,
+      createModelQueryBuilder(queryFn),
+      qModel,
+      {
+        method: ODataHttpMethods.Post,
+        data: model,
+        headers,
+        mainRequestConverter: qModel,
+      },
+    );
   }
 
-  public update(model: EditableT) {
-    const { client, qModel, path, getDefaultHeaders } = this.__base;
+  public update(model: EditableT, queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void) {
+    const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
 
-    return new UrlRequestCmd<ClientType, undefined, EditableT>(client, ODataHttpMethods.Put, path, model, {
-      headers: getDefaultHeaders(),
-      mainRequestConverter: qModel,
-    });
+    return new UrlBuilderRequestCmdV2<ClientType, undefined, Q, ModelQueryBuilderV2<Q>, EditableT>(
+      client,
+      createModelQueryBuilder(queryFn),
+      qModel,
+      {
+        method: ODataHttpMethods.Put,
+        data: model,
+        headers: getDefaultHeaders(),
+        mainRequestConverter: qModel,
+      },
+    );
   }
 
   public delete() {

--- a/packages/odata-service/src/v2/EntitySetServiceV2.ts
+++ b/packages/odata-service/src/v2/EntitySetServiceV2.ts
@@ -86,11 +86,11 @@ export abstract class EntitySetServiceV2<
 
     return new UrlBuilderRequestCmdV2<ClientType, ODataEntityModelResponseV2<T>, Q, ModelQueryBuilderV2<Q>, EditableT>(
       client,
+      ODataHttpMethods.Post,
       createModelQueryBuilder(queryFn),
       qModel,
+      model,
       {
-        method: ODataHttpMethods.Post,
-        data: model,
         headers: getDefaultHeaders(),
         mainRequestConverter: qModel,
         mainResponseConverter: new EntityResponseConverterV2(qModel),
@@ -110,8 +110,10 @@ export abstract class EntitySetServiceV2<
 
     return new UrlBuilderRequestCmdV2<ClientType, ODataCollectionResponseV2<ReturnType>, Q>(
       client,
+      ODataHttpMethods.Get,
       createQueryBuilder(queryFn),
       qModel,
+      undefined,
       {
         headers: getDefaultHeaders(),
         mainResponseConverter: new CollectionResponseConverterV2(qModel),

--- a/packages/odata-service/src/v2/EntitySetServiceV2.ts
+++ b/packages/odata-service/src/v2/EntitySetServiceV2.ts
@@ -1,6 +1,6 @@
 import { ODataHttpClient, ODataHttpMethods } from "@odata2ts/http-client-api";
 import { ODataCollectionResponseV2, ODataEntityModelResponseV2 } from "@odata2ts/odata-core";
-import { CollectionQueryBuilderV2 } from "@odata2ts/odata-query-builder";
+import { CollectionQueryBuilderV2, ModelQueryBuilderV2 } from "@odata2ts/odata-query-builder";
 import {
   CollectionResponseConverterV2,
   EntityResponseConverterV2,
@@ -8,7 +8,7 @@ import {
   QueryObjectModel,
 } from "@odata2ts/odata-query-objects";
 import { ODataServiceOptions } from "../ODataServiceOptions";
-import { UrlBuilderRequestCmdV2, UrlRequestCmd } from "../request";
+import { UrlBuilderRequestCmdV2 } from "../request";
 import { ServiceStateHelperV2 } from "./ServiceStateHelperV2.js";
 
 export abstract class EntitySetServiceV2<
@@ -81,15 +81,16 @@ export abstract class EntitySetServiceV2<
    * @param model
    * @return
    */
-  public create(model: EditableT) {
-    const { path, client, qModel, getDefaultHeaders } = this.__base;
+  public create(model: EditableT, queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void) {
+    const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
 
-    return new UrlRequestCmd<ClientType, ODataEntityModelResponseV2<T>, EditableT>(
+    return new UrlBuilderRequestCmdV2<ClientType, ODataEntityModelResponseV2<T>, Q, ModelQueryBuilderV2<Q>, EditableT>(
       client,
-      ODataHttpMethods.Post,
-      path,
-      model,
+      createModelQueryBuilder(queryFn),
+      qModel,
       {
+        method: ODataHttpMethods.Post,
+        data: model,
         headers: getDefaultHeaders(),
         mainRequestConverter: qModel,
         mainResponseConverter: new EntityResponseConverterV2(qModel),
@@ -102,7 +103,9 @@ export abstract class EntitySetServiceV2<
    *
    * @param queryFn provide the query logic with the help of the builder and the query-object
    */
-  public query<ReturnType extends Partial<T> = T>(queryFn?: (builder: CollectionQueryBuilderV2<Q>, qObject: Q) => void) {
+  public query<ReturnType extends Partial<T> = T>(
+    queryFn?: (builder: CollectionQueryBuilderV2<Q>, qObject: Q) => void,
+  ) {
     const { client, qModel, getDefaultHeaders, createQueryBuilder } = this.__base;
 
     return new UrlBuilderRequestCmdV2<ClientType, ODataCollectionResponseV2<ReturnType>, Q>(

--- a/packages/odata-service/src/v2/EntityTypeServiceV2.ts
+++ b/packages/odata-service/src/v2/EntityTypeServiceV2.ts
@@ -33,11 +33,11 @@ export class EntityTypeServiceV2<in out ClientType extends ODataHttpClient, T, E
 
     return new UrlBuilderRequestCmdV2<ClientType, undefined, Q, ModelQueryBuilderV2<Q>, Partial<EditableT>>(
       client,
+      ODataHttpMethods.Post,
       createModelQueryBuilder(queryFn),
       qModel,
+      model,
       {
-        method: ODataHttpMethods.Post,
-        data: model,
         headers,
         mainRequestConverter: qModel,
       },
@@ -57,11 +57,11 @@ export class EntityTypeServiceV2<in out ClientType extends ODataHttpClient, T, E
 
     return new UrlBuilderRequestCmdV2<ClientType, undefined, Q, ModelQueryBuilderV2<Q>, EditableT>(
       client,
+      ODataHttpMethods.Put,
       createModelQueryBuilder(queryFn),
       qModel,
+      model,
       {
-        method: ODataHttpMethods.Put,
-        data: model,
         headers: getDefaultHeaders(),
         mainRequestConverter: qModel,
       },
@@ -84,8 +84,10 @@ export class EntityTypeServiceV2<in out ClientType extends ODataHttpClient, T, E
 
     return new UrlBuilderRequestCmdV2<ClientType, ODataEntityModelResponseV2<ReturnType>, Q, ModelQueryBuilderV2<Q>>(
       client,
+      ODataHttpMethods.Get,
       createModelQueryBuilder(queryFn),
       qModel,
+      undefined,
       {
         headers: getDefaultHeaders(),
         mainResponseConverter: new EntityResponseConverterV2(qModel),

--- a/packages/odata-service/src/v2/EntityTypeServiceV2.ts
+++ b/packages/odata-service/src/v2/EntityTypeServiceV2.ts
@@ -27,14 +27,21 @@ export class EntityTypeServiceV2<in out ClientType extends ODataHttpClient, T, E
    *
    * @param model
    */
-  public patch(model: Partial<EditableT>) {
-    const { client, qModel, path, getDefaultHeaders } = this.__base;
+  public patch(model: Partial<EditableT>, queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void) {
+    const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
     const headers = { ...getDefaultHeaders(), ...MERGE_HEADERS };
 
-    return new UrlRequestCmd<ClientType, undefined, Partial<EditableT>>(client, ODataHttpMethods.Post, path, model, {
-      headers,
-      mainRequestConverter: qModel,
-    });
+    return new UrlBuilderRequestCmdV2<ClientType, undefined, Q, ModelQueryBuilderV2<Q>, Partial<EditableT>>(
+      client,
+      createModelQueryBuilder(queryFn),
+      qModel,
+      {
+        method: ODataHttpMethods.Post,
+        data: model,
+        headers,
+        mainRequestConverter: qModel,
+      },
+    );
   }
 
   /**
@@ -45,13 +52,20 @@ export class EntityTypeServiceV2<in out ClientType extends ODataHttpClient, T, E
    *
    * @param model
    */
-  public update(model: EditableT) {
-    const { client, qModel, path, getDefaultHeaders } = this.__base;
+  public update(model: EditableT, queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void) {
+    const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
 
-    return new UrlRequestCmd<ClientType, undefined, EditableT>(client, ODataHttpMethods.Put, path, model, {
-      headers: getDefaultHeaders(),
-      mainRequestConverter: qModel,
-    });
+    return new UrlBuilderRequestCmdV2<ClientType, undefined, Q, ModelQueryBuilderV2<Q>, EditableT>(
+      client,
+      createModelQueryBuilder(queryFn),
+      qModel,
+      {
+        method: ODataHttpMethods.Put,
+        data: model,
+        headers: getDefaultHeaders(),
+        mainRequestConverter: qModel,
+      },
+    );
   }
 
   /**

--- a/packages/odata-service/src/v4/CollectionServiceV4.ts
+++ b/packages/odata-service/src/v4/CollectionServiceV4.ts
@@ -1,6 +1,6 @@
 import { ODataHttpClient, ODataHttpMethods } from "@odata2ts/http-client-api";
 import { ODataCollectionResponseV4, ODataModelPayloadV4 } from "@odata2ts/odata-core";
-import { CollectionQueryBuilderV4 } from "@odata2ts/odata-query-builder";
+import { CollectionQueryBuilderV4, ModelQueryBuilderV4 } from "@odata2ts/odata-query-builder";
 import {
   CollectionResponseConverterV4,
   MainResponseConverter,
@@ -50,23 +50,28 @@ export class CollectionServiceV4<
    *
    * @param model primitive value
    */
-  public add<Response extends boolean = false>(model: ODataModelPayloadV4<PrimitiveT>) {
-    const { path, client, getDefaultHeaders, qModel } = this.__base;
+  public add<Response extends boolean = false>(
+    model: ODataModelPayloadV4<PrimitiveT>,
+    queryFn?: (builder: ModelQueryBuilderV4<Q>, qObject: Q) => void,
+  ) {
+    const { client, getDefaultHeaders, qModel, createModelQueryBuilder } = this.__base;
 
-    return new UrlRequestCmd<ClientType, CollectionModificationResponseV4<Response, PrimitiveT>, PrimitiveT>(
-      client,
-      ODataHttpMethods.Post,
-      path,
-      model,
-      {
-        headers: getDefaultHeaders(),
-        mainRequestConverter: qModel,
-        mainResponseConverter: new CollectionResponseConverterV4(qModel) as MainResponseConverter<
-          CollectionModificationResponseV4<Response, PrimitiveT>,
-          T
-        >,
-      },
-    );
+    return new UrlBuilderRequestCmdV4<
+      ClientType,
+      CollectionModificationResponseV4<Response, PrimitiveT>,
+      Q,
+      ModelQueryBuilderV4<Q>,
+      PrimitiveT
+    >(client, createModelQueryBuilder(queryFn), qModel, {
+      method: ODataHttpMethods.Post,
+      data: model,
+      headers: getDefaultHeaders(),
+      mainRequestConverter: qModel,
+      mainResponseConverter: new CollectionResponseConverterV4(qModel) as MainResponseConverter<
+        CollectionModificationResponseV4<Response, PrimitiveT>,
+        T
+      >,
+    });
   }
 
   /**
@@ -83,23 +88,28 @@ export class CollectionServiceV4<
    *
    * @param models set of primitive values
    */
-  public update<Response extends boolean = false>(models: Array<ODataModelPayloadV4<PrimitiveT>>) {
-    const { path, client, getDefaultHeaders, qModel } = this.__base;
+  public update<Response extends boolean = false>(
+    models: Array<ODataModelPayloadV4<PrimitiveT>>,
+    queryFn?: (builder: ModelQueryBuilderV4<Q>, qObject: Q) => void,
+  ) {
+    const { client, getDefaultHeaders, qModel, createModelQueryBuilder } = this.__base;
 
-    return new UrlRequestCmd<ClientType, CollectionModificationResponseV4<Response, PrimitiveT>, Array<PrimitiveT>>(
-      client,
-      ODataHttpMethods.Put,
-      path,
-      models,
-      {
-        headers: getDefaultHeaders(),
-        mainRequestConverter: qModel,
-        mainResponseConverter: new CollectionResponseConverterV4(qModel) as MainResponseConverter<
-          CollectionModificationResponseV4<Response, PrimitiveT>,
-          T
-        >,
-      },
-    );
+    return new UrlBuilderRequestCmdV4<
+      ClientType,
+      CollectionModificationResponseV4<Response, PrimitiveT>,
+      Q,
+      ModelQueryBuilderV4<Q>,
+      Array<PrimitiveT>
+    >(client, createModelQueryBuilder(queryFn), qModel, {
+      method: ODataHttpMethods.Put,
+      data: models,
+      headers: getDefaultHeaders(),
+      mainRequestConverter: qModel,
+      mainResponseConverter: new CollectionResponseConverterV4(qModel) as MainResponseConverter<
+        CollectionModificationResponseV4<Response, PrimitiveT>,
+        T
+      >,
+    });
   }
 
   /**

--- a/packages/odata-service/src/v4/CollectionServiceV4.ts
+++ b/packages/odata-service/src/v4/CollectionServiceV4.ts
@@ -62,9 +62,7 @@ export class CollectionServiceV4<
       Q,
       ModelQueryBuilderV4<Q>,
       PrimitiveT
-    >(client, createModelQueryBuilder(queryFn), qModel, {
-      method: ODataHttpMethods.Post,
-      data: model,
+    >(client, ODataHttpMethods.Post, createModelQueryBuilder(queryFn), qModel, model, {
       headers: getDefaultHeaders(),
       mainRequestConverter: qModel,
       mainResponseConverter: new CollectionResponseConverterV4(qModel) as MainResponseConverter<
@@ -100,9 +98,7 @@ export class CollectionServiceV4<
       Q,
       ModelQueryBuilderV4<Q>,
       Array<PrimitiveT>
-    >(client, createModelQueryBuilder(queryFn), qModel, {
-      method: ODataHttpMethods.Put,
-      data: models,
+    >(client, ODataHttpMethods.Put, createModelQueryBuilder(queryFn), qModel, models, {
       headers: getDefaultHeaders(),
       mainRequestConverter: qModel,
       mainResponseConverter: new CollectionResponseConverterV4(qModel) as MainResponseConverter<
@@ -133,8 +129,10 @@ export class CollectionServiceV4<
 
     return new UrlBuilderRequestCmdV4<ClientType, ODataCollectionResponseV4<ReturnType>, Q>(
       client,
+      ODataHttpMethods.Get,
       createQueryBuilder(queryFn),
       qModel,
+      undefined,
       {
         headers: getDefaultHeaders(),
         mainResponseConverter: new CollectionResponseConverterV4(qModel),

--- a/packages/odata-service/src/v4/EntitySetServiceV4.ts
+++ b/packages/odata-service/src/v4/EntitySetServiceV4.ts
@@ -1,6 +1,6 @@
 import { ODataHttpClient, ODataHttpMethods } from "@odata2ts/http-client-api";
 import { ODataCollectionResponseV4, ODataModelPayloadV4 } from "@odata2ts/odata-core";
-import { CollectionQueryBuilderV4 } from "@odata2ts/odata-query-builder";
+import { CollectionQueryBuilderV4, ModelQueryBuilderV4 } from "@odata2ts/odata-query-builder";
 import {
   CollectionResponseConverterV4,
   ModelResponseConverterV4,
@@ -8,7 +8,7 @@ import {
   QueryObjectModel,
 } from "@odata2ts/odata-query-objects";
 import { ODataServiceOptionsInternal } from "../ODataServiceOptions";
-import { UrlBuilderRequestCmdV4, UrlRequestCmd } from "../request";
+import { UrlBuilderRequestCmdV4 } from "../request";
 import { EntityModificationResponseV4 } from "./ResponseTypeChoicesV4";
 import { ServiceStateHelperV4, SubtypeOptions } from "./ServiceStateHelperV4.js";
 
@@ -106,24 +106,28 @@ export abstract class EntitySetServiceV4<
   public create<Response extends boolean = true>(
     model: ODataModelPayloadV4<EditableT>,
     createOptions?: SubtypeOptions,
+    queryFn?: (builder: ModelQueryBuilderV4<Q>, qObject: Q) => void,
   ) {
-    const { client, basePath, path, getDefaultHeaders, qModel } = this.__base;
+    const { client, basePath, path, getDefaultHeaders, qModel, createModelQueryBuilder } = this.__base;
     const { dontUseCastPathSegment, useTypeCi } = this.__base.evaluateSubtypeOptions(createOptions);
 
     // add control info automatically, if required
     const data = useTypeCi ? this.__base.addTypeControlInfo(model) : model;
+    const actualPath = dontUseCastPathSegment ? basePath : path;
 
-    return new UrlRequestCmd<ClientType, EntityModificationResponseV4<Response, T>, ODataModelPayloadV4<EditableT>>(
-      client,
-      ODataHttpMethods.Post,
-      dontUseCastPathSegment ? basePath : path,
+    return new UrlBuilderRequestCmdV4<
+      ClientType,
+      EntityModificationResponseV4<Response, T>,
+      Q,
+      ModelQueryBuilderV4<Q>,
+      ODataModelPayloadV4<EditableT>
+    >(client, createModelQueryBuilder(queryFn, actualPath), qModel, {
+      method: ODataHttpMethods.Post,
       data,
-      {
-        headers: getDefaultHeaders(),
-        mainRequestConverter: qModel,
-        mainResponseConverter: new ModelResponseConverterV4(qModel),
-      },
-    );
+      headers: getDefaultHeaders(),
+      mainRequestConverter: qModel,
+      mainResponseConverter: new ModelResponseConverterV4(qModel),
+    });
   }
 
   /**
@@ -132,7 +136,9 @@ export abstract class EntitySetServiceV4<
    *
    * @param queryFn provide the query logic with the help of the builder and the query-object
    */
-  public query<ReturnType extends Partial<T> = T>(queryFn?: (builder: CollectionQueryBuilderV4<Q>, qObject: Q) => void) {
+  public query<ReturnType extends Partial<T> = T>(
+    queryFn?: (builder: CollectionQueryBuilderV4<Q>, qObject: Q) => void,
+  ) {
     const { client, qModel, createQueryBuilder, getDefaultHeaders } = this.__base;
 
     return new UrlBuilderRequestCmdV4<ClientType, ODataCollectionResponseV4<ReturnType>, Q>(

--- a/packages/odata-service/src/v4/EntitySetServiceV4.ts
+++ b/packages/odata-service/src/v4/EntitySetServiceV4.ts
@@ -121,9 +121,7 @@ export abstract class EntitySetServiceV4<
       Q,
       ModelQueryBuilderV4<Q>,
       ODataModelPayloadV4<EditableT>
-    >(client, createModelQueryBuilder(queryFn, actualPath), qModel, {
-      method: ODataHttpMethods.Post,
-      data,
+    >(client, ODataHttpMethods.Post, createModelQueryBuilder(queryFn, actualPath), qModel, data, {
       headers: getDefaultHeaders(),
       mainRequestConverter: qModel,
       mainResponseConverter: new ModelResponseConverterV4(qModel),
@@ -143,8 +141,10 @@ export abstract class EntitySetServiceV4<
 
     return new UrlBuilderRequestCmdV4<ClientType, ODataCollectionResponseV4<ReturnType>, Q>(
       client,
+      ODataHttpMethods.Get,
       createQueryBuilder(queryFn),
       qModel,
+      undefined,
       {
         headers: getDefaultHeaders(),
         mainResponseConverter: new CollectionResponseConverterV4(qModel),

--- a/packages/odata-service/src/v4/EntityTypeServiceV4.ts
+++ b/packages/odata-service/src/v4/EntityTypeServiceV4.ts
@@ -57,9 +57,7 @@ export class EntityTypeServiceV4<in out ClientType extends ODataHttpClient, T, E
       Q,
       ModelQueryBuilderV4<Q>,
       ODataModelPayloadV4<Partial<EditableT>>
-    >(client, createModelQueryBuilder(queryFn, actualPath), qModel, {
-      method: ODataHttpMethods.Patch,
-      data,
+    >(client, ODataHttpMethods.Patch, createModelQueryBuilder(queryFn, actualPath), qModel, data, {
       headers: getDefaultHeaders(),
       mainRequestConverter: qModel,
       mainResponseConverter: new ModelResponseConverterV4(qModel),
@@ -99,9 +97,7 @@ export class EntityTypeServiceV4<in out ClientType extends ODataHttpClient, T, E
       Q,
       ModelQueryBuilderV4<Q>,
       ODataModelPayloadV4<EditableT>
-    >(client, createModelQueryBuilder(queryFn, actualPath), qModel, {
-      method: ODataHttpMethods.Put,
-      data,
+    >(client, ODataHttpMethods.Put, createModelQueryBuilder(queryFn, actualPath), qModel, data, {
       headers: getDefaultHeaders(),
       mainRequestConverter: qModel,
       mainResponseConverter: new ModelResponseConverterV4(qModel),
@@ -132,8 +128,10 @@ export class EntityTypeServiceV4<in out ClientType extends ODataHttpClient, T, E
 
     return new UrlBuilderRequestCmdV4<ClientType, ODataModelResponseV4<ReturnType>, Q, ModelQueryBuilderV4<Q>>(
       client,
+      ODataHttpMethods.Get,
       createModelQueryBuilder(queryFn),
       qModel,
+      undefined,
       {
         headers: getDefaultHeaders(),
         mainResponseConverter: new ModelResponseConverterV4(qModel),

--- a/packages/odata-service/src/v4/EntityTypeServiceV4.ts
+++ b/packages/odata-service/src/v4/EntityTypeServiceV4.ts
@@ -42,18 +42,24 @@ export class EntityTypeServiceV4<in out ClientType extends ODataHttpClient, T, E
   public patch<Response extends boolean = false>(
     model: ODataModelPayloadV4<Partial<EditableT>>,
     patchOptions?: SubtypeOptions,
+    queryFn?: (builder: ModelQueryBuilderV4<Q>, qObject: Q) => void,
   ) {
-    const { client, qModel, basePath, path, getDefaultHeaders } = this.__base;
+    const { client, qModel, basePath, path, getDefaultHeaders, createModelQueryBuilder } = this.__base;
     const { dontUseCastPathSegment, useTypeCi } = this.__base.evaluateSubtypeOptions(patchOptions);
 
     // add control info automatically, if required
     const data = useTypeCi ? this.__base.addTypeControlInfo(model) : model;
+    const actualPath = dontUseCastPathSegment ? basePath : path;
 
-    return new UrlRequestCmd<
+    return new UrlBuilderRequestCmdV4<
       ClientType,
       EntityModificationResponseV4<Response, T>,
+      Q,
+      ModelQueryBuilderV4<Q>,
       ODataModelPayloadV4<Partial<EditableT>>
-    >(client, ODataHttpMethods.Patch, dontUseCastPathSegment ? basePath : path, data, {
+    >(client, createModelQueryBuilder(queryFn, actualPath), qModel, {
+      method: ODataHttpMethods.Patch,
+      data,
       headers: getDefaultHeaders(),
       mainRequestConverter: qModel,
       mainResponseConverter: new ModelResponseConverterV4(qModel),
@@ -78,25 +84,28 @@ export class EntityTypeServiceV4<in out ClientType extends ODataHttpClient, T, E
   public update<Response extends boolean = false>(
     model: ODataModelPayloadV4<EditableT>,
     updateOptions?: SubtypeOptions,
+    queryFn?: (builder: ModelQueryBuilderV4<Q>, qObject: Q) => void,
   ) {
-    const { client, basePath, path, getDefaultHeaders, qModel } = this.__base;
+    const { client, basePath, path, getDefaultHeaders, qModel, createModelQueryBuilder } = this.__base;
     const { dontUseCastPathSegment, useTypeCi } = this.__base.evaluateSubtypeOptions(updateOptions);
 
     // add control info automatically, if required
     const data = useTypeCi ? this.__base.addTypeControlInfo(model) : model;
+    const actualPath = dontUseCastPathSegment ? basePath : path;
 
-    // return convertV4ModelResponse(result, qResponseType);
-    return new UrlRequestCmd<ClientType, EntityModificationResponseV4<Response, T>, ODataModelPayloadV4<EditableT>>(
-      client,
-      ODataHttpMethods.Put,
-      dontUseCastPathSegment ? basePath : path,
+    return new UrlBuilderRequestCmdV4<
+      ClientType,
+      EntityModificationResponseV4<Response, T>,
+      Q,
+      ModelQueryBuilderV4<Q>,
+      ODataModelPayloadV4<EditableT>
+    >(client, createModelQueryBuilder(queryFn, actualPath), qModel, {
+      method: ODataHttpMethods.Put,
       data,
-      {
-        headers: getDefaultHeaders(),
-        mainRequestConverter: qModel,
-        mainResponseConverter: new ModelResponseConverterV4(qModel),
-      },
-    );
+      headers: getDefaultHeaders(),
+      mainRequestConverter: qModel,
+      mainResponseConverter: new ModelResponseConverterV4(qModel),
+    });
   }
 
   /**

--- a/packages/odata-service/test/fixture/QPerson.ts
+++ b/packages/odata-service/test/fixture/QPerson.ts
@@ -1,5 +1,4 @@
 import { QId, QStringParam } from "@odata2ts/odata-query-objects";
-
 import { PersonId } from "./PersonModel";
 
 /**

--- a/packages/odata-service/test/request/ComposableUrlRequestCmd.test.ts
+++ b/packages/odata-service/test/request/ComposableUrlRequestCmd.test.ts
@@ -1,8 +1,8 @@
 import { HttpResponseModel } from "@odata2ts/http-client-api";
 import { ODataCollectionResponseV4, ODataModelResponseV4 } from "@odata2ts/odata-core";
+import { CollectionQueryBuilderV4, ModelQueryBuilderV4 } from "@odata2ts/odata-query-builder";
 import { ModelResponseConverterV4 } from "@odata2ts/odata-query-objects";
 import { beforeEach, describe, expect, expectTypeOf, test } from "vitest";
-import { CollectionQueryBuilderV4, ModelQueryBuilderV4 } from "@odata2ts/odata-query-builder";
 import { ComposableUrlRequestCmd, UrlBuilderRequestCmdV4 } from "../../src";
 import { Feature, PersonModel } from "../fixture/PersonModel";
 import { PersonModelService } from "../fixture/v4/PersonModelService";

--- a/packages/odata-service/test/request/UrlBuilderRequestCmdV2.test.ts
+++ b/packages/odata-service/test/request/UrlBuilderRequestCmdV2.test.ts
@@ -1,4 +1,4 @@
-import { HttpResponseModel } from "@odata2ts/http-client-api";
+import { HttpResponseModel, ODataHttpMethods } from "@odata2ts/http-client-api";
 import { ODataEntityModelResponseV2 } from "@odata2ts/odata-core";
 import { CollectionQueryBuilderV2, createQueryBuilderV2 } from "@odata2ts/odata-query-builder";
 import { EntityResponseConverterV2 } from "@odata2ts/odata-query-objects";
@@ -24,6 +24,41 @@ describe("UrlBuilderRequestCmd tests", () => {
 
     expect(candidate.getUrl()).toBe(DEFAULT_URL);
     expect(candidate.getInfo().url).toBe(DEFAULT_URL);
+  });
+
+  test("defaults to GET with no data when no method/data option is given", () => {
+    const candidate = new UrlBuilderRequestCmdV2(client, queryBuilder, qPersonV2);
+
+    expect(candidate.getInfo().method).toBe(ODataHttpMethods.Get);
+    expect(candidate.getInfo().data).toBeUndefined();
+  });
+
+  test("carries an explicit method and data payload, e.g. for a write operation", () => {
+    const candidate = new UrlBuilderRequestCmdV2<
+      MockClient,
+      undefined,
+      QPersonV2,
+      CollectionQueryBuilderV2<QPersonV2>,
+      PersonModel
+    >(client, queryBuilder, qPersonV2, { method: ODataHttpMethods.Put, data: { userName: "tester" } as PersonModel });
+
+    expect(candidate.getInfo().method).toBe(ODataHttpMethods.Put);
+    expect(candidate.getInfo().data).toStrictEqual({ userName: "tester" });
+  });
+
+  test("addToQuery on a write Cmd keeps method and data intact", () => {
+    const candidate = new UrlBuilderRequestCmdV2<
+      MockClient,
+      undefined,
+      QPersonV2,
+      CollectionQueryBuilderV2<QPersonV2>,
+      PersonModel
+    >(client, queryBuilder, qPersonV2, { method: ODataHttpMethods.Put, data: { userName: "tester" } as PersonModel });
+    const newCandidate = candidate.addToQuery((builder) => builder.select("age"));
+
+    expect(newCandidate.getUrl()).toBe(DEFAULT_URL + "?$select=Age");
+    expect(newCandidate.getInfo().method).toBe(ODataHttpMethods.Put);
+    expect(newCandidate.getInfo().data).toStrictEqual({ userName: "tester" });
   });
 
   test("add to query", () => {

--- a/packages/odata-service/test/request/UrlBuilderRequestCmdV2.test.ts
+++ b/packages/odata-service/test/request/UrlBuilderRequestCmdV2.test.ts
@@ -20,14 +20,14 @@ describe("UrlBuilderRequestCmd tests", () => {
   });
 
   test("base props", () => {
-    const candidate = new UrlBuilderRequestCmdV2(client, queryBuilder, qPersonV2);
+    const candidate = new UrlBuilderRequestCmdV2(client, ODataHttpMethods.Get, queryBuilder, qPersonV2);
 
     expect(candidate.getUrl()).toBe(DEFAULT_URL);
     expect(candidate.getInfo().url).toBe(DEFAULT_URL);
   });
 
-  test("defaults to GET with no data when no method/data option is given", () => {
-    const candidate = new UrlBuilderRequestCmdV2(client, queryBuilder, qPersonV2);
+  test("defaults to no data when no data param is given", () => {
+    const candidate = new UrlBuilderRequestCmdV2(client, ODataHttpMethods.Get, queryBuilder, qPersonV2);
 
     expect(candidate.getInfo().method).toBe(ODataHttpMethods.Get);
     expect(candidate.getInfo().data).toBeUndefined();
@@ -40,7 +40,7 @@ describe("UrlBuilderRequestCmd tests", () => {
       QPersonV2,
       CollectionQueryBuilderV2<QPersonV2>,
       PersonModel
-    >(client, queryBuilder, qPersonV2, { method: ODataHttpMethods.Put, data: { userName: "tester" } as PersonModel });
+    >(client, ODataHttpMethods.Put, queryBuilder, qPersonV2, { userName: "tester" } as PersonModel);
 
     expect(candidate.getInfo().method).toBe(ODataHttpMethods.Put);
     expect(candidate.getInfo().data).toStrictEqual({ userName: "tester" });
@@ -53,7 +53,7 @@ describe("UrlBuilderRequestCmd tests", () => {
       QPersonV2,
       CollectionQueryBuilderV2<QPersonV2>,
       PersonModel
-    >(client, queryBuilder, qPersonV2, { method: ODataHttpMethods.Put, data: { userName: "tester" } as PersonModel });
+    >(client, ODataHttpMethods.Put, queryBuilder, qPersonV2, { userName: "tester" } as PersonModel);
     const newCandidate = candidate.addToQuery((builder) => builder.select("age"));
 
     expect(newCandidate.getUrl()).toBe(DEFAULT_URL + "?$select=Age");
@@ -62,7 +62,7 @@ describe("UrlBuilderRequestCmd tests", () => {
   });
 
   test("add to query", () => {
-    const candidate = new UrlBuilderRequestCmdV2(client, queryBuilder, qPersonV2);
+    const candidate = new UrlBuilderRequestCmdV2(client, ODataHttpMethods.Get, queryBuilder, qPersonV2);
     const newCandidate = candidate.addToQuery((builder) => builder.select("userName"));
 
     expect(candidate.getUrl()).toBe(DEFAULT_URL);
@@ -70,7 +70,7 @@ describe("UrlBuilderRequestCmd tests", () => {
   });
 
   test("new URL multiple times", () => {
-    const candidate = new UrlBuilderRequestCmdV2(client, queryBuilder, qPersonV2);
+    const candidate = new UrlBuilderRequestCmdV2(client, ODataHttpMethods.Get, queryBuilder, qPersonV2);
     const newCandidate = candidate
       .addToQuery((builder, qPerson) => builder.select("userName"))
       .addToQuery((builder, qPerson) => builder.filter(qPerson.age.gt("40")));
@@ -81,8 +81,10 @@ describe("UrlBuilderRequestCmd tests", () => {
   test("execute", async () => {
     const candidate = new UrlBuilderRequestCmdV2<MockClient, ODataEntityModelResponseV2<PersonModel>, QPersonV2>(
       client,
+      ODataHttpMethods.Get,
       queryBuilder,
       qPersonV2,
+      undefined,
       {
         headers: DEFAULT_HEADERS,
         mainResponseConverter: new EntityResponseConverterV2(qPersonV2),

--- a/packages/odata-service/test/request/UrlBuilderRequestCmdV4.test.ts
+++ b/packages/odata-service/test/request/UrlBuilderRequestCmdV4.test.ts
@@ -20,14 +20,14 @@ describe("UrlBuilderRequestCmdV4 tests", () => {
   });
 
   test("base props", () => {
-    const candidate = new UrlBuilderRequestCmdV4(client, queryBuilder, qPersonV4);
+    const candidate = new UrlBuilderRequestCmdV4(client, ODataHttpMethods.Get, queryBuilder, qPersonV4);
 
     expect(candidate.getUrl()).toBe(DEFAULT_URL);
     expect(candidate.getInfo().url).toBe(DEFAULT_URL);
   });
 
-  test("defaults to GET with no data when no method/data option is given", () => {
-    const candidate = new UrlBuilderRequestCmdV4(client, queryBuilder, qPersonV4);
+  test("defaults to no data when no data param is given", () => {
+    const candidate = new UrlBuilderRequestCmdV4(client, ODataHttpMethods.Get, queryBuilder, qPersonV4);
 
     expect(candidate.getInfo().method).toBe(ODataHttpMethods.Get);
     expect(candidate.getInfo().data).toBeUndefined();
@@ -40,7 +40,7 @@ describe("UrlBuilderRequestCmdV4 tests", () => {
       QPersonV4,
       CollectionQueryBuilderV4<QPersonV4>,
       PersonModel
-    >(client, queryBuilder, qPersonV4, { method: ODataHttpMethods.Put, data: { userName: "tester" } as PersonModel });
+    >(client, ODataHttpMethods.Put, queryBuilder, qPersonV4, { userName: "tester" } as PersonModel);
 
     expect(candidate.getInfo().method).toBe(ODataHttpMethods.Put);
     expect(candidate.getInfo().data).toStrictEqual({ userName: "tester" });
@@ -53,7 +53,7 @@ describe("UrlBuilderRequestCmdV4 tests", () => {
       QPersonV4,
       CollectionQueryBuilderV4<QPersonV4>,
       PersonModel
-    >(client, queryBuilder, qPersonV4, { method: ODataHttpMethods.Put, data: { userName: "tester" } as PersonModel });
+    >(client, ODataHttpMethods.Put, queryBuilder, qPersonV4, { userName: "tester" } as PersonModel);
     const newCandidate = candidate.addToQuery((builder) => builder.select("age"));
 
     expect(newCandidate.getUrl()).toBe(DEFAULT_URL + "?$select=Age");
@@ -62,7 +62,7 @@ describe("UrlBuilderRequestCmdV4 tests", () => {
   });
 
   test("add to query", () => {
-    const candidate = new UrlBuilderRequestCmdV4(client, queryBuilder, qPersonV4);
+    const candidate = new UrlBuilderRequestCmdV4(client, ODataHttpMethods.Get, queryBuilder, qPersonV4);
     const newCandidate = candidate.addToQuery((builder) => builder.select("userName"));
 
     expect(candidate.getUrl()).toBe(DEFAULT_URL);
@@ -70,7 +70,7 @@ describe("UrlBuilderRequestCmdV4 tests", () => {
   });
 
   test("add to query multiple times", () => {
-    const candidate = new UrlBuilderRequestCmdV4(client, queryBuilder, qPersonV4);
+    const candidate = new UrlBuilderRequestCmdV4(client, ODataHttpMethods.Get, queryBuilder, qPersonV4);
     const newCandidate = candidate
       .addToQuery((builder) => builder.select("userName"))
       .addToQuery((builder, qPerson) => builder.filter(qPerson.age.gt("40")));
@@ -81,8 +81,10 @@ describe("UrlBuilderRequestCmdV4 tests", () => {
   test("execute", async () => {
     const candidate = new UrlBuilderRequestCmdV4<MockClient, ODataModelResponseV4<PersonModel>, QPersonV4>(
       client,
+      ODataHttpMethods.Get,
       queryBuilder,
       qPersonV4,
+      undefined,
       {
         headers: DEFAULT_HEADERS,
         mainResponseConverter: new ModelResponseConverterV4(qPersonV4),
@@ -120,8 +122,10 @@ describe("UrlBuilderRequestCmdV4 tests", () => {
   test("as POST request", () => {
     const candidate = new UrlBuilderRequestCmdV4<MockClient, ODataModelResponseV4<PersonModel>, QPersonV4>(
       client,
+      ODataHttpMethods.Get,
       queryBuilder,
       qPersonV4,
+      undefined,
       {
         headers: DEFAULT_HEADERS,
         mainResponseConverter: new ModelResponseConverterV4(qPersonV4),

--- a/packages/odata-service/test/request/UrlBuilderRequestCmdV4.test.ts
+++ b/packages/odata-service/test/request/UrlBuilderRequestCmdV4.test.ts
@@ -1,4 +1,4 @@
-import { HttpResponseModel } from "@odata2ts/http-client-api";
+import { HttpResponseModel, ODataHttpMethods } from "@odata2ts/http-client-api";
 import { ODataModelResponseV4 } from "@odata2ts/odata-core";
 import { CollectionQueryBuilderV4, createQueryBuilderV4 } from "@odata2ts/odata-query-builder";
 import { ModelResponseConverterV4 } from "@odata2ts/odata-query-objects";
@@ -24,6 +24,41 @@ describe("UrlBuilderRequestCmdV4 tests", () => {
 
     expect(candidate.getUrl()).toBe(DEFAULT_URL);
     expect(candidate.getInfo().url).toBe(DEFAULT_URL);
+  });
+
+  test("defaults to GET with no data when no method/data option is given", () => {
+    const candidate = new UrlBuilderRequestCmdV4(client, queryBuilder, qPersonV4);
+
+    expect(candidate.getInfo().method).toBe(ODataHttpMethods.Get);
+    expect(candidate.getInfo().data).toBeUndefined();
+  });
+
+  test("carries an explicit method and data payload, e.g. for a write operation", () => {
+    const candidate = new UrlBuilderRequestCmdV4<
+      MockClient,
+      undefined,
+      QPersonV4,
+      CollectionQueryBuilderV4<QPersonV4>,
+      PersonModel
+    >(client, queryBuilder, qPersonV4, { method: ODataHttpMethods.Put, data: { userName: "tester" } as PersonModel });
+
+    expect(candidate.getInfo().method).toBe(ODataHttpMethods.Put);
+    expect(candidate.getInfo().data).toStrictEqual({ userName: "tester" });
+  });
+
+  test("addToQuery on a write Cmd keeps method and data intact", () => {
+    const candidate = new UrlBuilderRequestCmdV4<
+      MockClient,
+      undefined,
+      QPersonV4,
+      CollectionQueryBuilderV4<QPersonV4>,
+      PersonModel
+    >(client, queryBuilder, qPersonV4, { method: ODataHttpMethods.Put, data: { userName: "tester" } as PersonModel });
+    const newCandidate = candidate.addToQuery((builder) => builder.select("age"));
+
+    expect(newCandidate.getUrl()).toBe(DEFAULT_URL + "?$select=Age");
+    expect(newCandidate.getInfo().method).toBe(ODataHttpMethods.Put);
+    expect(newCandidate.getInfo().data).toStrictEqual({ userName: "tester" });
   });
 
   test("add to query", () => {

--- a/packages/odata-service/test/v2/CollectionServiceV2.test.ts
+++ b/packages/odata-service/test/v2/CollectionServiceV2.test.ts
@@ -81,6 +81,29 @@ describe("CollectionService V2 Tests", () => {
     expectTypeOf(response).toEqualTypeOf<RESPONSE_TYPE_ENUM>();
   });
 
+  test("numeric enum collection: add with select/expand", async () => {
+    const enumService = enumConstructor(BASE_PATH, NAME_ENUM);
+    const params = getParams({ $select: "*" });
+
+    const cmd = enumService.add(NumericTestEnum.A, (b) => b.select("*"));
+    const result = cmd.getInfo();
+
+    expect(result.url).toBe(NAME_ENUM + params);
+    expect(result.method).toBe("POST");
+  });
+
+  test("collection: update with select/expand and addToQuery", async () => {
+    const stringService = stringConstructor(BASE_PATH, NAME_STRING);
+    const model = ["test1", "t2"];
+    const params = getParams({ $select: "*" });
+
+    const request = stringService.update(model).addToQuery((b) => b.select("*"));
+
+    expect(request.getInfo().url).toBe(NAME_STRING + params);
+    expect(request.getInfo().method).toBe("PUT");
+    expect(request.getInfo().data).toEqual(model);
+  });
+
   test("collection: update", async () => {
     const stringService = stringConstructor(BASE_PATH, NAME_STRING);
     const model = ["test1", "t2"];

--- a/packages/odata-service/test/v2/ComplexTypeServiceV2.test.ts
+++ b/packages/odata-service/test/v2/ComplexTypeServiceV2.test.ts
@@ -58,4 +58,30 @@ describe("ComplexTypeService V2 Test", () => {
 
     expectTypeOf(await request.execute()).toEqualTypeOf<HttpResponseModel<undefined>>();
   });
+
+  test("complexType: patch with select/expand", async () => {
+    const unencodedService = new FakedComplexServiceV2(odataClient, BASE_URL, NAME, { noUrlEncoding: true });
+    const model: Partial<PersonModel> = { age: "45" };
+
+    const request = unencodedService.patch(model, (b) => b.select("age"));
+
+    expect(request.getInfo().url).toBe(EXPECTED_PATH + "?$select=Age");
+    expect(request.getInfo().method).toBe("POST");
+  });
+
+  test("complexType: update returns a builder-backed Cmd, addToQuery works", async () => {
+    const unencodedService = new FakedComplexServiceV2(odataClient, BASE_URL, NAME, { noUrlEncoding: true });
+    const model: EditablePersonModel = {
+      userName: "tester",
+      age: "14",
+      favFeature: Feature.Feature1,
+      features: [Feature.Feature1],
+    };
+
+    const request = unencodedService.update(model).addToQuery((b) => b.select("age"));
+
+    expect(request.getInfo().url).toBe(EXPECTED_PATH + "?$select=Age");
+    expect(request.getInfo().method).toBe("PUT");
+    expect(request.getInfo().data).toEqual(model);
+  });
 });

--- a/packages/odata-service/test/v2/EntitySetServiceV2.test.ts
+++ b/packages/odata-service/test/v2/EntitySetServiceV2.test.ts
@@ -53,4 +53,39 @@ describe("V2 EntitySetService Test", () => {
     expect(response.data).toStrictEqual({ d: model });
     expectTypeOf(response).toEqualTypeOf<HttpResponseModel<ODataEntityModelResponseV2<PersonModel>>>();
   });
+
+  test("entitySet: create with select/expand", async () => {
+    const unencodedService = new PersonModelV2CollectionService(odataClient, BASE_URL, NAME, {
+      noUrlEncoding: true,
+    });
+    const model: EditablePersonModel = {
+      userName: "tester",
+      age: "14",
+      favFeature: Feature.Feature1,
+      features: [Feature.Feature1],
+    };
+
+    const request = unencodedService.create(model, (b) => b.select("userName"));
+
+    expect(request.getInfo().url).toBe(EXPECTED_PATH + "?$select=UserName");
+    expect(request.getInfo().method).toBe("POST");
+  });
+
+  test("entitySet: create returns a builder-backed Cmd, addToQuery works", async () => {
+    const unencodedService = new PersonModelV2CollectionService(odataClient, BASE_URL, NAME, {
+      noUrlEncoding: true,
+    });
+    const model: EditablePersonModel = {
+      userName: "tester",
+      age: "14",
+      favFeature: Feature.Feature1,
+      features: [Feature.Feature1],
+    };
+
+    const request = unencodedService.create(model).addToQuery((b) => b.select("userName"));
+
+    expect(request.getInfo().url).toBe(EXPECTED_PATH + "?$select=UserName");
+    expect(request.getInfo().method).toBe("POST");
+    expect(request.getInfo().data).toEqual(model);
+  });
 });

--- a/packages/odata-service/test/v2/EntityTypeServiceV2.test.ts
+++ b/packages/odata-service/test/v2/EntityTypeServiceV2.test.ts
@@ -64,6 +64,57 @@ describe("EntityTypeService V2 Test", () => {
     expectTypeOf(await request.execute()).toEqualTypeOf<HttpResponseModel<undefined>>();
   });
 
+  test("entityType: patch with select/expand", async () => {
+    const unencodedService = new PersonModelV2Service(odataClient, BASE_URL, NAME, { noUrlEncoding: true });
+    const model: Partial<PersonModel> = { age: "45" };
+
+    const request = unencodedService.patch(model, (b) => b.select("age"));
+
+    expect(request.getInfo().url).toBe(EXPECTED_PATH + "?$select=Age");
+    expect(request.getInfo().method).toBe("POST");
+    expect(request.getInfo().headers).toStrictEqual({ ...DEFAULT_HEADERS, ...MERGE_HEADERS });
+  });
+
+  test("entityType: update with select/expand", async () => {
+    const unencodedService = new PersonModelV2Service(odataClient, BASE_URL, NAME, { noUrlEncoding: true });
+    const model: EditablePersonModel = {
+      userName: "tester",
+      age: "14",
+      favFeature: Feature.Feature1,
+      features: [Feature.Feature1],
+    };
+
+    const request = unencodedService.update(model, (b) => b.expanding("bestFriend", (nested) => nested.select("age")));
+
+    expect(request.getInfo().url).toBe(EXPECTED_PATH + "?$select=BestFriend/Age&$expand=BestFriend");
+    expect(request.getInfo().method).toBe("PUT");
+  });
+
+  test("entityType: update returns a builder-backed Cmd, addToQuery works", async () => {
+    const unencodedService = new PersonModelV2Service(odataClient, BASE_URL, NAME, { noUrlEncoding: true });
+    const model: EditablePersonModel = {
+      userName: "tester",
+      age: "14",
+      favFeature: Feature.Feature1,
+      features: [Feature.Feature1],
+    };
+
+    const request = unencodedService.update(model).addToQuery((b) => b.select("age"));
+
+    expect(request.getInfo().url).toBe(EXPECTED_PATH + "?$select=Age");
+    expect(request.getInfo().method).toBe("PUT");
+    expect(request.getInfo().data).toEqual(model);
+  });
+
+  test("entityType: update query builder only allows select/expand/expanding", () => {
+    testService.update({} as EditablePersonModel, (b, q) => {
+      // @ts-expect-error: filter is not available for a single-model write response builder
+      b.filter(q.age.gt("1"));
+      // @ts-expect-error: top is not available for a single-model write response builder
+      b.top(1);
+    });
+  });
+
   test("entityType V2: function params", async () => {
     const expected =
       EXPECTED_PATH +

--- a/packages/odata-service/test/v4/CollectionServiceV4.test.ts
+++ b/packages/odata-service/test/v4/CollectionServiceV4.test.ts
@@ -79,6 +79,17 @@ describe("CollectionService V4 Tests", () => {
     expectTypeOf(response).toEqualTypeOf<RESPONSE_TYPE_ENUM>();
   });
 
+  test("string enum collection: add with select/expand", async () => {
+    const enumService = enumConstructor(BASE_PATH, NAME_ENUM);
+
+    const cmd = enumService.add(StringTestEnum.A, (b) => b.select("*"));
+    const request = cmd.getInfo();
+
+    expect(request.url).toBe(`${NAME_ENUM}?${encodeURIComponent("$select")}=${encodeURIComponent("*")}`);
+    expect(request.method).toBe("POST");
+    expect(request.data).toEqual(StringTestEnum.A);
+  });
+
   test("collection: add with converter", async () => {
     const request = serviceConv.add<true>(1);
     const result = request.getInfoConverted();
@@ -115,6 +126,17 @@ describe("CollectionService V4 Tests", () => {
     expect(response.data).toStrictEqual({ value: userModel });
 
     expectTypeOf(response).toEqualTypeOf<HttpResponseModel<ODataCollectionResponseV4<number>>>();
+  });
+
+  test("collection: update with select/expand and addToQuery", async () => {
+    const service = serviceConv;
+    const userModel = [1, 0];
+
+    const request = service.update(userModel).addToQuery((b) => b.select("*"));
+
+    expect(request.getInfo().url).toBe(`${NAME_STRING}?${encodeURIComponent("$select")}=${encodeURIComponent("*")}`);
+    expect(request.getInfo().method).toBe("PUT");
+    expect(request.getInfo().data).toEqual(userModel);
   });
 
   test("string enum collection: filter", async () => {

--- a/packages/odata-service/test/v4/EntitySetServiceV4.test.ts
+++ b/packages/odata-service/test/v4/EntitySetServiceV4.test.ts
@@ -67,6 +67,37 @@ describe("V4 EntitySetService Test", () => {
     expect(result.data).toStrictEqual(odataModel);
   });
 
+  test("entitySet: create with select/expand", async () => {
+    const unencodedService = new PersonModelCollectionService(odataClient, BASE_URL, NAME, { noUrlEncoding: true });
+    const model: EditablePersonModel = {
+      userName: "tester",
+      age: "14",
+      favFeature: Feature.Feature1,
+      features: [Feature.Feature1],
+    };
+
+    const request = unencodedService.create(model, undefined, (b) => b.select("userName"));
+
+    expect(request.getInfo().url).toBe(EXPECTED_PATH + "?$select=UserName");
+    expect(request.getInfo().method).toBe("POST");
+  });
+
+  test("entitySet: create returns a builder-backed Cmd, addToQuery works", async () => {
+    const unencodedService = new PersonModelCollectionService(odataClient, BASE_URL, NAME, { noUrlEncoding: true });
+    const model: EditablePersonModel = {
+      userName: "tester",
+      age: "14",
+      favFeature: Feature.Feature1,
+      features: [Feature.Feature1],
+    };
+
+    const request = unencodedService.create(model).addToQuery((b) => b.select("userName"));
+
+    expect(request.getInfo().url).toBe(EXPECTED_PATH + "?$select=UserName");
+    expect(request.getInfo().method).toBe("POST");
+    expect(request.getInfo().data).toEqual(model);
+  });
+
   test("entitySet: create subtype", async () => {
     const serviceToTest = new PlanItemCollectionService(odataClient, BASE_URL, NAME).asFlightCollectionService();
     const inputModel: EditableFlightModel = {

--- a/packages/odata-service/test/v4/EntityTypeServiceV4.test.ts
+++ b/packages/odata-service/test/v4/EntityTypeServiceV4.test.ts
@@ -90,6 +90,71 @@ describe("EntityTypeService V4 Tests", () => {
     expectTypeOf(response).toEqualTypeOf<HttpResponseModel<ODataModelResponseV4<PersonModel>>>();
   });
 
+  test("entityType V4: patch with select/expand", async () => {
+    const unencodedService = new PersonModelService(odataClient, BASE_URL, NAME, { noUrlEncoding: true });
+    const model: Partial<PersonModel> = { age: "45" };
+
+    const request = unencodedService.patch(model, undefined, (b) => b.select("age"));
+
+    expect(request.getInfo().url).toBe(EXPECTED_PATH + "?$select=Age");
+    expect(request.getInfo().method).toBe("PATCH");
+  });
+
+  test("entityType V4: update with select/expand", async () => {
+    const unencodedService = new PersonModelService(odataClient, BASE_URL, NAME, { noUrlEncoding: true });
+    const model: EditablePersonModel = {
+      userName: "tester",
+      age: "14",
+      favFeature: Feature.Feature1,
+      features: [Feature.Feature1],
+    };
+
+    const request = unencodedService.update(model, undefined, (b) =>
+      b.expanding("bestFriend", (nested) => nested.select("age")),
+    );
+
+    expect(request.getInfo().url).toBe(EXPECTED_PATH + "?$expand=BestFriend($select=Age)");
+    expect(request.getInfo().method).toBe("PUT");
+  });
+
+  test("entityType V4: update returns a builder-backed Cmd, addToQuery works", async () => {
+    const unencodedService = new PersonModelService(odataClient, BASE_URL, NAME, { noUrlEncoding: true });
+    const model: EditablePersonModel = {
+      userName: "tester",
+      age: "14",
+      favFeature: Feature.Feature1,
+      features: [Feature.Feature1],
+    };
+
+    const request = unencodedService.update(model).addToQuery((b) => b.select("age"));
+
+    expect(request.getInfo().url).toBe(EXPECTED_PATH + "?$select=Age");
+    expect(request.getInfo().method).toBe("PUT");
+    expect(request.getInfo().data).toEqual(model);
+  });
+
+  test("entityType V4: update query builder only allows select/expand/expanding", () => {
+    testService.update({} as EditablePersonModel, undefined, (b, q) => {
+      // @ts-expect-error: filter is not available for a single-model write response builder
+      b.filter(q.age.gt("1"));
+      // @ts-expect-error: top is not available for a single-model write response builder
+      b.top(1);
+    });
+  });
+
+  test("entityType V4: patch & update subtype with select/expand respects cast path", async () => {
+    const serviceToTest = new PlanItemService(odataClient, BASE_URL, NAME, { noUrlEncoding: true }).asFlightService();
+    const inputModel: EditableFlightModel = {
+      id: 123,
+      name: "Optional",
+      flightNumber: "F123",
+    };
+
+    const request = serviceToTest.update(inputModel, { withCastPathSegment: true }, (b) => b.select("name"));
+
+    expect(request.getInfo().url).toBe(EXPECTED_PATH + "/Tester.Flight?$select=Name");
+  });
+
   test("entityType V4: patch & update subtype", async () => {
     const serviceToTest = new PlanItemService(odataClient, BASE_URL, NAME).asFlightService();
     const inputModel: EditableFlightModel = {


### PR DESCRIPTION
- `create()`, `update()`/`patch()` (EntityType/EntitySet/ComplexType) and `add()`/`update()` (Collection) now accept an optional `queryFn` to shape the write response via `$select`/`$expand`, returning a builder-backed Cmd that also supports `.addToQuery()` afterward - consistent with `.query()`.
- `UrlBuilderRequestCmdV4`/`V2` gained explicit `method`/`data` constructor parameters (matching `UrlRequestCmd`'s existing shape) instead of nesting them in the options bag.
