### PR TITLE
fix(int-test): always pull the server image behind a moving tag

### DIFF
--- a/int-test/asp-net/test/globalSetup.ts
+++ b/int-test/asp-net/test/globalSetup.ts
@@ -1,4 +1,4 @@
-import { GenericContainer, StartedTestContainer, Wait } from "testcontainers";
+import { GenericContainer, PullPolicy, StartedTestContainer, Wait } from "testcontainers";
 import type { TestProject } from "vitest/node";
 
 /**
@@ -16,7 +16,8 @@ import type { TestProject } from "vitest/node";
  * The image is language-agnostic on purpose: further servers (Java, ...) implement the same
  * standardized model and only differ in the image name, so this file is the single point that changes.
  */
-const IMAGE = process.env.ASPNET_SERVER_IMAGE ?? "ghcr.io/odata2ts/test-server-asp-net:latest";
+const CUSTOM_IMAGE = process.env.ASPNET_SERVER_IMAGE;
+const IMAGE = CUSTOM_IMAGE ?? "ghcr.io/odata2ts/test-server-asp-net:latest";
 const SERVICE_PATH = "/odata/v4/library";
 const CONTAINER_PORT = 4004;
 
@@ -29,15 +30,24 @@ export default async function setup(project: TestProject) {
 
   let container: StartedTestContainer;
   try {
-    container = await new GenericContainer(IMAGE)
+    let candidate = new GenericContainer(IMAGE)
       .withExposedPorts(CONTAINER_PORT)
-      .withWaitStrategy(Wait.forHttp(`${SERVICE_PATH}/`, CONTAINER_PORT).forStatusCode(200))
-      .start();
+      .withWaitStrategy(Wait.forHttp(`${SERVICE_PATH}/`, CONTAINER_PORT).forStatusCode(200));
+
+    // Testcontainers keeps a locally present image, and `latest` moves - so once the tag has been pulled,
+    // every later run silently tests against that old server. The failures this produces look exactly
+    // like client bugs, which costs far more than the digest check this saves. An image named explicitly
+    // is left alone: that one may well have been built locally and not exist in any registry.
+    if (!CUSTOM_IMAGE) {
+      candidate = candidate.withPullPolicy(PullPolicy.alwaysPull());
+    }
+
+    container = await candidate.start();
   } catch (e) {
     throw new Error(
       `Could not start the test server container "${IMAGE}".\n` +
         `Is a Docker daemon running? Without Docker, run against a server you started yourself:\n` +
-        `  LIBRARY_BASE_URL=http://localhost:4004${SERVICE_PATH} yarn int-test:cap\n` +
+        `  LIBRARY_BASE_URL=http://localhost:4004${SERVICE_PATH} yarn int-test:asp-net\n` +
         `Original error: ${e instanceof Error ? e.message : String(e)}`,
       { cause: e },
     );

--- a/int-test/cap/test/globalSetup.ts
+++ b/int-test/cap/test/globalSetup.ts
@@ -1,4 +1,4 @@
-import { GenericContainer, StartedTestContainer, Wait } from "testcontainers";
+import { GenericContainer, PullPolicy, StartedTestContainer, Wait } from "testcontainers";
 import type { TestProject } from "vitest/node";
 
 /**
@@ -16,7 +16,8 @@ import type { TestProject } from "vitest/node";
  * The image is language-agnostic on purpose: future servers (ASP.NET, Java, ...) implement the same
  * standardized model and only differ in the image name, so this file is the single point that changes.
  */
-const IMAGE = process.env.CAP_SERVER_IMAGE ?? "ghcr.io/odata2ts/test-server-cap:latest";
+const CUSTOM_IMAGE = process.env.CAP_SERVER_IMAGE;
+const IMAGE = CUSTOM_IMAGE ?? "ghcr.io/odata2ts/test-server-cap:latest";
 const SERVICE_PATH = "/odata/v4/library";
 const CONTAINER_PORT = 4004;
 
@@ -29,10 +30,19 @@ export default async function setup(project: TestProject) {
 
   let container: StartedTestContainer;
   try {
-    container = await new GenericContainer(IMAGE)
+    let candidate = new GenericContainer(IMAGE)
       .withExposedPorts(CONTAINER_PORT)
-      .withWaitStrategy(Wait.forHttp(`${SERVICE_PATH}/`, CONTAINER_PORT).forStatusCode(200))
-      .start();
+      .withWaitStrategy(Wait.forHttp(`${SERVICE_PATH}/`, CONTAINER_PORT).forStatusCode(200));
+
+    // Testcontainers keeps a locally present image, and `latest` moves - so once the tag has been pulled,
+    // every later run silently tests against that old server. The failures this produces look exactly
+    // like client bugs, which costs far more than the digest check this saves. An image named explicitly
+    // is left alone: that one may well have been built locally and not exist in any registry.
+    if (!CUSTOM_IMAGE) {
+      candidate = candidate.withPullPolicy(PullPolicy.alwaysPull());
+    }
+
+    container = await candidate.start();
   } catch (e) {
     throw new Error(
       `Could not start the test server container "${IMAGE}".\n` +


### PR DESCRIPTION
The six ASP.NET failures were not failures of this repository: the local Docker image was stale.

`test-server-asp-net` fixed all three causes on the server side - `feat: accept query options in the request body` and `fix: serve DELETE for streams and copies, and stop dropping copy properties` - and published a new image. Testcontainers, however, keeps an image that is already present locally, and both servers are addressed by `latest`. So a machine that pulled the tag once keeps testing against that old server forever. With the current image all 83 tests pass, without a single change to odata2ts.

What that costs is the point: the symptoms were a 405 on `POST /$query`, a 405 on `DELETE` of a stream property and three properties silently dropped on create - each of which reads exactly like a client bug, and I chased them as such before curl against the container showed the server answering that way all by itself.

- both global setups pull the image before starting the container, so a moving tag cannot go stale
- an image named explicitly via `ASPNET_SERVER_IMAGE` / `CAP_SERVER_IMAGE` keeps the old behaviour: that one may have been built locally and need not exist in any registry
- fixed the copy-paste in the asp-net failure hint, which suggested `yarn int-test:cap`

CI is unaffected - a fresh runner has nothing cached - this is purely about local runs.