### PR TITLE
fix: declare OData version 4.0 on V4 requests carrying a body

### DIFF
--- a/examples/main/test/odataV2/RequestHeaders.test.ts
+++ b/examples/main/test/odataV2/RequestHeaders.test.ts
@@ -1,0 +1,37 @@
+import { BigNumber } from "bignumber.js";
+import { describe, expect, test } from "vitest";
+import { EditableProductModel } from "../../src-generated/odataV2/ODataDemoModel.js";
+import { ODataDemoService } from "../../src-generated/odataV2/ODataDemoService.js";
+import { MockODataClient } from "../MockODataClient.js";
+
+/**
+ * The OData-Version header addresses the difference between OData 4.0 and 4.01 and is therefore only
+ * relevant for V4 services. V2 must never declare it.
+ */
+describe("Testing OData version header of ODataDemoService (V2)", () => {
+  const odataClient = new MockODataClient(true);
+  const testService = new ODataDemoService(odataClient, "test", { noUrlEncoding: true });
+
+  const model: EditableProductModel = {
+    id: 123,
+    name: "test",
+    price: new BigNumber("12.03"),
+    rating: 5,
+    releaseDate: "xyz",
+    description: "Description",
+    discontinuedDate: null,
+  };
+
+  test("no version is declared when creating", async () => {
+    await testService.products().create(model).execute();
+
+    expect(odataClient.lastOperation).toBe("POST");
+    expect(odataClient.additionalHeaders?.["OData-Version"]).toBeUndefined();
+  });
+
+  test("no version is declared when patching", async () => {
+    await testService.products(123).patch({ name: "changed" }).execute();
+
+    expect(odataClient.additionalHeaders?.["OData-Version"]).toBeUndefined();
+  });
+});

--- a/examples/main/test/trippin/RequestHeaders.test.ts
+++ b/examples/main/test/trippin/RequestHeaders.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { EditablePersonModel, FeatureModel, PersonGenderModel } from "../../src-generated/trippin/TrippinModel.js";
+import { ODATA_CLIENT, TRIPPIN } from "./TrippinTestConstants.js";
+
+/**
+ * odata2ts targets OData 4.0, which is declared via the OData-Version header on each request carrying a body.
+ * It is what makes the payload notations we generate valid, e.g. `@odata.bind` for association binding.
+ */
+describe("Testing OData version header of TrippinService", () => {
+  const ID = "williams";
+  const userModel: EditablePersonModel = {
+    traditionalGenderCategories: PersonGenderModel.Unknown,
+    user: ID,
+    age: 66,
+    favoriteFeature: FeatureModel.Feature1,
+    features: [],
+    firstName: "Heinz",
+  };
+
+  beforeEach(() => {
+    ODATA_CLIENT.additionalHeaders = undefined;
+  });
+
+  test("create declares version 4.0", async () => {
+    await TRIPPIN.people().create(userModel).execute();
+
+    expect(ODATA_CLIENT.lastOperation).toBe("POST");
+    expect(ODATA_CLIENT.additionalHeaders?.["OData-Version"]).toBe("4.0");
+  });
+
+  test("update declares version 4.0", async () => {
+    await TRIPPIN.people(ID).update(userModel).execute();
+
+    expect(ODATA_CLIENT.lastOperation).toBe("PUT");
+    expect(ODATA_CLIENT.additionalHeaders?.["OData-Version"]).toBe("4.0");
+  });
+
+  test("patch declares version 4.0", async () => {
+    await TRIPPIN.people(ID).patch({ age: 30 }).execute();
+
+    expect(ODATA_CLIENT.lastOperation).toBe("PATCH");
+    expect(ODATA_CLIENT.additionalHeaders?.["OData-Version"]).toBe("4.0");
+  });
+
+  test("collection update declares version 4.0", async () => {
+    await TRIPPIN.people(ID).addressInfo().update([]).execute();
+
+    expect(ODATA_CLIENT.lastOperation).toBe("PUT");
+    expect(ODATA_CLIENT.additionalHeaders?.["OData-Version"]).toBe("4.0");
+  });
+
+  test("no version is declared without a request body", async () => {
+    await TRIPPIN.people().query().execute();
+
+    expect(ODATA_CLIENT.lastOperation).toBe("GET");
+    expect(ODATA_CLIENT.additionalHeaders?.["OData-Version"]).toBeUndefined();
+  });
+
+  test("no version is declared when deleting", async () => {
+    await TRIPPIN.people(ID).delete().execute();
+
+    expect(ODATA_CLIENT.lastOperation).toBe("DELETE");
+    expect(ODATA_CLIENT.additionalHeaders?.["OData-Version"]).toBeUndefined();
+  });
+});

