### PR TITLE
test: integration tests against the ASP.NET Core test server

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -22,6 +22,8 @@ jobs:
         include:
           - name: cap
             package: "@odata2ts/int-test-cap"
+          - name: asp-net
+            package: "@odata2ts/int-test-asp-net"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/int-test/README.md
+++ b/int-test/README.md
@@ -33,9 +33,10 @@ start Docker containers.
 
 ## The servers
 
-| package                  | server                                                          |
-| ------------------------ | --------------------------------------------------------------- |
-| [`cap`](./cap/README.md) | SAP CAP implementation of the standardized "Library" test model |
+| package                          | server                                                          |
+| -------------------------------- | --------------------------------------------------------------- |
+| [`cap`](./cap/README.md)         | SAP CAP implementation of the standardized "Library" test model |
+| [`asp-net`](./asp-net/README.md) | ASP.NET Core implementation of the same model                   |
 
 ## Layout of a package
 

--- a/int-test/asp-net/README.md
+++ b/int-test/asp-net/README.md
@@ -1,0 +1,40 @@
+# Integration Tests: ASP.NET Core
+
+Runs odata2ts against [`odata2ts/test-server-asp-net`](https://github.com/odata2ts/test-server-asp-net),
+the ASP.NET Core implementation of the standardized "Library" OData V4 feature test model.
+
+See [../README.md](../README.md) for how this group fits into the repository and for the test-file scheme
+used here. The server is consumed as a Docker image, started and stopped around the test run by
+`test/globalSetup.ts`:
+
+```bash
+yarn int-test:asp-net
+```
+
+Override the image with `ASPNET_SERVER_IMAGE`, or point at an already running server with
+`LIBRARY_BASE_URL` to work without Docker.
+
+## Why this package exists next to `cap`
+
+The same reference model, a completely different server stack - which is the point: a feature that works
+against one implementation is not thereby proven. Two things in particular are only testable here.
+
+**The binding notations.** `test/feature/Binding.test.ts` is the first place `@odata.bind` and the 4.01
+`{"@id": …}` are exercised end to end. Until now the feature (odata2ts#38) was proven at generator level
+only, against fixtures - and a fixture cannot show that the link actually moved on the other side. The
+file asserts the round trip _and_ that the previously linked entity is left untouched, because getting
+that wrong is silent: the server answers 204 either way.
+
+**Operation overloads.** The reference model carries two overload pairs, and generating this client is
+what surfaced odata2ts#423 - both overloads produced the same Q-object name, so the generated file did
+not compile. `test/core/Operations.test.ts` covers the resulting behaviour.
+
+## Generation
+
+The client is generated offline from `resource/library.xml`, a committed snapshot of the server's actual
+`$metadata`, so generation stays server-independent. That metadata deliberately is what ASP.NET Core
+OData really emits, not the idealized reference model: it has no `TypeDefinition`, no `Partner`
+attributes and no `SRID` facets, none of which the model builder can express. The server's
+`FEATURE-COVERAGE.md` records why.
+
+`enableBindingProps` is switched on, since proving the binding notations is the point of this package.

--- a/int-test/asp-net/odata2ts.config.ts
+++ b/int-test/asp-net/odata2ts.config.ts
@@ -1,0 +1,31 @@
+import { ConfigFileOptions, EmitModes, Modes } from "@odata2ts/odata2ts";
+
+/**
+ * Generates the odata2ts client for the standardized "Library" OData V4 test model, as served by the
+ * ASP.NET Core implementation (repo `odata2ts/test-server-asp-net`).
+ *
+ * The source is a committed snapshot of the server's actual `$metadata` (`resource/library.xml`), so
+ * generation stays offline and server-independent - odata2ts is tested against the metadata ASP.NET Core
+ * OData really emits, not against the idealized reference model. Notably that metadata has no
+ * `TypeDefinition`, no `Partner` attributes and no `SRID` facets, none of which the model builder can
+ * express; see FEATURE-COVERAGE.md in the server repo.
+ *
+ * `enableBindingProps` is on, because this server is the first one we have that actually honours the
+ * binding notations - proving them out end to end is the point of this package.
+ */
+const config: ConfigFileOptions = {
+  mode: Modes.service,
+  emitMode: EmitModes.ts,
+  prettier: true,
+  debug: true,
+  enableBindingProps: true,
+  services: {
+    library: {
+      serviceName: "Library",
+      source: "resource/library.xml",
+      output: "src-generated/library",
+    },
+  },
+};
+
+export default config;

--- a/int-test/asp-net/package.json
+++ b/int-test/asp-net/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@odata2ts/int-test-asp-net",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Integration tests running odata2ts against the ASP.NET Core implementation of the standardized \"Library\" OData V4 test server",
+  "repository": "git@github.com:odata2ts/odata2ts.git",
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "build": "yarn clean && yarn generate",
+    "clean": "rimraf build src-generated",
+    "generate": "odata2ts",
+    "test": "node ../../node_modules/.bin/vitest run",
+    "test-compile": "node ../../node_modules/.bin/tsc"
+  },
+  "dependencies": {
+    "@odata2ts/http-client-fetch": "^0.10.0",
+    "@odata2ts/odata-service": "workspace:^"
+  },
+  "devDependencies": {
+    "@odata2ts/odata2ts": "workspace:^",
+    "testcontainers": "^12.0.4"
+  }
+}

