### PR TITLE
chore: raise test coverage to >=95% across all packages

### DIFF
--- a/packages/odata-query-builder/test/ODataQueryBuilder.test.ts
+++ b/packages/odata-query-builder/test/ODataQueryBuilder.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+import { ODataQueryBuilder } from "../src/ODataQueryBuilder";
+import { qPerson } from "./fixture/types/QSimplePersonModel";
+
+describe("ODataQueryBuilder engine tests (internal)", () => {
+  // buildNested() is only invoked internally via expanding() on complex-typed props, but is itself public.
+  // Note: buildQuery()'s `filterConcat` truthy-check (line 312) is structurally unreachable - Array.reduce()
+  // without an initial value on a non-empty array always yields a truthy object - and is not tested here.
+
+  test("buildNested: complex context, encoded (default) with no params", () => {
+    const engine = new ODataQueryBuilder("Address", qPerson, { expandingBuilder: true });
+
+    expect(engine.buildNested(true)).toStrictEqual({ content: "Address", hoistedExpands: [] });
+  });
+
+  test("buildNested: complex context, unencoded and expandingBuilder combined", () => {
+    const engine = new ODataQueryBuilder("Address", qPerson, { unencoded: true, expandingBuilder: true });
+    engine.select(["name"]);
+
+    expect(engine.buildNested(true).content).toBe("Address($select=name)");
+  });
+});

--- a/packages/odata-query-builder/test/ODataQueryBuilderV2.test.ts
+++ b/packages/odata-query-builder/test/ODataQueryBuilderV2.test.ts
@@ -1,6 +1,6 @@
 import { QSelectExpression } from "@odata2ts/odata-query-objects";
 import { beforeEach, describe, expect, test } from "vitest";
-import { CollectionQueryBuilderV2, createQueryBuilderV2 } from "../src";
+import { CollectionQueryBuilderV2, createExpandingQueryBuilderV2, createQueryBuilderV2 } from "../src";
 import { QPerson, qPerson } from "./fixture/types/QSimplePersonModel";
 import { createBaseTests } from "./ODataQueryBuilderBaseTests";
 
