### PR TITLE
fix(odata2ts)!: distinguish bound operations by the cardinality they bind to

### DIFF
--- a/packages/odata2ts/src/data-model/DataModelDigestionV4.ts
+++ b/packages/odata2ts/src/data-model/DataModelDigestionV4.ts
@@ -235,7 +235,21 @@ class DigesterV4 extends Digester<SchemaV4, EntityTypeV4, ComplexTypeV4> {
       }
 
       const bindingProp = isBound ? params.shift() : undefined;
-      const bindingEntityName = bindingProp ? this.dataModel.getModel(bindingProp!.fqType)?.name : undefined;
+      /*
+       * The binding type alone does not identify a bound operation: the spec allows two overloads that
+       * differ only in cardinality - one bound to `Medium`, one to `Collection(Medium)`. Both carry the
+       * same fully qualified name and the same binding type, so a name derived from the type alone
+       * collides and the generated Q-objects end up with a duplicate identifier.
+       *
+       * Collection-bound operations therefore get a `Collection` infix, which is the same distinction
+       * odata2ts already draws for services (`MediumService` vs. `MediumCollectionService`).
+       */
+      const bindingModel = bindingProp ? this.dataModel.getModel(bindingProp.fqType) : undefined;
+      const bindingEntityName = bindingModel
+        ? bindingProp!.isCollection
+          ? `${bindingModel.name}Collection`
+          : bindingModel.name
+        : undefined;
 
       const opName = bindingEntityName
         ? this.nameValidator.addBoundOperationType(bindingEntityName, fqName, opConfig?.mappedName || odataName, type)