--- a/int-test/asp-net/resource/library.xml
+++ b/int-test/asp-net/resource/library.xml
@@ -1,0 +1,386 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Library.Catalog">
+      <ComplexType Name="Address" Abstract="true">
+        <Property Name="Street" Type="Edm.String" MaxLength="120"/>
+        <Property Name="City" Type="Edm.String" MaxLength="80"/>
+      </ComplexType>
+      <ComplexType Name="PostalAddress" BaseType="Library.Catalog.Address">
+        <Property Name="PostalCode" Type="Edm.String" MaxLength="10"/>
+        <Property Name="Country" Type="Edm.String" MaxLength="60"/>
+      </ComplexType>
+      <EntityType Name="Medium" Abstract="true">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="PopularityScore" Type="Edm.Double"/>
+        <Property Name="Title" Type="Edm.String" Nullable="false" MaxLength="200"/>
+        <Property Name="Language" Type="Edm.String" MaxLength="40"/>
+        <Property Name="PublicationDate" Type="Edm.Date"/>
+        <Property Name="Keywords" Type="Collection(Edm.String)"/>
+        <NavigationProperty Name="Copies" Type="Collection(Library.Circulation.Copy)"/>
+      </EntityType>
+      <EntityType Name="PrintMedium" BaseType="Library.Catalog.Medium" Abstract="true">
+        <Property Name="ISBN" Type="Edm.String" MaxLength="13"/>
+      </EntityType>
+      <EntityType Name="Book" BaseType="Library.Catalog.PrintMedium">
+        <Property Name="PageCount" Type="Edm.Int16" Nullable="false"/>
+        <Property Name="AgeRating" Type="Edm.Byte" Nullable="false"/>
+        <NavigationProperty Name="Publisher" Type="PublisherRegistry.Publisher"/>
+      </EntityType>
+      <EntityType Name="Magazine" BaseType="Library.Catalog.PrintMedium">
+        <Property Name="IssueNumber" Type="Edm.Int32" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="TradeJournal" BaseType="Library.Catalog.Magazine">
+        <Property Name="Field" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="AudioMedium" BaseType="Library.Catalog.Medium" Abstract="true">
+        <Property Name="Duration" Type="Edm.Duration"/>
+      </EntityType>
+      <EntityType Name="DVD" BaseType="Library.Catalog.AudioMedium">
+        <Property Name="RegionCode" Type="Edm.Byte" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="Audiobook" BaseType="Library.Catalog.AudioMedium">
+        <Property Name="Narrator" Type="Edm.String"/>
+        <Property Name="Sample" Type="Edm.Stream"/>
+        <NavigationProperty Name="Chapters" Type="Collection(Library.Catalog.AudiobookChapter)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="AudiobookChapter" HasStream="true">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="Title" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="EBook" BaseType="Library.Catalog.Medium" HasStream="true">
+        <Property Name="FileFormat" Type="Edm.String" MaxLength="20"/>
+      </EntityType>
+      <EntityType Name="CollectorsItem" BaseType="Library.Catalog.Medium" OpenType="true">
+        <Property Name="ExtraData" Type="Edm.Untyped"/>
+        <NavigationProperty Name="StorageLocation" Type="Library.Circulation.Branch"/>
+      </EntityType>
+      <ComplexType Name="MediumStats">
+        <Property Name="TotalLoanCount" Type="Edm.Int64" Nullable="false"/>
+        <Property Name="AverageLoanDuration" Type="Edm.Duration" Nullable="false"/>
+      </ComplexType>
+      <ComplexType Name="ConditionReport">
+        <Property Name="ConditionBefore" Type="Edm.Byte" Nullable="false"/>
+        <Property Name="ConditionAfter" Type="Edm.Byte" Nullable="false"/>
+        <Property Name="Remark" Type="Edm.String"/>
+      </ComplexType>
+      <EnumType Name="Amenities" IsFlags="true">
+        <Member Name="WheelchairAccessible" Value="1"/>
+        <Member Name="Parking" Value="2"/>
+        <Member Name="Café" Value="4"/>
+        <Member Name="KidsArea" Value="8"/>
+        <Member Name="StudyRoom" Value="16"/>
+        <Member Name="FullService" Value="31"/>
+      </EnumType>
+      <EnumType Name="AvailabilityStatus" UnderlyingType="Edm.Byte">
+        <Member Name="Available" Value="0"/>
+        <Member Name="OnLoan" Value="1"/>
+        <Member Name="InRepair" Value="2"/>
+        <Member Name="Missing" Value="3"/>
+      </EnumType>
+      <Annotations Target="Library.Catalog.Medium/PopularityScore">
+        <Annotation Term="Org.OData.Core.V1.Computed" Bool="true"/>
+      </Annotations>
+    </Schema>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Library.Circulation">
+      <EntityType Name="Member">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="ActiveSince" Type="Edm.DateTimeOffset" Precision="7"/>
+        <Property Name="Balance" Type="Edm.Decimal" Nullable="false" Precision="9" Scale="2"/>
+        <Property Name="Name" Type="Edm.String" Nullable="false" MaxLength="100"/>
+        <Property Name="DateOfBirth" Type="Edm.Date"/>
+        <Property Name="Address" Type="Library.Catalog.PostalAddress"/>
+        <Property Name="PreviousAddresses" Type="Collection(Library.Catalog.PostalAddress)" Nullable="false"/>
+        <NavigationProperty Name="Loans" Type="Collection(Library.Circulation.Loan)">
+          <OnDelete Action="Cascade"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Reservations" Type="Collection(Library.Circulation.Reservation)"/>
+        <NavigationProperty Name="IdDocument" Type="Library.Circulation.IdDocument"/>
+      </EntityType>
+      <EntityType Name="Loan">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="LoanedAt" Type="Edm.DateTimeOffset" Nullable="false" Precision="7"/>
+        <Property Name="ReturnedAt" Type="Edm.DateTimeOffset" Precision="7"/>
+        <Property Name="LateFee" Type="Edm.Decimal" Precision="5" Scale="2"/>
+        <Property Name="DueDate" Type="Edm.Date" Nullable="false"/>
+        <NavigationProperty Name="Member" Type="Library.Circulation.Member" Nullable="false"/>
+        <NavigationProperty Name="Copy" Type="Library.Circulation.Copy" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="Reservation">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="ReservedAt" Type="Edm.DateTimeOffset" Nullable="false" Precision="7"/>
+      </EntityType>
+      <EntityType Name="IdDocument">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="UploadedAt" Type="Edm.DateTimeOffset" Nullable="false" Precision="7"/>
+        <Property Name="Scan" Type="Edm.Binary"/>
+      </EntityType>
+      <EntityType Name="Branch">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="Name" Type="Edm.String" Nullable="false" MaxLength="100"/>
+        <Property Name="Address" Type="Library.Catalog.PostalAddress"/>
+        <Property Name="Location" Type="Edm.GeographyPoint"/>
+        <Property Name="CatchmentArea" Type="Edm.GeographyPolygon"/>
+        <Property Name="LowestFloor" Type="Edm.SByte" Nullable="false"/>
+        <Property Name="FloorPlanOrigin" Type="Edm.GeometryPoint"/>
+        <Property Name="FloorPlanShapes" Type="Edm.GeometryCollection"/>
+        <Property Name="OpensAt" Type="Edm.TimeOfDay"/>
+        <Property Name="ClosesAt" Type="Edm.TimeOfDay"/>
+        <Property Name="Amenities" Type="Library.Catalog.Amenities"/>
+        <Property Name="Population" Type="Edm.Int64" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="Bookmobile">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="LicensePlate" Type="Edm.String" MaxLength="12"/>
+        <Property Name="Route" Type="Edm.GeographyLineString"/>
+        <Property Name="CurrentPosition" Type="Edm.GeographyPoint"/>
+      </EntityType>
+      <EntityType Name="Copy">
+        <Key>
+          <PropertyRef Name="InventoryNumber"/>
+          <PropertyRef Name="MediumId"/>
+        </Key>
+        <Property Name="MediumId" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="InventoryNumber" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="IsLoanable" Type="Edm.Boolean" DefaultValue="true" Nullable="false"/>
+        <Property Name="Condition" Type="Edm.Byte" Nullable="false"/>
+        <Property Name="Status" Type="Library.Catalog.AvailabilityStatus"/>
+        <Property Name="AcquisitionDate" Type="Edm.Date"/>
+        <Property Name="WeightKg" Type="Edm.Single" Nullable="false"/>
+        <Property Name="Location_" Type="Edm.String" MaxLength="10"/>
+        <NavigationProperty Name="Medium" Type="Library.Catalog.Medium" Nullable="false">
+          <ReferentialConstraint Property="MediumId" ReferencedProperty="Id"/>
+        </NavigationProperty>
+        <NavigationProperty Name="Location" Type="Library.Circulation.Branch"/>
+      </EntityType>
+      <ComplexType Name="OverdueNotice">
+        <Property Name="Amount" Type="Edm.Decimal" Nullable="false" Precision="5" Scale="2"/>
+        <Property Name="CreatedAt" Type="Edm.DateTimeOffset" Nullable="false" Precision="7"/>
+        <Property Name="Reason" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="AnnualReport">
+        <Property Name="TotalLateFees" Type="Edm.Decimal" Nullable="false" Precision="12" Scale="2"/>
+        <Property Name="Year" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="TotalLoans" Type="Edm.Int64" Nullable="false"/>
+      </ComplexType>
+      <ComplexType Name="DateRange">
+        <Property Name="From" Type="Edm.Date"/>
+        <Property Name="To" Type="Edm.Date"/>
+      </ComplexType>
+      <ComplexType Name="LoanStats">
+        <Property Name="TotalLoans" Type="Edm.Int64" Nullable="false"/>
+        <Property Name="AverageLoanDuration" Type="Edm.Duration" Nullable="false"/>
+      </ComplexType>
+      <ComplexType Name="BranchStats">
+        <Property Name="BranchId" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="LoanCount" Type="Edm.Int64" Nullable="false"/>
+      </ComplexType>
+      <Function Name="TotalMediaCount">
+        <ReturnType Type="Edm.Int64" Nullable="false"/>
+      </Function>
+      <Function Name="AllLanguages">
+        <ReturnType Type="Collection(Edm.String)"/>
+      </Function>
+      <Function Name="LoanStatistics">
+        <Parameter Name="Period" Type="Library.Circulation.DateRange"/>
+        <ReturnType Type="Library.Circulation.LoanStats"/>
+      </Function>
+      <Function Name="StatsPerBranch">
+        <ReturnType Type="Collection(Library.Circulation.BranchStats)"/>
+      </Function>
+      <Function Name="MostReadMedium">
+        <ReturnType Type="Library.Catalog.Medium"/>
+      </Function>
+      <Function Name="NewReleases" IsComposable="true">
+        <ReturnType Type="Collection(Library.Catalog.Medium)"/>
+      </Function>
+      <Function Name="Search">
+        <Parameter Name="Term" Type="Edm.String"/>
+        <ReturnType Type="Collection(Library.Catalog.Medium)"/>
+      </Function>
+      <Function Name="Search">
+        <Parameter Name="Term" Type="Edm.String"/>
+        <Parameter Name="MaxResults" Type="Edm.Int32" Nullable="false"/>
+        <ReturnType Type="Collection(Library.Catalog.Medium)"/>
+      </Function>
+      <Action Name="ClosureDay">
+        <Parameter Name="Date" Type="Edm.Date" Nullable="false"/>
+      </Action>
+      <Action Name="NextInventoryNumber">
+        <ReturnType Type="Edm.Int32" Nullable="false"/>
+      </Action>
+      <Action Name="CleanUpKeywords">
+        <Parameter Name="Obsolete" Type="Collection(Edm.String)"/>
+        <ReturnType Type="Collection(Edm.String)"/>
+      </Action>
+      <Action Name="YearEndClosing">
+        <Parameter Name="Year" Type="Edm.Int32" Nullable="false"/>
+        <ReturnType Type="Library.Circulation.AnnualReport"/>
+      </Action>
+      <Action Name="RunOverdueNotices">
+        <ReturnType Type="Collection(Library.Circulation.OverdueNotice)"/>
+      </Action>
+      <Action Name="AcquireCollectorsItem">
+        <Parameter Name="Title" Type="Edm.String"/>
+        <Parameter Name="Description" Type="Edm.String"/>
+        <ReturnType Type="Library.Catalog.Medium"/>
+      </Action>
+      <Action Name="RunStockCheck">
+        <ReturnType Type="Collection(Library.Catalog.Medium)"/>
+      </Action>
+      <Function Name="OutstandingBalance" IsBound="true">
+        <Parameter Name="member" Type="Library.Circulation.Member"/>
+        <ReturnType Type="Edm.Decimal" Nullable="false" Scale="variable"/>
+      </Function>
+      <Function Name="AvailableLanguages" IsBound="true">
+        <Parameter Name="media" Type="Collection(Library.Catalog.Medium)"/>
+        <ReturnType Type="Collection(Edm.String)"/>
+      </Function>
+      <Function Name="LoanMetrics" IsBound="true">
+        <Parameter Name="medium" Type="Library.Catalog.Medium"/>
+        <ReturnType Type="Library.Catalog.MediumStats"/>
+      </Function>
+      <Function Name="NoticeHistory" IsBound="true">
+        <Parameter Name="member" Type="Library.Circulation.Member"/>
+        <ReturnType Type="Collection(Library.Circulation.OverdueNotice)"/>
+      </Function>
+      <Function Name="AvailableCopy" IsBound="true">
+        <Parameter Name="medium" Type="Library.Catalog.Medium"/>
+        <ReturnType Type="Library.Circulation.Copy"/>
+      </Function>
+      <Function Name="AvailableCopies" IsBound="true" IsComposable="true">
+        <Parameter Name="medium" Type="Library.Catalog.Medium"/>
+        <ReturnType Type="Collection(Library.Circulation.Copy)"/>
+      </Function>
+      <Function Name="AvailableCopies" IsBound="true" IsComposable="true">
+        <Parameter Name="media" Type="Collection(Library.Catalog.Medium)"/>
+        <ReturnType Type="Collection(Library.Circulation.Copy)"/>
+      </Function>
+      <Action Name="CheckOut" IsBound="true">
+        <Parameter Name="copy" Type="Library.Circulation.Copy"/>
+        <Parameter Name="MemberId" Type="Edm.Int32" Nullable="false"/>
+      </Action>
+      <Action Name="Reserve" IsBound="true">
+        <Parameter Name="medium" Type="Library.Catalog.Medium"/>
+        <Parameter Name="MemberId" Type="Edm.Int32" Nullable="false"/>
+        <ReturnType Type="Edm.Int32"/>
+      </Action>
+      <Action Name="BulkRenew" IsBound="true">
+        <Parameter Name="loans" Type="Collection(Library.Circulation.Loan)"/>
+        <ReturnType Type="Collection(Edm.String)"/>
+      </Action>
+      <Action Name="AssessCondition" IsBound="true">
+        <Parameter Name="copy" Type="Library.Circulation.Copy"/>
+        <Parameter Name="NewCondition" Type="Edm.Byte" Nullable="false"/>
+        <Parameter Name="Remark" Type="Edm.String"/>
+        <ReturnType Type="Library.Catalog.ConditionReport"/>
+      </Action>
+      <Action Name="RunReminders" IsBound="true">
+        <Parameter Name="member" Type="Library.Circulation.Member"/>
+        <ReturnType Type="Collection(Library.Circulation.OverdueNotice)"/>
+      </Action>
+      <Action Name="Renew" IsBound="true">
+        <Parameter Name="loan" Type="Library.Circulation.Loan"/>
+        <ReturnType Type="Library.Circulation.Loan"/>
+      </Action>
+      <Action Name="RenewAll" IsBound="true">
+        <Parameter Name="loans" Type="Collection(Library.Circulation.Loan)"/>
+        <ReturnType Type="Collection(Library.Circulation.Loan)"/>
+      </Action>
+    </Schema>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="PublisherRegistry">
+      <EntityType Name="Publisher">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="Name" Type="Edm.String" Nullable="false" MaxLength="100"/>
+        <Property Name="Country" Type="Edm.String" MaxLength="60"/>
+        <Property Name="Founded" Type="Edm.Date"/>
+        <NavigationProperty Name="Books" Type="Collection(Library.Catalog.Book)"/>
+      </EntityType>
+      <EntityType Name="Branch">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="City" Type="Edm.String" MaxLength="80"/>
+        <Property Name="Country" Type="Edm.String" MaxLength="60"/>
+      </EntityType>
+    </Schema>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Library.Service">
+      <EntityContainer Name="LibraryService">
+        <EntitySet Name="Media" EntityType="Library.Catalog.Medium">
+          <NavigationPropertyBinding Path="Copies" Target="Copies"/>
+          <NavigationPropertyBinding Path="Library.Catalog.Book/Publisher" Target="Publishers"/>
+          <NavigationPropertyBinding Path="Library.Catalog.CollectorsItem/StorageLocation" Target="Branches"/>
+        </EntitySet>
+        <EntitySet Name="Copies" EntityType="Library.Circulation.Copy">
+          <NavigationPropertyBinding Path="Location" Target="Branches"/>
+          <NavigationPropertyBinding Path="Medium" Target="Media"/>
+          <Annotation Term="Org.OData.Core.V1.OptimisticConcurrency">
+            <Collection>
+              <PropertyPath>Condition</PropertyPath>
+            </Collection>
+          </Annotation>
+        </EntitySet>
+        <EntitySet Name="Members" EntityType="Library.Circulation.Member">
+          <NavigationPropertyBinding Path="IdDocument" Target="IdDocuments"/>
+          <NavigationPropertyBinding Path="Loans" Target="Loans"/>
+          <NavigationPropertyBinding Path="Reservations" Target="Reservations"/>
+        </EntitySet>
+        <EntitySet Name="Loans" EntityType="Library.Circulation.Loan">
+          <NavigationPropertyBinding Path="Copy" Target="Copies"/>
+          <NavigationPropertyBinding Path="Member" Target="Members"/>
+        </EntitySet>
+        <EntitySet Name="Reservations" EntityType="Library.Circulation.Reservation"/>
+        <EntitySet Name="IdDocuments" EntityType="Library.Circulation.IdDocument"/>
+        <EntitySet Name="Branches" EntityType="Library.Circulation.Branch"/>
+        <EntitySet Name="Bookmobiles" EntityType="Library.Circulation.Bookmobile"/>
+        <EntitySet Name="Publishers" EntityType="PublisherRegistry.Publisher">
+          <NavigationPropertyBinding Path="Books" Target="Media"/>
+        </EntitySet>
+        <EntitySet Name="PublisherBranches" EntityType="PublisherRegistry.Branch"/>
+        <Singleton Name="MainBranch" Type="Library.Circulation.Branch"/>
+        <FunctionImport Name="TotalMediaCount" Function="Library.Circulation.TotalMediaCount" IncludeInServiceDocument="true"/>
+        <FunctionImport Name="AllLanguages" Function="Library.Circulation.AllLanguages" IncludeInServiceDocument="true"/>
+        <FunctionImport Name="LoanStatistics" Function="Library.Circulation.LoanStatistics" IncludeInServiceDocument="true"/>
+        <FunctionImport Name="StatsPerBranch" Function="Library.Circulation.StatsPerBranch" IncludeInServiceDocument="true"/>
+        <FunctionImport Name="MostReadMedium" Function="Library.Circulation.MostReadMedium" EntitySet="Media" IncludeInServiceDocument="true"/>
+        <FunctionImport Name="NewReleases" Function="Library.Circulation.NewReleases" EntitySet="Media" IncludeInServiceDocument="true"/>
+        <FunctionImport Name="Search" Function="Library.Circulation.Search" EntitySet="Media" IncludeInServiceDocument="true"/>
+        <ActionImport Name="ClosureDay" Action="Library.Circulation.ClosureDay"/>
+        <ActionImport Name="NextInventoryNumber" Action="Library.Circulation.NextInventoryNumber"/>
+        <ActionImport Name="CleanUpKeywords" Action="Library.Circulation.CleanUpKeywords"/>
+        <ActionImport Name="YearEndClosing" Action="Library.Circulation.YearEndClosing"/>
+        <ActionImport Name="RunOverdueNotices" Action="Library.Circulation.RunOverdueNotices"/>
+        <ActionImport Name="AcquireCollectorsItem" Action="Library.Circulation.AcquireCollectorsItem" EntitySet="Media"/>
+        <ActionImport Name="RunStockCheck" Action="Library.Circulation.RunStockCheck" EntitySet="Media"/>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/int-test/asp-net/test/LibraryTestConstants.ts
+++ b/int-test/asp-net/test/LibraryTestConstants.ts
@@ -1,0 +1,20 @@
+import { FetchClient } from "@odata2ts/http-client-fetch";
+import { inject } from "vitest";
+import { LibraryService } from "../src-generated/library/LibraryService.js";
+
+/** Base URL of the running server, provided by `globalSetup` (container or external server). */
+export const BASE_URL = inject("libraryBaseUrl");
+export const ODATA_CLIENT = new FetchClient();
+export const LIBRARY = new LibraryService(ODATA_CLIENT, BASE_URL);
+
+// Fixed keys from the server's seed data.
+
+/** "Der Prozess" - a book with fixed, well-known values. */
+export const BOOK_DER_PROZESS = "11111111-1111-1111-1111-111111111111";
+export const AUDIOBOOK = "22222222-2222-2222-2222-222222222222";
+export const EBOOK = "33333333-3333-3333-3333-333333333333";
+export const UNKNOWN_ID = "00000000-0000-0000-0000-000000000000";
+
+/** The two branches, used as the two ends of a re-binding. */
+export const BRANCH_CENTRAL = 1;
+export const BRANCH_SUBURBAN = 2;

