### PR TITLE
build: add CI check verifying the minimum supported TypeScript version

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -48,6 +48,8 @@ jobs:
       - name: Build packages
         run: yarn build
       - name: Install floor TypeScript version
-        run: yarn workspace @odata2ts/example-ts-floor-check run install-floor-ts
+        working-directory: examples/ts-floor-check
+        run: yarn install-floor-ts
       - name: Verify generated output type-checks under the declared minimum TypeScript version
-        run: yarn workspace @odata2ts/example-ts-floor-check run int-test
+        working-directory: examples/ts-floor-check
+        run: yarn int-test

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node: [ 24 ]
+        node: [24]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -34,3 +34,20 @@ jobs:
         uses: coverallsapp/github-action@v1.1.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  ts-floor-check:
+    name: TypeScript Floor Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Install packages
+        run: yarn --immutable
+      - name: Build packages
+        run: yarn build
+      - name: Install floor TypeScript version
+        run: yarn workspace @odata2ts/example-ts-floor-check run install-floor-ts
+      - name: Verify generated output type-checks under the declared minimum TypeScript version
+        run: yarn workspace @odata2ts/example-ts-floor-check run int-test

--- a/examples/ts-floor-check/floor-ts/package-lock.json
+++ b/examples/ts-floor-check/floor-ts/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "floor-ts",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "floor-ts",
+      "dependencies": {
+        "typescript": "4.7.4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  }
+}

--- a/examples/ts-floor-check/floor-ts/package.json
+++ b/examples/ts-floor-check/floor-ts/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "floor-ts",
+  "private": true,
+  "description": "Isolated, plain-npm-managed install of the minimum TypeScript version declared in packages/odata2ts's peerDependencies (>= 4.7). Kept out of the Yarn workspace on purpose so it never gets hoisted/overridden by the repo's own (newer) typescript devDependency. If that peer floor is ever raised, update the pinned version here to match.",
+  "dependencies": {
+    "typescript": "4.7.4"
+  }
+}

