### PR TITLE
feat(odata2ts): resolve V2 navigation property bindings from AssociationSet

### DIFF
--- a/packages/odata2ts/src/data-model/DataModelDigestionV2.ts
+++ b/packages/odata2ts/src/data-model/DataModelDigestionV2.ts
@@ -1,12 +1,18 @@
-import { MappedConverterChains, loadConverters } from "@odata2ts/converter-runtime";
+import { loadConverters, MappedConverterChains } from "@odata2ts/converter-runtime";
 import { ODataTypesV2, ODataVersions } from "@odata2ts/odata-core";
-
 import { DigesterFunction, DigestionOptions } from "../FactoryFunctionModel.js";
 import { withNamespace } from "./DataModel.js";
 import { Digester, TypeModel } from "./DataModelDigestion.js";
-import { ODataVersion, OperationTypes, PropertyModel } from "./DataTypeModel.js";
+import { NavPropBindingType, ODataVersion, OperationTypes, PropertyModel } from "./DataTypeModel.js";
 import { ComplexType, Property } from "./edmx/ODataEdmxModelBase.js";
-import { AssociationEnd, ComplexTypeV3, EntityTypeV3, NavigationProperty, SchemaV3 } from "./edmx/ODataEdmxModelV3.js";
+import {
+  AssociationEnd,
+  ComplexTypeV3,
+  EntityContainerV3,
+  EntityTypeV3,
+  NavigationProperty,
+  SchemaV3,
+} from "./edmx/ODataEdmxModelV3.js";
 import { NamingHelper } from "./NamingHelper.js";
 
 /**
@@ -28,7 +34,7 @@ class DigesterV3 extends Digester<SchemaV3, EntityTypeV3, ComplexTypeV3> {
     schemas: Array<SchemaV3>,
     options: DigestionOptions,
     namingHelper: NamingHelper,
-    converters: MappedConverterChains | undefined
+    converters: MappedConverterChains | undefined,
   ) {
     super(ODataVersion.V2, schemas, options, namingHelper, converters);
   }
@@ -45,6 +51,51 @@ class DigesterV3 extends Digester<SchemaV3, EntityTypeV3, ComplexTypeV3> {
       }
     }
     throw new Error(`Association end couldn't be determined for NavigationProperty [${np.$.Name}]`);
+  }
+
+  private findEdmxEntityType(fqTypeName: string): EntityTypeV3 | undefined {
+    const name = this.namingHelper.stripServicePrefix(fqTypeName);
+    for (let schema of this.schemas) {
+      const found = schema.EntityType?.find((et) => et.$.Name === name);
+      if (found) {
+        return found;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * The V2 counterpart of V4's NavigationPropertyBinding: an AssociationSet states by which EntitySets the
+   * two ends of an association are realized, which is exactly the information needed to know where a
+   * navigation property points to.
+   *
+   * The same association can be realized by more than one AssociationSet, hence the matching one is the one
+   * whose end for the source role is this very entity set.
+   */
+  private getNavPropBindings(
+    container: EntityContainerV3,
+    entitySetName: string,
+    fqEntityTypeName: string,
+  ): Array<NavPropBindingType> {
+    const navProps = this.findEdmxEntityType(fqEntityTypeName)?.NavigationProperty;
+    if (!navProps?.length || !container.AssociationSet?.length) {
+      return [];
+    }
+
+    return navProps.reduce<Array<NavPropBindingType>>((collector, np) => {
+      const relationship = this.namingHelper.stripServicePrefix(np.$.Relationship);
+      const associationSet = container.AssociationSet!.find(
+        (as) =>
+          this.namingHelper.stripServicePrefix(as.$.Association) === relationship &&
+          as.End.some((end) => end.$.Role === np.$.FromRole && end.$.EntitySet === entitySetName),
+      );
+      const target = associationSet?.End.find((end) => end.$.Role === np.$.ToRole)?.$.EntitySet;
+
+      if (target) {
+        collector.push({ path: np.$.Name, target });
+      }
+      return collector;
+    }, []);
   }
 
   protected getNavigationProps(entityType: ComplexType | EntityTypeV3): Array<Property> {
@@ -133,6 +184,7 @@ class DigesterV3 extends Digester<SchemaV3, EntityTypeV3, ComplexTypeV3> {
           odataName,
           name,
           entityType,
+          navPropBinding: this.getNavPropBindings(container, odataName, entitySet.$.EntityType),
         });
       });
     }