--- a/int-test/asp-net/test/core/CrudOperations.test.ts
+++ b/int-test/asp-net/test/core/CrudOperations.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "vitest";
+import { BOOK_DER_PROZESS, LIBRARY, UNKNOWN_ID } from "../LibraryTestConstants.js";
+
+describe("ASP.NET Library: CRUD", () => {
+  test("read entity by key", async () => {
+    const result = await LIBRARY.Media(BOOK_DER_PROZESS).query().execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.Title).toBe("Der Prozess");
+    expect(result.data.Language).toBe("de");
+  });
+
+  test("read entity collection", async () => {
+    const result = await LIBRARY.Media().query().execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.value.length).toBeGreaterThan(0);
+  });
+
+  test("read with unknown key yields 404", async () => {
+    await expect(LIBRARY.Media(UNKNOWN_ID).query().execute()).rejects.toThrow();
+  });
+
+  test("create, read, patch and delete an entity", async () => {
+    const created = await LIBRARY.Members()
+      .create({ Name: "Integration Test", Balance: 0, PreviousAddresses: [] })
+      .execute();
+    expect(created.status).toBe(201);
+
+    const id = created.data.Id;
+    const member = LIBRARY.Members(id);
+
+    const read = await member.query().execute();
+    expect(read.data.Name).toBe("Integration Test");
+
+    await member.patch({ Name: "Integration Test (patched)" }).execute();
+    expect((await member.query().execute()).data.Name).toBe("Integration Test (patched)");
+
+    const deleted = await member.delete().execute();
+    expect(deleted.status).toBe(204);
+    await expect(member.query().execute()).rejects.toThrow();
+  });
+
+  test("deep insert creates the nested entity as well", async () => {
+    // The nested entity has to become addressable in its own set, not just through the parent - the
+    // server had that wrong at first, answering 201 while leaving the child keyless and invisible.
+    const before = await LIBRARY.Loans()
+      .query((b) => b.count().top(0))
+      .execute();
+
+    const created = await LIBRARY.Members()
+      .create({
+        Name: "Deep Insert",
+        Balance: 0,
+        PreviousAddresses: [],
+        Loans: [{ LoanedAt: "2026-08-01T10:00:00Z", DueDate: "2026-09-01" }],
+      } as never)
+      .execute();
+
+    expect(created.status).toBe(201);
+
+    const after = await LIBRARY.Loans()
+      .query((b) => b.count().top(0))
+      .execute();
+    expect(Number(after.data["@odata.count"])).toBe(Number(before.data["@odata.count"]) + 1);
+  });
+});