--- a/examples/ts-floor-check/int-test/fixture/trippin.xml
+++ b/examples/ts-floor-check/int-test/fixture/trippin.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="Trippin" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="Person">
+        <Key>
+          <PropertyRef Name="UserName" />
+        </Key>
+        <Property Name="UserName" Type="Edm.String" Nullable="false" />
+        <Property Name="FirstName" Type="Edm.String" Nullable="false" />
+        <Property Name="LastName" Type="Edm.String" MaxLength="26" />
+        <Property Name="MiddleName" Type="Edm.String" />
+        <Property Name="Gender" Type="Trippin.PersonGender" Nullable="false" />
+        <Property Name="Age" Type="Edm.Int64" />
+        <Property Name="Emails" Type="Collection(Edm.String)" />
+        <Property Name="AddressInfo" Type="Collection(Trippin.Location)" />
+        <Property Name="HomeAddress" Type="Trippin.Location" />
+        <Property Name="FavoriteFeature" Type="Trippin.Feature" Nullable="false" />
+        <Property Name="Features" Type="Collection(Trippin.Feature)" Nullable="false" />
+        <NavigationProperty Name="Friends" Type="Collection(Trippin.Person)" />
+        <NavigationProperty Name="BestFriend" Type="Trippin.Person" />
+        <NavigationProperty Name="Trips" Type="Collection(Trippin.Trip)" />
+      </EntityType>
+      <EntityType Name="Airline">
+        <Key>
+          <PropertyRef Name="AirlineCode" />
+        </Key>
+        <Property Name="AirlineCode" Type="Edm.String" Nullable="false" />
+        <Property Name="Name" Type="Edm.String" />
+      </EntityType>
+      <EntityType Name="Airport">
+        <Key>
+          <PropertyRef Name="IcaoCode" />
+        </Key>
+        <Property Name="Name" Type="Edm.String" />
+        <Property Name="IcaoCode" Type="Edm.String" Nullable="false" />
+        <Property Name="IataCode" Type="Edm.String" />
+        <Property Name="Location" Type="Trippin.AirportLocation" />
+      </EntityType>
+      <ComplexType Name="Location">
+        <Property Name="Address" Type="Edm.String" />
+        <Property Name="City" Type="Trippin.City" />
+      </ComplexType>
+      <ComplexType Name="City">
+        <Property Name="Name" Type="Edm.String" />
+        <Property Name="CountryRegion" Type="Edm.String" />
+        <Property Name="Region" Type="Edm.String" />
+      </ComplexType>
+      <ComplexType Name="AirportLocation" BaseType="Trippin.Location">
+        <Property Name="Loc" Type="Edm.GeographyPoint" />
+      </ComplexType>
+      <ComplexType Name="EventLocation" BaseType="Trippin.Location">
+        <Property Name="BuildingInfo" Type="Edm.String" />
+      </ComplexType>
+      <EntityType Name="Trip">
+        <Key>
+          <PropertyRef Name="TripId" />
+        </Key>
+        <Property Name="TripId" Type="Edm.Int32" Nullable="false" />
+        <Property Name="ShareId" Type="Edm.Guid" Nullable="false" />
+        <Property Name="Name" Type="Edm.String" />
+        <Property Name="Budget" Type="Edm.Single" Nullable="false" />
+        <Property Name="Description" Type="Edm.String" />
+        <Property Name="Tags" Type="Collection(Edm.String)" />
+        <Property Name="StartsAt" Type="Edm.DateTimeOffset" Nullable="false" />
+        <Property Name="EndsAt" Type="Edm.DateTimeOffset" Nullable="false" />
+        <NavigationProperty Name="PlanItems" Type="Collection(Trippin.PlanItem)" />
+      </EntityType>
+      <EntityType Name="PlanItem">
+        <Key>
+          <PropertyRef Name="PlanItemId" />
+        </Key>
+        <Property Name="PlanItemId" Type="Edm.Int32" Nullable="false" />
+        <Property Name="ConfirmationCode" Type="Edm.String" />
+        <Property Name="StartsAt" Type="Edm.DateTimeOffset" Nullable="false" />
+        <Property Name="EndsAt" Type="Edm.DateTimeOffset" Nullable="false" />
+        <Property Name="Duration" Type="Edm.Duration" Nullable="false" />
+      </EntityType>
+      <EntityType Name="Event" BaseType="Trippin.PlanItem">
+        <Property Name="OccursAt" Type="Trippin.EventLocation" />
+        <Property Name="Description" Type="Edm.String" />
+      </EntityType>
+      <EntityType Name="PublicTransportation" BaseType="Trippin.PlanItem">
+        <Property Name="SeatNumber" Type="Edm.String" />
+      </EntityType>
+      <EntityType Name="Flight" BaseType="Trippin.PublicTransportation">
+        <Property Name="FlightNumber" Type="Edm.String" />
+        <NavigationProperty Name="Airline" Type="Trippin.Airline" />
+        <NavigationProperty Name="From" Type="Trippin.Airport" />
+        <NavigationProperty Name="To" Type="Trippin.Airport" />
+      </EntityType>
+      <EntityType Name="Employee" BaseType="Trippin.Person">
+        <Property Name="Cost" Type="Edm.Int64" Nullable="false" />
+        <NavigationProperty Name="Peers" Type="Collection(Trippin.Person)" />
+      </EntityType>
+      <EntityType Name="Manager" BaseType="Trippin.Person">
+        <Property Name="Budget" Type="Edm.Int64" Nullable="false" />
+        <Property Name="BossOffice" Type="Trippin.Location" />
+        <NavigationProperty Name="DirectReports" Type="Collection(Trippin.Person)" />
+      </EntityType>
+      <EnumType Name="PersonGender">
+        <Member Name="Male" Value="0" />
+        <Member Name="Female" Value="1" />
+        <Member Name="Unknown" Value="2" />
+      </EnumType>
+      <EnumType Name="Feature">
+        <Member Name="Feature1" Value="0" />
+        <Member Name="Feature2" Value="1" />
+        <Member Name="Feature3" Value="2" />
+        <Member Name="Feature4" Value="3" />
+      </EnumType>
+      <Function Name="GetPersonWithMostFriends">
+        <ReturnType Type="Trippin.Person" />
+      </Function>
+      <Function Name="GetNearestAirport">
+        <Parameter Name="lat" Type="Edm.Double" Nullable="false" />
+        <Parameter Name="lon" Type="Edm.Double" Nullable="false" />
+        <ReturnType Type="Trippin.Airport" />
+      </Function>
+      <Function Name="GetFavoriteAirline" IsBound="true" EntitySetPath="person">
+        <Parameter Name="person" Type="Trippin.Person" />
+        <ReturnType Type="Trippin.Airline" />
+      </Function>
+      <Function Name="GetFriendsTrips" IsBound="true">
+        <Parameter Name="person" Type="Trippin.Person" />
+        <Parameter Name="userName" Type="Edm.String" Nullable="false" Unicode="false" />
+        <ReturnType Type="Collection(Trippin.Trip)" />
+      </Function>
+      <Function Name="GetInvolvedPeople" IsBound="true">
+        <Parameter Name="trip" Type="Trippin.Trip" />
+        <ReturnType Type="Collection(Trippin.Person)" />
+      </Function>
+      <Action Name="ResetDataSource" />
+      <Action Name="UpdateLastName" IsBound="true">
+        <Parameter Name="person" Type="Trippin.Person" />
+        <Parameter Name="lastName" Type="Edm.String" Nullable="false" Unicode="false" />
+        <ReturnType Type="Edm.Boolean" Nullable="false" />
+      </Action>
+      <Action Name="ShareTrip" IsBound="true">
+        <Parameter Name="personInstance" Type="Trippin.Person" />
+        <Parameter Name="userName" Type="Edm.String" Nullable="false" Unicode="false" />
+        <Parameter Name="tripId" Type="Edm.Int32" Nullable="false" />
+      </Action>
+      <EntityContainer Name="Container">
+        <EntitySet Name="People" EntityType="Trippin.Person">
+          <NavigationPropertyBinding Path="BestFriend" Target="People" />
+          <NavigationPropertyBinding Path="Friends" Target="People" />
+          <NavigationPropertyBinding Path="Trippin.Employee/Peers" Target="People" />
+          <NavigationPropertyBinding Path="Trippin.Manager/DirectReports" Target="People" />
+        </EntitySet>
+        <EntitySet Name="Airlines" EntityType="Trippin.Airline">
+          <Annotation Term="Org.OData.Core.V1.OptimisticConcurrency">
+            <Collection>
+              <PropertyPath>Name</PropertyPath>
+            </Collection>
+          </Annotation>
+        </EntitySet>
+        <EntitySet Name="Airports" EntityType="Trippin.Airport" />
+        <Singleton Name="Me" Type="Trippin.Person">
+          <NavigationPropertyBinding Path="BestFriend" Target="People" />
+          <NavigationPropertyBinding Path="Friends" Target="People" />
+          <NavigationPropertyBinding Path="Trippin.Employee/Peers" Target="People" />
+          <NavigationPropertyBinding Path="Trippin.Manager/DirectReports" Target="People" />
+        </Singleton>
+        <FunctionImport
+          Name="GetPersonWithMostFriends"
+          Function="Trippin.GetPersonWithMostFriends"
+          EntitySet="People"
+        />
+        <FunctionImport Name="GetNearestAirport" Function="Trippin.GetNearestAirport" EntitySet="Airports" />
+        <ActionImport Name="ResetDataSource" Action="Trippin.ResetDataSource" />
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/examples/ts-floor-check/int-test/floor-check.test.ts
+++ b/examples/ts-floor-check/int-test/floor-check.test.ts
@@ -1,0 +1,74 @@
+import { exec } from "child_process";
+import { access, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { rimraf } from "rimraf";
+import { afterAll, describe, expect, test } from "vitest";
+
+// Resolves the actually compiled CLI entrypoint via the real (workspace-linked) dependency,
+// so this test generates from the same artefact a real npm consumer would use. As with the
+// other examples/* packages, the workspace must already be built (`yarn build`) beforehand;
+// this test does not build it itself.
+const CLI_BIN = createRequire(import.meta.url).resolve("@odata2ts/odata2ts/lib/run-cli.js");
+
+// Resolved relative to this file, not `process.cwd()`: a root-level `vitest run` across the
+// whole workspace does not chdir into each project, so plain relative paths would resolve
+// against the repo root instead of this package.
+const PACKAGE_ROOT = path.resolve(import.meta.dirname, "..");
+const FIXTURE = path.join(PACKAGE_ROOT, "int-test/fixture/trippin.xml");
+const OUT_DIR = path.join(PACKAGE_ROOT, "build");
+const FLOOR_TSC = path.join(PACKAGE_ROOT, "floor-ts/node_modules/.bin/tsc");
+
+// Deliberately conservative: what a project on the declared minimum TS version would
+// realistically configure, not this repo's own (much newer) tsconfig.settings.json.
+const MINIMAL_TSCONFIG = {
+  compilerOptions: {
+    target: "ES2016",
+    module: "CommonJS",
+    moduleResolution: "node",
+    strict: true,
+    esModuleInterop: true,
+    skipLibCheck: true,
+    noEmit: true,
+  },
+};
+
+interface CliResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+function run(command: string, cwd: string): Promise<CliResult> {
+  return new Promise((resolve) => {
+    exec(command, { cwd }, (error, stdout, stderr) => {
+      resolve({ code: error && "code" in error ? Number(error.code) : 0, stdout, stderr });
+    });
+  });
+}
+
+describe("TypeScript floor check", () => {
+  afterAll(() => rimraf(OUT_DIR));
+
+  test("floor-ts is installed (run `yarn install-floor-ts` first)", async () => {
+    await expect(access(FLOOR_TSC)).resolves.toBeUndefined();
+  });
+
+  // Spawns a real CLI generation run (the full client — models, q-objects and services, the
+  // default mode) plus a full `tsc` type-check pass, which can comfortably exceed the default
+  // timeout when run alongside the rest of the workspace's test suite (this file is not exempt
+  // from the combined root-level `vitest run`/`yarn coverage` sweep, so the timeout must be set
+  // here rather than only via a CLI flag on this package's own scripts).
+  test("generated Trippin client type-checks under the declared floor TS", async () => {
+    const generated = await run(`node ${CLI_BIN} -s ${FIXTURE} -o ${OUT_DIR} --emit-mode ts`, PACKAGE_ROOT);
+    if (generated.code !== 0) {
+      throw new Error(`Generation failed, exit ${generated.code}:\n${generated.stdout}\n${generated.stderr}`);
+    }
+
+    await writeFile(path.join(OUT_DIR, "tsconfig.json"), JSON.stringify(MINIMAL_TSCONFIG, null, 2));
+    const result = await run(`${FLOOR_TSC} -p tsconfig.json`, OUT_DIR);
+
+    expect(result.stdout + result.stderr).toBe("");
+    expect(result.code).toBe(0);
+  }, 30_000);
+});

--- a/examples/ts-floor-check/int-test/floor-check.test.ts
+++ b/examples/ts-floor-check/int-test/floor-check.test.ts
@@ -1,5 +1,6 @@
 import { exec } from "child_process";
-import { access, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { rimraf } from "rimraf";
@@ -18,6 +19,11 @@ const PACKAGE_ROOT = path.resolve(import.meta.dirname, "..");
 const FIXTURE = path.join(PACKAGE_ROOT, "int-test/fixture/trippin.xml");
 const OUT_DIR = path.join(PACKAGE_ROOT, "build");
 const FLOOR_TSC = path.join(PACKAGE_ROOT, "floor-ts/node_modules/.bin/tsc");
+
+// This file gets swept up by any workspace-wide `vitest run` (e.g. the root `yarn coverage`),
+// not just this package's own `int-test` script. Only the latter is preceded by
+// `yarn install-floor-ts`, so skip gracefully instead of failing when floor-ts isn't there.
+const FLOOR_TS_INSTALLED = existsSync(FLOOR_TSC);
 
 // Deliberately conservative: what a project on the declared minimum TS version would
 // realistically configure, not this repo's own (much newer) tsconfig.settings.json.
@@ -50,25 +56,25 @@ function run(command: string, cwd: string): Promise<CliResult> {
 describe("TypeScript floor check", () => {
   afterAll(() => rimraf(OUT_DIR));
 
-  test("floor-ts is installed (run `yarn install-floor-ts` first)", async () => {
-    await expect(access(FLOOR_TSC)).resolves.toBeUndefined();
-  });
-
   // Spawns a real CLI generation run (the full client — models, q-objects and services, the
   // default mode) plus a full `tsc` type-check pass, which can comfortably exceed the default
   // timeout when run alongside the rest of the workspace's test suite (this file is not exempt
   // from the combined root-level `vitest run`/`yarn coverage` sweep, so the timeout must be set
   // here rather than only via a CLI flag on this package's own scripts).
-  test("generated Trippin client type-checks under the declared floor TS", async () => {
-    const generated = await run(`node ${CLI_BIN} -s ${FIXTURE} -o ${OUT_DIR} --emit-mode ts`, PACKAGE_ROOT);
-    if (generated.code !== 0) {
-      throw new Error(`Generation failed, exit ${generated.code}:\n${generated.stdout}\n${generated.stderr}`);
-    }
+  test.skipIf(!FLOOR_TS_INSTALLED)(
+    "generated Trippin client type-checks under the declared floor TS",
+    async () => {
+      const generated = await run(`node ${CLI_BIN} -s ${FIXTURE} -o ${OUT_DIR} --emit-mode ts`, PACKAGE_ROOT);
+      if (generated.code !== 0) {
+        throw new Error(`Generation failed, exit ${generated.code}:\n${generated.stdout}\n${generated.stderr}`);
+      }
 
-    await writeFile(path.join(OUT_DIR, "tsconfig.json"), JSON.stringify(MINIMAL_TSCONFIG, null, 2));
-    const result = await run(`${FLOOR_TSC} -p tsconfig.json`, OUT_DIR);
+      await writeFile(path.join(OUT_DIR, "tsconfig.json"), JSON.stringify(MINIMAL_TSCONFIG, null, 2));
+      const result = await run(`${FLOOR_TSC} -p tsconfig.json`, OUT_DIR);
 
-    expect(result.stdout + result.stderr).toBe("");
-    expect(result.code).toBe(0);
-  }, 30_000);
+      expect(result.stdout + result.stderr).toBe("");
+      expect(result.code).toBe(0);
+    },
+    30_000,
+  );
 });

--- a/examples/ts-floor-check/package.json
+++ b/examples/ts-floor-check/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "clean": "rimraf build",
     "install-floor-ts": "npm --prefix floor-ts install",
-    "int-test": "vitest run"
+    "int-test": "node ../../node_modules/.bin/vitest run"
   },
   "dependencies": {
     "@odata2ts/odata-service": "workspace:^"

--- a/examples/ts-floor-check/package.json
+++ b/examples/ts-floor-check/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@odata2ts/example-ts-floor-check",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Verifies that a generated full client (models, q-objects and services) and the runtime packages it imports still type-check under the minimum TypeScript version declared in packages/odata2ts's peerDependencies",
+  "repository": "git@github.com:odata2ts/odata2ts.git",
+  "license": "MIT",
+  "author": "texttechne",
+  "type": "module",
+  "scripts": {
+    "clean": "rimraf build",
+    "install-floor-ts": "npm --prefix floor-ts install",
+    "int-test": "vitest run"
+  },
+  "dependencies": {
+    "@odata2ts/odata-service": "workspace:^"
+  },
+  "devDependencies": {
+    "@odata2ts/odata2ts": "workspace:^"
+  }
+}

--- a/examples/ts-floor-check/tsconfig.json
+++ b/examples/ts-floor-check/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.settings.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": ["int-test"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -559,6 +559,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@odata2ts/example-ts-floor-check@workspace:examples/ts-floor-check":
+  version: 0.0.0-use.local
+  resolution: "@odata2ts/example-ts-floor-check@workspace:examples/ts-floor-check"
+  dependencies:
+    "@odata2ts/odata-service": "workspace:^"
+    "@odata2ts/odata2ts": "workspace:^"
+  languageName: unknown
+  linkType: soft
+
 "@odata2ts/http-client-api@npm:^0.6.4":
   version: 0.6.4
   resolution: "@odata2ts/http-client-api@npm:0.6.4"


### PR DESCRIPTION
Add a `TypeScript Floor Check` job (coverage.yml) that generates the full client against the
Trippin servic and type-checks it with an isolated install of the exact minimum TypeScript version odata2ts declares as its peer floor (typescript: ">= 4.7" in packages/odata2ts/package.json, currently 4.7.4).