### PR TITLE
fix: pin internal odata2ts deps in examples to workspace protocol

### DIFF
--- a/examples/bookshop/package.json
+++ b/examples/bookshop/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@odata2ts/converter-big-number": "^0.2.8",
     "@odata2ts/http-client-axios": "^0.12.2",
-    "@odata2ts/odata-service": "^0.23.2",
+    "@odata2ts/odata-service": "workspace:^",
     "@sap/cds": "7.9.4",
     "@sap/cds-odata-v2-adapter-proxy": "^1.9.21",
     "axios": "0.27.2",
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@cap-js/sqlite": "^1",
-    "@odata2ts/odata2ts": "^0.40.2",
+    "@odata2ts/odata2ts": "workspace:^",
     "sqlite3": "^5"
   },
   "publishConfig": {

--- a/examples/main/package.json
+++ b/examples/main/package.json
@@ -22,13 +22,13 @@
     "@odata2ts/converter-v2-to-v4": "^0.5.7",
     "@odata2ts/http-client-axios": "^0.12.2",
     "@odata2ts/http-client-fetch": "^0.9.2",
-    "@odata2ts/odata-service": "^0.23.2",
+    "@odata2ts/odata-service": "workspace:^",
     "axios": "^1.13.1",
     "bignumber.js": "^9.1.2",
     "luxon": "^3.5.0"
   },
   "devDependencies": {
-    "@odata2ts/odata2ts": "^0.40.2",
+    "@odata2ts/odata2ts": "workspace:^",
     "@types/luxon": "^3.4.2"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -741,15 +741,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@odata2ts/odata-query-builder@npm:^0.19.0, @odata2ts/odata-query-builder@workspace:packages/odata-query-builder":
+"@odata2ts/odata-query-builder@npm:^0.18.6, @odata2ts/odata-query-builder@workspace:packages/odata-query-builder":
   version: 0.0.0-use.local
   resolution: "@odata2ts/odata-query-builder@workspace:packages/odata-query-builder"
   dependencies:
-    "@odata2ts/odata-query-objects": "npm:^0.29.0"
+    "@odata2ts/odata-query-objects": "npm:^0.28.2"
   languageName: unknown
   linkType: soft
 
-"@odata2ts/odata-query-objects@npm:^0.29.0, @odata2ts/odata-query-objects@workspace:packages/odata-query-objects":
+"@odata2ts/odata-query-objects@npm:^0.28.2, @odata2ts/odata-query-objects@workspace:packages/odata-query-objects":
   version: 0.0.0-use.local
   resolution: "@odata2ts/odata-query-objects@workspace:packages/odata-query-objects"
   dependencies:
@@ -760,13 +760,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@odata2ts/odata-service@npm:^0.24.0, @odata2ts/odata-service@workspace:^, @odata2ts/odata-service@workspace:packages/odata-service":
+"@odata2ts/odata-service@npm:^0.23.2, @odata2ts/odata-service@workspace:^, @odata2ts/odata-service@workspace:packages/odata-service":
   version: 0.0.0-use.local
   resolution: "@odata2ts/odata-service@workspace:packages/odata-service"
   dependencies:
     "@odata2ts/http-client-api": "npm:^0.6.5"
-    "@odata2ts/odata-query-builder": "npm:^0.19.0"
-    "@odata2ts/odata-query-objects": "npm:^0.29.0"
+    "@odata2ts/odata-query-builder": "npm:^0.18.6"
+    "@odata2ts/odata-query-objects": "npm:^0.28.2"
     ts-expect: "npm:^1.3.0"
   languageName: unknown
   linkType: soft
@@ -780,8 +780,8 @@ __metadata:
     "@odata2ts/converter-v2-to-v4": "npm:^0.5.1"
     "@odata2ts/http-client-api": "npm:^0.6.5"
     "@odata2ts/odata-core": "npm:^0.6.1"
-    "@odata2ts/odata-query-objects": "npm:^0.29.0"
-    "@odata2ts/odata-service": "npm:^0.24.0"
+    "@odata2ts/odata-query-objects": "npm:^0.28.2"
+    "@odata2ts/odata-service": "npm:^0.23.2"
     "@odata2ts/test-converters": "npm:^0.5.0"
     "@prettier/plugin-xml": "npm:^3.4.1"
     "@types/node": "npm:^22.4.0"
@@ -801,8 +801,8 @@ __metadata:
     upper-case-first: "npm:^2.0.2"
     xml2js: "npm:^0.6.0"
   peerDependencies:
-    "@odata2ts/odata-query-objects": ^0.29.0
-    "@odata2ts/odata-service": ^0.24.0
+    "@odata2ts/odata-query-objects": ^0.28.2
+    "@odata2ts/odata-service": ^0.23.2
     typescript: ">= 4.7"
   bin:
     odata2ts: lib/run-cli.js

--- a/yarn.lock
+++ b/yarn.lock
@@ -654,8 +654,8 @@ __metadata:
     "@cap-js/sqlite": "npm:^1"
     "@odata2ts/converter-big-number": "npm:^0.2.8"
     "@odata2ts/http-client-axios": "npm:^0.12.2"
-    "@odata2ts/odata-service": "npm:^0.23.2"
-    "@odata2ts/odata2ts": "npm:^0.40.2"
+    "@odata2ts/odata-service": "workspace:^"
+    "@odata2ts/odata2ts": "workspace:^"
     "@sap/cds": "npm:7.9.4"
     "@sap/cds-odata-v2-adapter-proxy": "npm:^1.9.21"
     axios: "npm:0.27.2"
@@ -676,8 +676,8 @@ __metadata:
     "@odata2ts/converter-v2-to-v4": "npm:^0.5.7"
     "@odata2ts/http-client-axios": "npm:^0.12.2"
     "@odata2ts/http-client-fetch": "npm:^0.9.2"
-    "@odata2ts/odata-service": "npm:^0.23.2"
-    "@odata2ts/odata2ts": "npm:^0.40.2"
+    "@odata2ts/odata-service": "workspace:^"
+    "@odata2ts/odata2ts": "workspace:^"
     "@types/luxon": "npm:^3.4.2"
     axios: "npm:^1.13.1"
     bignumber.js: "npm:^9.1.2"
@@ -741,15 +741,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@odata2ts/odata-query-builder@npm:^0.18.6, @odata2ts/odata-query-builder@workspace:packages/odata-query-builder":
+"@odata2ts/odata-query-builder@npm:^0.19.0, @odata2ts/odata-query-builder@workspace:packages/odata-query-builder":
   version: 0.0.0-use.local
   resolution: "@odata2ts/odata-query-builder@workspace:packages/odata-query-builder"
   dependencies:
-    "@odata2ts/odata-query-objects": "npm:^0.28.2"
+    "@odata2ts/odata-query-objects": "npm:^0.29.0"
   languageName: unknown
   linkType: soft
 
-"@odata2ts/odata-query-objects@npm:^0.28.2, @odata2ts/odata-query-objects@workspace:packages/odata-query-objects":
+"@odata2ts/odata-query-objects@npm:^0.29.0, @odata2ts/odata-query-objects@workspace:packages/odata-query-objects":
   version: 0.0.0-use.local
   resolution: "@odata2ts/odata-query-objects@workspace:packages/odata-query-objects"
   dependencies:
@@ -760,18 +760,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@odata2ts/odata-service@npm:^0.23.2, @odata2ts/odata-service@workspace:packages/odata-service":
+"@odata2ts/odata-service@npm:^0.24.0, @odata2ts/odata-service@workspace:^, @odata2ts/odata-service@workspace:packages/odata-service":
   version: 0.0.0-use.local
   resolution: "@odata2ts/odata-service@workspace:packages/odata-service"
   dependencies:
     "@odata2ts/http-client-api": "npm:^0.6.5"
-    "@odata2ts/odata-query-builder": "npm:^0.18.6"
-    "@odata2ts/odata-query-objects": "npm:^0.28.2"
+    "@odata2ts/odata-query-builder": "npm:^0.19.0"
+    "@odata2ts/odata-query-objects": "npm:^0.29.0"
     ts-expect: "npm:^1.3.0"
   languageName: unknown
   linkType: soft
 
-"@odata2ts/odata2ts@npm:^0.40.2, @odata2ts/odata2ts@workspace:packages/odata2ts":
+"@odata2ts/odata2ts@workspace:^, @odata2ts/odata2ts@workspace:packages/odata2ts":
   version: 0.0.0-use.local
   resolution: "@odata2ts/odata2ts@workspace:packages/odata2ts"
   dependencies:
@@ -780,8 +780,8 @@ __metadata:
     "@odata2ts/converter-v2-to-v4": "npm:^0.5.1"
     "@odata2ts/http-client-api": "npm:^0.6.5"
     "@odata2ts/odata-core": "npm:^0.6.1"
-    "@odata2ts/odata-query-objects": "npm:^0.28.2"
-    "@odata2ts/odata-service": "npm:^0.23.2"
+    "@odata2ts/odata-query-objects": "npm:^0.29.0"
+    "@odata2ts/odata-service": "npm:^0.24.0"
     "@odata2ts/test-converters": "npm:^0.5.0"
     "@prettier/plugin-xml": "npm:^3.4.1"
     "@types/node": "npm:^22.4.0"
@@ -801,8 +801,8 @@ __metadata:
     upper-case-first: "npm:^2.0.2"
     xml2js: "npm:^0.6.0"
   peerDependencies:
-    "@odata2ts/odata-query-objects": ^0.28.2
-    "@odata2ts/odata-service": ^0.23.2
+    "@odata2ts/odata-query-objects": ^0.29.0
+    "@odata2ts/odata-service": ^0.24.0
     typescript: ">= 4.7"
   bin:
     odata2ts: lib/run-cli.js


### PR DESCRIPTION


- examples/main and examples/bookshop declared @odata2ts/odata-service and @odata2ts/odata2ts with plain semver ranges (e.g. ^0.23.2); release-please only manages packages/* and never bumps these ranges, so they silently go stale whenever those packages get a minor release
- once the local workspace version falls outside the stale range, yarn cannot resolve it locally and instead pulls a mismatched published version from the registry, which diverges from the rest of the workspace and breaks module resolution during build (observed as odata-core/lib/index.js not found)
- switching to workspace:^ always resolves to the local, freshly-built package regardless of published version drift, eliminating this class of failure for good; both packages are private and never published, so this has no publish-time implications
- verified by rebuilding all five packages/* in dependency order, then running examples/main generation, test-compile, and the full test suite against the result