--- a/int-test/asp-net/test/core/Operations.test.ts
+++ b/int-test/asp-net/test/core/Operations.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "vitest";
+import { BOOK_DER_PROZESS, LIBRARY } from "../LibraryTestConstants.js";
+
+describe("ASP.NET Library: functions and actions", () => {
+  test("unbound function without params", async () => {
+    const result = await LIBRARY.TotalMediaCount().execute();
+
+    expect(result.status).toBe(200);
+    expect(Number(result.data.value)).toBeGreaterThan(0);
+  });
+
+  test("unbound function returning a collection", async () => {
+    const result = await LIBRARY.AllLanguages().execute();
+
+    expect(result.data.value).toContain("de");
+  });
+
+  test("unbound function with params", async () => {
+    const result = await LIBRARY.Search({ Term: "Prozess" }).execute();
+
+    expect(result.data.value.length).toBe(1);
+    expect(result.data.value[0].Title).toBe("Der Prozess");
+  });
+
+  test("overload of the same function, differing in parameter count", async () => {
+    // Both overloads survive into the metadata; this proves the second one is callable and honours its
+    // extra parameter.
+    const unlimited = await LIBRARY.Search({ Term: "e" }).execute();
+    const limited = await LIBRARY.Search({ Term: "e", MaxResults: 2 }).execute();
+
+    expect(unlimited.data.value.length).toBeGreaterThan(2);
+    expect(limited.data.value.length).toBe(2);
+  });
+
+  test("unbound function returning an entity", async () => {
+    const result = await LIBRARY.MostReadMedium().execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.Title).toBeDefined();
+  });
+
+  test("unbound action", async () => {
+    const result = await LIBRARY.NextInventoryNumber().execute();
+
+    expect(result.status).toBe(200);
+    expect(Number(result.data.value)).toBeGreaterThan(0);
+  });
+
+  test("unbound action with a collection parameter", async () => {
+    const result = await LIBRARY.CleanUpKeywords({ Obsolete: ["Fragment"] }).execute();
+
+    expect(result.data.value).not.toContain("Fragment");
+  });
+
+  test("bound function on a single entity", async () => {
+    const result = await LIBRARY.Members(1).OutstandingBalance().execute();
+
+    expect(result.status).toBe(200);
+    expect(Number(result.data.value)).toBeGreaterThanOrEqual(0);
+  });
+
+  test("bound function on a collection", async () => {
+    const result = await LIBRARY.Media().AvailableLanguages().execute();
+
+    expect(result.data.value).toContain("de");
+  });
+
+  test("bound function returning a complex type", async () => {
+    const result = await LIBRARY.Media(BOOK_DER_PROZESS).LoanMetrics().execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data).toHaveProperty("TotalLoanCount");
+  });
+
+  test("bound action", async () => {
+    const result = await LIBRARY.Media(BOOK_DER_PROZESS).Reserve({ MemberId: 1 }).execute();
+
+    expect(result.status).toBe(200);
+    expect(Number(result.data.value)).toBeGreaterThan(0);
+  });
+});