@@ -214,6 +214,31 @@ describe("ODataQueryBuilderV2 Test", () => {
     );
 
     expect(candidate).toBe(expected);
+  });
+
+  // Note: expanding()'s `expands.length` check (this file, ~line 98) is structurally unreachable - the inner
+  // ExpandingODataQueryBuilderV2's own `expands` Set is always seeded with its `property` in its constructor,
+  // so `expander.build().expands` can never be empty. Not tested here.
+
+  test("expanding: nested expanding without a select produces no selects, only expands", () => {
+    const candidate = toTest
+      .expanding("bestFriend", (builder) => {
+        builder.expanding("friends", () => {});
+      })
+      .build();
+    const expected = addBase("$expand=bestFriend,bestFriend/friends");
+
+    expect(candidate).toBe(expected);
+  });
+
+  test("expanding builder (internal): select/expand ignore nullables", () => {
+    const expander = createExpandingQueryBuilderV2("bestFriend", qPerson);
+
+    // Note: the `expands.length` check hit by this call (expander's own expands, ~line 73) is structurally
+    // unreachable in the other direction - it always has at least the seeded `property` - but this call still
+    // exercises the empty-input guards in select()/expand() themselves (~lines 38, 49).
+    expect(expander.select(null, undefined).build().selects).toStrictEqual([]);
+    expect(expander.expand(null, undefined).build().expands).toStrictEqual(["bestFriend"]);
   });
 
   test("clone: all fields set", () => {

--- a/packages/odata-query-builder/test/ODataQueryBuilderV4.test.ts
+++ b/packages/odata-query-builder/test/ODataQueryBuilderV4.test.ts
@@ -1,6 +1,6 @@
 import { QSelectExpression, searchTerm } from "@odata2ts/odata-query-objects";
 import { beforeEach, describe, expect, test } from "vitest";
-import { CollectionQueryBuilderV4, createQueryBuilderV4 } from "../src";
+import { CollectionQueryBuilderV4, createExpandingQueryBuilderV4, createQueryBuilderV4 } from "../src";
 import { QPerson, qPerson } from "./fixture/types/QSimplePersonModel";
 import { createBaseTests } from "./ODataQueryBuilderBaseTests";
 
@@ -281,6 +281,26 @@ describe("ODataQueryBuilderV4 Test", () => {
     expect(candidate).toBe(expected);
   });
 
+  test("expanding: hoisting bucket is reused across multiple complex hops on the same builder", () => {
+    const candidate = toTest
+      .expanding("address", (builder) => {
+        builder.select("street").expanding("responsible", (respBuilder) => {
+          respBuilder.select("name");
+        });
+      })
+      .expanding("altAddresses", (builder) => {
+        builder.select("street").expanding("responsible", (respBuilder) => {
+          respBuilder.select("age");
+        });
+      })
+      .build();
+    const expected = addBase(
+      "$select=Address($select=street),AltAdresses($select=street)&$expand=Address/responsible($select=name),AltAdresses/responsible($select=age)",
+    );
+
+    expect(candidate).toBe(expected);
+  });
+
   test("expanding: complex prop nested inside entity stays inline", () => {
     const candidate = toTest
       .expanding("bestFriend", (builder) => {
@@ -369,6 +389,12 @@ describe("ODataQueryBuilderV4 Test", () => {
     expect(candidate).toBe(addBase("$search=testing AND test2"));
   });
 
+  test("search: consecutive calls append to the already initialized term list", () => {
+    const candidate = toTest.search("testing").search("more").build();
+
+    expect(candidate).toBe(addBase("$search=testing AND more"));
+  });
+
   test("search: with operators", () => {
     const candidate = toTest.search(searchTerm("testing").not().and("test2").or("phrase is a phrase")).build();
 
@@ -390,5 +416,37 @@ describe("ODataQueryBuilderV4 Test", () => {
     const result = toTest.clone();
 
     expect(JSON.stringify(result)).toStrictEqual(JSON.stringify(toTest));
+  });
+
+  test("clone: skips explicitly undefined own properties", () => {
+    toTest.select("name");
+    // simulate an own property that was explicitly reset to undefined (e.g. hoistedExpandsBucket after build())
+    (toTest as any).builder.itemsCount = undefined;
+
+    const result = toTest.clone();
+
+    expect(JSON.stringify(result)).toStrictEqual(JSON.stringify(toTest));
+  });
+
+  test("engine (internal): addSelects/addExpands ignore an empty path list", () => {
+    (toTest as any).builder.addSelects();
+    (toTest as any).builder.addExpands();
+
+    expect(toTest.build()).toBe(addBase(""));
+  });
+
+  test("expanding builder (internal): build() renders its own query string", () => {
+    const expander = createExpandingQueryBuilderV4("bestFriend", qPerson);
+
+    expect(expander.select("age").build()).toBe("bestFriend($select=age)");
+  });
+
+  test("expanding builder (internal): expanding() with a nullish callback is a no-op", () => {
+    const expander = createExpandingQueryBuilderV4("bestFriend", qPerson);
+
+    // @ts-ignore
+    expect(expander.expanding("friends", null).build()).toBe("bestFriend");
+    // @ts-ignore
+    expect(expander.expanding("friends", undefined).build()).toBe("bestFriend");
   });
 });

--- a/packages/odata-query-objects/test/param/enum/QEnumParam.test.ts
+++ b/packages/odata-query-objects/test/param/enum/QEnumParam.test.ts
@@ -57,4 +57,9 @@ describe("QEnumParam Tests", () => {
     expect(toTest.parseUrlValue("null")).toBe(null);
     expect(toTest.parseUrlValue(undefined)).toBe(undefined);
   });
+
+  // Note: BaseEnumParam.parseUrlValue()'s JSON-array fallback branch (`if (value && parsed === undefined)`)
+  // is structurally unreachable - parseWithQuotes() throws for any truthy, non-"null", unquoted string before
+  // that check is reached, and parseNullValue() only ever produces `undefined` when `value` itself is falsy
+  // (making the `value &&` half of the condition false). Not tested here.
 });

--- a/packages/odata-query-objects/test/param/enum/QNumericEnumParam.test.ts
+++ b/packages/odata-query-objects/test/param/enum/QNumericEnumParam.test.ts
@@ -28,6 +28,13 @@ describe("QNumericEnumParam Tests", () => {
     expect(() => new QNumericEnumParam(TestEnum, null)).toThrowError();
   });
 
+  test("fail creation: missing enum with a valid name", () => {
+    // @ts-expect-error
+    expect(() => new QNumericEnumParam(null, NAME)).toThrow("Enum must be supplied!");
+    // @ts-expect-error
+    expect(() => new QNumericEnumParam(undefined, NAME)).toThrow("Enum must be supplied!");
+  });
+
   test("mapped name", () => {
     const mappedName = "testB";
     const toTest = new QNumericEnumParam(TestEnum, NAME, mappedName);
@@ -48,4 +55,7 @@ describe("QNumericEnumParam Tests", () => {
     expect(toTest.parseUrlValue("null")).toBe(null);
     expect(toTest.parseUrlValue(undefined)).toBe(undefined);
   });
+
+  // Note: see QEnumParam.test.ts for why BaseEnumParam.parseUrlValue()'s JSON-array fallback branch is
+  // structurally unreachable and not tested here.
 });

--- a/packages/odata-query-objects/test/path/base/BaseFunctions.test.ts
+++ b/packages/odata-query-objects/test/path/base/BaseFunctions.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "vitest";
+import { filterIn } from "../../../src/path/base/BaseFunctions";
+
+describe("BaseFunctions: filterIn tests", () => {
+  const mapValue = (value: string) => `'${value}'`;
+
+  test("filterIn: single value", () => {
+    const result = filterIn("name", mapValue)("Horst");
+
+    expect(result.toString()).toBe("name in ('Horst')");
+  });
+
+  test("filterIn: multiple values, including a nested array", () => {
+    const result = filterIn("name", mapValue)("Horst", ["Kai", "Zebra"]);
+
+    expect(result.toString()).toBe("name in ('Horst','Kai','Zebra')");
+  });
+});

--- a/packages/odata-query-objects/test/path/enum/QEnumPath.test.ts
+++ b/packages/odata-query-objects/test/path/enum/QEnumPath.test.ts
@@ -24,11 +24,11 @@ describe("QEnumPath test", () => {
 
   test("fails without enum", () => {
     // @ts-expect-error
-    expect(() => new QNumericEnumPath("feature")).toThrow();
+    expect(() => new QEnumPath("feature")).toThrow("QEnumPath: Enum must be supplied! ");
     // @ts-expect-error
-    expect(() => new QNumericEnumPath("feature", null)).toThrow();
+    expect(() => new QEnumPath("feature", null)).toThrow("QEnumPath: Enum must be supplied! ");
     // @ts-expect-error
-    expect(() => new QNumericEnumPath("feature", undefined)).toThrow();
+    expect(() => new QEnumPath("feature", undefined)).toThrow("QEnumPath: Enum must be supplied! ");
   });
 
   test("orderBy asc", () => {

--- a/packages/odata-query-objects/test/primitive-collection/PrimitiveCollections.test.ts
+++ b/packages/odata-query-objects/test/primitive-collection/PrimitiveCollections.test.ts
@@ -19,6 +19,7 @@ import {
   QNumberV2Collection,
   QNumericEnumCollection,
   QStringCollection,
+  QStringNumberV2Collection,
   QStringV2Collection,
   QTimeOfDayCollection,
   QTimeV2Collection,
@@ -54,6 +55,7 @@ describe("PrimitiveCollections tests", () => {
   const STRING_BASED_COLLECTIONS = [
     QStringCollection,
     QStringV2Collection,
+    QStringNumberV2Collection,
     QGuidCollection,
     QGuidV2Collection,
     QDateTimeOffsetCollection,

--- a/packages/odata-query-objects/test/response/MainResponseConverter.test.ts
+++ b/packages/odata-query-objects/test/response/MainResponseConverter.test.ts
@@ -1,0 +1,21 @@
+import { HttpResponseModel } from "@odata2ts/http-client-api";
+import { describe, expect, test } from "vitest";
+import { MainResponseConverter } from "../../src/response/MainResponseConverter";
+
+class TestResponseConverter extends MainResponseConverter<any, any> {
+  public convert(response: HttpResponseModel<any>): HttpResponseModel<any> {
+    return response;
+  }
+
+  public exposeApplyConverter(value: any) {
+    return this.applyConverter(value);
+  }
+}
+
+describe("MainResponseConverter tests", () => {
+  test("applyConverter: falls back to the raw value when the converter has neither convertFromOData nor convertFrom", () => {
+    const candidate = new TestResponseConverter({} as any);
+
+    expect(candidate.exposeApplyConverter("raw value")).toBe("raw value");
+  });
+});

--- a/packages/odata-service/test/CollectionServiceTests.ts
+++ b/packages/odata-service/test/CollectionServiceTests.ts
@@ -36,6 +36,22 @@ export function commonCollectionTests(
     expect(stringService.patch).toBeUndefined();
   });
 
+  test("collection: getPath", () => {
+    expect(stringService.getPath()).toBe(STRING_URL);
+    expect(enumService.getPath()).toBe(ENUM_URL);
+  });
+
+  test("collection: delete", async () => {
+    const request = stringService.delete();
+    const result = request.getInfo();
+
+    expect(result.url).toBe(STRING_URL);
+    expect(result.method).toBe("DELETE");
+    expect(result.data).toBeUndefined();
+
+    expectTypeOf(await request.execute()).toEqualTypeOf<HttpResponseModel<undefined>>();
+  });
+
   test("collection: query", async () => {
     let request = stringService.query().getInfo();
 

--- a/packages/odata-service/test/EntitySetServiceTests.ts
+++ b/packages/odata-service/test/EntitySetServiceTests.ts
@@ -45,6 +45,12 @@ export function commonEntitySetTests(
     expect(testService.createKey({ userName: "&/?" }, true)).toBe(`${NAME}(UserName='&/?')`);
   });
 
+  test("entitySet: createKey strips leading slash produced by the id function", async () => {
+    const slashService = new serviceConstructor(odataClient, BASE_URL, "/" + NAME);
+
+    expect(slashService.createKey("xxx")).toBe(`${NAME}('xxx')`);
+  });
+
   test("entitySet: parseKey", async () => {
     expect(testService.parseKey(`${NAME}('xxx')`)).toBe("xxx");
     expect(testService.parseKey(`${NAME}(UserName='xxx')`)).toStrictEqual({ userName: "xxx" });

--- a/packages/odata-service/test/ServiceStateHelper.test.ts
+++ b/packages/odata-service/test/ServiceStateHelper.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "vitest";
+import { BIG_NUMBERS_HEADERS, DEFAULT_HEADERS } from "../src/RequestHeaders.js";
+import { ServiceStateHelper } from "../src/ServiceStateHelper";
+import { MockClient } from "./mock/MockClient";
+
+describe("ServiceStateHelper tests", () => {
+  const client = new MockClient(false);
+
+  // Note: addFullPath()'s `this.path ?? ""` fallback is structurally unreachable — `path` is a required,
+  // readonly string field that the constructor always assigns a string to (falling back to `name || ""` in the
+  // worst case), so it can never be null/undefined. Not tested here.
+
+  test("path: basePath and name given", () => {
+    const helper = new ServiceStateHelper(client, "base", "name");
+    expect(helper.path).toBe("base/name");
+  });
+
+  test("path: only basePath given", () => {
+    const helper = new ServiceStateHelper(client, "base");
+    expect(helper.path).toBe("base");
+  });
+
+  test("path: only name given", () => {
+    const helper = new ServiceStateHelper(client, "", "name");
+    expect(helper.path).toBe("name");
+  });
+
+  test("path: neither basePath nor name given", () => {
+    const helper = new ServiceStateHelper(client, "");
+    expect(helper.path).toBe("");
+  });
+
+  test("getDefaultHeaders", () => {
+    expect(new ServiceStateHelper(client, "base", "name").getDefaultHeaders()).toStrictEqual(DEFAULT_HEADERS);
+    expect(
+      new ServiceStateHelper(client, "base", "name", { bigNumbersAsString: true }).getDefaultHeaders(),
+    ).toStrictEqual(BIG_NUMBERS_HEADERS);
+  });
+
+  test("isUrlNotEncoded", () => {
+    expect(new ServiceStateHelper(client, "base").isUrlNotEncoded()).toBe(false);
+    expect(new ServiceStateHelper(client, "base", "name", { noUrlEncoding: true }).isUrlNotEncoded()).toBe(true);
+  });
+});

--- a/packages/odata-service/test/fixture/v2/FakedComplexServiceV2.ts
+++ b/packages/odata-service/test/fixture/v2/FakedComplexServiceV2.ts
@@ -1,5 +1,5 @@
 import { ODataHttpClient } from "@odata2ts/http-client-api";
-import { ComplexTypeServiceV2, ODataServiceOptions } from "@odata2ts/odata-service";
+import { ComplexTypeServiceV2, ODataServiceOptions } from "../../../src";
 import { EditablePersonModel, PersonModel } from "../PersonModel";
 import { qPersonV2, QPersonV2 } from "./QPersonV2";
 

--- a/packages/odata-service/test/request/ComposableUrlRequestCmd.test.ts
+++ b/packages/odata-service/test/request/ComposableUrlRequestCmd.test.ts
@@ -33,6 +33,22 @@ describe("ComposableUrlRequestCmd tests", () => {
     expect(candidate.getInfo().url).toBe(DEFAULT_URL);
   });
 
+  test("with new URL: guard against empty url", () => {
+    expect(() => candidate.withUrl("")).toThrow("withUrl requires a new URL!");
+    expect(() => candidate.withUrl("   ")).toThrow("withUrl requires a new URL!");
+  });
+
+  test("without options argument", () => {
+    const noOptionsCandidate = new ComposableUrlRequestCmd<MockClient, PersonModelService<MockClient>, undefined>(
+      client,
+      DEFAULT_URL,
+      (url: string) => new PersonModelService(client, url, "", { noUrlEncoding: true }),
+    );
+
+    expect(noOptionsCandidate.getUrl()).toBe(DEFAULT_URL);
+    expect(noOptionsCandidate.getInfo().headers).toBeUndefined();
+  });
+
   test("with new URL", () => {
     const newUrl = "hey/ho/there";
     const newCandidate = candidate.withUrl(newUrl);

--- a/packages/odata-service/test/request/RequestCmd.test.ts
+++ b/packages/odata-service/test/request/RequestCmd.test.ts
@@ -1,0 +1,30 @@
+import { ODataHttpMethods } from "@odata2ts/http-client-api";
+import { describe, expect, test } from "vitest";
+import { RequestCmd } from "../../src/request/RequestCmd";
+import { MockClient } from "../mock/MockClient";
+
+class TestRequestCmd extends RequestCmd<MockClient, void> {
+  public getUrl(): string {
+    return "test/ing";
+  }
+}
+
+describe("RequestCmd tests", () => {
+  // Note: RequestCmd.getInfoConverted() and the private convertResponse() each guard against a missing
+  // converter chain (`if (!converter)`). Both requestConverter and responseConverter are private readonly
+  // fields that the constructor always sets to a real RequestConverterChain/ResponseConverterChain instance,
+  // so those guards are structurally unreachable through any legitimate construction path and are not tested here.
+
+  test("constructor without options argument", () => {
+    const client = new MockClient(false);
+    const candidate = new TestRequestCmd(client, ODataHttpMethods.Get);
+
+    expect(candidate.getInfo()).toMatchObject({
+      method: ODataHttpMethods.Get,
+      url: "test/ing",
+      headers: undefined,
+      data: undefined,
+    });
+    expect(candidate.getInfoConverted()).toStrictEqual(candidate.getInfo());
+  });
+});

--- a/packages/odata-service/test/request/UrlBuilderRequestCmdV2.test.ts
+++ b/packages/odata-service/test/request/UrlBuilderRequestCmdV2.test.ts
@@ -61,6 +61,14 @@ describe("UrlBuilderRequestCmd tests", () => {
     expect(newCandidate.getInfo().data).toStrictEqual({ userName: "tester" });
   });
 
+  test("add to query: guard against missing modification function", () => {
+    const candidate = new UrlBuilderRequestCmdV2(client, ODataHttpMethods.Get, queryBuilder, qPersonV2);
+
+    expect(() => candidate.addToQuery(undefined as any)).toThrow(
+      "changeUrl requires the modification function as first argument!",
+    );
+  });
+
   test("add to query", () => {
     const candidate = new UrlBuilderRequestCmdV2(client, ODataHttpMethods.Get, queryBuilder, qPersonV2);
     const newCandidate = candidate.addToQuery((builder) => builder.select("userName"));

--- a/packages/odata-service/test/request/UrlBuilderRequestCmdV4.test.ts
+++ b/packages/odata-service/test/request/UrlBuilderRequestCmdV4.test.ts
@@ -61,6 +61,14 @@ describe("UrlBuilderRequestCmdV4 tests", () => {
     expect(newCandidate.getInfo().data).toStrictEqual({ userName: "tester" });
   });
 
+  test("add to query: guard against missing modification function", () => {
+    const candidate = new UrlBuilderRequestCmdV4(client, ODataHttpMethods.Get, queryBuilder, qPersonV4);
+
+    expect(() => candidate.addToQuery(undefined as any)).toThrow(
+      "changeUrl requires the modification function as first argument!",
+    );
+  });
+
   test("add to query", () => {
     const candidate = new UrlBuilderRequestCmdV4(client, ODataHttpMethods.Get, queryBuilder, qPersonV4);
     const newCandidate = candidate.addToQuery((builder) => builder.select("userName"));
@@ -137,6 +145,15 @@ describe("UrlBuilderRequestCmdV4 tests", () => {
       url: DEFAULT_URL + "/$query",
       headers: { "Content-Type": "text/plain" },
       data: "$select=UserName",
+    });
+  });
+
+  test("as POST request: no-op when url has no query params", () => {
+    const candidate = new UrlBuilderRequestCmdV4(client, ODataHttpMethods.Get, queryBuilder, qPersonV4);
+
+    expect(candidate.asPostRequest().getInfo()).toMatchObject({
+      method: ODataHttpMethods.Get,
+      url: DEFAULT_URL,
     });
   });
 });

--- a/packages/odata-service/test/request/UrlGetRequestCmd.test.ts
+++ b/packages/odata-service/test/request/UrlGetRequestCmd.test.ts
@@ -33,4 +33,13 @@ describe("UrlRequestCmd tests", () => {
       data: "x=y&zz=top",
     });
   });
+
+  test("as POST request: no-op when url has no query params", () => {
+    const noQueryCandidate = new UrlGetRequestCmd(CLIENT, "test/ing");
+
+    expect(noQueryCandidate.asPostRequest().getInfo()).toMatchObject({
+      method: "GET",
+      url: "test/ing",
+    });
+  });
 });

--- a/packages/odata-service/test/request/UrlRequestCmd.test.ts
+++ b/packages/odata-service/test/request/UrlRequestCmd.test.ts
@@ -87,6 +87,13 @@ describe("UrlRequestCmd tests", () => {
     expect(newCandy.getInfo()).toMatchObject({ ...candidate.getInfo(), url: newUrl });
   });
 
+  test("with new url: guard against empty url", () => {
+    const candidate = new UrlRequestCmd<MockClient, void>(client, ODataHttpMethods.Get, DEFAULT_URL);
+
+    expect(() => candidate.withUrl("")).toThrow("withUrl requires a new URL!");
+    expect(() => candidate.withUrl("   ")).toThrow("withUrl requires a new URL!");
+  });
+
   test("execute", async () => {
     const candidate = new UrlRequestCmd<MockClient, void>(client, ODataHttpMethods.Get, DEFAULT_URL);
 

--- a/packages/odata-service/test/request/converter/RequestConverterChain.test.ts
+++ b/packages/odata-service/test/request/converter/RequestConverterChain.test.ts
@@ -88,6 +88,15 @@ describe("RequestConverterChain tests", () => {
     );
   });
 
+  test("throws for a main converter with wrong signature", () => {
+    const invalidConverter = {} as MainRequestConverter<number, any>;
+    const candidate = new RequestConverterChain(invalidConverter);
+
+    expect(() => candidate.convert(testRequestInfo)).toThrow(
+      "Wrong conversion function signature for request converter!",
+    );
+  });
+
   test("mixed append and prepend", () => {
     blankCandidate.prependConverter((value) => value.withData(value.data! * 2));
     blankCandidate.appendConverter((value) => value.withData(value.data! * 3));

--- a/packages/odata-service/test/v2/ComplexTypeServiceV2.test.ts
+++ b/packages/odata-service/test/v2/ComplexTypeServiceV2.test.ts
@@ -1,4 +1,5 @@
 import { HttpResponseModel } from "@odata2ts/http-client-api";
+import { ODataComplexModelResponseV2 } from "@odata2ts/odata-core";
 import { beforeEach, describe, expect, expectTypeOf, test } from "vitest";
 import { DEFAULT_HEADERS, MERGE_HEADERS } from "../../src";
 import { EditablePersonModel, Feature, PersonModel } from "../fixture/PersonModel";
@@ -15,6 +16,43 @@ describe("ComplexTypeService V2 Test", () => {
 
   beforeEach(() => {
     testService = new FakedComplexServiceV2(odataClient, BASE_URL, NAME);
+  });
+
+  test("complexType: getPath", () => {
+    expect(testService.getPath()).toBe(EXPECTED_PATH);
+  });
+
+  test("complexType: delete", async () => {
+    const request = testService.delete();
+    const result = request.getInfo();
+
+    expect(result.url).toBe(EXPECTED_PATH);
+    expect(result.method).toBe("DELETE");
+    expect(result.data).toBeUndefined();
+
+    expectTypeOf(await request.execute()).toEqualTypeOf<HttpResponseModel<undefined>>();
+  });
+
+  test("complexType: query", async () => {
+    const request = testService.query();
+    const result = request.getInfo();
+
+    expect(result.url).toBe(EXPECTED_PATH);
+    expect(result.method).toBe("GET");
+    expect(result.data).toBeUndefined();
+
+    expectTypeOf(await request.execute()).toEqualTypeOf<
+      HttpResponseModel<ODataComplexModelResponseV2<PersonModel>>
+    >();
+  });
+
+  test("complexType: query with select", async () => {
+    const unencodedService = new FakedComplexServiceV2(odataClient, BASE_URL, NAME, { noUrlEncoding: true });
+
+    const request = unencodedService.query((b) => b.select("age"));
+
+    expect(request.getInfo().url).toBe(EXPECTED_PATH + "?$select=Age");
+    expect(request.getInfo().method).toBe("GET");
   });
 
   test("complexType: patch = merge", async () => {

--- a/packages/odata-service/test/v2/PrimitiveTypeServiceV2.test.ts
+++ b/packages/odata-service/test/v2/PrimitiveTypeServiceV2.test.ts
@@ -22,6 +22,34 @@ describe("PrimitiveTypeService V2 Test", () => {
     expect(testService.getPath()).toBe(EXPECTED_PATH);
   });
 
+  test("primitiveType V2: internal converter name and mapped name", () => {
+    const converter = (testService as any).__converter;
+
+    expect(converter.getName()).toBe(PROPERTY_NAME);
+    expect(converter.getMappedName()).toBe("userName");
+  });
+
+  test("primitiveType V2: internal converter without mapped name falls back to name", () => {
+    const noMappedNameService = new PrimitiveTypeServiceV2<MockClient, string>(odataClient, BASE_URL, NAME);
+    const converter = (noMappedNameService as any).__converter;
+
+    expect(converter.getMappedName()).toBe(NAME);
+  });
+
+  test("primitiveType V2: internal converter with explicit mapped name", () => {
+    const mappedService = new PrimitiveTypeServiceV2<MockClient, string>(
+      odataClient,
+      BASE_URL,
+      NAME,
+      undefined,
+      "mappedUserName",
+    );
+    const converter = (mappedService as any).__converter;
+
+    expect(converter.getName()).toBe(NAME);
+    expect(converter.getMappedName()).toBe("mappedUserName");
+  });
+
   test("primitiveType V2: get value", async () => {
     const request = testService.getValue();
     const result = request.getInfo();

--- a/packages/odata-service/test/v4/PrimitiveTypeServiceV4.test.ts
+++ b/packages/odata-service/test/v4/PrimitiveTypeServiceV4.test.ts
@@ -25,6 +25,15 @@ describe("PrimitiveTypeService V4 Test", () => {
     expect(service.getPath()).toBe(EXPECTED_PATH);
   });
 
+  test("primitiveType V4: defaults to identity converter when none is given", async () => {
+    const defaultService = new PrimitiveTypeServiceV4<MockClient, string>(odataClient, BASE_URL, NAME);
+
+    odataClient.setValueResponse("tester");
+    const response = await defaultService.getValue().execute();
+
+    expect(response.data?.value).toBe("tester");
+  });
+
   test("primitiveType V4: get value", async () => {
     const request = service.getValue();
     const result = request.getInfo();

--- a/packages/odata2ts/test/cli/processCliArgs.test.ts
+++ b/packages/odata2ts/test/cli/processCliArgs.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "vitest";
+import { processCliArgs } from "../../src/cli/processCliArgs";
+
+describe("processCliArgs tests", () => {
+  const BASE_ARGV = ["node", "cli.js"];
+
+  test("no positional services given", () => {
+    const result = processCliArgs(BASE_ARGV);
+
+    expect(result.services).toBeUndefined();
+  });
+
+  test("positional services are collected", () => {
+    const result = processCliArgs([...BASE_ARGV, "serviceA", "serviceB"]);
+
+    expect(result.services).toStrictEqual(["serviceA", "serviceB"]);
+  });
+});

--- a/packages/odata2ts/test/download/downloadMetadata.test.ts
+++ b/packages/odata2ts/test/download/downloadMetadata.test.ts
@@ -72,6 +72,20 @@ describe("Download Test", () => {
     expect(axiosSpy).toHaveBeenCalledWith({ auth: config, ...DEFAULT_REQUEST_CONFIG });
   });
 
+  test("url already ending with $metadata is used as is", async () => {
+    const url = DEFAULT_URL + "/$metadata";
+
+    await downloadMetadata(url);
+
+    expect(axiosSpy).toHaveBeenCalledWith(DEFAULT_REQUEST_CONFIG);
+  });
+
+  test("url already ending with a slash doesn't get a double slash", async () => {
+    await downloadMetadata(DEFAULT_URL + "/");
+
+    expect(axiosSpy).toHaveBeenCalledWith(DEFAULT_REQUEST_CONFIG);
+  });
+
   test("with debug", async () => {
     await downloadMetadata(DEFAULT_URL, undefined, true);
 
@@ -87,6 +101,19 @@ describe("Download Test", () => {
       url: "http://localhost:3000/api/$metadata",
       headers: { Accept: "application/xml" },
     });
+  });
+
+  test("with debug - auth without a password is logged as is", async () => {
+    const config: UrlSourceConfiguration = {
+      custom: { baseURL: DEFAULT_URL, auth: { username: "user" } as any },
+    };
+
+    await downloadMetadata(DEFAULT_URL, config, true);
+
+    expect(logInfoSpy).toHaveBeenLastCalledWith(
+      "Request configuration:",
+      expect.objectContaining({ auth: { username: "user" } }),
+    );
   });
 
   test("custom request config", async () => {

--- a/packages/odata2ts/test/generator/ImportContainer.test.ts
+++ b/packages/odata2ts/test/generator/ImportContainer.test.ts
@@ -86,4 +86,135 @@ describe("ImportContainer tests", function () {
       ],
     });
   });
+
+  test("addQObject then addQObjectType: regular import wins, no typeOnly added", async () => {
+    await createImportContainer();
+
+    importContainer.addQObject("QFoo");
+    importContainer.addQObjectType("QFoo");
+
+    const importDecls = importContainer.getImportDeclarations();
+
+    expect(importDecls.length).toBe(1);
+    expect(importDecls[0].isTypeOnly).toBe(false);
+  });
+
+  test("addQObjectType then addQObject: typeOnly import gets removed, regular added", async () => {
+    await createImportContainer();
+
+    importContainer.addQObjectType("QFoo");
+    importContainer.addQObject("QFoo");
+
+    const importDecls = importContainer.getImportDeclarations();
+
+    expect(importDecls.length).toBe(1);
+    expect(importDecls[0].isTypeOnly).toBe(false);
+  });
+
+  describe("generated imports: bundled file generation", () => {
+    test("addGeneratedModel: same file is a no-op (returns name unchanged, no import)", async () => {
+      await createImportContainer("TestModel");
+
+      const result = importContainer.addGeneratedModel("", "SomeName");
+
+      expect(result).toBe("SomeName");
+      expect(importContainer.getImportDeclarations().length).toBe(0);
+    });
+
+    test("addGeneratedModel/QObject/Service import from the shared bundle file", async () => {
+      await createImportContainer();
+
+      importContainer.addGeneratedModel("Test.Foo", "FooModel");
+      importContainer.addGeneratedQObject("Test.Foo", "qFoo");
+      importContainer.addGeneratedService("Test.Foo", "FooService");
+
+      const importDecls = importContainer.getImportDeclarations();
+
+      expect(importDecls).toHaveLength(3);
+      expect(importDecls.map((d) => d.moduleSpecifier)).toStrictEqual(["./TestModel", "./QTest", "./TestService"]);
+    });
+  });
+
+  describe("generated imports: non-bundled file generation", () => {
+    test("addGeneratedModel: unknown fqName throws", async () => {
+      await createImportContainer(DEFAULT_FILE_NAME, "", [], false);
+
+      expect(() => importContainer.addGeneratedModel("Test.DoesNotExist", "Foo")).toThrow(
+        "Cannot find model by its fully qualified name: Test.DoesNotExist!",
+      );
+    });
+
+    test("addGeneratedQObject: unknown fqName throws", async () => {
+      await createImportContainer(DEFAULT_FILE_NAME, "", [], false);
+
+      expect(() => importContainer.addGeneratedQObject("Test.DoesNotExist", "qFoo")).toThrow(
+        "Cannot find q-object by its fully qualified name: Test.DoesNotExist!",
+      );
+    });
+
+    test("addGeneratedModel/QObject: empty fqName falls back to the main file names", async () => {
+      await createImportContainer(DEFAULT_FILE_NAME, "", [], false);
+
+      importContainer.addGeneratedModel("", "FooModel");
+      importContainer.addGeneratedQObject("", "qFoo");
+
+      const importDecls = importContainer.getImportDeclarations();
+
+      expect(importDecls.map((d) => d.moduleSpecifier)).toStrictEqual(["./TestModel", "./QTest"]);
+    });
+
+    test("addGeneratedModel/QObject/Service: known fqName imports from the model's own file", async () => {
+      odataBuilder.addEntityType("Foo", undefined, (builder) => builder.addKeyProp("id", "Edm.String"));
+      await createImportContainer(DEFAULT_FILE_NAME, "", [], false);
+
+      importContainer.addGeneratedModel("Test.Foo", "FooModel");
+      importContainer.addGeneratedQObject("Test.Foo", "qFoo");
+      importContainer.addGeneratedService("Test.Foo", "FooService");
+
+      const importDecls = importContainer.getImportDeclarations();
+
+      expect(importDecls.length).toBe(3);
+      expect(importDecls.every((d) => typeof d.moduleSpecifier === "string" && d.moduleSpecifier.length > 0)).toBe(
+        true,
+      );
+    });
+
+    test("addGeneratedQBaseObject: model without a base type throws", async () => {
+      odataBuilder.addEntityType("Foo", undefined, (builder) => builder.addKeyProp("id", "Edm.String"));
+      await createImportContainer(DEFAULT_FILE_NAME, "", [], false);
+      const dataModel = (importContainer as any).dataModel;
+      const model = dataModel.getModel("Test.Foo");
+
+      expect(() => importContainer.addGeneratedQBaseObject(model)).toThrow("Model Test.Foo has no base type!");
+    });
+
+    test("addGeneratedQBaseObject: model with a base type imports the base q-object", async () => {
+      odataBuilder
+        .addEntityType("Parent", undefined, (builder) => builder.addKeyProp("id", "Edm.String"))
+        .addEntityType("Child", { baseType: "Test.Parent" }, () => {});
+      await createImportContainer(DEFAULT_FILE_NAME, "", [], false);
+      const dataModel = (importContainer as any).dataModel;
+      // qBaseName is assigned to the base type (Parent) during digestion, not the subtype (Child)
+      const model = dataModel.getModel("Test.Parent");
+
+      const result = importContainer.addGeneratedQBaseObject(model);
+
+      expect(result).toBe(model.qBaseName);
+      expect(importContainer.getImportDeclarations().length).toBe(1);
+    });
+
+    test("addGeneratedQBaseObject: bundled file generation imports the base q-object from the shared bundle", async () => {
+      odataBuilder
+        .addEntityType("Parent", undefined, (builder) => builder.addKeyProp("id", "Edm.String"))
+        .addEntityType("Child", { baseType: "Test.Parent" }, () => {});
+      await createImportContainer();
+      const dataModel = (importContainer as any).dataModel;
+      const model = dataModel.getModel("Test.Parent");
+
+      importContainer.addGeneratedQBaseObject(model);
+
+      const importDecls = importContainer.getImportDeclarations();
+      expect(importDecls[0].moduleSpecifier).toBe("./QTest");
+    });
+  });
 });

--- a/packages/odata2ts/test/generator/ImportedNameValidator.test.ts
+++ b/packages/odata2ts/test/generator/ImportedNameValidator.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "vitest";
+import { ImportedNameValidator } from "../../src/generator/ImportedNameValidator";
+
+describe("ImportedNameValidator tests", () => {
+  test("first registration of a name returns it unchanged", () => {
+    const validator = new ImportedNameValidator();
+
+    expect(validator.validateName("moduleA", "Foo")).toBe("Foo");
+  });
+
+  test("same qualifier and name returns the cached result", () => {
+    const validator = new ImportedNameValidator();
+
+    validator.validateName("moduleA", "Foo");
+
+    expect(validator.validateName("moduleA", "Foo")).toBe("Foo");
+  });
+
+  test("same name from a different qualifier gets a suffixed alias", () => {
+    const validator = new ImportedNameValidator();
+
+    validator.validateName("moduleA", "Foo");
+
+    expect(validator.validateName("moduleB", "Foo")).toBe("Foo_1");
+  });
+
+  test("reserved names are pre-registered and get suffixed on first real use", () => {
+    const validator = new ImportedNameValidator(["Foo"]);
+
+    expect(validator.validateName("moduleA", "Foo")).toBe("Foo_1");
+  });
+});

--- a/packages/odata2ts/test/generator/import/ImportResponseHelper.test.ts
+++ b/packages/odata2ts/test/generator/import/ImportResponseHelper.test.ts
@@ -1,0 +1,75 @@
+import { ODataVersions } from "@odata2ts/odata-core";
+import { describe, expect, test, vi } from "vitest";
+import { DataTypes, ReturnTypeModel } from "../../../src/data-model/DataTypeModel";
+import { ImportContainer } from "../../../src/generator/ImportContainer";
+import { CoreImports } from "../../../src/generator/import/ImportObjects";
+import {
+  importMainResponseConverter,
+  importReturnType,
+} from "../../../src/generator/import/ImportResponseHelper";
+
+function mockImports() {
+  return {
+    addCoreLib: vi.fn((_v: ODataVersions, lib: any) => String(lib)),
+    addQObject: vi.fn((qo: any) => String(qo)),
+  } as unknown as ImportContainer;
+}
+
+function mkReturnType(dataType: DataTypes, isCollection: boolean): ReturnTypeModel {
+  return { dataType, isCollection } as ReturnTypeModel;
+}
+
+describe("ImportResponseHelper tests", () => {
+  describe("importReturnType", () => {
+    test("V2: complex type (non-collection, non-primitive)", () => {
+      const imports = mockImports();
+      importReturnType(ODataVersions.V2, imports, mkReturnType(DataTypes.ComplexType, false));
+
+      expect(imports.addCoreLib).toHaveBeenCalledWith(ODataVersions.V2, CoreImports.ODataComplexModelResponseV2);
+    });
+
+    test("V2: entity/model type (non-collection, non-primitive)", () => {
+      const imports = mockImports();
+      importReturnType(ODataVersions.V2, imports, mkReturnType(DataTypes.ModelType, false));
+
+      expect(imports.addCoreLib).toHaveBeenCalledWith(ODataVersions.V2, CoreImports.ODataEntityModelResponseV2);
+    });
+
+    test("V4: entity/model type (non-collection, non-primitive)", () => {
+      const imports = mockImports();
+      importReturnType(ODataVersions.V4, imports, mkReturnType(DataTypes.ModelType, false));
+
+      expect(imports.addCoreLib).toHaveBeenCalledWith(ODataVersions.V4, CoreImports.ODataModelResponseV4);
+    });
+  });
+
+  describe("importMainResponseConverter", () => {
+    test("V2: collection", () => {
+      const imports = mockImports();
+      importMainResponseConverter(ODataVersions.V2, imports, mkReturnType(DataTypes.ModelType, true));
+
+      expect(imports.addQObject).toHaveBeenCalledWith("CollectionResponseConverterV2");
+    });
+
+    test("V2: entity/model type", () => {
+      const imports = mockImports();
+      importMainResponseConverter(ODataVersions.V2, imports, mkReturnType(DataTypes.ModelType, false));
+
+      expect(imports.addQObject).toHaveBeenCalledWith("EntityResponseConverterV2");
+    });
+
+    test("V2: complex type", () => {
+      const imports = mockImports();
+      importMainResponseConverter(ODataVersions.V2, imports, mkReturnType(DataTypes.ComplexType, false));
+
+      expect(imports.addQObject).toHaveBeenCalledWith("ComplexResponseConverterV2");
+    });
+
+    test("V2: primitive type", () => {
+      const imports = mockImports();
+      importMainResponseConverter(ODataVersions.V2, imports, mkReturnType(DataTypes.PrimitiveType, false));
+
+      expect(imports.addQObject).toHaveBeenCalledWith("ValueResponseConverterV2");
+    });
+  });
+});

--- a/packages/odata2ts/test/project/FileHandler.test.ts
+++ b/packages/odata2ts/test/project/FileHandler.test.ts
@@ -23,7 +23,8 @@ describe("FileHandler Test", () => {
 
   const mockFile: SourceFile = {
     addImportDeclarations: vi.fn(),
-    addStatements: vi.fn(),
+    // @ts-ignore
+    addStatements: vi.fn(() => [{ setOrder: vi.fn() }]),
     emit: vi.fn(),
     // @ts-ignore
     getFilePath: () => MOCKED_FILE_PATH,
@@ -38,12 +39,22 @@ describe("FileHandler Test", () => {
     vi.clearAllMocks();
   });
 
-  function createFileHandler(options: { path?: string; fileName?: string; reservedNames?: Array<string> } = {}) {
-    const { path = DEFAULT_PATH, fileName = DEFAULT_FILENAME, reservedNames = [] } = options;
+  function createFileHandler(
+    options: {
+      path?: string;
+      fileName?: string;
+      reservedNames?: Array<string>;
+      allowTypeChecking?: boolean;
+      formatter?: FileFormatter | undefined;
+    } = {},
+  ) {
+    const { path = DEFAULT_PATH, fileName = DEFAULT_FILENAME, reservedNames = [], allowTypeChecking = true } =
+      options;
+    const fileFormatter = "formatter" in options ? options.formatter : formatter;
 
     const imports = new ImportContainer(path, fileName, DEFAULT_DATA_MODEL, MAIN_FILE_NAMES, true, reservedNames);
 
-    return new FileHandler(path, fileName, mockFile, imports, formatter, true);
+    return new FileHandler(path, fileName, mockFile, imports, fileFormatter, allowTypeChecking);
   }
 
   test("Smoke Test", () => {
@@ -127,5 +138,53 @@ describe("FileHandler Test", () => {
 
     // imports should have been added, but we don't test that here
     // => other tests rely on this fact
+  });
+
+  test("write: adds @ts-nocheck when type checking is disallowed", async () => {
+    const pm = createFileHandler({ allowTypeChecking: false });
+
+    await pm.write(EmitModes.ts);
+
+    expect(mockFile.addStatements).toHaveBeenCalledTimes(1);
+  });
+
+  test("write: invalid emit mode throws", async () => {
+    const pm = createFileHandler();
+
+    await expect(pm.write("invalid" as EmitModes)).rejects.toThrow('Emit mode "invalid" is invalid!');
+  });
+
+  test("write TS file: no formatter writes the raw content", async () => {
+    const pm = createFileHandler({ formatter: undefined });
+
+    await pm.write(EmitModes.ts);
+
+    expect(formatter.format).not.toHaveBeenCalled();
+    expect(writeFile).toHaveBeenCalledWith(MOCKED_FILE_PATH, MOCKED_FILE_CONTENT);
+  });
+
+  // Note: formatAndWriteFile()'s inner `catch (writeError)` around `writeFile(...)` (=> process.exit(3)) is
+  // structurally unreachable - the call is `return writeFile(...)` without `await`, so a rejection surfaces
+  // asynchronously outside that synchronous try block and is never caught there. Not tested here.
+
+  test("write TS file: formatting failure logs, writes error.log and exits with code 99", async () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const failingFormatter: FileFormatter = {
+      getSettings: () => ({}),
+      format: vi.fn(async () => {
+        throw new Error("bad syntax");
+      }),
+    };
+
+    const pm = createFileHandler({ formatter: failingFormatter });
+    await pm.write(EmitModes.ts);
+
+    expect(errorSpy).toHaveBeenCalledWith("Formatting failed", expect.any(Error));
+    expect(writeFile).toHaveBeenCalledWith("error.log", "Error: bad syntax");
+    expect(exitSpy).toHaveBeenCalledWith(99);
+
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 });

--- a/packages/odata2ts/test/project/TsMorphHelperMocked.test.ts
+++ b/packages/odata2ts/test/project/TsMorphHelperMocked.test.ts
@@ -1,0 +1,97 @@
+import { NewLineKind } from "@ts-morph/common";
+import { ModuleKind, ModuleResolutionKind, ScriptTarget } from "typescript";
+import { describe, expect, test, vi } from "vitest";
+import { EmitModes } from "../../src";
+import { loadTsMorphCompilerOptions } from "../../src/project/TsMorphHelper";
+
+const mockedLoad = vi.hoisted(() => vi.fn());
+
+vi.mock("ts-morph");
+vi.mock("tsconfig-loader", () => ({
+  default: mockedLoad,
+}));
+
+describe("TsMorphHelper tests (mocked tsconfig-loader)", () => {
+  const DEFAULT_TS_CONFIG = "tsconfig.json";
+  const DEFAULT_OUTPUT_DIR = "build/unitTest";
+
+  test("no config found falls back to an empty compilerOptions object", async () => {
+    mockedLoad.mockReturnValueOnce(undefined);
+
+    const result = await loadTsMorphCompilerOptions(DEFAULT_TS_CONFIG, EmitModes.ts, DEFAULT_OUTPUT_DIR);
+
+    expect(result).toMatchObject({ outDir: DEFAULT_OUTPUT_DIR, declaration: false });
+  });
+
+  test("no lib specified: compilerOpts.lib stays unset", async () => {
+    mockedLoad.mockReturnValueOnce({ tsConfig: { compilerOptions: {} } });
+
+    const result = await loadTsMorphCompilerOptions(DEFAULT_TS_CONFIG, EmitModes.ts, DEFAULT_OUTPUT_DIR);
+
+    expect(result.lib).toBeUndefined();
+  });
+
+  test.each([
+    ["lf", NewLineKind.LineFeed],
+    ["crlf", NewLineKind.CarriageReturnLineFeed],
+  ])("newLine=%s maps to %s", async (newLine, expected) => {
+    mockedLoad.mockReturnValueOnce({ tsConfig: { compilerOptions: { newLine } } });
+
+    const result = await loadTsMorphCompilerOptions(DEFAULT_TS_CONFIG, EmitModes.ts, DEFAULT_OUTPUT_DIR);
+
+    expect(result.newLine).toBe(expected);
+  });
+
+  test("unrecognized moduleResolution/module/target yield undefined", async () => {
+    mockedLoad.mockReturnValueOnce({
+      tsConfig: {
+        compilerOptions: {
+          moduleResolution: "totallyUnknown",
+          module: "totallyUnknown",
+          target: "totallyUnknown",
+        },
+      },
+    });
+
+    const result = await loadTsMorphCompilerOptions(DEFAULT_TS_CONFIG, EmitModes.ts, DEFAULT_OUTPUT_DIR);
+
+    expect(result.moduleResolution).toBeUndefined();
+    expect(result.module).toBeUndefined();
+    expect(result.target).toBeUndefined();
+  });
+
+  test("undefined moduleResolution/module/target yield undefined", async () => {
+    mockedLoad.mockReturnValueOnce({
+      tsConfig: {
+        compilerOptions: {},
+      },
+    });
+
+    const result = await loadTsMorphCompilerOptions(DEFAULT_TS_CONFIG, EmitModes.ts, DEFAULT_OUTPUT_DIR);
+
+    expect(result.moduleResolution).toBeUndefined();
+    expect(result.module).toBeUndefined();
+    expect(result.target).toBeUndefined();
+  });
+
+  test("moduleResolution 'node' maps via the nodejs alias to Node10", async () => {
+    mockedLoad.mockReturnValueOnce({
+      tsConfig: { compilerOptions: { moduleResolution: "node" } },
+    });
+
+    const result = await loadTsMorphCompilerOptions(DEFAULT_TS_CONFIG, EmitModes.ts, DEFAULT_OUTPUT_DIR);
+
+    expect(result.moduleResolution).toBe(ModuleResolutionKind.Node10);
+  });
+
+  test("module and target are case-insensitively matched", async () => {
+    mockedLoad.mockReturnValueOnce({
+      tsConfig: { compilerOptions: { module: "commonjs", target: "es2016" } },
+    });
+
+    const result = await loadTsMorphCompilerOptions(DEFAULT_TS_CONFIG, EmitModes.ts, DEFAULT_OUTPUT_DIR);
+
+    expect(result.module).toBe(ModuleKind.CommonJS);
+    expect(result.target).toBe(ScriptTarget.ES2016);
+  });
+});

--- a/packages/odata2ts/test/project/formatter/BaseFormatter.test.ts
+++ b/packages/odata2ts/test/project/formatter/BaseFormatter.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+import { BaseFormatter } from "../../../src/project/formatter/BaseFormatter";
+
+class TestFormatter extends BaseFormatter {
+  public async init(): Promise<BaseFormatter> {
+    this.settings = { useTrailingCommas: true };
+    return this;
+  }
+
+  public async format(source: string): Promise<string> {
+    return source;
+  }
+}
+
+describe("BaseFormatter tests", () => {
+  test("getSettings returns settings populated by init()", async () => {
+    const formatter = new TestFormatter("./test.ts");
+    await formatter.init();
+
+    expect(formatter.getSettings()).toStrictEqual({ useTrailingCommas: true });
+  });
+});

--- a/packages/odata2ts/test/project/formatter/NoopFormatter.test.ts
+++ b/packages/odata2ts/test/project/formatter/NoopFormatter.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "vitest";
+import { NoopFormatter } from "../../../src/project/formatter/NoopFormatter";
+
+describe("NoopFormatter tests", () => {
+  test("init resolves to itself", async () => {
+    const formatter = new NoopFormatter("./test.ts");
+
+    expect(await formatter.init()).toBe(formatter);
+  });
+
+  test("format returns the source unchanged", async () => {
+    const formatter = new NoopFormatter("./test.ts");
+    const source = "const x = 1;";
+
+    expect(await formatter.format(source)).toBe(source);
+  });
+});

--- a/packages/odata2ts/test/project/formatter/PrettierFormatter.test.ts
+++ b/packages/odata2ts/test/project/formatter/PrettierFormatter.test.ts
@@ -1,0 +1,102 @@
+import { IndentationText, NewLineKind, QuoteKind } from "ts-morph";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { PrettierFormatter } from "../../../src/project/formatter/PrettierFormatter";
+
+const mockedPrettier = vi.hoisted(() => ({
+  resolveConfig: vi.fn(),
+  format: vi.fn(),
+}));
+
+vi.mock("prettier", () => ({
+  default: mockedPrettier,
+}));
+
+describe("PrettierFormatter tests", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("init: no config found falls back to empty settings", async () => {
+    mockedPrettier.resolveConfig.mockResolvedValueOnce(null);
+
+    const formatter = new PrettierFormatter("./test.ts");
+    await formatter.init();
+
+    expect(formatter.getSettings()).toStrictEqual({});
+  });
+
+  test("init: bracketSpacing/singleQuote/trailingComma settings", async () => {
+    mockedPrettier.resolveConfig.mockResolvedValueOnce({
+      bracketSpacing: false,
+      singleQuote: true,
+      trailingComma: "none",
+    });
+
+    const formatter = new PrettierFormatter("./test.ts");
+    await formatter.init();
+
+    expect(formatter.getSettings()).toMatchObject({
+      insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces: false,
+      quoteKind: QuoteKind.Single,
+      useTrailingCommas: false,
+    });
+  });
+
+  test("init: default bracketSpacing and trailingComma when not specified", async () => {
+    mockedPrettier.resolveConfig.mockResolvedValueOnce({});
+
+    const formatter = new PrettierFormatter("./test.ts");
+    await formatter.init();
+
+    expect(formatter.getSettings()).toMatchObject({
+      insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces: true,
+      quoteKind: QuoteKind.Double,
+      useTrailingCommas: true,
+    });
+  });
+
+  test("format delegates to prettier.format with the typescript parser", async () => {
+    mockedPrettier.resolveConfig.mockResolvedValueOnce({ singleQuote: true });
+    mockedPrettier.format.mockResolvedValueOnce("formatted!");
+
+    const formatter = new PrettierFormatter("./test.ts");
+    await formatter.init();
+    const result = await formatter.format("const x=1");
+
+    expect(result).toBe("formatted!");
+    expect(mockedPrettier.format).toHaveBeenCalledWith(
+      "const x=1",
+      expect.objectContaining({ parser: "typescript" }),
+    );
+  });
+
+  test.each([
+    [true, undefined, IndentationText.Tab],
+    [false, 2, IndentationText.TwoSpaces],
+    [false, 4, IndentationText.FourSpaces],
+    [false, 8, IndentationText.EightSpaces],
+    [false, undefined, IndentationText.TwoSpaces],
+  ])("convertIndentation: useTabs=%s tabWidth=%s => %s", async (useTabs, tabWidth, expected) => {
+    mockedPrettier.resolveConfig.mockResolvedValueOnce({ useTabs, tabWidth });
+
+    const formatter = new PrettierFormatter("./test.ts");
+    await formatter.init();
+
+    expect(formatter.getSettings().indentationText).toBe(expected);
+  });
+
+  test.each([
+    ["lf", NewLineKind.LineFeed],
+    ["crlf", NewLineKind.CarriageReturnLineFeed],
+    ["cr", NewLineKind.CarriageReturnLineFeed],
+    ["auto", NewLineKind.LineFeed],
+    [undefined, NewLineKind.LineFeed],
+  ])("convertNewline: endOfLine=%s => %s", async (endOfLine, expected) => {
+    mockedPrettier.resolveConfig.mockResolvedValueOnce({ endOfLine });
+
+    const formatter = new PrettierFormatter("./test.ts");
+    await formatter.init();
+
+    expect(formatter.getSettings().newLineKind).toBe(expected);
+  });
+});

--- a/packages/odata2ts/test/project/formatter/index.test.ts
+++ b/packages/odata2ts/test/project/formatter/index.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "vitest";
+import { createFormatter } from "../../../src/project/formatter/index";
+import { NoopFormatter } from "../../../src/project/formatter/NoopFormatter";
+import { PrettierFormatter } from "../../../src/project/formatter/PrettierFormatter";
+
+describe("formatter factory tests", () => {
+  test("usePrettier=false creates an initialized NoopFormatter", async () => {
+    const formatter = await createFormatter("./out", false);
+
+    expect(formatter).toBeInstanceOf(NoopFormatter);
+  });
+
+  test("usePrettier=true creates an initialized PrettierFormatter", async () => {
+    const formatter = await createFormatter("./out", true);
+
+    expect(formatter).toBeInstanceOf(PrettierFormatter);
+  });
+});


### PR DESCRIPTION
- odata-service: fix false-negative import in FakedComplexServiceV2.ts fixture (ComplexTypeServiceV2.ts was never actually instrumented); add tests for previously untested getPath/delete/query, guard branches, and RequestCmd default options
- odata-query-builder: add tests for addSelects/addExpands empty-path guards, copyState with an explicitly undefined field, hoisted-expands-bucket reuse, consecutive search() calls, buildNested encoding/expandingBuilder combos, and the previously unexercised expanding-builder build()
- odata-query-objects: fix a broken assertion in QEnumPath.test.ts (referenced an undefined symbol instead of QEnumPath itself); add tests for enum-path/param guards and previously untested MainResponseConverter, BaseFunctions.filterIn, and QStringNumberV2Collection
- odata2ts: add direct unit tests for ImportContainer's non-bundled generation paths, FileHandler's emit-mode and formatter branches, the NoopFormatter/BaseFormatter/PrettierFormatter formatters, and several previously test-less modules (ImportedNameValidator, processCliArgs, ImportResponseHelper, TsMorphHelper, formatter factory)
- document a handful of branches that are structurally unreachable through any legitimate call to the public API (verified via source inspection) as accepted exceptions rather than forcing artificial tests
- lines/functions/branches now exceed 95% both per package and in aggregate across all four packages; no coverage thresholds were added, per explicit scope of this task