--- a/packages/odata2ts/test/data-model/v4/ActionDigestion.test.ts
+++ b/packages/odata2ts/test/data-model/v4/ActionDigestion.test.ts
@@ -157,8 +157,8 @@ describe("Action Digestion Test", () => {
       {
         fqName: withNs("archiveAll"),
         name: "archiveAll",
-        qName: "User_QArchiveAll",
-        paramsModelName: "User_ArchiveAllParams",
+        qName: "UserCollection_QArchiveAll",
+        paramsModelName: "UserCollection_ArchiveAllParams",
         type: OperationTypes.Action,
         parameters: [
           {

--- a/packages/odata2ts/test/data-model/v4/FunctionDigestion.test.ts
+++ b/packages/odata2ts/test/data-model/v4/FunctionDigestion.test.ts
@@ -219,8 +219,8 @@ describe("Function Digestion Test", () => {
       {
         fqName: withNs("countActive"),
         name: "countActive",
-        qName: "User_QCountActive",
-        paramsModelName: "User_CountActiveParams",
+        qName: "UserCollection_QCountActive",
+        paramsModelName: "UserCollection_CountActiveParams",
         type: OperationTypes.Function,
         parameters: [],
       },

--- a/packages/odata2ts/test/fixture/generator/model/operation-bound-collection.ts
+++ b/packages/odata2ts/test/fixture/generator/model/operation-bound-collection.ts
@@ -1,0 +1,8 @@
+export interface Book {
+  id: boolean;
+}
+
+export interface BookCollection_MinOperationParams {
+  test: string;
+  optTest?: string | null;
+}

--- a/packages/odata2ts/test/fixture/generator/qobject/function-bound-collection.ts
+++ b/packages/odata2ts/test/fixture/generator/qobject/function-bound-collection.ts
@@ -1,0 +1,25 @@
+import type { ODataValueResponseV4 } from "@odata2ts/odata-core";
+import { QBooleanParam, QBooleanPath, QFunctionV4, QStringParam, QueryObject } from "@odata2ts/odata-query-objects";
+// @ts-ignore
+import type { BookCollection_MinFunctionParams } from "./TesterModel.js";
+
+export class QBook extends QueryObject {
+  public readonly id = new QBooleanPath(this.withPrefix("id"));
+}
+
+export const qBook = new QBook();
+
+export class BookCollection_QMinFunction extends QFunctionV4<
+  BookCollection_MinFunctionParams,
+  ODataValueResponseV4<boolean>
+> {
+  private readonly params = [new QStringParam("test"), new QBooleanParam("optTest")];
+
+  constructor() {
+    super("Tester.MinFunction");
+  }
+
+  getParams() {
+    return this.params;
+  }
+}

--- a/packages/odata2ts/test/fixture/generator/service/v4/action-rt-enum.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/action-rt-enum.ts
@@ -11,9 +11,16 @@ import {
 // @ts-ignore
 import type { QBook } from "./QTester.js";
 // @ts-ignore
-import { Book_QLike, Book_QRate, Book_QRatings, qBook, QBookId } from "./QTester.js";
-// @ts-ignore
-import type { Book, Book_RateParams, Book_RatingsParams, BookId, EditableBook, Rating } from "./TesterModel.js";
+import { Book_QLike, Book_QRate, BookCollection_QRatings, qBook, QBookId } from "./QTester.js";
+import type {
+  Book,
+  Book_RateParams,
+  BookCollection_RatingsParams,
+  BookId,
+  EditableBook,
+  Rating,
+  // @ts-ignore
+} from "./TesterModel.js";
 
 export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
   public books(): BookCollectionService<ClientType>;
@@ -77,29 +84,29 @@ export class BookCollectionService<
   in out ClientType extends ODataHttpClient,
   V extends ODataVersionV4 = "4.0",
 > extends EntitySetServiceV4<ClientType, Book, EditableBook, QBook, BookId, V> {
-  private _bookQRatings?: Book_QRatings;
+  private _bookCollectionQRatings?: BookCollection_QRatings;
 
   constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qBook, new QBookId(name), options);
   }
 
-  public ratings(params: Book_RatingsParams) {
-    if (!this._bookQRatings) {
-      this._bookQRatings = new Book_QRatings();
+  public ratings(params: BookCollection_RatingsParams) {
+    if (!this._bookCollectionQRatings) {
+      this._bookCollectionQRatings = new BookCollection_QRatings();
     }
 
     const { addFullPath, client, getDefaultHeaders } = this.__base;
-    const url = addFullPath(this._bookQRatings.buildUrl());
+    const url = addFullPath(this._bookCollectionQRatings.buildUrl());
 
-    return new UrlRequestCmd<ClientType, ODataCollectionResponseV4<Rating>, Book_RatingsParams>(
+    return new UrlRequestCmd<ClientType, ODataCollectionResponseV4<Rating>, BookCollection_RatingsParams>(
       client,
       ODataHttpMethods.Post,
       url,
       params,
       {
         headers: getDefaultHeaders(),
-        mainRequestConverter: this._bookQRatings.getRequestConverter(),
-        mainResponseConverter: this._bookQRatings.getResponseConverter(),
+        mainRequestConverter: this._bookCollectionQRatings.getRequestConverter(),
+        mainResponseConverter: this._bookCollectionQRatings.getResponseConverter(),
       },
     );
   }

--- a/packages/odata2ts/test/fixture/generator/service/v4/function-rt-complex.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/function-rt-complex.ts
@@ -10,9 +10,9 @@ import {
 // @ts-ignore
 import type { QBook } from "./QTester.js";
 // @ts-ignore
-import { Book_QBestReview, Book_QFilterReviews, qBook, QBookId } from "./QTester.js";
+import { Book_QBestReview, BookCollection_QFilterReviews, qBook, QBookId } from "./QTester.js";
 // @ts-ignore
-import type { Book, Book_FilterReviewsParams, BookId, EditableBook, Review } from "./TesterModel.js";
+import type { Book, BookCollection_FilterReviewsParams, BookId, EditableBook, Review } from "./TesterModel.js";
 
 export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
   public books(): BookCollectionService<ClientType>;
@@ -55,23 +55,23 @@ export class BookCollectionService<
   in out ClientType extends ODataHttpClient,
   V extends ODataVersionV4 = "4.0",
 > extends EntitySetServiceV4<ClientType, Book, EditableBook, QBook, BookId, V> {
-  private _bookQFilterReviews?: Book_QFilterReviews;
+  private _bookCollectionQFilterReviews?: BookCollection_QFilterReviews;
 
   constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qBook, new QBookId(name), options);
   }
 
-  public filterReviews(params: Book_FilterReviewsParams) {
-    if (!this._bookQFilterReviews) {
-      this._bookQFilterReviews = new Book_QFilterReviews();
+  public filterReviews(params: BookCollection_FilterReviewsParams) {
+    if (!this._bookCollectionQFilterReviews) {
+      this._bookCollectionQFilterReviews = new BookCollection_QFilterReviews();
     }
 
     const { addFullPath, client, getDefaultHeaders, isUrlNotEncoded } = this.__base;
-    const url = addFullPath(this._bookQFilterReviews.buildUrl(params, isUrlNotEncoded()));
+    const url = addFullPath(this._bookCollectionQFilterReviews.buildUrl(params, isUrlNotEncoded()));
 
     return new UrlGetRequestCmd<ClientType, ODataCollectionResponseV4<Review>>(client, url, {
       headers: getDefaultHeaders(),
-      mainResponseConverter: this._bookQFilterReviews.getResponseConverter(),
+      mainResponseConverter: this._bookCollectionQFilterReviews.getResponseConverter(),
     });
   }
 }

--- a/packages/odata2ts/test/generator/v4/ModelGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/ModelGenerator.test.ts
@@ -136,8 +136,9 @@ describe("Model Generator Tests V4", () => {
       );
 
     // when generating model
-    // then match fixture text => actually there's no diff in the generated param models between bound-to-entity and bound-to-collection
-    await generateAndCompare("operation-bound.ts");
+    // then the params model is named after the *collection* binding: an operation bound to a single
+    // instance and one bound to the collection are different overloads and must not share a name.
+    await generateAndCompare("operation-bound-collection.ts");
   });
 
   test(`${TEST_SUITE_NAME}: Entity relationships`, async () => {

--- a/packages/odata2ts/test/generator/v4/QueryObjectGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/QueryObjectGenerator.test.ts
@@ -133,7 +133,7 @@ describe("Query Object Generator Tests V4", () => {
           .addParam("optTest", ODataTypesV4.Boolean, true),
       );
 
-    await generateAndCompare("function-bound.ts");
+    await generateAndCompare("function-bound-collection.ts");
   });
 
   test("QFunction: primitive collection response", async () => {


### PR DESCRIPTION
A bound operation was named after its binding type alone. The spec allows two overloads that differ only in cardinality - one bound to `Medium`, one to `Collection(Medium)` - and those carry the same fully qualified name and the same binding type, so both produced the same names. The generated Q-object file then declared the same class twice and did not compile.

Collection-bound operations now carry a `Collection` infix, which is the distinction odata2ts already draws for services (`MediumService` vs. `MediumCollectionService`). Derived from one place, so the Q-object name, the params model name and the clash-resolver key stay in step - otherwise the collision would just move into the params model.

BREAKING CHANGE: Q-objects and params models of collection-bound operations are renamed from `<Type>_Q<Operation>` to `<Type>Collection_Q<Operation>`. Only collection-bound operations are affected; operations bound to a single instance and unbound operations keep their names.