--- a/int-test/asp-net/test/core/QueryFunctionality.test.ts
+++ b/int-test/asp-net/test/core/QueryFunctionality.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "vitest";
+import { BASE_URL, BOOK_DER_PROZESS, LIBRARY } from "../LibraryTestConstants.js";
+
+describe("ASP.NET Library: query functionality", () => {
+  test("$count", async () => {
+    const result = await LIBRARY.Media()
+      .query((builder) => {
+        builder.count().top(0);
+      })
+      .execute();
+
+    expect(result.status).toBe(200);
+    expect(Number(result.data["@odata.count"])).toBeGreaterThan(0);
+  });
+
+  test("$select", async () => {
+    const result = await LIBRARY.Media(BOOK_DER_PROZESS)
+      .query((builder) => {
+        builder.select("Title");
+      })
+      .execute();
+
+    expect(result.data.Title).toBe("Der Prozess");
+    expect(result.data.Language).toBeUndefined();
+  });
+
+  test("$filter", async () => {
+    const result = await LIBRARY.Media()
+      .query((builder, qMedium) => {
+        builder.filter(qMedium.Language.eq("de"));
+      })
+      .execute();
+
+    expect(result.data.value.length).toBeGreaterThan(0);
+    expect(result.data.value.every((medium) => medium.Language === "de")).toBe(true);
+  });
+
+  test("$orderby with $top and $skip", async () => {
+    const all = await LIBRARY.Media()
+      .query((builder, qMedium) => {
+        builder.orderBy(qMedium.Title.asc());
+      })
+      .execute();
+
+    const skipped = await LIBRARY.Media()
+      .query((builder, qMedium) => {
+        builder.orderBy(qMedium.Title.asc()).top(2).skip(1);
+      })
+      .execute();
+
+    expect(skipped.data.value.length).toBe(2);
+    expect(skipped.data.value[0].Title).toBe(all.data.value[1].Title);
+  });
+
+  test("$expand", async () => {
+    const result = await LIBRARY.Media(BOOK_DER_PROZESS)
+      .query((builder) => {
+        builder.select("Title").expand("Copies");
+      })
+      .execute();
+
+    expect(result.data.Copies?.length).toBeGreaterThan(0);
+  });
+
+  test("$search actually filters", async () => {
+    // The server only searches because a binder was written for it. Without one the option is accepted
+    // and silently ignored, which is why this asserts a *smaller* result rather than just a 200.
+    const all = await LIBRARY.Media()
+      .query((builder) => {
+        builder.count().top(0);
+      })
+      .execute();
+
+    const found = await LIBRARY.Media()
+      .query((builder) => {
+        builder.search("Prozess");
+      })
+      .execute();
+
+    expect(found.data.value.length).toBeGreaterThan(0);
+    expect(found.data.value.length).toBeLessThan(Number(all.data["@odata.count"]));
+    expect(found.data.value.every((medium) => medium.Title.includes("Prozess"))).toBe(true);
+  });
+
+  test("type-cast segment reaches the derived type", async () => {
+    const response = await fetch(`${BASE_URL}/Media/Library.Catalog.Book`);
+
+    expect(response.status).toBe(200);
+  });
+});

