### PR TITLE
test(odata-service): pin the unquoted plain text body of a GET as POST request

### DIFF
--- a/examples/main/int-test/trippin/TrippinRwIntegration.test.ts
+++ b/examples/main/int-test/trippin/TrippinRwIntegration.test.ts
@@ -122,6 +122,14 @@ describe("Integration Testing of Service Generation", () => {
     await trippinService.airports("LIRA").patch({ name: originalName }).execute();
   });
 
+  /**
+   * Skipped because this service does not implement "$query" at all: POST to it answers with 500
+   * ("Value cannot be null. Parameter name: type"), regardless of the request body, while the equivalent
+   * plain GET works. So it cannot tell a correct request from a broken one - see the double quoting of
+   * https://github.com/odata2ts/odata2ts/issues/383, which went unnoticed for exactly that reason.
+   *
+   * To be enabled once we run our own test servers.
+   */
   test.skip("GET as POST request", async () => {
     const candidate = trippinService.people("russellwhyte").query((builder) => builder.select("userName"));
 

--- a/packages/odata-service/test/request/UrlGetRequestCmd.test.ts
+++ b/packages/odata-service/test/request/UrlGetRequestCmd.test.ts
@@ -34,6 +34,21 @@ describe("UrlRequestCmd tests", () => {
     });
   });
 
+  /**
+   * The query options are passed to the client as a raw string, so that they reach the server as they are:
+   * JSON serializing them would wrap them into double quotes, which the server cannot parse.
+   * See https://github.com/odata2ts/odata2ts/issues/383.
+   */
+  test("as POST request: client receives the unquoted query string", async () => {
+    await candidate.asPostRequest().execute();
+
+    expect(CLIENT.lastOperation).toBe("POST");
+    expect(CLIENT.lastUrl).toBe("test/ing/$query");
+    expect(CLIENT.lastData).toBe("x=y&zz=top");
+    expect(CLIENT.lastData).not.toMatch(/^"/);
+    expect(CLIENT.additionalHeaders).toMatchObject({ "Content-Type": "text/plain" });
+  });
+
   test("as POST request: no-op when url has no query params", () => {
     const noQueryCandidate = new UrlGetRequestCmd(CLIENT, "test/ing");
 


### PR DESCRIPTION
Test-only companion to https://github.com/odata2ts/http-client/pull/35, which carries the actual fix for #383.

- `odata-service` was never at fault: `asPostRequest()` and the `GetToPostConverter` already hand the query options to the client as a raw string plus `Content-Type: text/plain`. The double quotes came from the http clients serializing that body as JSON.
- new test executing the request against the `MockClient` and pinning what the client receives: an unquoted `x=y&zz=top`, `POST` to `test/ing/$query`, `Content-Type: text/plain`. Any future quoting is then unambiguously the client's doing.
- documents why the integration test for this feature stays skipped: the Trippin service does not implement `$query` at all and answers with 500 (`Value cannot be null. Parameter name: type`) regardless of the request body, while the equivalent plain GET works. It cannot tell a correct request from a broken one, which is why the bug went unnoticed in the first place.

Real end-to-end coverage for `$query` wants our own test servers.