--- a/packages/odata2ts/test/data-model/builder/v2/ODataEntityTypeBuilderV2.ts
+++ b/packages/odata2ts/test/data-model/builder/v2/ODataEntityTypeBuilderV2.ts
@@ -12,15 +12,25 @@ export class ODataEntityTypeBuilderV2 extends ODataEntityTypeBuilderBase<EntityT
     return this.associations;
   }
 
-  public addNavProp(name: string, type: string, relationship: string, multiplicity: string) {
+  /**
+   * @param roles the association roles; by default they are derived from the two type names, which is not
+   * unique as soon as one entity type points at another one more than once - specify them in that case
+   */
+  public addNavProp(
+    name: string,
+    type: string,
+    relationship: string,
+    multiplicity: string,
+    roles?: { fromRole: string; toRole: string },
+  ) {
     if (!this.entityType.NavigationProperty) {
       this.entityType.NavigationProperty = [];
     }
 
     const tmp = type.split(".");
     const eType = tmp.length === 1 ? tmp[0] : tmp[1];
-    const fromRole = `${this.entityType.$.Name}_${eType}`;
-    const toRole = `${eType}_${this.entityType.$.Name}`;
+    const fromRole = roles?.fromRole ?? `${this.entityType.$.Name}_${eType}`;
+    const toRole = roles?.toRole ?? `${eType}_${this.entityType.$.Name}`;
 
     this.associations.push({
       $: { Name: relationship },

--- a/packages/odata2ts/test/data-model/builder/v2/ODataModelBuilderV2.ts
+++ b/packages/odata2ts/test/data-model/builder/v2/ODataModelBuilderV2.ts
@@ -31,6 +31,24 @@ export class ODataModelBuilderV2 extends ODataModelBuilder<ODataEdmxModelV3, Sch
     return this;
   }
 
+  /**
+   * The V2 counterpart of V4's NavigationPropertyBinding: states by which EntitySets the ends of an
+   * association are realized.
+   */
+  public addAssociationSet(name: string, association: string, ends: Array<{ role: string; entitySet: string }>) {
+    const container = this.getEntityContainer();
+    if (!container.AssociationSet) {
+      container.AssociationSet = [];
+    }
+
+    container.AssociationSet.push({
+      $: { Name: name, Association: association },
+      End: ends.map(({ role, entitySet }) => ({ $: { Role: role, EntitySet: entitySet } })),
+    });
+
+    return this;
+  }
+
   public addFunctionImport(
     name: string,
     returnType?: string,

--- a/packages/odata2ts/test/data-model/v2/EntitySetDigestion.test.ts
+++ b/packages/odata2ts/test/data-model/v2/EntitySetDigestion.test.ts
@@ -43,4 +43,106 @@ describe("EntitySet Digestion Test", () => {
 
     await expect(() => doDigest()).rejects.toThrow('Entity type "EntitySetTest.Product" not found!');
   });
+
+  test("EntitySet: navigation property binding from AssociationSet", async () => {
+    odataBuilder
+      .addEntityType("Category", undefined, (b) => b.addKeyProp("id", ODataTypesV2.String))
+      .addEntityType("Product", undefined, (b) =>
+        b.addKeyProp("id", ODataTypesV2.String).addNavProp("category", withNs("Category"), "Product_Category", "0..1"),
+      )
+      .addEntitySet("Products", withNs("Product"))
+      .addEntitySet("Categories", withNs("Category"))
+      .addAssociationSet("Products_Categories", withNs("Product_Category"), [
+        { role: "Product_Category", entitySet: "Products" },
+        { role: "Category_Product", entitySet: "Categories" },
+      ]);
+
+    const result = await doDigest();
+
+    expect(result.getEntityContainer().entitySets[withEc("Products")]).toMatchObject({
+      navPropBinding: [{ path: "category", target: "Categories" }],
+    });
+  });
+
+  test("EntitySet: AssociationSet disambiguates two entity sets of the same type", async () => {
+    // the heuristic of matching by entity type alone cannot resolve this, the AssociationSet can
+    odataBuilder
+      .addEntityType("BusinessPartner", undefined, (b) => b.addKeyProp("id", ODataTypesV2.String))
+      .addEntityType("Order", undefined, (b) =>
+        b
+          .addKeyProp("id", ODataTypesV2.String)
+          .addNavProp("customer", withNs("BusinessPartner"), "Order_Customer", "0..1", {
+            fromRole: "Order_Customer",
+            toRole: "Customer_Orders",
+          })
+          .addNavProp("supplier", withNs("BusinessPartner"), "Order_Supplier", "0..1", {
+            fromRole: "Order_Supplier",
+            toRole: "Supplier_Orders",
+          }),
+      )
+      .addEntitySet("Orders", withNs("Order"))
+      .addEntitySet("Customers", withNs("BusinessPartner"))
+      .addEntitySet("Suppliers", withNs("BusinessPartner"))
+      .addAssociationSet("Orders_Customers", withNs("Order_Customer"), [
+        { role: "Order_Customer", entitySet: "Orders" },
+        { role: "Customer_Orders", entitySet: "Customers" },
+      ])
+      .addAssociationSet("Orders_Suppliers", withNs("Order_Supplier"), [
+        { role: "Order_Supplier", entitySet: "Orders" },
+        { role: "Supplier_Orders", entitySet: "Suppliers" },
+      ]);
+
+    const result = await doDigest();
+
+    expect(result.getEntityContainer().entitySets[withEc("Orders")]).toMatchObject({
+      navPropBinding: [
+        { path: "customer", target: "Customers" },
+        { path: "supplier", target: "Suppliers" },
+      ],
+    });
+  });
+
+  test("EntitySet: the AssociationSet of the very entity set is used", async () => {
+    // the same association realized twice: the binding of Orders must not pick up the one of Archive
+    odataBuilder
+      .addEntityType("Category", undefined, (b) => b.addKeyProp("id", ODataTypesV2.String))
+      .addEntityType("Product", undefined, (b) =>
+        b.addKeyProp("id", ODataTypesV2.String).addNavProp("category", withNs("Category"), "Product_Category", "0..1"),
+      )
+      .addEntitySet("Products", withNs("Product"))
+      .addEntitySet("ArchivedProducts", withNs("Product"))
+      .addEntitySet("Categories", withNs("Category"))
+      .addEntitySet("ArchivedCategories", withNs("Category"))
+      .addAssociationSet("Archive", withNs("Product_Category"), [
+        { role: "Product_Category", entitySet: "ArchivedProducts" },
+        { role: "Category_Product", entitySet: "ArchivedCategories" },
+      ])
+      .addAssociationSet("Current", withNs("Product_Category"), [
+        { role: "Product_Category", entitySet: "Products" },
+        { role: "Category_Product", entitySet: "Categories" },
+      ]);
+
+    const result = await doDigest();
+
+    expect(result.getEntityContainer().entitySets[withEc("Products")]).toMatchObject({
+      navPropBinding: [{ path: "category", target: "Categories" }],
+    });
+    expect(result.getEntityContainer().entitySets[withEc("ArchivedProducts")]).toMatchObject({
+      navPropBinding: [{ path: "category", target: "ArchivedCategories" }],
+    });
+  });
+
+  test("EntitySet: without AssociationSet the binding stays empty", async () => {
+    odataBuilder
+      .addEntityType("Category", undefined, (b) => b.addKeyProp("id", ODataTypesV2.String))
+      .addEntityType("Product", undefined, (b) =>
+        b.addKeyProp("id", ODataTypesV2.String).addNavProp("category", withNs("Category"), "Product_Category", "0..1"),
+      )
+      .addEntitySet("Products", withNs("Product"))
+      .addEntitySet("Categories", withNs("Category"));
+
+    const result = await doDigest();
+
+    expect(result.getEntityContainer().entitySets[withEc("Products")]).toMatchObject({ navPropBinding: [] });
+  });
 });


### PR DESCRIPTION
- read the `AssociationSet` of the entity container to populate `navPropBinding` for V2 entity sets, symmetric to what V4 already does with `NavigationPropertyBinding`
- resolves the case a heuristic by entity type cannot: one entity type exposed by two entity sets, e.g. `BusinessPartner` as both `Customers` and `Suppliers`, where `Order.customer` and `Order.supplier` have to end up at different targets
- test builder gained `addAssociationSet`, and `addNavProp` accepts explicit roles

Nothing consumes `navPropBinding` yet.