--- a/int-test/asp-net/test/feature/Binding.test.ts
+++ b/int-test/asp-net/test/feature/Binding.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "vitest";
+import { BASE_URL, BOOK_DER_PROZESS, BRANCH_CENTRAL, BRANCH_SUBURBAN, LIBRARY } from "../LibraryTestConstants.js";
+
+/**
+ * The binding notations of odata2ts issue #38, end to end against a real server.
+ *
+ * This is the first server we have that honours them, which is why they get their own file: until now
+ * the feature was only ever proven at generator level, against fixtures. A fixture cannot show that the
+ * link actually moved on the other side.
+ *
+ * The client is generated for OData 4.0, so the generated property is `Nav@odata.bind` carrying a URL.
+ * The 4.01 spelling - a nested `{"@id": …}` - is sent by hand in the last test, since a 4.0 client does
+ * not emit it.
+ */
+describe("ASP.NET Library: binding existing entities", () => {
+  const branchUrl = (id: number) => `${BASE_URL}/Branches(${id})`;
+
+  /** Copies only this file touches, so re-binding cannot race the other test files. */
+  const BOUND_ON_CREATE = 4001;
+  const BOUND_TO_CONSTRAINED_NAV = 4002;
+  const BOUND_WITH_401_NOTATION = 4003;
+
+  const copyKey = (inventoryNumber: number) => ({
+    MediumId: BOOK_DER_PROZESS,
+    InventoryNumber: inventoryNumber,
+  });
+
+  test("create with a binding links the entity", async () => {
+    const created = await LIBRARY.Copies()
+      .create({
+        MediumId: BOOK_DER_PROZESS,
+        InventoryNumber: BOUND_ON_CREATE,
+        Condition: 1,
+        IsLoanable: true,
+        WeightKg: 0.4,
+        "Location@odata.bind": branchUrl(BRANCH_CENTRAL),
+      })
+      .execute();
+
+    expect(created.status).toBe(201);
+
+    const location = await LIBRARY.Copies(copyKey(BOUND_ON_CREATE)).Location().query().execute();
+
+    expect(location.data.Id).toBe(BRANCH_CENTRAL);
+    expect(location.data.Name).toBe("Central Library");
+  });
+
+  test("patching the binding re-points the link", async () => {
+    const copy = LIBRARY.Copies(copyKey(BOUND_ON_CREATE));
+
+    const patched = await copy.patch({ "Location@odata.bind": branchUrl(BRANCH_SUBURBAN) }).execute();
+    expect(patched.status).toBe(204);
+
+    const location = await copy.Location().query().execute();
+    expect(location.data.Id).toBe(BRANCH_SUBURBAN);
+    // The decisive assertion. Routing the binding through Delta<T> on the server would have written the
+    // new key into the *previously* linked branch instead of re-pointing the reference, leaving two
+    // entities with the same key behind - and still answering 204.
+    expect(location.data.Name).toBe("Suburban Branch");
+  });
+
+  test("re-binding leaves the branches themselves untouched", async () => {
+    const branches = await LIBRARY.Branches()
+      .query((builder, qBranch) => {
+        builder.select("Id", "Name").orderBy(qBranch.Id.asc());
+      })
+      .execute();
+
+    expect(branches.data.value.map((branch) => [branch.Id, branch.Name])).toStrictEqual([
+      [BRANCH_CENTRAL, "Central Library"],
+      [BRANCH_SUBURBAN, "Suburban Branch"],
+    ]);
+  });
+
+  test("binding to null clears the link", async () => {
+    const copy = LIBRARY.Copies(copyKey(BOUND_ON_CREATE));
+
+    const patched = await copy.patch({ "Location@odata.bind": null }).execute();
+    expect(patched.status).toBe(204);
+
+    await expect(copy.Location().query().execute()).rejects.toThrow();
+  });
+
+  test("binding a navigation property backed by a referential constraint", async () => {
+    // `Copy/Medium` is tied to `MediumId` by a ReferentialConstraint. That is the case the OData
+    // deserializer refuses outright, so the server parses such a payload itself - see FEATURE-COVERAGE.md
+    // of test-server-asp-net.
+    const created = await LIBRARY.Copies()
+      .create({
+        MediumId: BOOK_DER_PROZESS,
+        InventoryNumber: BOUND_TO_CONSTRAINED_NAV,
+        Condition: 1,
+        IsLoanable: true,
+        WeightKg: 0.4,
+        "Medium@odata.bind": `${BASE_URL}/Media(${BOOK_DER_PROZESS})`,
+      })
+      .execute();
+
+    expect(created.status).toBe(201);
+
+    const medium = await LIBRARY.Copies(copyKey(BOUND_TO_CONSTRAINED_NAV)).Medium().query().execute();
+    expect(medium.data.Title).toBe("Der Prozess");
+  });
+
+  test("the server honours the 4.01 notation as well", async () => {
+    // Sent by hand: a client generated for 4.0 emits `Nav@odata.bind`. The point is the server side -
+    // both notations have to move the link, otherwise a client generated with `odataVersionV4: "4.01"`
+    // would fail against it, silently.
+    const response = await fetch(`${BASE_URL}/Copies`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        MediumId: BOOK_DER_PROZESS,
+        InventoryNumber: BOUND_WITH_401_NOTATION,
+        Condition: 1,
+        Location: { "@id": branchUrl(BRANCH_SUBURBAN) },
+      }),
+    });
+
+    expect(response.status).toBe(201);
+
+    const location = await LIBRARY.Copies(copyKey(BOUND_WITH_401_NOTATION)).Location().query().execute();
+
+    expect(location.data.Id).toBe(BRANCH_SUBURBAN);
+    expect(location.data.Name).toBe("Suburban Branch");
+  });
+});

