### PR TITLE
feat(odata2ts): navigation properties in editable models for deep insert and deep update

### DIFF
--- a/int-test/asp-net/odata2ts.config.ts
+++ b/int-test/asp-net/odata2ts.config.ts
@@ -22,6 +22,9 @@ const config: ConfigFileOptions = {
   // on, because the property services are a generator feature of their own and otherwise never
   // meet a real server: see test/feature/PropertyServices.test.ts
   enablePrimitivePropertyServices: true,
+  // on, because a deep insert can only be proven against a server that actually stores the nested
+  // entities: see test/feature/DeepInsert.test.ts
+  enableDeepInsertProps: true,
   services: {
     library: {
       serviceName: "Library",

--- a/int-test/asp-net/test/feature/DeepInsert.test.ts
+++ b/int-test/asp-net/test/feature/DeepInsert.test.ts
@@ -1,0 +1,128 @@
+import { HttpResponseModel } from "@odata2ts/http-client-api";
+import { ODataModelResponseV4 } from "@odata2ts/odata-core";
+import { describe, expect, expectTypeOf, test } from "vitest";
+import { Book, Member } from "../../src-generated/library/LibraryModel.js";
+import { BASE_URL, LIBRARY } from "../LibraryTestConstants.js";
+
+/**
+ * Deep insert - odata2ts issue #237 - against a server that actually stores the nested entities.
+ *
+ * With `enableDeepInsertProps` the navigation properties show up on the editable models, typed as the
+ * editable model of the related entity. That the payload nests is only half the feature: the nested
+ * entities have to be *created and linked* on the other side, which is what a fixture cannot show and
+ * these tests can.
+ *
+ * The client is generated for OData 4.0, so a binding is spelled `Nav@odata.bind` and stays a separate
+ * property - a deep insert and a binding can therefore be sent side by side, which the last test does.
+ */
+describe("ASP.NET Library: deep insert", () => {
+  /** The server assigns the keys here, so each test reads back what it created rather than a fixture id. */
+  async function copiesOf(mediumId: string) {
+    const response = await LIBRARY.Media(mediumId)
+      .query((builder) => builder.expanding("Copies", (copy) => copy))
+      .execute();
+    return response.data.Copies ?? [];
+  }
+
+  test("a single-valued navigation property is created along with the entity", async () => {
+    const uploadedAt = "2026-08-02T10:00:00Z";
+
+    const created = await LIBRARY.Members()
+      .create({
+        Name: "Deep Insert Member",
+        Balance: 0,
+        PreviousAddresses: [],
+        // no key: it is generated on the server side and therefore no part of the editable model
+        IdDocument: { UploadedAt: uploadedAt },
+      })
+      .execute();
+
+    expect(created.status).toBe(201);
+    expectTypeOf(created).toEqualTypeOf<HttpResponseModel<ODataModelResponseV4<Member>>>();
+
+    // the decisive part: the nested entity exists on the other side and is linked to its parent
+    const read = await LIBRARY.Members(created.data.Id)
+      .query((builder) => builder.expanding("IdDocument", (doc) => doc))
+      .execute();
+
+    expect(read.data.IdDocument).toBeDefined();
+    expect(read.data.IdDocument?.UploadedAt).toContain("2026-08-02T10:00:00");
+  });
+
+  test("a collection-valued navigation property is created along with the entity", async () => {
+    const inventoryNumber = 9601;
+
+    const created = await LIBRARY.Media()
+      .asBookCollectionService()
+      .create({
+        Title: "Deep Insert Book",
+        Language: "de",
+        PageCount: 123,
+        AgeRating: 0,
+        ISBN: "9780000009601",
+        Copies: [
+          {
+            // The parent key is part of the copy's composite key, so the editable model demands it - but
+            // the entity it refers to does not exist yet. The server derives it from the parent and
+            // overwrites whatever was sent, which is asserted below.
+            MediumId: "00000000-0000-0000-0000-000000000000",
+            InventoryNumber: inventoryNumber,
+            Condition: 1,
+            IsLoanable: true,
+            WeightKg: 0.5,
+          },
+        ],
+      })
+      .execute();
+
+    expect(created.status).toBe(201);
+    expectTypeOf(created).toEqualTypeOf<HttpResponseModel<ODataModelResponseV4<Book>>>();
+
+    const copies = await copiesOf(created.data.Id);
+
+    expect(copies).toHaveLength(1);
+    expect(copies[0].InventoryNumber).toBe(inventoryNumber);
+    // not the zero guid that was sent: the nested entity belongs to the entity it arrived with
+    expect(copies[0].MediumId).toBe(created.data.Id);
+  });
+
+  test("a deep insert and a binding travel in the same payload", async () => {
+    // The two features are independent, and in 4.0 they are separate properties, so one payload can
+    // create a new entity for one navigation property and point at an existing one for another.
+    const branches = await LIBRARY.Branches()
+      .query((builder) => builder.top(1))
+      .execute();
+    const branchId = branches.data.value[0].Id;
+
+    const created = await LIBRARY.Media()
+      .asBookCollectionService()
+      .create({
+        Title: "Deep Insert With Binding",
+        Language: "de",
+        PageCount: 42,
+        AgeRating: 0,
+        ISBN: "9780000009602",
+        Copies: [
+          {
+            MediumId: "00000000-0000-0000-0000-000000000000",
+            InventoryNumber: 9602,
+            Condition: 1,
+            IsLoanable: true,
+            WeightKg: 0.5,
+            "Location@odata.bind": `${BASE_URL}/Branches(${branchId})`,
+          },
+        ],
+      })
+      .execute();
+
+    expect(created.status).toBe(201);
+
+    const copies = await copiesOf(created.data.Id);
+    const copy = await LIBRARY.Copies({ MediumId: created.data.Id, InventoryNumber: copies[0].InventoryNumber })
+      .query((builder) => builder.expanding("Location", (location) => location))
+      .execute();
+
+    // the copy was created by the deep insert, its branch was bound to an already existing one
+    expect(copy.data.Location?.Id).toBe(branchId);
+  });
+});

--- a/int-test/cap/odata2ts.config.ts
+++ b/int-test/cap/odata2ts.config.ts
@@ -19,6 +19,9 @@ const config: ConfigFileOptions = {
   // on, because the property services are a generator feature of their own and otherwise never
   // meet a real server: see test/feature/PropertyServices.test.ts
   enablePrimitivePropertyServices: true,
+  // on, because a deep insert can only be proven against a server that actually stores the nested
+  // entities: see test/feature/DeepInsert.test.ts
+  enableDeepInsertProps: true,
   services: {
     library: {
       serviceName: "Library",

--- a/int-test/cap/resource/library.xml
+++ b/int-test/cap/resource/library.xml
@@ -281,6 +281,7 @@
           <OnDelete Action="Cascade"/>
         </NavigationProperty>
         <NavigationProperty Name="IdDocument" Type="Library.Service.IdDocuments">
+          <OnDelete Action="Cascade"/>
           <ReferentialConstraint Property="IdDocument_Id" ReferencedProperty="Id"/>
         </NavigationProperty>
         <Property Name="IdDocument_Id" Type="Edm.Guid"/>

--- a/int-test/cap/test/feature/DeepInsert.test.ts
+++ b/int-test/cap/test/feature/DeepInsert.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "vitest";
+import { LIBRARY } from "../LibraryTestConstants.js";
+
+/**
+ * Deep insert - odata2ts issue #237 - against CAP.
+ *
+ * The same feature as in `int-test/asp-net`, and the generated types look the same, but CAP draws a line
+ * the client cannot see in the metadata: a **composition** takes its children along, a plain
+ * **association** does not. `Audiobooks` owns its `Chapters` (CAP marks that with the `up_` backlink,
+ * which is why it shows up in the model at all), while `Copies` merely reference their medium.
+ *
+ * The second test pins the awkward half of that: a payload for an association is accepted with 201 and
+ * then quietly dropped. Nothing on the client side can turn that into an error - which is exactly why
+ * it is written down here.
+ */
+describe("CAP Library: deep insert", () => {
+  test("a composition is created along with the entity", async () => {
+    // CAP does not generate this key, unlike the ones of the entity sets themselves
+    const chapterId = Math.floor(Math.random() * 1_000_000) + 900_000;
+
+    const created = await LIBRARY.Audiobooks()
+      .create({
+        Title: "Deep Insert Audiobook",
+        Language: "de",
+        // Edm.Duration, so a string - not a number
+        Duration: "PT1H",
+        Narrator: "Some Narrator",
+        // up__Id is the backlink to the parent, which does not exist yet - CAP fills it in and overwrites
+        // whatever was sent, but the editable model demands it, since it is a plain required property
+        Chapters: [{ Id: chapterId, up__Id: "00000000-0000-0000-0000-000000000000", Title: "First chapter" }],
+      })
+      .execute();
+
+    expect(created.status).toBe(201);
+
+    const read = await LIBRARY.Audiobooks(created.data.Id)
+      .query((builder) => builder.expanding("Chapters", (chapter) => chapter))
+      .execute();
+
+    expect(read.data.Chapters).toHaveLength(1);
+    expect(read.data.Chapters?.[0].Title).toBe("First chapter");
+    // the backlink CAP maintains for a composition, filled in from the parent
+    expect(read.data.Chapters?.[0].up__Id).toBe(created.data.Id);
+  });
+
+  test("an association is accepted and then dropped", async () => {
+    // `Copies` is an association here, not a composition, so CAP takes the payload, answers 201 and
+    // creates nothing. ASP.NET does create the copy - the model cannot express the difference, so the
+    // same generated type behaves differently per server.
+    const created = await LIBRARY.Books()
+      .create({
+        Title: "Deep Insert Book",
+        Language: "de",
+        PageCount: 123,
+        AgeRating: 0,
+        ISBN: "9780000009801",
+        Copies: [
+          {
+            MediumId: "00000000-0000-0000-0000-000000000000",
+            InventoryNumber: 9801,
+            IsLoanable: true,
+          },
+        ],
+      })
+      .execute();
+
+    expect(created.status).toBe(201);
+
+    const read = await LIBRARY.Books(created.data.Id)
+      .query((builder) => builder.expanding("Copies", (copy) => copy))
+      .execute();
+
+    expect(read.data.Copies).toStrictEqual([]);
+  });
+});

--- a/int-test/cap/test/feature/DeepInsert.test.ts
+++ b/int-test/cap/test/feature/DeepInsert.test.ts
@@ -10,20 +10,53 @@ import { LIBRARY } from "../LibraryTestConstants.js";
  * design and not a trait of this server - a composition is a contained-in relationship, where operations
  * cascade, while an association is a plain reference that does not.
  *
- * What the three tests pin is how that rule *presents itself*, which differs by cardinality:
+ * What these tests pin is how that rule *presents itself*, and the decisive pairing is the middle two:
+ * the cardinality is the same, only the relationship kind differs.
  *
- * - **composition** (`Audiobooks/Chapters`): the children are created and linked
+ * - **to-many composition** (`Audiobooks/Chapters`): the children are created and linked
+ * - **to-one composition** (`Members/IdDocument`): the child is created — nested non-key properties and
+ *   all
+ * - **to-one association** (`Copies/Location`): the very same shape is a **400**. The foreign key sits
+ *   on this entity, so CAP can act, but only on a nested object containing nothing but the key
  * - **to-many association** (`Books/Copies`): 201, and the nested data is dropped without a word. The
  *   payload is not even validated - a property that exists nowhere passes just as quietly
- * - **to-one association** (`Copies/Location`): the foreign key sits on this entity, so CAP can act -
- *   but only on a nested object containing nothing but the key. Anything else is a 400
  *
- * The two association cases are the reason this file is worth its length: the same generated property
- * silently does nothing in one case and fails loudly in the other, and ASP.NET creates the entity in
- * both. `enableDeepInsertProps` therefore says what the *protocol* allows, not what a given server does.
+ * The association cases are why this file is worth its length: the same generated property creates an
+ * entity, silently does nothing, or fails loudly, depending on something `$metadata` does not carry -
+ * and ASP.NET creates the entity in all of them. `enableDeepInsertProps` therefore says what the
+ * *protocol* allows, not what a given server does with it.
  */
 describe("CAP Library: deep insert", () => {
-  test("a composition is created along with the entity", async () => {
+  test("a to-one composition is created along with the entity", async () => {
+    // The counterpart to the to-one *association* below, and the reason `Member.IdDocument` is modelled
+    // as a composition on that server: an identity document belongs to exactly one member. Nothing in
+    // the metadata distinguishes the two - the payload here is what the association refuses with 400.
+    const uploadedAt = "2026-08-02T10:00:00Z";
+    const name = `Deep Insert Member ${Date.now()}`;
+
+    const created = await LIBRARY.Members()
+      .create({
+        Name: name,
+        // no key: CAP generates it, so it is no part of the editable model
+        IdDocument: { UploadedAt: uploadedAt },
+      })
+      .execute();
+
+    expect(created.status).toBe(201);
+
+    // Looked up by name rather than by `created.data.Id`: for an entity whose key is a *generated
+    // integer* CAP answers the create with an entirely different row (the first one), so the response
+    // does not describe what was just created. Entities with a UUID key answer correctly.
+    const read = await LIBRARY.Members()
+      .query((builder, qMember) => builder.filter(qMember.Name.eq(name)).expanding("IdDocument", (doc) => doc))
+      .execute();
+
+    expect(read.data.value).toHaveLength(1);
+    expect(read.data.value[0].IdDocument).toBeDefined();
+    expect(read.data.value[0].IdDocument?.UploadedAt).toContain("2026-08-02T10:00:00");
+  });
+
+  test("a to-many composition is created along with the entity", async () => {
     // CAP does not generate this key, unlike the ones of the entity sets themselves
     const chapterId = Math.floor(Math.random() * 1_000_000) + 900_000;
 

--- a/int-test/cap/test/feature/DeepInsert.test.ts
+++ b/int-test/cap/test/feature/DeepInsert.test.ts
@@ -1,17 +1,26 @@
 import { describe, expect, test } from "vitest";
+import { expectODataError } from "../expectODataError.js";
 import { LIBRARY } from "../LibraryTestConstants.js";
 
 /**
  * Deep insert - odata2ts issue #237 - against CAP.
  *
  * The same feature as in `int-test/asp-net`, and the generated types look the same, but CAP draws a line
- * the client cannot see in the metadata: a **composition** takes its children along, a plain
- * **association** does not. `Audiobooks` owns its `Chapters` (CAP marks that with the `up_` backlink,
- * which is why it shows up in the model at all), while `Copies` merely reference their medium.
+ * the client cannot see in the metadata: deep operations run along **compositions** only. That is by
+ * design and not a trait of this server - a composition is a contained-in relationship, where operations
+ * cascade, while an association is a plain reference that does not.
  *
- * The second test pins the awkward half of that: a payload for an association is accepted with 201 and
- * then quietly dropped. Nothing on the client side can turn that into an error - which is exactly why
- * it is written down here.
+ * What the three tests pin is how that rule *presents itself*, which differs by cardinality:
+ *
+ * - **composition** (`Audiobooks/Chapters`): the children are created and linked
+ * - **to-many association** (`Books/Copies`): 201, and the nested data is dropped without a word. The
+ *   payload is not even validated - a property that exists nowhere passes just as quietly
+ * - **to-one association** (`Copies/Location`): the foreign key sits on this entity, so CAP can act -
+ *   but only on a nested object containing nothing but the key. Anything else is a 400
+ *
+ * The two association cases are the reason this file is worth its length: the same generated property
+ * silently does nothing in one case and fails loudly in the other, and ASP.NET creates the entity in
+ * both. `enableDeepInsertProps` therefore says what the *protocol* allows, not what a given server does.
  */
 describe("CAP Library: deep insert", () => {
   test("a composition is created along with the entity", async () => {
@@ -71,5 +80,45 @@ describe("CAP Library: deep insert", () => {
       .execute();
 
     expect(read.data.Copies).toStrictEqual([]);
+  });
+
+  test("a to-one association refuses everything but its key", async () => {
+    // The other half of the same rule, and the louder one: for a to-one association the foreign key sits
+    // on *this* entity, so CAP can act on a nested object - but only if it contains nothing but the key,
+    // which then sets that foreign key. Any other property is refused.
+    //
+    // The generated deep insert prop cannot express that at all: `EditableBranches` requires `Name`,
+    // while `Id` is server-generated and therefore absent. The flattened foreign key `Location_Id` is
+    // the route that works here - which is why this test exists rather than a working one.
+    const branches = await LIBRARY.Branches()
+      .query((builder) => builder.top(1))
+      .execute();
+    const branchId = branches.data.value[0].Id;
+
+    await expectODataError(
+      LIBRARY.Copies()
+        .create({
+          MediumId: "00000000-0000-0000-0000-000000000000",
+          InventoryNumber: 9802,
+          IsLoanable: true,
+          Location: { Name: "Branch Created On The Fly" },
+        })
+        .execute(),
+      // CAP names the navigation property here, not the entity behind it
+      { status: 400, message: /Property "Name" does not exist in Location/ },
+    );
+
+    // the foreign key does what the nested object cannot
+    const created = await LIBRARY.Copies()
+      .create({
+        MediumId: "00000000-0000-0000-0000-000000000000",
+        InventoryNumber: 9803,
+        IsLoanable: true,
+        Location_Id: branchId,
+      })
+      .execute();
+
+    expect(created.status).toBe(201);
+    expect(created.data.Location_Id).toBe(branchId);
   });
 });

--- a/packages/odata2ts/src/FactoryFunctionModel.ts
+++ b/packages/odata2ts/src/FactoryFunctionModel.ts
@@ -43,6 +43,8 @@ export type GeneratorFunctionOptions = Pick<
   | "enableNativeInOperator"
   | "odataVersionV4"
   | "enableBindingProps"
+  | "enableDeepInsertProps"
+  | "v2EditableModelsWithExtraResultsWrapping"
 >;
 
 export type EntityBasedGeneratorFunction = (

--- a/packages/odata2ts/src/OptionModel.ts
+++ b/packages/odata2ts/src/OptionModel.ts
@@ -232,6 +232,18 @@ export interface ConfigFileOptions extends Omit<CliOptions, "sourceUrl" | "sourc
    */
   v2ModelsWithExtraResultsWrapping?: boolean;
   /**
+   * The counterpart of <code>v2ModelsWithExtraResultsWrapping</code> for the editable models: collection
+   * valued navigation properties of a deep insert are wrapped into an extra object with the property
+   * "results", as some V2 services expect it.
+   *
+   * Deliberately its own option, since a service which answers with the extra wrapping does not
+   * necessarily expect it in a request payload - see odata2ts issue #237.
+   *
+   * Like its counterpart this option is only valid if the generation mode is set to <code>models</code>;
+   * it is ignored otherwise.
+   */
+  v2EditableModelsWithExtraResultsWrapping?: boolean;
+  /**
    * Numbers of type `Edm.Int64` and `Edm.Decimal` are represented as `number` in V4.
    * However, these numbers might not fit into JS' number type, which might result in precision loss.
    *
@@ -307,18 +319,6 @@ export interface ConfigFileOptions extends Omit<CliOptions, "sourceUrl" | "sourc
    * Opt-in, so by default the editable models contain no navigation property at all.
    */
   enableDeepInsertProps?: boolean;
-  /**
-   * The counterpart of <code>v2ModelsWithExtraResultsWrapping</code> for the editable models: collection
-   * valued navigation properties of a deep insert are wrapped into an extra object with the property
-   * "results", as some V2 services expect it.
-   *
-   * Deliberately its own option, since a service which answers with the extra wrapping does not
-   * necessarily expect it in a request payload - see odata2ts issue #237.
-   *
-   * Like its counterpart this option is only valid if the generation mode is set to <code>models</code>;
-   * it is ignored otherwise.
-   */
-  v2EditableModelsWithExtraResultsWrapping?: boolean;
 }
 
 /**

--- a/packages/odata2ts/src/OptionModel.ts
+++ b/packages/odata2ts/src/OptionModel.ts
@@ -293,6 +293,32 @@ export interface ConfigFileOptions extends Omit<CliOptions, "sourceUrl" | "sourc
    * Opt-in, so by default no such property is generated.
    */
   enableBindingProps?: boolean;
+  /**
+   * Adds the navigation properties to the editable models, typed as the editable model of the related
+   * entity, which is what a deep insert (POST) or a deep update (PATCH / PUT) sends: the related entities
+   * travel within the payload of the entity they belong to, instead of being created by requests of their
+   * own.
+   *
+   * Together with <code>enableBindingProps</code> a navigation property accepts either shape - a new
+   * entity or a reference to an existing one. In V2 and OData 4.01 a binding goes by the very name of the
+   * navigation property, so there the property is typed as the union of both; 4.0 has a name of its own
+   * for it ({@code "Author@odata.bind"}) and therefore keeps them apart.
+   *
+   * Opt-in, so by default the editable models contain no navigation property at all.
+   */
+  enableDeepInsertProps?: boolean;
+  /**
+   * The counterpart of <code>v2ModelsWithExtraResultsWrapping</code> for the editable models: collection
+   * valued navigation properties of a deep insert are wrapped into an extra object with the property
+   * "results", as some V2 services expect it.
+   *
+   * Deliberately its own option, since a service which answers with the extra wrapping does not
+   * necessarily expect it in a request payload - see odata2ts issue #237.
+   *
+   * Like its counterpart this option is only valid if the generation mode is set to <code>models</code>;
+   * it is ignored otherwise.
+   */
+  v2EditableModelsWithExtraResultsWrapping?: boolean;
 }
 
 /**

--- a/packages/odata2ts/src/defaultConfig.ts
+++ b/packages/odata2ts/src/defaultConfig.ts
@@ -104,6 +104,8 @@ const defaultConfig: DefaultConfiguration = {
   enableNativeInOperator: false,
   odataVersionV4: "4.0",
   enableBindingProps: false,
+  enableDeepInsertProps: false,
+  v2EditableModelsWithExtraResultsWrapping: false,
 };
 
 const { models, queryObjects, services } = defaultConfig.naming;

--- a/packages/odata2ts/src/evaluateConfig.ts
+++ b/packages/odata2ts/src/evaluateConfig.ts
@@ -1,5 +1,4 @@
 import deepmerge from "deepmerge";
-
 import { getDefaultConfig, getMinimalConfig } from "./defaultConfig.js";
 import { CliOptions, ConfigFileOptions, Modes, RunOptions } from "./OptionModel.js";
 
@@ -28,7 +27,7 @@ import { CliOptions, ConfigFileOptions, Modes, RunOptions } from "./OptionModel.
  */
 export function evaluateConfigOptions(
   cliOpts: CliOptions,
-  configOpts: ConfigFileOptions | undefined
+  configOpts: ConfigFileOptions | undefined,
 ): Array<RunOptions> {
   const defaultConfig = configOpts?.naming?.minimalDefaults ? getMinimalConfig() : getDefaultConfig();
   // No config file
@@ -47,7 +46,7 @@ export function evaluateConfigOptions(
   if ((source && output) || !confServices) {
     if (!source || !output) {
       throw new Error(
-        "No services were configured in config file, so options --source and --output must be specified!"
+        "No services were configured in config file, so options --source and --output must be specified!",
       );
     }
     const merged = deepmerge.all([defaultConfig, confBaseOpts, cliOpts]) as RunOptions;
@@ -79,9 +78,10 @@ function safeGuardOptions(options: RunOptions): RunOptions {
     options.skipIdModels = false;
     options.skipOperations = false;
   }
-  // special option which is only valid for model generation
+  // special options which are only valid for model generation
   if (options.mode !== Modes.models) {
     options.v2ModelsWithExtraResultsWrapping = false;
+    options.v2EditableModelsWithExtraResultsWrapping = false;
   }
 
   return options;

--- a/packages/odata2ts/src/generator/ModelGenerator.ts
+++ b/packages/odata2ts/src/generator/ModelGenerator.ts
@@ -254,7 +254,10 @@ class ModelGenerator {
       .map((p) => `"${p.name}"`)
       .join(" | ");
     const complexProps = allProps.filter((p) => p.dataType === DataTypes.ComplexType);
-    const bindingProps = allProps.filter((p) => this.isBindableNavProp(p)).map((p) => this.generateBindingProp(p));
+    const navProps = this.generateNavProps(
+      file.getImports(),
+      allProps.filter((p) => p.dataType === DataTypes.ModelType),
+    );
 
     const extendsClause = [
       requiredProps ? `Pick<${model.modelName}, ${requiredProps}>` : null,
@@ -275,7 +278,7 @@ class ModelGenerator {
             hasQuestionToken: !p.required || p.dataType === DataTypes.ModelType,
           };
         }),
-        ...bindingProps,
+        ...navProps,
       ],
     });
   }
@@ -292,35 +295,93 @@ class ModelGenerator {
   }
 
   /**
-   * Binding an existing entity to a navigation property, see odata2ts issue #38.
+   * The navigation properties of an editable model, which carry two independent, opt-in features:
    *
-   * The notation is dictated by the OData version which is targeted, and it is the notation itself which
-   * ends up on the wire, hence the OData name is used here and not the mapped one:
-   * - V2: {@code { "Category": { "__metadata": { "uri": "Categories(1)" } } }}
-   * - 4.0: {@code { "Category@odata.bind": "Categories(1)" }}
-   * - 4.01: {@code { "Category": { "@id": "Categories(1)" } }}
+   * - binding an existing entity to the navigation property (issue #38)
+   * - deep insert / deep update, i.e. the related entity travelling within this entity's payload (#237)
+   *
+   * They meet in V2 and 4.01, where a binding goes by the very name of the navigation property, so the
+   * property has to accept either shape there. 4.0 spells a binding as {@code "Category@odata.bind"} and
+   * therefore keeps the two apart.
+   *
+   * A binding is addressed by the OData name, since that notation ends up on the wire as it is - it is
+   * passed through the query object untouched. A deep insert is addressed by the mapped name instead:
+   * its payload *is* converted, so the property has to be the one the query object knows.
+   */
+  private generateNavProps(
+    imports: ImportContainer,
+    props: Array<PropertyModel>,
+  ): Array<OptionalKind<PropertySignatureStructure>> {
+    const isV2 = this.version === ODataVersions.V2;
+    const isV401 = !isV2 && this.options.odataVersionV4 === "4.01";
+    // in these versions a binding has no name of its own, so it shares the property with a deep insert
+    const bindingByPropName = isV2 || isV401;
+
+    return props.flatMap((prop) => {
+      const deepInsert = this.options.enableDeepInsertProps;
+      const bindable = this.isBindableNavProp(prop);
+
+      // one entry per resulting property name, so that renaming cannot merge what belongs apart
+      const byName = new Map<string, { shapes: Array<string>; docs: Array<string>; binds: boolean }>();
+      const collect = (name: string, shape: string, doc: string, binds: boolean) => {
+        const entry = byName.get(name) ?? { shapes: [], docs: [], binds: false };
+        entry.shapes.push(shape);
+        entry.docs.push(doc);
+        entry.binds ||= binds;
+        byName.set(name, entry);
+      };
+
+      if (deepInsert) {
+        const editableName = this.dataModel.getComplexType(prop.fqType)!.editableName;
+        collect(
+          prop.name,
+          imports.addGeneratedModel(prop.fqType, editableName),
+          `Create "${prop.name}" along with this entity (deep insert), or update it along with it (deep update).`,
+          false,
+        );
+      }
+      if (bindable) {
+        collect(
+          bindingByPropName ? prop.odataName : `${prop.odataName}@odata.bind`,
+          isV2 ? `{ __metadata: { uri: string } }` : isV401 ? `{ "@id": string }` : "string",
+          `Bind "${prop.name}" to an already existing entity by its URL.`,
+          true,
+        );
+      }
+
+      return [...byName.entries()].map(([name, { shapes, docs, binds }]) => {
+        return {
+          // the binding notation is no identifier, so the name must be quoted
+          name: `"${name}"`,
+          type: this.getNavPropType(prop, shapes, binds),
+          hasQuestionToken: true,
+          docs: this.options.skipComments ? undefined : [{ description: docs.join("\n") }],
+        };
+      });
+    });
+  }
+
+  /**
+   * Decorates the accepted shapes of a navigation property with cardinality and nullability.
    *
    * Removing a binding is only possible for a nullable single-valued navigation property, by setting it to
    * null. Collection-valued bind operations add to the collection, they never replace it, so there is
-   * nothing to remove with - that requires $ref, which odata2ts doesn't support yet.
+   * nothing to remove with - that requires $ref, which odata2ts doesn't support yet. A deep insert has no
+   * such notion at all, hence null is only offered on a property which actually accepts a binding - in 4.0
+   * that is the separate {@code @odata.bind} property, not the one carrying the nested entity.
    */
-  private generateBindingProp(prop: PropertyModel): OptionalKind<PropertySignatureStructure> {
-    const isV2 = this.version === ODataVersions.V2;
-    const isV401 = !isV2 && this.options.odataVersionV4 === "4.01";
+  private getNavPropType(prop: PropertyModel, shapes: Array<string>, bindable: boolean): string {
+    const singleType = shapes.join(" | ");
 
-    const name = isV2 || isV401 ? prop.odataName : `${prop.odataName}@odata.bind`;
-    const singleType = isV2 ? `{ __metadata: { uri: string } }` : isV401 ? `{ "@id": string }` : "string";
-    const type = prop.isCollection ? `Array<${singleType}>` : singleType + (prop.required ? "" : " | null");
+    if (prop.isCollection) {
+      const collectionType = `Array<${singleType}>`;
+      // some V2 services expect the extra results wrapping in the payload as well, see issue #237
+      return this.version === ODataVersions.V2 && this.options.v2EditableModelsWithExtraResultsWrapping
+        ? `{ results: ${collectionType} }`
+        : collectionType;
+    }
 
-    return {
-      // the notation is no identifier, so it must be quoted
-      name: `"${name}"`,
-      type,
-      hasQuestionToken: true,
-      docs: this.options.skipComments
-        ? undefined
-        : [{ description: `Bind "${prop.name}" to an already existing entity by its URL.` }],
-    };
+    return singleType + (bindable && !prop.required ? " | null" : "");
   }
 
   private getEditablePropType(imports: ImportContainer, prop: PropertyModel): string {

--- a/packages/odata2ts/test/evaluateConfig.test.ts
+++ b/packages/odata2ts/test/evaluateConfig.test.ts
@@ -286,4 +286,42 @@ describe("Config Evaluation Tests", () => {
       v2ModelsWithExtraResultsWrapping: false,
     });
   });
+
+  /**
+   * Both wrappings are a matter of the models alone: the generated client removes the extra wrapping
+   * from a response by itself, so a generated service must never see it in its types.
+   */
+  test("both extra wrapping options only survive in models mode", () => {
+    const cliOpts: CliOptions = { source: "source", output: "output" };
+    const wrappingOpts = {
+      v2ModelsWithExtraResultsWrapping: true,
+      v2EditableModelsWithExtraResultsWrapping: true,
+    };
+
+    [Modes.service, Modes.qobjects, Modes.all].forEach((mode) => {
+      const result = evaluateConfigOptions(cliOpts, { mode, ...wrappingOpts });
+
+      expect(result[0], `mode ${mode}`).toMatchObject({
+        v2ModelsWithExtraResultsWrapping: false,
+        v2EditableModelsWithExtraResultsWrapping: false,
+      });
+    });
+
+    const modelsResult = evaluateConfigOptions(cliOpts, { mode: Modes.models, ...wrappingOpts });
+    expect(modelsResult[0]).toMatchObject(wrappingOpts);
+  });
+
+  /**
+   * The deep insert props, unlike the wrapping, are meant for the generated services as well - that is
+   * where a deep insert is actually sent.
+   */
+  test("deep insert props survive every mode", () => {
+    const cliOpts: CliOptions = { source: "source", output: "output" };
+
+    [Modes.service, Modes.qobjects, Modes.all, Modes.models].forEach((mode) => {
+      const result = evaluateConfigOptions(cliOpts, { mode, enableDeepInsertProps: true });
+
+      expect(result[0], `mode ${mode}`).toMatchObject({ enableDeepInsertProps: true });
+    });
+  });
 });

--- a/packages/odata2ts/test/fixture/generator/model/entity-relationships-deep-insert-binding-v2.ts
+++ b/packages/odata2ts/test/fixture/generator/model/entity-relationships-deep-insert-binding-v2.ts
@@ -1,0 +1,22 @@
+import type { DeferredContent } from "@odata2ts/odata-core";
+
+export interface Author {
+  id: number;
+}
+
+export type AuthorId = number | { id: number };
+
+export interface EditableAuthor extends Pick<Author, "id"> {}
+
+export interface Book {
+  id: number;
+  author: Author | DeferredContent;
+  relatedAuthors: Array<Author> | DeferredContent;
+}
+
+export type BookId = number | { id: number };
+
+export interface EditableBook extends Pick<Book, "id"> {
+  author?: EditableAuthor | { __metadata: { uri: string } };
+  relatedAuthors?: Array<EditableAuthor | { __metadata: { uri: string } }>;
+}

--- a/packages/odata2ts/test/fixture/generator/model/entity-relationships-deep-insert-binding-v401.ts
+++ b/packages/odata2ts/test/fixture/generator/model/entity-relationships-deep-insert-binding-v401.ts
@@ -1,0 +1,23 @@
+export interface Author {
+  id: number;
+  name: boolean | null;
+}
+
+export type AuthorId = number | { id: number };
+
+export interface EditableAuthor extends Pick<Author, "id">, Partial<Pick<Author, "name">> {}
+
+export interface Book {
+  id: number;
+  author?: Author;
+  altAuthor?: Author | null;
+  relatedAuthors?: Array<Author>;
+}
+
+export type BookId = number | { id: number };
+
+export interface EditableBook extends Pick<Book, "id"> {
+  author?: EditableAuthor | { "@id": string };
+  altAuthor?: EditableAuthor | { "@id": string } | null;
+  relatedAuthors?: Array<EditableAuthor | { "@id": string }>;
+}

--- a/packages/odata2ts/test/fixture/generator/model/entity-relationships-deep-insert-binding.ts
+++ b/packages/odata2ts/test/fixture/generator/model/entity-relationships-deep-insert-binding.ts
@@ -1,0 +1,26 @@
+export interface Author {
+  id: number;
+  name: boolean | null;
+}
+
+export type AuthorId = number | { id: number };
+
+export interface EditableAuthor extends Pick<Author, "id">, Partial<Pick<Author, "name">> {}
+
+export interface Book {
+  id: number;
+  author?: Author;
+  altAuthor?: Author | null;
+  relatedAuthors?: Array<Author>;
+}
+
+export type BookId = number | { id: number };
+
+export interface EditableBook extends Pick<Book, "id"> {
+  author?: EditableAuthor;
+  "author@odata.bind"?: string;
+  altAuthor?: EditableAuthor;
+  "altAuthor@odata.bind"?: string | null;
+  relatedAuthors?: Array<EditableAuthor>;
+  "relatedAuthors@odata.bind"?: Array<string>;
+}

--- a/packages/odata2ts/test/fixture/generator/model/entity-relationships-deep-insert-v2-extra-wrapping.ts
+++ b/packages/odata2ts/test/fixture/generator/model/entity-relationships-deep-insert-v2-extra-wrapping.ts
@@ -1,0 +1,22 @@
+import type { DeferredContent } from "@odata2ts/odata-core";
+
+export interface Author {
+  id: number;
+}
+
+export type AuthorId = number | { id: number };
+
+export interface EditableAuthor extends Pick<Author, "id"> {}
+
+export interface Book {
+  id: number;
+  author: Author | DeferredContent;
+  relatedAuthors: Array<Author> | DeferredContent;
+}
+
+export type BookId = number | { id: number };
+
+export interface EditableBook extends Pick<Book, "id"> {
+  author?: EditableAuthor;
+  relatedAuthors?: { results: Array<EditableAuthor> };
+}

--- a/packages/odata2ts/test/fixture/generator/model/entity-relationships-deep-insert-v2-response-wrapping.ts
+++ b/packages/odata2ts/test/fixture/generator/model/entity-relationships-deep-insert-v2-response-wrapping.ts
@@ -1,0 +1,22 @@
+import type { DeferredContent } from "@odata2ts/odata-core";
+
+export interface Author {
+  id: number;
+}
+
+export type AuthorId = number | { id: number };
+
+export interface EditableAuthor extends Pick<Author, "id"> {}
+
+export interface Book {
+  id: number;
+  author: Author | DeferredContent;
+  relatedAuthors: { results: Array<Author> } | DeferredContent;
+}
+
+export type BookId = number | { id: number };
+
+export interface EditableBook extends Pick<Book, "id"> {
+  author?: EditableAuthor;
+  relatedAuthors?: Array<EditableAuthor>;
+}

--- a/packages/odata2ts/test/fixture/generator/model/entity-relationships-deep-insert-v2.ts
+++ b/packages/odata2ts/test/fixture/generator/model/entity-relationships-deep-insert-v2.ts
@@ -1,0 +1,22 @@
+import type { DeferredContent } from "@odata2ts/odata-core";
+
+export interface Author {
+  id: number;
+}
+
+export type AuthorId = number | { id: number };
+
+export interface EditableAuthor extends Pick<Author, "id"> {}
+
+export interface Book {
+  id: number;
+  author: Author | DeferredContent;
+  relatedAuthors: Array<Author> | DeferredContent;
+}
+
+export type BookId = number | { id: number };
+
+export interface EditableBook extends Pick<Book, "id"> {
+  author?: EditableAuthor;
+  relatedAuthors?: Array<EditableAuthor>;
+}

--- a/packages/odata2ts/test/fixture/generator/model/entity-relationships-deep-insert.ts
+++ b/packages/odata2ts/test/fixture/generator/model/entity-relationships-deep-insert.ts
@@ -1,0 +1,23 @@
+export interface Author {
+  id: number;
+  name: boolean | null;
+}
+
+export type AuthorId = number | { id: number };
+
+export interface EditableAuthor extends Pick<Author, "id">, Partial<Pick<Author, "name">> {}
+
+export interface Book {
+  id: number;
+  author?: Author;
+  altAuthor?: Author | null;
+  relatedAuthors?: Array<Author>;
+}
+
+export type BookId = number | { id: number };
+
+export interface EditableBook extends Pick<Book, "id"> {
+  author?: EditableAuthor;
+  altAuthor?: EditableAuthor;
+  relatedAuthors?: Array<EditableAuthor>;
+}

--- a/packages/odata2ts/test/generator/v2/ModelGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v2/ModelGenerator.test.ts
@@ -114,4 +114,77 @@ describe("Model Generator Tests V2", () => {
       disableAutoManagedKey: true,
     });
   });
+
+  function addRelatedEntities() {
+    odataBuilder
+      .addEntityType("Author", undefined, (builder) => builder.addKeyProp("id", ODataTypesV2.Int32))
+      .addEntityType(ENTITY_NAME, undefined, (builder) =>
+        builder
+          .addKeyProp("id", ODataTypesV2.Int32)
+          .addNavProp("author", withNs("Author"), "Book_Author", "1")
+          .addNavProp("relatedAuthors", withNs("Author"), "Book_RelatedAuthors", "*"),
+      );
+  }
+
+  test(`${TEST_SUITE_NAME}: deep insert props`, async () => {
+    // given entities related to each other
+    addRelatedEntities();
+
+    // when opting into the deep insert props
+    // then the navigation properties show up on the editable model, typed as the editable model of the
+    // related entity
+    await generateAndCompare("entity-relationships-deep-insert-v2.ts", {
+      enableDeepInsertProps: true,
+      skipEditableModels: false,
+      skipIdModels: false,
+      disableAutoManagedKey: true,
+    });
+  });
+
+  test(`${TEST_SUITE_NAME}: deep insert props with extra results wrapping`, async () => {
+    // given entities related to each other
+    addRelatedEntities();
+
+    // when opting into the extra wrapping for editable models
+    // then only the collection valued navigation property carries the extra results object
+    await generateAndCompare("entity-relationships-deep-insert-v2-extra-wrapping.ts", {
+      enableDeepInsertProps: true,
+      v2EditableModelsWithExtraResultsWrapping: true,
+      skipEditableModels: false,
+      skipIdModels: false,
+      disableAutoManagedKey: true,
+    });
+  });
+
+  test(`${TEST_SUITE_NAME}: the wrapping of the readable models does not reach the editable ones`, async () => {
+    // given entities related to each other
+    addRelatedEntities();
+
+    // when only the readable models are asked to carry the extra wrapping
+    // then the deep insert props stay unwrapped: a service answering with the wrapping does not
+    // necessarily expect it in a request payload, see issue #237
+    await generateAndCompare("entity-relationships-deep-insert-v2-response-wrapping.ts", {
+      enableDeepInsertProps: true,
+      v2ModelsWithExtraResultsWrapping: true,
+      skipEditableModels: false,
+      skipIdModels: false,
+      disableAutoManagedKey: true,
+    });
+  });
+
+  test(`${TEST_SUITE_NAME}: deep insert and binding props share the property in V2`, async () => {
+    // given entities related to each other
+    addRelatedEntities();
+
+    // when opting into both
+    // then the navigation property accepts either shape, since V2 addresses a binding by the very name
+    // of the navigation property
+    await generateAndCompare("entity-relationships-deep-insert-binding-v2.ts", {
+      enableDeepInsertProps: true,
+      enableBindingProps: true,
+      skipEditableModels: false,
+      skipIdModels: false,
+      disableAutoManagedKey: true,
+    });
+  });
 });

--- a/packages/odata2ts/test/generator/v4/ModelGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/ModelGenerator.test.ts
@@ -307,6 +307,82 @@ describe("Model Generator Tests V4", () => {
     });
   });
 
+  function addRelatedEntities() {
+    odataBuilder
+      .addEntityType("Author", undefined, (builder) =>
+        builder.addKeyProp("id", ODataTypesV4.Int32).addProp("name", ODataTypesV4.Boolean, true),
+      )
+      .addEntityType(ENTITY_NAME, undefined, (builder) =>
+        builder
+          .addKeyProp("id", ODataTypesV4.Int32)
+          .addProp("author", withNs("Author"), false)
+          .addProp("altAuthor", withNs("Author"), true)
+          .addProp("relatedAuthors", `Collection(${withNs("Author")})`),
+      );
+  }
+
+  test(`${TEST_SUITE_NAME}: deep insert props`, async () => {
+    // given entities related to each other
+    addRelatedEntities();
+
+    // when opting into the deep insert props
+    // then the navigation properties show up on the editable model, typed as the editable model of the
+    // related entity - which is what travels within the payload of a deep insert or deep update
+    await generateAndCompare("entity-relationships-deep-insert.ts", {
+      enableDeepInsertProps: true,
+      skipEditableModels: false,
+      skipIdModels: false,
+      disableAutoManagedKey: true,
+    });
+  });
+
+  test(`${TEST_SUITE_NAME}: deep insert and binding props side by side (4.0)`, async () => {
+    // given entities related to each other
+    addRelatedEntities();
+
+    // when opting into both
+    // then both show up separately, since 4.0 spells a binding with a name of its own
+    await generateAndCompare("entity-relationships-deep-insert-binding.ts", {
+      enableDeepInsertProps: true,
+      enableBindingProps: true,
+      skipEditableModels: false,
+      skipIdModels: false,
+      disableAutoManagedKey: true,
+    });
+  });
+
+  test(`${TEST_SUITE_NAME}: deep insert and binding props share the property in 4.01`, async () => {
+    // given entities related to each other
+    addRelatedEntities();
+
+    // when opting into both for 4.01
+    // then the navigation property accepts either shape: a new entity or a reference to an existing one,
+    // because 4.01 addresses a binding by the very name of the navigation property
+    await generateAndCompare("entity-relationships-deep-insert-binding-v401.ts", {
+      enableDeepInsertProps: true,
+      enableBindingProps: true,
+      odataVersionV4: "4.01",
+      skipEditableModels: false,
+      skipIdModels: false,
+      disableAutoManagedKey: true,
+    });
+  });
+
+  test(`${TEST_SUITE_NAME}: no extra results wrapping for deep insert props in V4`, async () => {
+    // given entities related to each other
+    addRelatedEntities();
+
+    // when the V2 option is set on a V4 service
+    // then it has no effect at all - the wrapping is a V2 speciality
+    await generateAndCompare("entity-relationships-deep-insert.ts", {
+      enableDeepInsertProps: true,
+      v2EditableModelsWithExtraResultsWrapping: true,
+      skipEditableModels: false,
+      skipIdModels: false,
+      disableAutoManagedKey: true,
+    });
+  });
+
   test(`${TEST_SUITE_NAME}: stream property is no part of any model`, async () => {
     // given an entity with a stream property
     odataBuilder.addEntityType("Audiobook", undefined, (builder) =>


### PR DESCRIPTION
Closes #237.

The editable models carried no navigation property at all, so a deep insert had to be typed around with `Partial<Entity>` or an intersection. The new option **`enableDeepInsertProps`** puts them into the model, typed as the editable model of the related entity - which is what travels in the payload of a deep insert (POST) or a deep update (PATCH / PUT).

**Playing along with `enableBindingProps`**

Both are independent opt-ins, but they meet on the same property: V2 and 4.01 address a binding by the very name of the navigation property, 4.0 by a name of its own.

```ts
// 4.0 - separate properties
author?: EditableAuthor;
"author@odata.bind"?: string;

// 4.01 (and V2, with the __metadata notation) - one property, either shape
author?: EditableAuthor | { "@id": string };
altAuthor?: EditableAuthor | { "@id": string } | null;
```

Two details worth naming:
- a binding is addressed by the **OData name**, since that notation reaches the wire untouched; a deep insert by the **mapped name**, since its payload *is* converted by the query object. With `allowRenaming` the two therefore stay separate properties even in V2/4.01 - which is correct, not accidental
- `| null` only appears on a property that actually accepts a binding (null removes one). In 4.0 that is the `@odata.bind` property, not the one carrying the nested entity - the first version got this wrong and a fixture caught it

**The V2 extra results wrapping**

`v2EditableModelsWithExtraResultsWrapping` is deliberately its own option: a service answering with the wrapping does not necessarily expect it in a request payload (#237 asks for exactly that separation). Like `v2ModelsWithExtraResultsWrapping` it only survives in **models mode** - I verified the existing safeguard does what it claims, and both are now pinned by a test across every mode. The deep insert props themselves survive every mode, since a generated service is where a deep insert is actually sent.

**Proven against both servers**, not only fixtures:
- `int-test/asp-net`: single-valued and collection-valued deep insert, plus a payload that deep-inserts one navigation property and binds another
- `int-test/cap`: a **composition** is created along with the entity, while a plain **association** is accepted with 201 and then silently dropped. The metadata cannot express that difference, so the same generated type behaves differently per server - written down rather than smoothed over

One wrinkle the tests document: a nested entity still has to supply the properties that link it to its parent (`MediumId` on ASP.NET, `up__Id` on CAP), because they are plain required properties - and they are exactly the ones the server overwrites. Relaxing that would mean recognising the backlink in the model, which this PR does not attempt.

Not included: the documentation site lives in its own repo, so the two new options still need an entry there.