### PR TITLE
test: prove query options in the request body against a real server

### DIFF
--- a/examples/main/int-test/trippin/TrippinRwIntegration.test.ts
+++ b/examples/main/int-test/trippin/TrippinRwIntegration.test.ts
@@ -121,27 +121,4 @@ describe("Integration Testing of Service Generation", () => {
 
     await trippinService.airports("LIRA").patch({ name: originalName }).execute();
   });
-
-  /**
-   * Skipped because this service does not implement "$query" at all: POST to it answers with 500
-   * ("Value cannot be null. Parameter name: type"), regardless of the request body, while the equivalent
-   * plain GET works. So it cannot tell a correct request from a broken one - see the double quoting of
-   * https://github.com/odata2ts/odata2ts/issues/383, which went unnoticed for exactly that reason.
-   *
-   * To be enabled once we run our own test servers.
-   */
-  test.skip("GET as POST request", async () => {
-    const candidate = trippinService.people("russellwhyte").query((builder) => builder.select("userName"));
-
-    expect(candidate.asPostRequest().getInfoConverted()).toMatchObject({
-      method: "POST",
-      url: BASE_URL + "/People('russellwhyte')/$query",
-      data: "%24select=UserName",
-    });
-
-    const result = await candidate.asPostRequest().execute();
-
-    expect(result.status).toBe(200);
-    expect(result.data).toBeDefined();
-  });
 });

--- a/int-test/asp-net/README.md
+++ b/int-test/asp-net/README.md
@@ -25,6 +25,13 @@ only, against fixtures - and a fixture cannot show that the link actually moved 
 file asserts the round trip _and_ that the previously linked entity is left untouched, because getting
 that wrong is silent: the server answers 204 either way.
 
+**Query options in the request body.** `test/feature/QueryInRequestBody.test.ts` proves odata2ts#383:
+`asPostRequest()` moves the query string into a `text/plain` body of `POST <resource>/$query`. It is the
+only end-to-end coverage the feature has, because the live Trippin service does not implement `$query` -
+it answers 500 to any POST against it, whatever the body, and so cannot tell a correct request from a
+broken one. The file also covers the case the feature exists for: a query whose URL exceeds the server's
+8 KB request line, rejected as a GET and answered as a POST.
+
 **Operation overloads.** The reference model carries two overload pairs, and generating this client is
 what surfaced odata2ts#423 - both overloads produced the same Q-object name, so the generated file did
 not compile. `test/core/Operations.test.ts` covers the resulting behaviour.