--- a/int-test/asp-net/test/globalSetup.ts
+++ b/int-test/asp-net/test/globalSetup.ts
@@ -1,0 +1,51 @@
+import { GenericContainer, StartedTestContainer, Wait } from "testcontainers";
+import type { TestProject } from "vitest/node";
+
+/**
+ * Provisions the ASP.NET Core "Library" OData server for the integration tests and tears it down afterwards.
+ *
+ * Two modes, switched by the `LIBRARY_BASE_URL` env var:
+ *
+ * - **external server** (`LIBRARY_BASE_URL` set): use an already-running server as-is. No Docker involved -
+ *   this is the path for machines without Docker (start `test-server-cap` manually) and lets the whole
+ *   setup be developed and run before any image exists.
+ * - **managed container** (default): start the published Docker image via testcontainers, wait for the
+ *   service to answer, expose it on a dynamic host port and stop + remove it when the run finishes. This
+ *   is the CI / Docker-machine path; `ubuntu-latest` ships Docker out of the box.
+ *
+ * The image is language-agnostic on purpose: further servers (Java, ...) implement the same
+ * standardized model and only differ in the image name, so this file is the single point that changes.
+ */
+const IMAGE = process.env.ASPNET_SERVER_IMAGE ?? "ghcr.io/odata2ts/test-server-asp-net:latest";
+const SERVICE_PATH = "/odata/v4/library";
+const CONTAINER_PORT = 4004;
+
+export default async function setup(project: TestProject) {
+  const externalBaseUrl = process.env.LIBRARY_BASE_URL;
+  if (externalBaseUrl) {
+    project.provide("libraryBaseUrl", externalBaseUrl.replace(/\/+$/, ""));
+    return () => {};
+  }
+
+  let container: StartedTestContainer;
+  try {
+    container = await new GenericContainer(IMAGE)
+      .withExposedPorts(CONTAINER_PORT)
+      .withWaitStrategy(Wait.forHttp(`${SERVICE_PATH}/`, CONTAINER_PORT).forStatusCode(200))
+      .start();
+  } catch (e) {
+    throw new Error(
+      `Could not start the test server container "${IMAGE}".\n` +
+        `Is a Docker daemon running? Without Docker, run against a server you started yourself:\n` +
+        `  LIBRARY_BASE_URL=http://localhost:4004${SERVICE_PATH} yarn int-test:cap\n` +
+        `Original error: ${e instanceof Error ? e.message : String(e)}`,
+      { cause: e },
+    );
+  }
+
+  project.provide("libraryBaseUrl", `http://localhost:${container.getMappedPort(CONTAINER_PORT)}${SERVICE_PATH}`);
+
+  return async () => {
+    await container.stop();
+  };
+}