--- a/packages/odata-core/src/ODataModelPayloadV4.ts
+++ b/packages/odata-core/src/ODataModelPayloadV4.ts
@@ -3,6 +3,9 @@
  *
  * Result object is directly returned.
  * Additional context attribute is merged into result object.
+ *
+ * Since odata2ts targets OData 4.0, control information is written with the {@code odata.} prefix, which is what
+ * 4.0 payloads require; the prefix-less form of 4.01 and greater is deliberately not used.
  */
 export type ODataModelPayloadV4<T> = T & {
   /**

--- a/packages/odata-core/src/ResponseModelV4.ts
+++ b/packages/odata-core/src/ResponseModelV4.ts
@@ -1,4 +1,12 @@
 /**
+ * odata2ts targets OData 4.0, hence all control information is modelled with the {@code odata.} prefix, which
+ * 4.0 payloads are required to use. Payloads of 4.01 or greater use the prefix-less form ({@code @count},
+ * {@code @type}, ...), which is deliberately not modelled here.
+ *
+ * See https://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html#sec_ControlInformation
+ */
+
+/**
  * Response to a collection query.
  */
 export interface ODataCollectionResponseV4<T> {

--- a/packages/odata-query-objects/src/QueryObject.ts
+++ b/packages/odata-query-objects/src/QueryObject.ts
@@ -15,6 +15,20 @@ function getMapping(q: QueryObject) {
   return result;
 }
 
+/**
+ * Retrieves the type control information of a model, which is used to detect subtypes.
+ *
+ * odata2ts targets OData 4.0, where this control information is named {@code @odata.type} and its value is
+ * prefixed with a hash symbol. Payloads of 4.01 or greater omit the {@code odata.} prefix and, for built-in
+ * primitive types, also the hash symbol. Since the response version is up to the service, both spellings are
+ * accepted here.
+ *
+ * See https://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html#sec_ControlInformationtypeodatatype
+ */
+function getTypeControlInfo(model: any): string | undefined {
+  return (model["@odata.type"] ?? model["@type"])?.replace(/^#/, "");
+}
+
 export const ENUMERABLE_PROP_DEFINITION = { enumerable: true };
 
 export class QueryObject<T extends object = any> implements QueryObjectModel<T> {
@@ -73,7 +87,7 @@ export class QueryObject<T extends object = any> implements QueryObjectModel<T> 
     const models = isList ? (odataModel as Array<T>) : [odataModel];
 
     const result = models.map((model) => {
-      const typeByCi = model["@odata.type"]?.replace(/^#/, "");
+      const typeByCi = getTypeControlInfo(model);
       return Object.entries(model).reduce((collector, [key, value]) => {
         let propKey = this.__getPropMapping().get(key);
         let finalKey: string = propKey as string;
@@ -156,8 +170,7 @@ export class QueryObject<T extends object = any> implements QueryObjectModel<T> 
     const models = isList ? userModel : [userModel];
 
     const result = models.map((model) => {
-      // @ts-ignore
-      const typeByCi = model["@odata.type"]?.replace(/^#/, "");
+      const typeByCi = getTypeControlInfo(model);
       return Object.entries(model).reduce((collector, [key, value]) => {
         let prop = this[key as keyof this] as QValuePathModel | undefined;
         let finalKey = prop?.getPath();

--- a/packages/odata-query-objects/src/odata/ODataModel.ts
+++ b/packages/odata-query-objects/src/odata/ODataModel.ts
@@ -18,7 +18,7 @@ export const enum StringFilterFunctions {
   LENGTH = "length",
   STARTS_WITH = "startswith",
   // SUBSTRING = "substring"
-  MATCHES_PATTERN = "matchesPattern", // v4 only
+  MATCHES_PATTERN = "matchesPattern", // v4 only; introduced in 4.01, but we don't differentiate 4.0 and 4.01
   TO_LOWER = "tolower",
   TO_UPPER = "toupper",
   TRIM = "trim",
@@ -35,7 +35,7 @@ export const enum NumberFilterOperators {
   SUBTRACTION = "sub",
   MULTIPLICATION = "mul",
   DIVISION = "div",
-  DIVISION_WITH_FRACTION = "divby", //v4 only
+  DIVISION_WITH_FRACTION = "divby", //v4 only; introduced in 4.01, but we don't differentiate 4.0 and 4.01
   MODULO = "mod",
 }
 

--- a/packages/odata-query-objects/test/QueryObject.test.ts
+++ b/packages/odata-query-objects/test/QueryObject.test.ts
@@ -251,4 +251,23 @@ describe("QueryObject tests", () => {
     const result2 = qBaseType.convertToOData(finalModel);
     expect(result2).toStrictEqual(rawModel);
   });
+
+  test("subtype casting via type control info without the odata prefix", () => {
+    const qBaseType = new QPlanItem();
+
+    // a service answering with OData 4.01 or greater omits the "odata." prefix as well as the hash symbol
+    const result = qBaseType.convertFromOData({
+      "@type": "Tester.Event",
+      Id: 123,
+      Name: "Test",
+      Description: "Desc",
+    });
+
+    expect(result).toStrictEqual({
+      "@type": "Tester.Event",
+      id: 123,
+      name: "Test",
+      description: "Desc",
+    });
+  });
 });

--- a/packages/odata-service/src/RequestHeaders.ts
+++ b/packages/odata-service/src/RequestHeaders.ts
@@ -4,3 +4,11 @@ const BIG_NUMBER_FORMAT = `${JSON_VALUE};IEEE754Compatible=true`;
 export const DEFAULT_HEADERS = { Accept: JSON_VALUE, "Content-Type": JSON_VALUE };
 export const BIG_NUMBERS_HEADERS = { Accept: BIG_NUMBER_FORMAT, "Content-Type": BIG_NUMBER_FORMAT };
 export const MERGE_HEADERS = { "X-Http-Method": "MERGE" };
+/**
+ * odata2ts targets OData 4.0 for V4 services: it is the more widely deployed and the more compatible version.
+ *
+ * Only declared on requests carrying a body, since the OData-Version header governs how the service interprets
+ * the request payload. It is what makes the `@odata.bind` notation valid, which clients must not use when
+ * declaring 4.01 (see OData JSON Format v4.01, chap. 8.5).
+ */
+export const ODATA_VERSION_HEADERS = { "OData-Version": "4.0" };

--- a/packages/odata-service/src/v4/CollectionServiceV4.ts
+++ b/packages/odata-service/src/v4/CollectionServiceV4.ts
@@ -9,6 +9,7 @@ import {
 } from "@odata2ts/odata-query-objects";
 import { ODataServiceOptionsInternal } from "../ODataServiceOptions";
 import { UrlBuilderRequestCmdV4, UrlRequestCmd } from "../request";
+import { ODATA_VERSION_HEADERS } from "../RequestHeaders.js";
 import { CollectionModificationResponseV4 } from "./ResponseTypeChoicesV4";
 import { ServiceStateHelperV4 } from "./ServiceStateHelperV4.js";
 
@@ -63,7 +64,7 @@ export class CollectionServiceV4<
       ModelQueryBuilderV4<Q>,
       PrimitiveT
     >(client, ODataHttpMethods.Post, createModelQueryBuilder(queryFn), qModel, model, {
-      headers: getDefaultHeaders(),
+      headers: { ...getDefaultHeaders(), ...ODATA_VERSION_HEADERS },
       mainRequestConverter: qModel,
       mainResponseConverter: new CollectionResponseConverterV4(qModel) as MainResponseConverter<
         CollectionModificationResponseV4<Response, PrimitiveT>,
@@ -99,7 +100,7 @@ export class CollectionServiceV4<
       ModelQueryBuilderV4<Q>,
       Array<PrimitiveT>
     >(client, ODataHttpMethods.Put, createModelQueryBuilder(queryFn), qModel, models, {
-      headers: getDefaultHeaders(),
+      headers: { ...getDefaultHeaders(), ...ODATA_VERSION_HEADERS },
       mainRequestConverter: qModel,
       mainResponseConverter: new CollectionResponseConverterV4(qModel) as MainResponseConverter<
         CollectionModificationResponseV4<Response, PrimitiveT>,

--- a/packages/odata-service/src/v4/EntitySetServiceV4.ts
+++ b/packages/odata-service/src/v4/EntitySetServiceV4.ts
@@ -9,6 +9,7 @@ import {
 } from "@odata2ts/odata-query-objects";
 import { ODataServiceOptionsInternal } from "../ODataServiceOptions";
 import { UrlBuilderRequestCmdV4 } from "../request";
+import { ODATA_VERSION_HEADERS } from "../RequestHeaders.js";
 import { EntityModificationResponseV4 } from "./ResponseTypeChoicesV4";
 import { ServiceStateHelperV4, SubtypeOptions } from "./ServiceStateHelperV4.js";
 
@@ -122,7 +123,7 @@ export abstract class EntitySetServiceV4<
       ModelQueryBuilderV4<Q>,
       ODataModelPayloadV4<EditableT>
     >(client, ODataHttpMethods.Post, createModelQueryBuilder(queryFn, actualPath), qModel, data, {
-      headers: getDefaultHeaders(),
+      headers: { ...getDefaultHeaders(), ...ODATA_VERSION_HEADERS },
       mainRequestConverter: qModel,
       mainResponseConverter: new ModelResponseConverterV4(qModel),
     });

--- a/packages/odata-service/src/v4/EntityTypeServiceV4.ts
+++ b/packages/odata-service/src/v4/EntityTypeServiceV4.ts
@@ -4,6 +4,7 @@ import { ModelQueryBuilderV4 } from "@odata2ts/odata-query-builder";
 import { ModelResponseConverterV4, QueryObjectModel } from "@odata2ts/odata-query-objects";
 import { ODataServiceOptionsInternal } from "../ODataServiceOptions";
 import { UrlBuilderRequestCmdV4, UrlRequestCmd } from "../request";
+import { ODATA_VERSION_HEADERS } from "../RequestHeaders.js";
 import { EntityModificationResponseV4 } from "./ResponseTypeChoicesV4";
 import { ServiceStateHelperV4, SubtypeOptions } from "./ServiceStateHelperV4.js";
 
@@ -58,7 +59,7 @@ export class EntityTypeServiceV4<in out ClientType extends ODataHttpClient, T, E
       ModelQueryBuilderV4<Q>,
       ODataModelPayloadV4<Partial<EditableT>>
     >(client, ODataHttpMethods.Patch, createModelQueryBuilder(queryFn, actualPath), qModel, data, {
-      headers: getDefaultHeaders(),
+      headers: { ...getDefaultHeaders(), ...ODATA_VERSION_HEADERS },
       mainRequestConverter: qModel,
       mainResponseConverter: new ModelResponseConverterV4(qModel),
     });
@@ -98,7 +99,7 @@ export class EntityTypeServiceV4<in out ClientType extends ODataHttpClient, T, E
       ModelQueryBuilderV4<Q>,
       ODataModelPayloadV4<EditableT>
     >(client, ODataHttpMethods.Put, createModelQueryBuilder(queryFn, actualPath), qModel, data, {
-      headers: getDefaultHeaders(),
+      headers: { ...getDefaultHeaders(), ...ODATA_VERSION_HEADERS },
       mainRequestConverter: qModel,
       mainResponseConverter: new ModelResponseConverterV4(qModel),
     });

--- a/packages/odata-service/src/v4/PrimitiveTypeServiceV4.ts
+++ b/packages/odata-service/src/v4/PrimitiveTypeServiceV4.ts
@@ -9,6 +9,7 @@ import {
 } from "@odata2ts/odata-query-objects";
 import { ODataServiceOptionsInternal } from "../ODataServiceOptions";
 import { UrlRequestCmd } from "../request";
+import { ODATA_VERSION_HEADERS } from "../RequestHeaders.js";
 import { ServiceStateHelper } from "../ServiceStateHelper.js";
 import { ValueModificationResponseV4 } from "./ResponseTypeChoicesV4";
 
@@ -87,7 +88,7 @@ export class PrimitiveTypeServiceV4<out ClientType extends ODataHttpClient, T> {
       path,
       value,
       {
-        headers: getDefaultHeaders(),
+        headers: { ...getDefaultHeaders(), ...ODATA_VERSION_HEADERS },
         mainRequestConverter: new ValueRequestConverter(converter),
         mainResponseConverter: new ValueResponseConverterV4<T>(converter) as MainResponseConverter<
           ValueModificationResponseV4<Response, T>,

--- a/packages/odata-service/test/v4/CollectionServiceV4.test.ts
+++ b/packages/odata-service/test/v4/CollectionServiceV4.test.ts
@@ -10,7 +10,13 @@ import {
 } from "@odata2ts/odata-query-objects";
 import { booleanToNumberConverter } from "@odata2ts/test-converters";
 import { describe, expect, expectTypeOf, test } from "vitest";
-import { CollectionServiceV4, DEFAULT_HEADERS, ODataServiceOptions, RequestInfo } from "../../src";
+import {
+  CollectionServiceV4,
+  DEFAULT_HEADERS,
+  ODATA_VERSION_HEADERS,
+  ODataServiceOptions,
+  RequestInfo,
+} from "../../src";
 import { commonCollectionTests, getParams } from "../CollectionServiceTests";
 import { MockClient } from "../mock/MockClient";
 
@@ -60,7 +66,7 @@ describe("CollectionService V4 Tests", () => {
 
     expect(request.url).toBe(NAME_ENUM);
     expect(request.method).toBe("POST");
-    expect(request.headers).toStrictEqual(DEFAULT_HEADERS);
+    expect(request.headers).toStrictEqual({ ...DEFAULT_HEADERS, ...ODATA_VERSION_HEADERS });
     expect(request.data).toEqual(StringTestEnum.A);
     expect(cmd.getInfoConverted().data).toEqual(StringTestEnum.A);
 
@@ -113,7 +119,7 @@ describe("CollectionService V4 Tests", () => {
 
     expect(result.url).toBe(NAME_STRING);
     expect(result.method).toBe("PUT");
-    expect(result.headers).toStrictEqual(DEFAULT_HEADERS);
+    expect(result.headers).toStrictEqual({ ...DEFAULT_HEADERS, ...ODATA_VERSION_HEADERS });
     expect(result.data).toEqual(userModel);
     expect(request.getInfoConverted().data).toStrictEqual(odataModel);
 

--- a/packages/odata-service/test/v4/EntitySetServiceV4.test.ts
+++ b/packages/odata-service/test/v4/EntitySetServiceV4.test.ts
@@ -1,7 +1,7 @@
 import { HttpResponseModel } from "@odata2ts/http-client-api";
 import { ODataModelPayloadV4, ODataModelResponseV4 } from "@odata2ts/odata-core";
 import { beforeEach, describe, expect, expectTypeOf, test } from "vitest";
-import { DEFAULT_HEADERS, RequestInfo } from "../../src";
+import { DEFAULT_HEADERS, ODATA_VERSION_HEADERS, RequestInfo } from "../../src";
 import { commonEntitySetTests } from "../EntitySetServiceTests";
 import { EditablePersonModel, Feature, PersonModel } from "../fixture/PersonModel";
 import {
@@ -49,7 +49,7 @@ describe("V4 EntitySetService Test", () => {
 
     expect(result.url).toBe(EXPECTED_PATH);
     expect(result.method).toBe("POST");
-    expect(result.headers).toStrictEqual(DEFAULT_HEADERS);
+    expect(result.headers).toStrictEqual({ ...DEFAULT_HEADERS, ...ODATA_VERSION_HEADERS });
     expect(result.data).toStrictEqual(model);
     expect(request.getInfoConverted().data).toStrictEqual(odataModel);
 

--- a/packages/odata-service/test/v4/EntityTypeServiceV4.test.ts
+++ b/packages/odata-service/test/v4/EntityTypeServiceV4.test.ts
@@ -1,7 +1,7 @@
 import { HttpResponseModel } from "@odata2ts/http-client-api";
 import { ODataModelPayloadV4, ODataModelResponseV4 } from "@odata2ts/odata-core";
 import { beforeEach, describe, expect, expectTypeOf, test } from "vitest";
-import { DEFAULT_HEADERS, RequestInfo } from "../../src";
+import { DEFAULT_HEADERS, ODATA_VERSION_HEADERS, RequestInfo } from "../../src";
 import { commonEntityTypeServiceTests } from "../EntityTypeServiceTests";
 import { EditablePersonModel, Feature, PersonModel } from "../fixture/PersonModel";
 import { EditableFlightModel, PlanItemService } from "../fixture/v4/BaseTypeModel";
@@ -33,7 +33,7 @@ describe("EntityTypeService V4 Tests", () => {
 
     expect(result.url).toBe(EXPECTED_PATH);
     expect(result.method).toBe("PATCH");
-    expect(result.headers).toStrictEqual(DEFAULT_HEADERS);
+    expect(result.headers).toStrictEqual({ ...DEFAULT_HEADERS, ...ODATA_VERSION_HEADERS });
     expect(result.data).toEqual(model);
     expect(request.getInfoConverted().data).toEqual(requestModel);
 
@@ -75,7 +75,7 @@ describe("EntityTypeService V4 Tests", () => {
 
     expect(result.url).toBe(EXPECTED_PATH);
     expect(result.method).toBe("PUT");
-    expect(result.headers).toStrictEqual(DEFAULT_HEADERS);
+    expect(result.headers).toStrictEqual({ ...DEFAULT_HEADERS, ...ODATA_VERSION_HEADERS });
     expect(result.data).toEqual(model);
     expect(request.getInfoConverted().data).toEqual(requestModel);
 

--- a/packages/odata-service/test/v4/PrimitiveTypeServiceV4.test.ts
+++ b/packages/odata-service/test/v4/PrimitiveTypeServiceV4.test.ts
@@ -1,7 +1,7 @@
 import { HttpResponseModel } from "@odata2ts/http-client-api";
 import { ODataValueResponseV4 } from "@odata2ts/odata-core";
 import { beforeEach, describe, expect, expectTypeOf, test } from "vitest";
-import { PrimitiveTypeServiceV4, RequestInfo } from "../../src/";
+import { DEFAULT_HEADERS, ODATA_VERSION_HEADERS, PrimitiveTypeServiceV4, RequestInfo } from "../../src/";
 import { PersonModelService } from "../fixture/v4/PersonModelService";
 import { MockClient } from "../mock/MockClient";
 
@@ -66,6 +66,7 @@ describe("PrimitiveTypeService V4 Test", () => {
     expect(result.url).toBe(EXPECTED_PATH);
     expect(result.data).toStrictEqual({ value });
     expect(result.method).toBe("PUT");
+    expect(result.headers).toStrictEqual({ ...DEFAULT_HEADERS, ...ODATA_VERSION_HEADERS });
     expect(odataClient.lastRequestConfig).toBeUndefined();
 
     expectTypeOf(request.getInfo()).toEqualTypeOf<RequestInfo<string>>();


### PR DESCRIPTION
- declare `OData-Version: 4.0` on the six V4 requests that carry a body (`EntitySetServiceV4` POST, `CollectionServiceV4` POST/PUT, `EntityTypeServiceV4` PATCH/PUT, `PrimitiveTypeServiceV4` PUT); GET, DELETE and all V2 paths stay untouched
- new `ODATA_VERSION_HEADERS` constant, spread explicitly per call site following the existing `MERGE_HEADERS` convention
- accept the type control information without the `odata.` prefix (`@type` next to `@odata.type`), since payloads of 4.01 or greater omit it and the response version is up to the service; extracted as `getTypeControlInfo()` replacing both duplicated lookups
- document in `odata-core` that odata2ts targets OData 4.0 and that the prefix-less 4.01 control info is deliberately not modelled
- note on `matchesPattern` and `divby` that they were introduced in 4.01, while odata2ts does not differentiate between 4.0 and 4.01 for filter options
- cover the version header in unit tests (incl. `PrimitiveTypeServiceV4.updateValue`, which had no header coverage) and in new integration tests for V4 and V2 in `examples/main`

Background: OData 4.0 is the more widely deployed and more compatible version, but odata2ts never declared it. The `OData-Version` header governs how a service interprets the request payload and is what makes the notations we generate valid, e.g. `@odata.bind`, which clients must not use when declaring 4.01 (OData JSON Format v4.01, chap. 8.5).

Prerequisite for #38, since the binding format follows from the declared version.