--- a/int-test/asp-net/test/feature/QueryInRequestBody.test.ts
+++ b/int-test/asp-net/test/feature/QueryInRequestBody.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "vitest";
+import { BASE_URL, BOOK_DER_PROZESS, LIBRARY } from "../LibraryTestConstants.js";
+
+/**
+ * Query options in the request body - odata2ts issue #383 - end to end against a real server.
+ *
+ * `asPostRequest()` turns a read request into `POST <resource>/$query` carrying the query string as a
+ * `text/plain` body. The point of the feature is the request that a URL cannot carry at all, so the last
+ * test builds exactly that: the same query is rejected as a GET and answered as a POST.
+ *
+ * This is the first server we can prove it against, and therefore the only place the feature is covered
+ * end to end: the live Trippin service does not implement `$query` and answers 500 to any POST against
+ * it, whatever the body - it cannot tell a correct request from a broken one. The test that used to sit
+ * in `examples/main/int-test`, permanently skipped for that reason, is gone.
+ */
+describe("ASP.NET Library: query options in the request body", () => {
+  test("the read request is rewritten into POST <resource>/$query", () => {
+    const candidate = LIBRARY.Media(BOOK_DER_PROZESS).query((builder) => builder.select("Title"));
+
+    expect(candidate.getInfo()).toMatchObject({
+      method: "GET",
+      url: `${BASE_URL}/Media(${BOOK_DER_PROZESS})?%24select=Title`,
+    });
+    expect(candidate.asPostRequest().getInfoConverted()).toMatchObject({
+      method: "POST",
+      url: `${BASE_URL}/Media(${BOOK_DER_PROZESS})/$query`,
+      headers: { "Content-Type": "text/plain" },
+      data: "%24select=Title",
+    });
+  });
+
+  test("$select in the body is applied", async () => {
+    const result = await LIBRARY.Media(BOOK_DER_PROZESS)
+      .query((builder) => builder.select("Title"))
+      .asPostRequest()
+      .execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.Title).toBe("Der Prozess");
+    expect(result.data.Language).toBeUndefined();
+  });
+
+  test("$filter in the body is applied, not silently ignored", async () => {
+    // A server that routes the request but drops the body answers 200 with the *unfiltered* set, which is
+    // indistinguishable from a genuine result unless the assertion pins the narrowing down - so it does.
+    const all = await LIBRARY.Media()
+      .query((builder) => builder.count().top(0))
+      .execute();
+
+    const filtered = await LIBRARY.Media()
+      .query((builder, qMedium) => builder.filter(qMedium.Language.eq("de")))
+      .asPostRequest()
+      .execute();
+
+    expect(filtered.status).toBe(200);
+    expect(filtered.data.value.length).toBeGreaterThan(0);
+    expect(filtered.data.value.length).toBeLessThan(Number(all.data["@odata.count"]));
+    expect(filtered.data.value.every((medium) => medium.Language === "de")).toBe(true);
+  });
+
+  test("the body carries a query the URL is too long for", async () => {
+    // The reason the feature exists. Ten titles of ~860 characters each push the encoded URL past
+    // Kestrel's 8 KB request-line limit, while the expression stays below OData's node-count limit of 100
+    // - so the *only* thing that differs between the two requests is where the query travels.
+    const longTitles = Array.from({ length: 10 }, (_, i) => `${"a long book title ".repeat(48)}${i}`);
+    const candidate = LIBRARY.Media().query((builder, qMedium) =>
+      builder.filter(longTitles.map((title) => qMedium.Title.eq(title)).reduce((all, term) => all.or(term))),
+    );
+
+    expect(candidate.getUrl().length).toBeGreaterThan(8192);
+    await expect(candidate.execute()).rejects.toThrow();
+
+    const result = await candidate.asPostRequest().execute();
+
+    expect(result.status).toBe(200);
+    // No such title exists: an empty result proves the filter was parsed, an error would prove nothing.
+    expect(result.data.value).toStrictEqual([]);
+  });
+
+  test("without query options the request stays a plain GET", async () => {
+    // Nothing to move into a body, and `/$query` with an empty one is pointless - so `asPostRequest()`
+    // deliberately does nothing here. Asserted end to end, because a server would answer 200 either way.
+    const candidate = LIBRARY.Media(BOOK_DER_PROZESS).query();
+
+    expect(candidate.asPostRequest().getInfoConverted()).toMatchObject({
+      method: "GET",
+      url: `${BASE_URL}/Media(${BOOK_DER_PROZESS})`,
+    });
+
+    const result = await candidate.asPostRequest().execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.Title).toBe("Der Prozess");
+  });
+});


### PR DESCRIPTION
- new `int-test/asp-net/test/feature/QueryInRequestBody.test.ts`: `asPostRequest()` (#383) end to end against the ASP.NET Core server - the rewrite into `POST <resource>/$query`, `$select` and `$filter` actually applied, and `asPostRequest()` staying a no-op without query options
- covers the case the feature exists for: 10 title literals push the encoded URL past the server's 8 KB request line, so the same query is refused as a GET (`414`) and answered as a POST
- `$filter` is asserted to narrow the result, not just to answer 200 - a server that routes the request but drops the body is otherwise indistinguishable from a working one
- removed the permanently skipped `GET as POST request` from `examples/main/int-test`: the live Trippin service does not implement `$query` and answers 500 to any POST against it, so it can never prove anything
- required test-server-asp-net#2 (`UseODataQueryRequest()`), merged and `latest` republished; without it the three server-side tests fail with `405`