--- a/int-test/asp-net/test/vitest.d.ts
+++ b/int-test/asp-net/test/vitest.d.ts
@@ -1,0 +1,10 @@
+import "vitest";
+
+/**
+ * Typing for the value handed from `globalSetup` to the tests via `provide` / `inject`.
+ */
+declare module "vitest" {
+  export interface ProvidedContext {
+    libraryBaseUrl: string;
+  }
+}

--- a/int-test/asp-net/tsconfig.json
+++ b/int-test/asp-net/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.settings.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "lib": ["ESNext", "DOM"]
+  },
+  "include": ["src-generated", "test"]
+}

--- a/int-test/asp-net/vitest.config.ts
+++ b/int-test/asp-net/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Integration tests for the CAP "Library" server.
+ *
+ * `globalSetup` provisions the running server (Docker container via testcontainers, or an externally
+ * started server when `LIBRARY_BASE_URL` is set) and hands its base URL to the tests via `provide` /
+ * `inject`. See `test/globalSetup.ts`.
+ */
+export default defineConfig({
+  test: {
+    globalSetup: ["./test/globalSetup.ts"],
+    include: ["test/**/*.test.ts"],
+    // integration tests hit a real server - no artificial timeouts
+    testTimeout: 30_000,
+    // pulling and starting the container happens within the setup hook
+    hookTimeout: 180_000,
+    // all files share one server instance, so writes in one file must not race reads in another
+    fileParallelism: false,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "clean": "rimraf coverage",
     "coverage": "vitest run --coverage",
     "int-test": "yarn workspaces foreach -A -p --include 'int-test/*' run test",
+    "int-test:asp-net": "yarn workspace @odata2ts/int-test-asp-net test",
     "int-test:cap": "yarn workspace @odata2ts/int-test-cap test",
     "test": "yarn workspaces foreach -A -p --include 'packages/*' --include 'examples/*' run test",
     "test-compile": "yarn workspaces foreach -A -p run test-compile"

--- a/yarn.lock
+++ b/yarn.lock
@@ -674,6 +674,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@odata2ts/int-test-asp-net@workspace:int-test/asp-net":
+  version: 0.0.0-use.local
+  resolution: "@odata2ts/int-test-asp-net@workspace:int-test/asp-net"
+  dependencies:
+    "@odata2ts/http-client-fetch": "npm:^0.10.0"
+    "@odata2ts/odata-service": "workspace:^"
+    "@odata2ts/odata2ts": "workspace:^"
+    testcontainers: "npm:^12.0.4"
+  languageName: unknown
+  linkType: soft
+
 "@odata2ts/int-test-cap@workspace:int-test/cap":
   version: 0.0.0-use.local
   resolution: "@odata2ts/int-test-cap@workspace:int-test/cap"


### PR DESCRIPTION
Second implementation of the same reference model in the `int-test/` group, next to `cap`. The point is not more coverage of odata2ts, but coverage against a *different* server stack: a feature that works against one implementation is not thereby proven.

- `test/feature/Binding.test.ts` — the first end-to-end proof of the binding notations (#38). Until now the feature was covered at generator level only, against fixtures, and a fixture cannot show that the link actually moved on the other side. Covers `@odata.bind`, the 4.01 `{"@id": …}`, binding to `null`, and a navigation property backed by a referential constraint.
- `test/core/*` — CRUD incl. deep insert, the query options, and the operations incl. both overload pairs.
- Client generated offline from a committed `$metadata` snapshot, so generation stays server-independent. The snapshot is what ASP.NET Core OData really emits — without `TypeDefinition`, `Partner` or `SRID`, none of which its model builder can express.
- One more entry in the CI matrix; adding a further server stays one package plus one matrix entry.

**Two assertions are worth reading closely, because both guard against silent failure:**

The binding test asserts not only that the link moved, but that the *previously* linked entity is untouched. Routing a binding through `Delta<T>` on the server side writes the new key into the old target instead of re-pointing the reference — and answers `204` either way. Only the second assertion catches it.

The `$search` test asserts a *smaller* result rather than a `200`. Without a search binder the option is accepted and silently ignored, which a status-code check cannot distinguish from a real hit.

**What this already found.** Generating this client surfaced #423: both overloads of a bound operation produced the same Q-object name, so the generated file did not compile. That is now fixed on main. The suite then found a second bug, in the test server: the `Search(Term, MaxResults)` overload was reachable but its parameter never bound, so it silently returned the unlimited result — fixed in odata2ts/test-server-asp-net.

29 tests, green against the published image.
