### PR TITLE
build: isolate the network int-tests from the main test run

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,6 +35,21 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  int-test:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Install packages
+        run: yarn --immutable
+      - name: Build packages
+        run: yarn build
+      - name: Run integration tests against the live OData services
+        run: yarn workspace @odata2ts/example-main int-test
+
   ts-floor-check:
     name: TypeScript Floor Check
     runs-on: ubuntu-latest

--- a/examples/main/package.json
+++ b/examples/main/package.json
@@ -11,7 +11,7 @@
     "build": "yarn clean && yarn generate",
     "clean": "rimraf build src-generated",
     "generate": "odata2ts",
-    "int-test": "vitest run --dir int-test",
+    "int-test": "node ../../node_modules/.bin/vitest run --dir int-test --testTimeout=30000 --retry=2",
     "test": "tsc && vitest run --dir test",
     "test-compile": "tsc"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,20 @@
-import { defineConfig } from "vitest/config";
+import { defaultExclude, defineConfig } from "vitest/config";
 import { coverageReporterOptions } from "./vitest-coverage.shared";
 
 export default defineConfig({
   test: {
     globals: true,
+    /*
+     * The int-tests of examples/main talk to the live OData services at services.odata.org, which makes them
+     * dependent on a third party being up and quick. They run in their own CI job (see coverage.yml) instead,
+     * so that a hiccup over there doesn't redden unrelated PRs. They contribute no coverage anyway: coverage
+     * only includes packages/**\/src, while examples resolve the packages to their built lib.
+     *
+     * The int-tests of cli-test and ts-floor-check stay in this run - they are local and deterministic.
+     *
+     * Note: a custom exclude replaces vitest's defaults instead of extending them, hence defaultExclude.
+     */
+    exclude: [...defaultExclude, "examples/main/int-test/**"],
     coverage: {
       ...coverageReporterOptions,
       include: ["packages/**/src/**"],


### PR DESCRIPTION
- exclude `examples/main/int-test` from the root run, so the coverage job no longer depends on services.odata.org being up and quick; a hiccup there turned unrelated PRs red before
- give the dedicated run a timeout which fits a real request (30s) plus two retries
- run it in its own blocking CI job, scoped to that workspace so it doesn't duplicate the ts-floor-check job
- keep the int-tests of `cli-test` and `ts-floor-check` in the main run: they are local and deterministic, only `examples/main` goes over the wire
- no coverage is lost, measured both ways on this branch: `Statements 97.47% (3124/3205)`, `Branches 96.05% (1752/1824)`, `Functions 99.18% (971/979)`, `Lines 97.44% (3051/3131)` - identical with and without the exclusion, since coverage only includes `packages/**/src` while the examples resolve the packages to their built `lib`
- the exclusion spreads vitest's exported `defaultExclude` instead of restating it, because a custom `exclude` replaces the defaults rather than extending them
- the dedicated script invokes the vitest binary directly, like `ts-floor-check` already does: with a plain `vitest run` the new job fails with `command not found: vitest`

Known follow-up, not addressed here: three of the four int-test base URLs embed session tokens (`https://services.odata.org/V4/(S(...))/TripPinServiceRW` and similar) which expire, at which point the tests fail permanently rather than flakily.