### PR TITLE
fix(odata-query-objects): let a V2 function import without a return type compile

### DIFF
--- a/int-test/README.md
+++ b/int-test/README.md
@@ -10,10 +10,14 @@ starts and stops itself. Dockerized.
 
 ## The servers
 
-| package                          | server                                                          |
-| -------------------------------- | --------------------------------------------------------------- |
-| [`cap`](./cap/README.md)         | SAP CAP implementation of the standardized "Library" test model |
-| [`asp-net`](./asp-net/README.md) | ASP.NET Core implementation of the same model                   |
+| package                          | server                                                                          |
+| -------------------------------- | ------------------------------------------------------------------------------- |
+| [`cap`](./cap/README.md)         | SAP CAP implementation of the standardized "Library" test model - V4 **and** V2 |
+| [`asp-net`](./asp-net/README.md) | ASP.NET Core implementation of the same model                                   |
+
+The CAP server is the only place where odata2ts meets a running **OData V2** service: the same server
+also answers V2 through the `@cap-js-community/odata-v2-adapter` middleware, so `int-test/cap/test/v2/`
+covers the V2 client against it. See that package's README.
 
 ## Layout of a package
 
@@ -25,7 +29,8 @@ int-test/<server>/
 └─ test/
    ├─ <Server>TestConstants.ts   service instance + seed-data keys
    ├─ core/                      what every OData server is expected to do
-   └─ feature/                   individual features, incl. their limitations
+   ├─ feature/                   individual features, incl. their limitations
+   └─ v2/                        the same scheme again, where a server also speaks V2 (cap only)
 ```
 
 Scripts: `build`/`generate` (offline codegen), `test` (the integration tests), `test-compile`
@@ -43,12 +48,17 @@ Test files follow the same scheme in every package, one concern per file:
 | `feature/Blobs.test.ts`               | binary content: stream properties and media entities                           |
 | `feature/Subtypes.test.ts`            | type cast segment and derived types' properties (ASP.NET only - CAP is flat)   |
 | `feature/PropertyServices.test.ts`    | services for individual properties (`enablePrimitivePropertyServices`)         |
-| `feature/DataTypes.test.ts`           | data types round tripped through the server (ASP.NET)                          |
+| `feature/DataTypes.test.ts`           | data types round tripped through the server (ASP.NET, and CAP's V2 suite)      |
 | `feature/DeepSelect.test.ts`          | `expanding()` into complex properties (ASP.NET only - CAP flattens them)       |
 | `feature/ComposableFunctions.test.ts` | composable functions (ASP.NET only - CAP has none)                             |
 
 Where a server does not support something, the test asserts the rejection rather than being dropped -
 that keeps the limitation visible instead of silently untested.
+
+A `v2/` folder repeats `core/` and `feature/` for the V2 protocol, dropping what V2 has no notion of
+(`Prefer: return=representation`, and therefore query options on write requests) and adding what only V2
+raises. `v2/core/Singleton.test.ts` keeps the file name although V2 has no singletons - it covers what
+became of that singleton, which is exactly the comparison the name is for.
 
 Two rules hold for every test here:
 

--- a/int-test/cap/README.md
+++ b/int-test/cap/README.md
@@ -1,7 +1,9 @@
 # Integration Tests: SAP CAP
 
 Runs odata2ts against [`odata2ts/test-server-cap`](https://github.com/odata2ts/test-server-cap), the
-SAP CAP implementation of the standardized "Library" OData V4 feature test model.
+SAP CAP implementation of the standardized "Library" OData V4 feature test model - **twice**: once over
+OData V4, and once over the OData **V2** face that the same server presents through
+[`@cap-js-community/odata-v2-adapter`](https://github.com/cap-js-community/odata-v2-adapter).
 
 See [../README.md](../README.md) for how this group fits into the repository as a whole and for the
 test-file scheme used here.
@@ -33,7 +35,11 @@ yarn int-test:cap
   so `test/core/Operations.test.ts` fails with 501 against such a server while the other files pass.
 
 Because all test files share one server instance, `fileParallelism` is off - writes in one file must
-not race reads in another.
+not race reads in another. That applies across the two protocol versions as well: `test/v2/` writes to
+the same rows as `test/core/`, so both restore the seed values they touch.
+
+The V2 base URL is not configured anywhere. `globalSetup` derives it from the V4 one by swapping the
+version segment, because that is what the adapter does - there is one server, on one port.
 
 ## Generation
 
@@ -42,6 +48,10 @@ actual `$metadata`. odata2ts is deliberately tested against the metadata CAP rea
 the aspect-based media hierarchy, alternate keys that exist only in the metadata - rather than against
 the idealized reference model. Refresh the snapshot from the running server (or via the server repo's
 `npm run metadata`) whenever the model changes.
+
+A second client is generated the same way from `resource/library-v2.xml`, the snapshot of
+`/odata/v2/library/$metadata`. It is not a second model: the adapter translates the one service on the
+fly, so that file is the translation, and testing against it is what makes the translation visible.
 
 Assertions use the fixed seed data from `db/data/*.csv` in the server repo.
 
@@ -69,3 +79,33 @@ limitation stays visible:
   with no `$value` and no type cast segment - the same feature reaches the ASP.NET server as
   `…/Media(<id>)/$value` and `…/Media(<id>)/Library.Catalog.Audiobook/Sample`. CAP also answers with the
   MIME type declared in its model rather than the uploaded one, where ASP.NET returns what it was given.
+
+## The V2 suite
+
+`test/v2/` mirrors the V4 folders file by file, against the same server through the V2 adapter. It exists
+because V2 is a different client in odata2ts - other services, other response models, other q-object paths -
+and until now it met no running server anywhere in this repository.
+
+Everything the adapter does to the _model_ is documented on the server side, in
+[FEATURE-COVERAGE-V2.md](https://github.com/odata2ts/test-server-cap/blob/main/FEATURE-COVERAGE-V2.md).
+What belongs here is what the **client** does with it:
+
+- **`Edm.Byte` and `Edm.SByte` are typed as `string` but arrive as numbers.** odata2ts groups them with the
+  string-serialised numeric types in `DataModelDigestionV2.mapODataType`, while V2's JSON format puts them
+  among the plain numbers - so `book.AgeRating === "16"` is `false` although both sides are typed `string`.
+  The other string-typed numbers (`Int64`, `Decimal`, `Double`, `Single`) are mapped correctly.
+  Pinned in `test/v2/feature/DataTypes.test.ts`.
+- **There is no binary content API in V2.** `StreamServiceV4` and `MediaEntityServiceV4` have no V2
+  counterpart, and the V2 generator emits neither. The adapter exposes the content properly, as media link
+  entries with `$value` and `media_src` - so this is the one feature where the server is ahead of the
+  client. `test/v2/feature/Blobs.test.ts` asserts the gap from both sides, with the only raw `fetch` calls
+  in this package, since there is no generated API to call.
+- **No ETag handling.** Nothing reads `__metadata.etag`, nothing sends `If-Match`, so `Copies` is
+  create-only - as it is over V4, except that the V2 metadata actually declares the token.
+- **A write answers with a body the typing does not admit.** V2 has no `Prefer: return=representation` and
+  no `<true>` switch, so `update`/`patch` are typed `HttpResponseModel<undefined>`; this server answers 200
+  with the full entity. The data is there and unreachable without a cast.
+- **`QFunctionV2`/`QFunctionV4` needed a default for `ResponseStructure`.** A void V2 operation is a
+  `FunctionImport` with `m:HttpMethod="POST"` - V2 has no separate action - and the generator then emits
+  `QFunctionV2<Params>` with one type argument. Both classes required two, so the generated code did not
+  compile. `QAction` already had the default; the function classes now do too.

--- a/int-test/cap/odata2ts.config.ts
+++ b/int-test/cap/odata2ts.config.ts
@@ -1,14 +1,20 @@
 import { ConfigFileOptions, EmitModes, Modes } from "@odata2ts/odata2ts";
 
 /**
- * Generates the odata2ts client for the standardized "Library" OData V4 test model, as served by the
- * SAP CAP implementation (repo `odata2ts/test-server-cap`).
+ * Generates the odata2ts clients for the standardized "Library" test model, as served by the SAP CAP
+ * implementation (repo `odata2ts/test-server-cap`) - once as OData V4 and once as OData V2.
  *
- * The source is a committed snapshot of the server's actual `$metadata` (`resource/library.xml`), so
- * generation stays offline and server-independent - odata2ts is deliberately tested against the metadata
- * CAP really emits (flat mode, aspect-based media hierarchy, alternate keys only in metadata, ...), not
- * against the idealized reference model. Refresh the snapshot from the running server (or the server
- * repo's `npm run metadata`) whenever the model changes.
+ * The sources are committed snapshots of the server's actual `$metadata` (`resource/library.xml` and
+ * `resource/library-v2.xml`), so generation stays offline and server-independent - odata2ts is
+ * deliberately tested against the metadata CAP really emits (flat mode, aspect-based media hierarchy,
+ * alternate keys only in metadata, ...), not against the idealized reference model. Refresh the
+ * snapshots from the running server (or the server repo's `npm run metadata`) whenever the model changes.
+ *
+ * The V2 model is not a second model: it is the very same service, translated on the fly by the
+ * `@cap-js-community/odata-v2-adapter` middleware that CAP runs in front of its V4 endpoint. Everything
+ * the V2 client sees is therefore that translation - which is exactly what makes it worth testing, since
+ * it is the shape SAP systems actually put on the wire. See test/v2/ and the server repo's
+ * FEATURE-COVERAGE-V2.md.
  */
 const config: ConfigFileOptions = {
   mode: Modes.service,
@@ -27,6 +33,11 @@ const config: ConfigFileOptions = {
       serviceName: "Library",
       source: "resource/library.xml",
       output: "src-generated/library",
+    },
+    libraryV2: {
+      serviceName: "LibraryV2",
+      source: "resource/library-v2.xml",
+      output: "src-generated/library-v2",
     },
   },
 };

--- a/int-test/cap/resource/library-v2.xml
+++ b/int-test/cap/resource/library-v2.xml
@@ -1,0 +1,972 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="1.0" xmlns:edmx="http://schemas.microsoft.com/ado/2007/06/edmx" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns:sap="http://www.sap.com/Protocols/SAPData">
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Capabilities.V1.xml" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+    <edmx:Include Alias="Capabilities" Namespace="Org.OData.Capabilities.V1"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/Common.xml" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+    <edmx:Include Alias="Common" Namespace="com.sap.vocabularies.Common.v1"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+    <edmx:Include Alias="Core" Namespace="Org.OData.Core.V1"/>
+  </edmx:Reference>
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Validation.V1.xml" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+    <edmx:Include Alias="Validation" Namespace="Org.OData.Validation.V1"/>
+  </edmx:Reference>
+  <edmx:DataServices m:DataServiceVersion="2.0">
+    <Schema Namespace="Library.Service" xmlns="http://schemas.microsoft.com/ado/2008/09/edm">
+      <Annotation Term="Core.Links" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Collection>
+          <Record>
+            <PropertyValue Property="rel" String="author"/>
+            <PropertyValue Property="href" String="https://cap.cloud.sap"/>
+          </Record>
+        </Collection>
+      </Annotation>
+      <EntityContainer Name="EntityContainer" m:IsDefaultEntityContainer="true">
+        <EntitySet Name="Books" EntityType="Library.Service.Books"/>
+        <FunctionImport Name="Books_LoanMetrics" ReturnType="Library.Service.Library_Catalog_MediumStats" m:HttpMethod="GET" sap:action-for="Library.Service.Books">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="Books_AvailableLanguages" ReturnType="Collection(Edm.String)" m:HttpMethod="GET" sap:action-for="Library.Service.Books">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="Books_AvailableCopies" EntitySet="Copies" ReturnType="Collection(Library.Service.Copies)" m:HttpMethod="GET" sap:action-for="Library.Service.Books">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="Books_AvailableCopy" EntitySet="Copies" ReturnType="Library.Service.Copies" m:HttpMethod="GET" sap:action-for="Library.Service.Books">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="Books_Reserve" ReturnType="Edm.Int32" m:HttpMethod="POST" sap:action-for="Library.Service.Books">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+          <Parameter Name="MemberId" Type="Edm.Int32" Mode="In" Nullable="true"/>
+        </FunctionImport>
+        <EntitySet Name="Copies" EntityType="Library.Service.Copies"/>
+        <FunctionImport Name="Copies_CheckOut" m:HttpMethod="POST" sap:action-for="Library.Service.Copies">
+          <Parameter Name="MediumId" Type="Edm.Guid" Nullable="false" Mode="In"/>
+          <Parameter Name="InventoryNumber" Type="Edm.Int32" Nullable="false" Mode="In"/>
+          <Parameter Name="MemberId" Type="Edm.Int32" Mode="In" Nullable="true"/>
+        </FunctionImport>
+        <FunctionImport Name="Copies_AssessCondition" ReturnType="Library.Service.Library_Catalog_ConditionReport" m:HttpMethod="POST" sap:action-for="Library.Service.Copies">
+          <Parameter Name="MediumId" Type="Edm.Guid" Nullable="false" Mode="In"/>
+          <Parameter Name="InventoryNumber" Type="Edm.Int32" Nullable="false" Mode="In"/>
+          <Parameter Name="NewCondition" Type="Edm.Byte" Mode="In" Nullable="true"/>
+          <Parameter Name="Remark" Type="Edm.String" Mode="In" Nullable="true"/>
+        </FunctionImport>
+        <EntitySet Name="Branches" EntityType="Library.Service.Branches"/>
+        <EntitySet Name="Publishers" EntityType="Library.Service.Publishers"/>
+        <EntitySet Name="Magazines" EntityType="Library.Service.Magazines"/>
+        <FunctionImport Name="Magazines_LoanMetrics" ReturnType="Library.Service.Library_Catalog_MediumStats" m:HttpMethod="GET" sap:action-for="Library.Service.Magazines">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="Magazines_AvailableLanguages" ReturnType="Collection(Edm.String)" m:HttpMethod="GET" sap:action-for="Library.Service.Magazines">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="Magazines_AvailableCopies" EntitySet="Copies" ReturnType="Collection(Library.Service.Copies)" m:HttpMethod="GET" sap:action-for="Library.Service.Magazines">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="Magazines_AvailableCopy" EntitySet="Copies" ReturnType="Library.Service.Copies" m:HttpMethod="GET" sap:action-for="Library.Service.Magazines">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="Magazines_Reserve" ReturnType="Edm.Int32" m:HttpMethod="POST" sap:action-for="Library.Service.Magazines">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+          <Parameter Name="MemberId" Type="Edm.Int32" Mode="In" Nullable="true"/>
+        </FunctionImport>
+        <EntitySet Name="TradeJournals" EntityType="Library.Service.TradeJournals"/>
+        <FunctionImport Name="TradeJournals_LoanMetrics" ReturnType="Library.Service.Library_Catalog_MediumStats" m:HttpMethod="GET" sap:action-for="Library.Service.TradeJournals">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="TradeJournals_AvailableLanguages" ReturnType="Collection(Edm.String)" m:HttpMethod="GET" sap:action-for="Library.Service.TradeJournals">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="TradeJournals_AvailableCopies" EntitySet="Copies" ReturnType="Collection(Library.Service.Copies)" m:HttpMethod="GET" sap:action-for="Library.Service.TradeJournals">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="TradeJournals_AvailableCopy" EntitySet="Copies" ReturnType="Library.Service.Copies" m:HttpMethod="GET" sap:action-for="Library.Service.TradeJournals">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="TradeJournals_Reserve" ReturnType="Edm.Int32" m:HttpMethod="POST" sap:action-for="Library.Service.TradeJournals">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+          <Parameter Name="MemberId" Type="Edm.Int32" Mode="In" Nullable="true"/>
+        </FunctionImport>
+        <EntitySet Name="Audiobooks" EntityType="Library.Service.Audiobooks"/>
+        <FunctionImport Name="Audiobooks_LoanMetrics" ReturnType="Library.Service.Library_Catalog_MediumStats" m:HttpMethod="GET" sap:action-for="Library.Service.Audiobooks">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="Audiobooks_AvailableLanguages" ReturnType="Collection(Edm.String)" m:HttpMethod="GET" sap:action-for="Library.Service.Audiobooks">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="Audiobooks_AvailableCopies" EntitySet="Copies" ReturnType="Collection(Library.Service.Copies)" m:HttpMethod="GET" sap:action-for="Library.Service.Audiobooks">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="Audiobooks_AvailableCopy" EntitySet="Copies" ReturnType="Library.Service.Copies" m:HttpMethod="GET" sap:action-for="Library.Service.Audiobooks">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="Audiobooks_Reserve" ReturnType="Edm.Int32" m:HttpMethod="POST" sap:action-for="Library.Service.Audiobooks">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+          <Parameter Name="MemberId" Type="Edm.Int32" Mode="In" Nullable="true"/>
+        </FunctionImport>
+        <EntitySet Name="AudiobookChapters" EntityType="Library.Service.AudiobookChapters"/>
+        <EntitySet Name="DVDs" EntityType="Library.Service.DVDs"/>
+        <FunctionImport Name="DVDs_LoanMetrics" ReturnType="Library.Service.Library_Catalog_MediumStats" m:HttpMethod="GET" sap:action-for="Library.Service.DVDs">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="DVDs_AvailableLanguages" ReturnType="Collection(Edm.String)" m:HttpMethod="GET" sap:action-for="Library.Service.DVDs">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="DVDs_AvailableCopies" EntitySet="Copies" ReturnType="Collection(Library.Service.Copies)" m:HttpMethod="GET" sap:action-for="Library.Service.DVDs">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="DVDs_AvailableCopy" EntitySet="Copies" ReturnType="Library.Service.Copies" m:HttpMethod="GET" sap:action-for="Library.Service.DVDs">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="DVDs_Reserve" ReturnType="Edm.Int32" m:HttpMethod="POST" sap:action-for="Library.Service.DVDs">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+          <Parameter Name="MemberId" Type="Edm.Int32" Mode="In" Nullable="true"/>
+        </FunctionImport>
+        <EntitySet Name="EBooks" EntityType="Library.Service.EBooks"/>
+        <FunctionImport Name="EBooks_LoanMetrics" ReturnType="Library.Service.Library_Catalog_MediumStats" m:HttpMethod="GET" sap:action-for="Library.Service.EBooks">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="EBooks_AvailableLanguages" ReturnType="Collection(Edm.String)" m:HttpMethod="GET" sap:action-for="Library.Service.EBooks">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="EBooks_AvailableCopies" EntitySet="Copies" ReturnType="Collection(Library.Service.Copies)" m:HttpMethod="GET" sap:action-for="Library.Service.EBooks">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="EBooks_AvailableCopy" EntitySet="Copies" ReturnType="Library.Service.Copies" m:HttpMethod="GET" sap:action-for="Library.Service.EBooks">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="EBooks_Reserve" ReturnType="Edm.Int32" m:HttpMethod="POST" sap:action-for="Library.Service.EBooks">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+          <Parameter Name="MemberId" Type="Edm.Int32" Mode="In" Nullable="true"/>
+        </FunctionImport>
+        <EntitySet Name="CollectorsItems" EntityType="Library.Service.CollectorsItems"/>
+        <FunctionImport Name="CollectorsItems_LoanMetrics" ReturnType="Library.Service.Library_Catalog_MediumStats" m:HttpMethod="GET" sap:action-for="Library.Service.CollectorsItems">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="CollectorsItems_AvailableLanguages" ReturnType="Collection(Edm.String)" m:HttpMethod="GET" sap:action-for="Library.Service.CollectorsItems">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="CollectorsItems_AvailableCopies" EntitySet="Copies" ReturnType="Collection(Library.Service.Copies)" m:HttpMethod="GET" sap:action-for="Library.Service.CollectorsItems">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="CollectorsItems_AvailableCopy" EntitySet="Copies" ReturnType="Library.Service.Copies" m:HttpMethod="GET" sap:action-for="Library.Service.CollectorsItems">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="CollectorsItems_Reserve" ReturnType="Edm.Int32" m:HttpMethod="POST" sap:action-for="Library.Service.CollectorsItems">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+          <Parameter Name="MemberId" Type="Edm.Int32" Mode="In" Nullable="true"/>
+        </FunctionImport>
+        <EntitySet Name="Members" EntityType="Library.Service.Members"/>
+        <FunctionImport Name="Members_OutstandingBalance" ReturnType="Edm.Decimal" m:HttpMethod="GET" sap:action-for="Library.Service.Members">
+          <Parameter Name="Id" Type="Edm.Int32" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="Members_NoticeHistory" ReturnType="Collection(Library.Service.Library_Circulation_OverdueNotice)" m:HttpMethod="GET" sap:action-for="Library.Service.Members">
+          <Parameter Name="Id" Type="Edm.Int32" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="Members_RunReminders" ReturnType="Collection(Library.Service.Library_Circulation_OverdueNotice)" m:HttpMethod="POST" sap:action-for="Library.Service.Members">
+          <Parameter Name="Id" Type="Edm.Int32" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <EntitySet Name="Loans" EntityType="Library.Service.Loans"/>
+        <FunctionImport Name="Loans_Renew" EntitySet="Loans" ReturnType="Library.Service.Loans" m:HttpMethod="POST" sap:action-for="Library.Service.Loans">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="Loans_RenewAll" EntitySet="Loans" ReturnType="Collection(Library.Service.Loans)" m:HttpMethod="POST" sap:action-for="Library.Service.Loans">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="Loans_BulkRenew" ReturnType="Collection(Edm.String)" m:HttpMethod="POST" sap:action-for="Library.Service.Loans">
+          <Parameter Name="Id" Type="Edm.Guid" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <EntitySet Name="Reservations" EntityType="Library.Service.Reservations"/>
+        <EntitySet Name="IdDocuments" EntityType="Library.Service.IdDocuments"/>
+        <EntitySet Name="Bookmobiles" EntityType="Library.Service.Bookmobiles"/>
+        <EntitySet Name="MainBranch" EntityType="Library.Service.MainBranch"/>
+        <EntitySet Name="PublisherBranches" EntityType="Library.Service.PublisherBranches"/>
+        <FunctionImport Name="TotalMediaCount" ReturnType="Edm.Int64" m:HttpMethod="GET"/>
+        <FunctionImport Name="AllLanguages" ReturnType="Collection(Edm.String)" m:HttpMethod="GET"/>
+        <FunctionImport Name="LoanStatistics" ReturnType="Library.Service.Library_Circulation_LoanStats" m:HttpMethod="GET">
+          <Parameter Name="Period" Type="Library.Service.Library_Circulation_DateRange" Mode="In" Nullable="true"/>
+        </FunctionImport>
+        <FunctionImport Name="StatsPerBranch" ReturnType="Collection(Library.Service.Library_Circulation_BranchStats)" m:HttpMethod="GET"/>
+        <FunctionImport Name="MostReadMedium" EntitySet="Books" ReturnType="Library.Service.Books" m:HttpMethod="GET"/>
+        <FunctionImport Name="NewReleases" EntitySet="Books" ReturnType="Collection(Library.Service.Books)" m:HttpMethod="GET"/>
+        <FunctionImport Name="Search" EntitySet="Books" ReturnType="Collection(Library.Service.Books)" m:HttpMethod="GET">
+          <Parameter Name="Term" Type="Edm.String" Nullable="false" Mode="In"/>
+          <Parameter Name="MaxResults" Type="Edm.Int32" Mode="In" Nullable="true"/>
+        </FunctionImport>
+        <FunctionImport Name="ClosureDay" m:HttpMethod="POST">
+          <Parameter Name="Day" Type="Edm.DateTime" Nullable="false" Mode="In" sap:display-format="Date"/>
+        </FunctionImport>
+        <FunctionImport Name="NextInventoryNumber" ReturnType="Edm.Int32" m:HttpMethod="POST"/>
+        <FunctionImport Name="CleanUpKeywords" ReturnType="Collection(Edm.String)" m:HttpMethod="POST">
+          <Parameter Name="Obsolete" Type="Collection(Edm.String)" Nullable="true" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="YearEndClosing" ReturnType="Library.Service.Library_Circulation_AnnualReport" m:HttpMethod="POST">
+          <Parameter Name="Year" Type="Edm.Int32" Nullable="false" Mode="In"/>
+        </FunctionImport>
+        <FunctionImport Name="RunOverdueNotices" ReturnType="Collection(Library.Service.Library_Circulation_OverdueNotice)" m:HttpMethod="POST"/>
+        <FunctionImport Name="AcquireCollectorsItem" EntitySet="CollectorsItems" ReturnType="Library.Service.CollectorsItems" m:HttpMethod="POST">
+          <Parameter Name="Title" Type="Edm.String" Nullable="false" Mode="In"/>
+          <Parameter Name="Description" Type="Edm.String" Mode="In" Nullable="true"/>
+        </FunctionImport>
+        <FunctionImport Name="RunStockCheck" EntitySet="Books" ReturnType="Collection(Library.Service.Books)" m:HttpMethod="POST"/>
+        <AssociationSet Name="Books_Copies" Association="Library.Service.Books_Copies">
+          <End Role="Books" EntitySet="Books"/>
+          <End Role="Copies" EntitySet="Copies"/>
+        </AssociationSet>
+        <AssociationSet Name="Books_Publisher" Association="Library.Service.Books_Publisher">
+          <End Role="Books" EntitySet="Books"/>
+          <End Role="Publishers" EntitySet="Publishers"/>
+        </AssociationSet>
+        <AssociationSet Name="Copies_Location" Association="Library.Service.Copies_Location">
+          <End Role="Copies" EntitySet="Copies"/>
+          <End Role="Branches" EntitySet="Branches"/>
+        </AssociationSet>
+        <AssociationSet Name="Magazines_Copies" Association="Library.Service.Magazines_Copies">
+          <End Role="Magazines" EntitySet="Magazines"/>
+          <End Role="Copies" EntitySet="Copies"/>
+        </AssociationSet>
+        <AssociationSet Name="TradeJournals_Copies" Association="Library.Service.TradeJournals_Copies">
+          <End Role="TradeJournals" EntitySet="TradeJournals"/>
+          <End Role="Copies" EntitySet="Copies"/>
+        </AssociationSet>
+        <AssociationSet Name="Audiobooks_Copies" Association="Library.Service.Audiobooks_Copies">
+          <End Role="Audiobooks" EntitySet="Audiobooks"/>
+          <End Role="Copies" EntitySet="Copies"/>
+        </AssociationSet>
+        <AssociationSet Name="AudiobookChapters_up_" Association="Library.Service.AudiobookChapters_up_">
+          <End Role="AudiobookChapters" EntitySet="AudiobookChapters"/>
+          <End Role="Audiobooks" EntitySet="Audiobooks"/>
+        </AssociationSet>
+        <AssociationSet Name="DVDs_Copies" Association="Library.Service.DVDs_Copies">
+          <End Role="DVDs" EntitySet="DVDs"/>
+          <End Role="Copies" EntitySet="Copies"/>
+        </AssociationSet>
+        <AssociationSet Name="EBooks_Copies" Association="Library.Service.EBooks_Copies">
+          <End Role="EBooks" EntitySet="EBooks"/>
+          <End Role="Copies" EntitySet="Copies"/>
+        </AssociationSet>
+        <AssociationSet Name="CollectorsItems_Copies" Association="Library.Service.CollectorsItems_Copies">
+          <End Role="CollectorsItems" EntitySet="CollectorsItems"/>
+          <End Role="Copies" EntitySet="Copies"/>
+        </AssociationSet>
+        <AssociationSet Name="CollectorsItems_StorageLocation" Association="Library.Service.CollectorsItems_StorageLocation">
+          <End Role="CollectorsItems" EntitySet="CollectorsItems"/>
+          <End Role="Branches" EntitySet="Branches"/>
+        </AssociationSet>
+        <AssociationSet Name="Members_IdDocument" Association="Library.Service.Members_IdDocument">
+          <End Role="Members" EntitySet="Members"/>
+          <End Role="IdDocuments" EntitySet="IdDocuments"/>
+        </AssociationSet>
+        <AssociationSet Name="Loans_Member" Association="Library.Service.Loans_Member">
+          <End Role="Loans" EntitySet="Loans"/>
+          <End Role="Members" EntitySet="Members"/>
+        </AssociationSet>
+        <AssociationSet Name="Loans_Copy" Association="Library.Service.Loans_Copy">
+          <End Role="Loans" EntitySet="Loans"/>
+          <End Role="Copies" EntitySet="Copies"/>
+        </AssociationSet>
+        <AssociationSet Name="Reservations_Member" Association="Library.Service.Reservations_Member">
+          <End Role="Reservations" EntitySet="Reservations"/>
+          <End Role="Members" EntitySet="Members"/>
+        </AssociationSet>
+      </EntityContainer>
+      <EntityType Name="Books">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="Title" Type="Edm.String" MaxLength="200" Nullable="false"/>
+        <Property Name="Language" Type="Edm.String" MaxLength="40"/>
+        <Property Name="PublicationDate" Type="Edm.DateTime" sap:display-format="Date"/>
+        <Property Name="Keywords" Type="Collection(Edm.String)" Nullable="true"/>
+        <Property Name="PopularityScore" Type="Edm.Double"/>
+        <NavigationProperty Name="Copies" Relationship="Library.Service.Books_Copies" FromRole="Books" ToRole="Copies"/>
+        <Property Name="ISBN" Type="Edm.String" MaxLength="13"/>
+        <Property Name="PageCount" Type="Edm.Int16"/>
+        <Property Name="AgeRating" Type="Edm.Byte"/>
+        <NavigationProperty Name="Publisher" Relationship="Library.Service.Books_Publisher" FromRole="Books" ToRole="Publishers"/>
+        <Property Name="Publisher_Id" Type="Edm.Int32"/>
+      </EntityType>
+      <EntityType Name="Copies">
+        <Key>
+          <PropertyRef Name="MediumId"/>
+          <PropertyRef Name="InventoryNumber"/>
+        </Key>
+        <Property Name="MediumId" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="InventoryNumber" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="Condition" Type="Edm.Byte" ConcurrencyMode="Fixed"/>
+        <Property Name="IsLoanable" Type="Edm.Boolean" Nullable="false"/>
+        <Property Name="Status" Type="Edm.Byte"/>
+        <Property Name="AcquisitionDate" Type="Edm.DateTime" sap:display-format="Date"/>
+        <Property Name="WeightKg" Type="Edm.Single"/>
+        <Property Name="Location_" Type="Edm.String" MaxLength="10"/>
+        <NavigationProperty Name="Location" Relationship="Library.Service.Copies_Location" FromRole="Copies" ToRole="Branches"/>
+        <Property Name="Location_Id" Type="Edm.Int32"/>
+      </EntityType>
+      <EntityType Name="Branches">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="Name" Type="Edm.String" MaxLength="100" Nullable="false"/>
+        <Property Name="Address_Street" Type="Edm.String" MaxLength="120"/>
+        <Property Name="Address_City" Type="Edm.String" MaxLength="80"/>
+        <Property Name="Address_PostalCode" Type="Edm.String" MaxLength="10"/>
+        <Property Name="Address_Country" Type="Edm.String" MaxLength="60"/>
+        <Property Name="Location" Type="Edm.String"/>
+        <Property Name="CatchmentArea" Type="Edm.String"/>
+        <Property Name="LowestFloor" Type="Edm.SByte"/>
+        <Property Name="FloorPlanOrigin" Type="Edm.String"/>
+        <Property Name="FloorPlanShapes" Type="Edm.String"/>
+        <Property Name="OpensAt" Type="Edm.Time"/>
+        <Property Name="ClosesAt" Type="Edm.Time"/>
+        <Property Name="Amenities" Type="Edm.Int32"/>
+        <Property Name="Population" Type="Edm.Int64"/>
+      </EntityType>
+      <EntityType Name="Publishers">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="Name" Type="Edm.String" MaxLength="100" Nullable="false"/>
+        <Property Name="Country" Type="Edm.String" MaxLength="60"/>
+        <Property Name="Founded" Type="Edm.DateTime" sap:display-format="Date"/>
+        <NavigationProperty Name="Books" Relationship="Library.Service.Books_Publisher" FromRole="Publishers" ToRole="Books"/>
+      </EntityType>
+      <EntityType Name="Magazines">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="Title" Type="Edm.String" MaxLength="200" Nullable="false"/>
+        <Property Name="Language" Type="Edm.String" MaxLength="40"/>
+        <Property Name="PublicationDate" Type="Edm.DateTime" sap:display-format="Date"/>
+        <Property Name="Keywords" Type="Collection(Edm.String)" Nullable="true"/>
+        <Property Name="PopularityScore" Type="Edm.Double"/>
+        <NavigationProperty Name="Copies" Relationship="Library.Service.Magazines_Copies" FromRole="Magazines" ToRole="Copies"/>
+        <Property Name="ISBN" Type="Edm.String" MaxLength="13"/>
+        <Property Name="IssueNumber" Type="Edm.Int32"/>
+      </EntityType>
+      <EntityType Name="TradeJournals">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="Title" Type="Edm.String" MaxLength="200" Nullable="false"/>
+        <Property Name="Language" Type="Edm.String" MaxLength="40"/>
+        <Property Name="PublicationDate" Type="Edm.DateTime" sap:display-format="Date"/>
+        <Property Name="Keywords" Type="Collection(Edm.String)" Nullable="true"/>
+        <Property Name="PopularityScore" Type="Edm.Double"/>
+        <NavigationProperty Name="Copies" Relationship="Library.Service.TradeJournals_Copies" FromRole="TradeJournals" ToRole="Copies"/>
+        <Property Name="ISBN" Type="Edm.String" MaxLength="13"/>
+        <Property Name="IssueNumber" Type="Edm.Int32"/>
+        <Property Name="Field" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="Audiobooks" m:HasStream="true">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="Title" Type="Edm.String" MaxLength="200" Nullable="false"/>
+        <Property Name="Language" Type="Edm.String" MaxLength="40"/>
+        <Property Name="PublicationDate" Type="Edm.DateTime" sap:display-format="Date"/>
+        <Property Name="Keywords" Type="Collection(Edm.String)" Nullable="true"/>
+        <Property Name="PopularityScore" Type="Edm.Double"/>
+        <NavigationProperty Name="Copies" Relationship="Library.Service.Audiobooks_Copies" FromRole="Audiobooks" ToRole="Copies"/>
+        <Property Name="Duration" Type="Edm.String"/>
+        <Property Name="Narrator" Type="Edm.String"/>
+        <NavigationProperty Name="Chapters" Relationship="Library.Service.AudiobookChapters_up_" FromRole="Audiobooks" ToRole="AudiobookChapters"/>
+      </EntityType>
+      <EntityType Name="AudiobookChapters" m:HasStream="true">
+        <Key>
+          <PropertyRef Name="Id"/>
+          <PropertyRef Name="up__Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <NavigationProperty Name="up_" Relationship="Library.Service.AudiobookChapters_up_" FromRole="AudiobookChapters" ToRole="Audiobooks"/>
+        <Property Name="up__Id" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="Title" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="DVDs">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="Title" Type="Edm.String" MaxLength="200" Nullable="false"/>
+        <Property Name="Language" Type="Edm.String" MaxLength="40"/>
+        <Property Name="PublicationDate" Type="Edm.DateTime" sap:display-format="Date"/>
+        <Property Name="Keywords" Type="Collection(Edm.String)" Nullable="true"/>
+        <Property Name="PopularityScore" Type="Edm.Double"/>
+        <NavigationProperty Name="Copies" Relationship="Library.Service.DVDs_Copies" FromRole="DVDs" ToRole="Copies"/>
+        <Property Name="Duration" Type="Edm.String"/>
+        <Property Name="RegionCode" Type="Edm.Byte"/>
+      </EntityType>
+      <EntityType Name="EBooks" m:HasStream="true">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="Title" Type="Edm.String" MaxLength="200" Nullable="false"/>
+        <Property Name="Language" Type="Edm.String" MaxLength="40"/>
+        <Property Name="PublicationDate" Type="Edm.DateTime" sap:display-format="Date"/>
+        <Property Name="Keywords" Type="Collection(Edm.String)" Nullable="true"/>
+        <Property Name="PopularityScore" Type="Edm.Double"/>
+        <NavigationProperty Name="Copies" Relationship="Library.Service.EBooks_Copies" FromRole="EBooks" ToRole="Copies"/>
+        <Property Name="FileFormat" Type="Edm.String" MaxLength="20"/>
+      </EntityType>
+      <EntityType Name="CollectorsItems">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="Title" Type="Edm.String" MaxLength="200" Nullable="false"/>
+        <Property Name="Language" Type="Edm.String" MaxLength="40"/>
+        <Property Name="PublicationDate" Type="Edm.DateTime" sap:display-format="Date"/>
+        <Property Name="Keywords" Type="Collection(Edm.String)" Nullable="true"/>
+        <Property Name="PopularityScore" Type="Edm.Double"/>
+        <NavigationProperty Name="Copies" Relationship="Library.Service.CollectorsItems_Copies" FromRole="CollectorsItems" ToRole="Copies"/>
+        <Property Name="ExtraData" Type="Edm.String"/>
+        <NavigationProperty Name="StorageLocation" Relationship="Library.Service.CollectorsItems_StorageLocation" FromRole="CollectorsItems" ToRole="Branches"/>
+        <Property Name="StorageLocation_Id" Type="Edm.Int32"/>
+      </EntityType>
+      <EntityType Name="Members">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="Name" Type="Edm.String" MaxLength="100" Nullable="false"/>
+        <Property Name="DateOfBirth" Type="Edm.DateTime" sap:display-format="Date"/>
+        <Property Name="Address_Street" Type="Edm.String" MaxLength="120"/>
+        <Property Name="Address_City" Type="Edm.String" MaxLength="80"/>
+        <Property Name="Address_PostalCode" Type="Edm.String" MaxLength="10"/>
+        <Property Name="Address_Country" Type="Edm.String" MaxLength="60"/>
+        <Property Name="PreviousAddresses" Type="Collection(Library.Service.Library_Catalog_PostalAddress)" Nullable="true"/>
+        <Property Name="ActiveSince" Type="Edm.DateTimeOffset" Precision="7"/>
+        <Property Name="Balance" Type="Edm.Decimal" Precision="9" Scale="2"/>
+        <NavigationProperty Name="Loans" Relationship="Library.Service.Loans_Member" FromRole="Members" ToRole="Loans"/>
+        <NavigationProperty Name="Reservations" Relationship="Library.Service.Reservations_Member" FromRole="Members" ToRole="Reservations"/>
+        <NavigationProperty Name="IdDocument" Relationship="Library.Service.Members_IdDocument" FromRole="Members" ToRole="IdDocuments"/>
+        <Property Name="IdDocument_Id" Type="Edm.Guid"/>
+      </EntityType>
+      <EntityType Name="Loans">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="LoanedAt" Type="Edm.DateTimeOffset" Precision="7" Nullable="false"/>
+        <Property Name="DueDate" Type="Edm.DateTime" Nullable="false" sap:display-format="Date"/>
+        <Property Name="ReturnedAt" Type="Edm.DateTimeOffset" Precision="7"/>
+        <Property Name="LateFee" Type="Edm.Decimal" Precision="5" Scale="2"/>
+        <NavigationProperty Name="Member" Relationship="Library.Service.Loans_Member" FromRole="Loans" ToRole="Members"/>
+        <Property Name="Member_Id" Type="Edm.Int32" Nullable="false"/>
+        <NavigationProperty Name="Copy" Relationship="Library.Service.Loans_Copy" FromRole="Loans" ToRole="Copies"/>
+        <Property Name="Copy_MediumId" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="Copy_InventoryNumber" Type="Edm.Int32" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="Reservations">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="ReservedAt" Type="Edm.DateTimeOffset" Precision="7"/>
+        <NavigationProperty Name="Member" Relationship="Library.Service.Reservations_Member" FromRole="Reservations" ToRole="Members"/>
+        <Property Name="Member_Id" Type="Edm.Int32"/>
+      </EntityType>
+      <EntityType Name="IdDocuments">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="Scan" Type="Edm.Binary"/>
+        <Property Name="UploadedAt" Type="Edm.DateTimeOffset" Precision="7"/>
+      </EntityType>
+      <EntityType Name="Bookmobiles">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="LicensePlate" Type="Edm.String" MaxLength="12"/>
+        <Property Name="Route" Type="Edm.String"/>
+        <Property Name="CurrentPosition" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="MainBranch">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="Name" Type="Edm.String" MaxLength="100" Nullable="false"/>
+        <Property Name="Address_Street" Type="Edm.String" MaxLength="120"/>
+        <Property Name="Address_City" Type="Edm.String" MaxLength="80"/>
+        <Property Name="Address_PostalCode" Type="Edm.String" MaxLength="10"/>
+        <Property Name="Address_Country" Type="Edm.String" MaxLength="60"/>
+        <Property Name="Location" Type="Edm.String"/>
+        <Property Name="CatchmentArea" Type="Edm.String"/>
+        <Property Name="LowestFloor" Type="Edm.SByte"/>
+        <Property Name="FloorPlanOrigin" Type="Edm.String"/>
+        <Property Name="FloorPlanShapes" Type="Edm.String"/>
+        <Property Name="OpensAt" Type="Edm.Time"/>
+        <Property Name="ClosesAt" Type="Edm.Time"/>
+        <Property Name="Amenities" Type="Edm.Int32"/>
+        <Property Name="Population" Type="Edm.Int64"/>
+      </EntityType>
+      <EntityType Name="PublisherBranches">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="City" Type="Edm.String" MaxLength="80"/>
+        <Property Name="Country" Type="Edm.String" MaxLength="60"/>
+      </EntityType>
+      <ComplexType Name="Library_Catalog_MediumStats">
+        <Property Name="TotalLoanCount" Type="Edm.Int64"/>
+        <Property Name="AverageLoanDuration" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="Library_Catalog_ConditionReport">
+        <Property Name="ConditionBefore" Type="Edm.Byte"/>
+        <Property Name="ConditionAfter" Type="Edm.Byte"/>
+        <Property Name="Remark" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="Library_Catalog_PostalAddress">
+        <Property Name="Street" Type="Edm.String" MaxLength="120"/>
+        <Property Name="City" Type="Edm.String" MaxLength="80"/>
+        <Property Name="PostalCode" Type="Edm.String" MaxLength="10"/>
+        <Property Name="Country" Type="Edm.String" MaxLength="60"/>
+      </ComplexType>
+      <ComplexType Name="Library_Circulation_OverdueNotice">
+        <Property Name="Reason" Type="Edm.String"/>
+        <Property Name="Amount" Type="Edm.Decimal" Precision="5" Scale="2"/>
+        <Property Name="CreatedAt" Type="Edm.DateTimeOffset" Precision="7"/>
+      </ComplexType>
+      <ComplexType Name="Library_Circulation_LoanStats">
+        <Property Name="TotalLoans" Type="Edm.Int64"/>
+        <Property Name="AverageLoanDuration" Type="Edm.String"/>
+      </ComplexType>
+      <ComplexType Name="Library_Circulation_DateRange">
+        <Property Name="From" Type="Edm.DateTime" sap:display-format="Date"/>
+        <Property Name="To" Type="Edm.DateTime" sap:display-format="Date"/>
+      </ComplexType>
+      <ComplexType Name="Library_Circulation_BranchStats">
+        <Property Name="BranchId" Type="Edm.Int32"/>
+        <Property Name="LoanCount" Type="Edm.Int64"/>
+      </ComplexType>
+      <ComplexType Name="Library_Circulation_AnnualReport">
+        <Property Name="Year" Type="Edm.Int32"/>
+        <Property Name="TotalLoans" Type="Edm.Int64"/>
+        <Property Name="TotalLateFees" Type="Edm.Decimal" Precision="12" Scale="2"/>
+      </ComplexType>
+      <Association Name="Books_Copies">
+        <End Role="Books" Type="Library.Service.Books" Multiplicity="*"/>
+        <End Role="Copies" Type="Library.Service.Copies" Multiplicity="*"/>
+      </Association>
+      <Association Name="Books_Publisher">
+        <End Role="Books" Type="Library.Service.Books" Multiplicity="*"/>
+        <End Role="Publishers" Type="Library.Service.Publishers" Multiplicity="0..1"/>
+        <ReferentialConstraint>
+          <Principal Role="Publishers">
+            <PropertyRef Name="Id"/>
+          </Principal>
+          <Dependent Role="Books">
+            <PropertyRef Name="Publisher_Id"/>
+          </Dependent>
+        </ReferentialConstraint>
+      </Association>
+      <Association Name="Copies_Location">
+        <End Role="Copies" Type="Library.Service.Copies" Multiplicity="*"/>
+        <End Role="Branches" Type="Library.Service.Branches" Multiplicity="0..1"/>
+        <ReferentialConstraint>
+          <Principal Role="Branches">
+            <PropertyRef Name="Id"/>
+          </Principal>
+          <Dependent Role="Copies">
+            <PropertyRef Name="Location_Id"/>
+          </Dependent>
+        </ReferentialConstraint>
+      </Association>
+      <Association Name="Magazines_Copies">
+        <End Role="Magazines" Type="Library.Service.Magazines" Multiplicity="*"/>
+        <End Role="Copies" Type="Library.Service.Copies" Multiplicity="*"/>
+      </Association>
+      <Association Name="TradeJournals_Copies">
+        <End Role="TradeJournals" Type="Library.Service.TradeJournals" Multiplicity="*"/>
+        <End Role="Copies" Type="Library.Service.Copies" Multiplicity="*"/>
+      </Association>
+      <Association Name="Audiobooks_Copies">
+        <End Role="Audiobooks" Type="Library.Service.Audiobooks" Multiplicity="*"/>
+        <End Role="Copies" Type="Library.Service.Copies" Multiplicity="*"/>
+      </Association>
+      <Association Name="AudiobookChapters_up_">
+        <End Role="AudiobookChapters" Type="Library.Service.AudiobookChapters" Multiplicity="*"/>
+        <End Role="Audiobooks" Type="Library.Service.Audiobooks" Multiplicity="0..1">
+          <OnDelete Action="Cascade"/>
+        </End>
+        <ReferentialConstraint>
+          <Principal Role="Audiobooks">
+            <PropertyRef Name="Id"/>
+          </Principal>
+          <Dependent Role="AudiobookChapters">
+            <PropertyRef Name="up__Id"/>
+          </Dependent>
+        </ReferentialConstraint>
+      </Association>
+      <Association Name="DVDs_Copies">
+        <End Role="DVDs" Type="Library.Service.DVDs" Multiplicity="*"/>
+        <End Role="Copies" Type="Library.Service.Copies" Multiplicity="*"/>
+      </Association>
+      <Association Name="EBooks_Copies">
+        <End Role="EBooks" Type="Library.Service.EBooks" Multiplicity="*"/>
+        <End Role="Copies" Type="Library.Service.Copies" Multiplicity="*"/>
+      </Association>
+      <Association Name="CollectorsItems_Copies">
+        <End Role="CollectorsItems" Type="Library.Service.CollectorsItems" Multiplicity="*"/>
+        <End Role="Copies" Type="Library.Service.Copies" Multiplicity="*"/>
+      </Association>
+      <Association Name="CollectorsItems_StorageLocation">
+        <End Role="CollectorsItems" Type="Library.Service.CollectorsItems" Multiplicity="*"/>
+        <End Role="Branches" Type="Library.Service.Branches" Multiplicity="0..1"/>
+        <ReferentialConstraint>
+          <Principal Role="Branches">
+            <PropertyRef Name="Id"/>
+          </Principal>
+          <Dependent Role="CollectorsItems">
+            <PropertyRef Name="StorageLocation_Id"/>
+          </Dependent>
+        </ReferentialConstraint>
+      </Association>
+      <Association Name="Members_IdDocument">
+        <End Role="Members" Type="Library.Service.Members" Multiplicity="1">
+          <OnDelete Action="Cascade"/>
+        </End>
+        <End Role="IdDocuments" Type="Library.Service.IdDocuments" Multiplicity="0..1"/>
+        <ReferentialConstraint>
+          <Principal Role="IdDocuments">
+            <PropertyRef Name="Id"/>
+          </Principal>
+          <Dependent Role="Members">
+            <PropertyRef Name="IdDocument_Id"/>
+          </Dependent>
+        </ReferentialConstraint>
+      </Association>
+      <Association Name="Loans_Member">
+        <End Role="Loans" Type="Library.Service.Loans" Multiplicity="*"/>
+        <End Role="Members" Type="Library.Service.Members" Multiplicity="1">
+          <OnDelete Action="Cascade"/>
+        </End>
+        <ReferentialConstraint>
+          <Principal Role="Members">
+            <PropertyRef Name="Id"/>
+          </Principal>
+          <Dependent Role="Loans">
+            <PropertyRef Name="Member_Id"/>
+          </Dependent>
+        </ReferentialConstraint>
+      </Association>
+      <Association Name="Loans_Copy">
+        <End Role="Loans" Type="Library.Service.Loans" Multiplicity="*"/>
+        <End Role="Copies" Type="Library.Service.Copies" Multiplicity="1"/>
+        <ReferentialConstraint>
+          <Principal Role="Copies">
+            <PropertyRef Name="MediumId"/>
+            <PropertyRef Name="InventoryNumber"/>
+          </Principal>
+          <Dependent Role="Loans">
+            <PropertyRef Name="Copy_MediumId"/>
+            <PropertyRef Name="Copy_InventoryNumber"/>
+          </Dependent>
+        </ReferentialConstraint>
+      </Association>
+      <Association Name="Reservations_Member">
+        <End Role="Reservations" Type="Library.Service.Reservations" Multiplicity="*"/>
+        <End Role="Members" Type="Library.Service.Members" Multiplicity="0..1">
+          <OnDelete Action="Cascade"/>
+        </End>
+        <ReferentialConstraint>
+          <Principal Role="Members">
+            <PropertyRef Name="Id"/>
+          </Principal>
+          <Dependent Role="Reservations">
+            <PropertyRef Name="Member_Id"/>
+          </Dependent>
+        </ReferentialConstraint>
+      </Association>
+      <Annotations Target="Library.Service.Books" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.AlternateKeys">
+          <Collection>
+            <Record Type="Core.AlternateKey">
+              <PropertyValue Property="Key">
+                <Collection>
+                  <Record Type="Core.PropertyRef">
+                    <PropertyValue Property="Name" PropertyPath="ISBN"/>
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="Library.Service.EntityContainer/Books" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Capabilities.SearchRestrictions">
+          <Record Type="Capabilities.SearchRestrictionsType">
+            <PropertyValue Property="Searchable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Core.AlternateKeys">
+          <Collection>
+            <Record Type="Core.AlternateKey">
+              <PropertyValue Property="Key">
+                <Collection>
+                  <Record Type="Core.PropertyRef">
+                    <PropertyValue Property="Name" PropertyPath="ISBN"/>
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="Library.Service.Books/Id" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.ComputedDefaultValue" Bool="true"/>
+      </Annotations>
+      <Annotations Target="Library.Service.Books/PopularityScore" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.Computed" Bool="true"/>
+      </Annotations>
+      <Annotations Target="Library.Service.Copies/MediumId" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.ComputedDefaultValue" Bool="true"/>
+      </Annotations>
+      <Annotations Target="Library.Service.Copies/Status" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Validation.AllowedValues">
+          <Collection>
+            <Record Type="Validation.AllowedValue">
+              <Annotation Term="Core.SymbolicName" String="Available"/>
+              <PropertyValue Property="Value" Int="0"/>
+            </Record>
+            <Record Type="Validation.AllowedValue">
+              <Annotation Term="Core.SymbolicName" String="OnLoan"/>
+              <PropertyValue Property="Value" Int="1"/>
+            </Record>
+            <Record Type="Validation.AllowedValue">
+              <Annotation Term="Core.SymbolicName" String="InRepair"/>
+              <PropertyValue Property="Value" Int="2"/>
+            </Record>
+            <Record Type="Validation.AllowedValue">
+              <Annotation Term="Core.SymbolicName" String="Missing"/>
+              <PropertyValue Property="Value" Int="3"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="Library.Service.Branches/Amenities" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Validation.AllowedValues">
+          <Collection>
+            <Record Type="Validation.AllowedValue">
+              <Annotation Term="Core.SymbolicName" String="WheelchairAccessible"/>
+              <PropertyValue Property="Value" Int="1"/>
+            </Record>
+            <Record Type="Validation.AllowedValue">
+              <Annotation Term="Core.SymbolicName" String="Parking"/>
+              <PropertyValue Property="Value" Int="2"/>
+            </Record>
+            <Record Type="Validation.AllowedValue">
+              <Annotation Term="Core.SymbolicName" String="Café"/>
+              <PropertyValue Property="Value" Int="4"/>
+            </Record>
+            <Record Type="Validation.AllowedValue">
+              <Annotation Term="Core.SymbolicName" String="KidsArea"/>
+              <PropertyValue Property="Value" Int="8"/>
+            </Record>
+            <Record Type="Validation.AllowedValue">
+              <Annotation Term="Core.SymbolicName" String="StudyRoom"/>
+              <PropertyValue Property="Value" Int="16"/>
+            </Record>
+            <Record Type="Validation.AllowedValue">
+              <Annotation Term="Core.SymbolicName" String="FullService"/>
+              <PropertyValue Property="Value" Int="31"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="Library.Service.Magazines" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.AlternateKeys">
+          <Collection>
+            <Record Type="Core.AlternateKey">
+              <PropertyValue Property="Key">
+                <Collection>
+                  <Record Type="Core.PropertyRef">
+                    <PropertyValue Property="Name" PropertyPath="ISBN"/>
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="Library.Service.EntityContainer/Magazines" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Capabilities.SearchRestrictions">
+          <Record Type="Capabilities.SearchRestrictionsType">
+            <PropertyValue Property="Searchable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Core.AlternateKeys">
+          <Collection>
+            <Record Type="Core.AlternateKey">
+              <PropertyValue Property="Key">
+                <Collection>
+                  <Record Type="Core.PropertyRef">
+                    <PropertyValue Property="Name" PropertyPath="ISBN"/>
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="Library.Service.Magazines/Id" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.ComputedDefaultValue" Bool="true"/>
+      </Annotations>
+      <Annotations Target="Library.Service.Magazines/PopularityScore" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.Computed" Bool="true"/>
+      </Annotations>
+      <Annotations Target="Library.Service.TradeJournals" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.AlternateKeys">
+          <Collection>
+            <Record Type="Core.AlternateKey">
+              <PropertyValue Property="Key">
+                <Collection>
+                  <Record Type="Core.PropertyRef">
+                    <PropertyValue Property="Name" PropertyPath="ISBN"/>
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="Library.Service.EntityContainer/TradeJournals" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Capabilities.SearchRestrictions">
+          <Record Type="Capabilities.SearchRestrictionsType">
+            <PropertyValue Property="Searchable" Bool="true"/>
+          </Record>
+        </Annotation>
+        <Annotation Term="Core.AlternateKeys">
+          <Collection>
+            <Record Type="Core.AlternateKey">
+              <PropertyValue Property="Key">
+                <Collection>
+                  <Record Type="Core.PropertyRef">
+                    <PropertyValue Property="Name" PropertyPath="ISBN"/>
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="Library.Service.TradeJournals/Id" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.ComputedDefaultValue" Bool="true"/>
+      </Annotations>
+      <Annotations Target="Library.Service.TradeJournals/PopularityScore" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.Computed" Bool="true"/>
+      </Annotations>
+      <Annotations Target="Library.Service.Audiobooks" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.MediaType" String="audio/mpeg"/>
+      </Annotations>
+      <Annotations Target="Library.Service.EntityContainer/Audiobooks" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Capabilities.SearchRestrictions">
+          <Record Type="Capabilities.SearchRestrictionsType">
+            <PropertyValue Property="Searchable" Bool="true"/>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="Library.Service.Audiobooks/Id" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.ComputedDefaultValue" Bool="true"/>
+      </Annotations>
+      <Annotations Target="Library.Service.Audiobooks/PopularityScore" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.Computed" Bool="true"/>
+      </Annotations>
+      <Annotations Target="Library.Service.AudiobookChapters" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.MediaType" String="audio/mpeg"/>
+      </Annotations>
+      <Annotations Target="Library.Service.EntityContainer/DVDs" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Capabilities.SearchRestrictions">
+          <Record Type="Capabilities.SearchRestrictionsType">
+            <PropertyValue Property="Searchable" Bool="true"/>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="Library.Service.DVDs/Id" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.ComputedDefaultValue" Bool="true"/>
+      </Annotations>
+      <Annotations Target="Library.Service.DVDs/PopularityScore" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.Computed" Bool="true"/>
+      </Annotations>
+      <Annotations Target="Library.Service.EBooks" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.MediaType" String="application/epub+zip"/>
+      </Annotations>
+      <Annotations Target="Library.Service.EntityContainer/EBooks" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Capabilities.SearchRestrictions">
+          <Record Type="Capabilities.SearchRestrictionsType">
+            <PropertyValue Property="Searchable" Bool="true"/>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="Library.Service.EBooks/Id" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.ComputedDefaultValue" Bool="true"/>
+      </Annotations>
+      <Annotations Target="Library.Service.EBooks/PopularityScore" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.Computed" Bool="true"/>
+      </Annotations>
+      <Annotations Target="Library.Service.EntityContainer/CollectorsItems" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Capabilities.SearchRestrictions">
+          <Record Type="Capabilities.SearchRestrictionsType">
+            <PropertyValue Property="Searchable" Bool="true"/>
+          </Record>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="Library.Service.CollectorsItems/Id" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.ComputedDefaultValue" Bool="true"/>
+      </Annotations>
+      <Annotations Target="Library.Service.CollectorsItems/PopularityScore" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.Computed" Bool="true"/>
+      </Annotations>
+      <Annotations Target="Library.Service.Loans/Id" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.ComputedDefaultValue" Bool="true"/>
+      </Annotations>
+      <Annotations Target="Library.Service.Reservations/Id" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.ComputedDefaultValue" Bool="true"/>
+      </Annotations>
+      <Annotations Target="Library.Service.IdDocuments/Id" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.ComputedDefaultValue" Bool="true"/>
+      </Annotations>
+      <Annotations Target="Library.Service.MainBranch/Amenities" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Validation.AllowedValues">
+          <Collection>
+            <Record Type="Validation.AllowedValue">
+              <Annotation Term="Core.SymbolicName" String="WheelchairAccessible"/>
+              <PropertyValue Property="Value" Int="1"/>
+            </Record>
+            <Record Type="Validation.AllowedValue">
+              <Annotation Term="Core.SymbolicName" String="Parking"/>
+              <PropertyValue Property="Value" Int="2"/>
+            </Record>
+            <Record Type="Validation.AllowedValue">
+              <Annotation Term="Core.SymbolicName" String="Café"/>
+              <PropertyValue Property="Value" Int="4"/>
+            </Record>
+            <Record Type="Validation.AllowedValue">
+              <Annotation Term="Core.SymbolicName" String="KidsArea"/>
+              <PropertyValue Property="Value" Int="8"/>
+            </Record>
+            <Record Type="Validation.AllowedValue">
+              <Annotation Term="Core.SymbolicName" String="StudyRoom"/>
+              <PropertyValue Property="Value" Int="16"/>
+            </Record>
+            <Record Type="Validation.AllowedValue">
+              <Annotation Term="Core.SymbolicName" String="FullService"/>
+              <PropertyValue Property="Value" Int="31"/>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/int-test/cap/test/globalSetup.ts
+++ b/int-test/cap/test/globalSetup.ts
@@ -15,16 +15,28 @@ import type { TestProject } from "vitest/node";
  *
  * The image is language-agnostic on purpose: future servers (ASP.NET, Java, ...) implement the same
  * standardized model and only differ in the image name, so this file is the single point that changes.
+ *
+ * The same server answers OData **V2** as well, on a path of its own: `@cap-js-community/odata-v2-adapter`
+ * runs as a CAP plugin in front of the V4 endpoint and translates both ways. Its URL is therefore derived
+ * from the V4 one rather than configured separately - there is only ever one server, see test/v2/.
  */
 const CUSTOM_IMAGE = process.env.CAP_SERVER_IMAGE;
 const IMAGE = CUSTOM_IMAGE ?? "ghcr.io/odata2ts/test-server-cap:latest";
 const SERVICE_PATH = "/odata/v4/library";
+const SERVICE_PATH_V2 = "/odata/v2/library";
 const CONTAINER_PORT = 4004;
+
+/** The V2 endpoint of the very same service - the adapter mirrors the path, only the version segment differs. */
+function toV2(baseUrl: string) {
+  return baseUrl.replace(/\/v4\//, "/v2/");
+}
 
 export default async function setup(project: TestProject) {
   const externalBaseUrl = process.env.LIBRARY_BASE_URL;
   if (externalBaseUrl) {
-    project.provide("libraryBaseUrl", externalBaseUrl.replace(/\/+$/, ""));
+    const trimmed = externalBaseUrl.replace(/\/+$/, "");
+    project.provide("libraryBaseUrl", trimmed);
+    project.provide("libraryV2BaseUrl", toV2(trimmed));
     return () => {};
   }
 
@@ -53,7 +65,9 @@ export default async function setup(project: TestProject) {
     );
   }
 
-  project.provide("libraryBaseUrl", `http://localhost:${container.getMappedPort(CONTAINER_PORT)}${SERVICE_PATH}`);
+  const host = `http://localhost:${container.getMappedPort(CONTAINER_PORT)}`;
+  project.provide("libraryBaseUrl", `${host}${SERVICE_PATH}`);
+  project.provide("libraryV2BaseUrl", `${host}${SERVICE_PATH_V2}`);
 
   return async () => {
     await container.stop();

--- a/int-test/cap/test/v2/LibraryV2TestConstants.ts
+++ b/int-test/cap/test/v2/LibraryV2TestConstants.ts
@@ -1,0 +1,22 @@
+import { FetchClient } from "@odata2ts/http-client-fetch";
+import { inject } from "vitest";
+import { LibraryV2Service } from "../../src-generated/library-v2/LibraryV2Service.js";
+
+/**
+ * Base URL of the V2 endpoint, provided by `globalSetup`. Same server, same data, same process as the V4
+ * one - only routed through `@cap-js-community/odata-v2-adapter`.
+ */
+export const BASE_URL = inject("libraryV2BaseUrl");
+export const ODATA_CLIENT = new FetchClient();
+export const LIBRARY_V2 = new LibraryV2Service(ODATA_CLIENT, BASE_URL);
+
+// Fixed keys from the seed data (`db/data/*.csv` in the test-server-cap repo) - the same rows the V4
+// tests use, since it is one database.
+
+/** "Der Prozess" - a book with fixed, well-known values. */
+export const BOOK_DER_PROZESS = "11111111-1111-1111-1111-111111111111";
+export const UNKNOWN_ID = "00000000-0000-0000-0000-000000000000";
+
+/** Carriers of binary content: `Audiobook.Sample` and `EBook.content` in the V4 model. */
+export const AUDIOBOOK = "44444444-4444-4444-4444-444444444441";
+export const EBOOK = "66666666-6666-6666-6666-666666666661";

--- a/int-test/cap/test/v2/core/CrudOperations.test.ts
+++ b/int-test/cap/test/v2/core/CrudOperations.test.ts
@@ -1,0 +1,190 @@
+import { HttpResponseModel } from "@odata2ts/http-client-api";
+import { ODataCollectionResponseV2, ODataEntityModelResponseV2 } from "@odata2ts/odata-core";
+import { describe, expect, expectTypeOf, test } from "vitest";
+import { Books, EditableBooks } from "../../../src-generated/library-v2/LibraryV2Model.js";
+import { expectODataError } from "../../expectODataError.js";
+import { BASE_URL, BOOK_DER_PROZESS, LIBRARY_V2, UNKNOWN_ID } from "../LibraryV2TestConstants.js";
+
+/**
+ * The plain CRUD surface over V2. Same entities, same rows, same server as `test/core/CrudOperations.test.ts` -
+ * so every difference here is a difference of the protocol version, or of the adapter translating it.
+ *
+ * The three that shape every test in this folder:
+ *
+ * - **the envelope**: V2 wraps everything in `d`, a collection additionally in `results`
+ * - **the key**: a key is typed in the URL (`Books(guid'...')`), not bare as in V4
+ * - **the write response**: V4 answers a write with 200 + representation only when asked; the adapter answers
+ *   200 + representation always - which odata2ts does not type, see the tests below
+ */
+describe("CAP Library V2: CRUD operations", () => {
+  test("a key is written with its type", () => {
+    expect(LIBRARY_V2.Books(BOOK_DER_PROZESS).getPath()).toBe(`${BASE_URL}/Books(guid'${BOOK_DER_PROZESS}')`);
+
+    // a compound key names its parts, each typed on its own
+    expect(LIBRARY_V2.Copies({ MediumId: BOOK_DER_PROZESS, InventoryNumber: 1001 }).getPath()).toBe(
+      `${BASE_URL}/Copies(MediumId=guid'${BOOK_DER_PROZESS}',InventoryNumber=1001)`,
+    );
+  });
+
+  test("read entity by key", async () => {
+    const result = await LIBRARY_V2.Books(BOOK_DER_PROZESS).query().execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.d).toMatchObject({
+      Id: BOOK_DER_PROZESS,
+      Title: "Der Prozess",
+      Language: "de",
+      ISBN: "9783150094440",
+      PageCount: 224,
+    });
+
+    // V2 keeps the payload inside `d` and adds `__metadata` to every entity - the single most visible
+    // difference to V4, where `result.data` *is* the entity
+    expect(result.data.d.__metadata.uri).toBe(`${BASE_URL}/Books(guid'${BOOK_DER_PROZESS}')`);
+    expect(result.data.d.__metadata.type).toBe("Library.Service.Books");
+
+    expectTypeOf(result).toEqualTypeOf<HttpResponseModel<ODataEntityModelResponseV2<Books>>>();
+    expectTypeOf(result.data.d.Title).toEqualTypeOf<string>();
+    expectTypeOf(result.data.d.PageCount).toEqualTypeOf<number | null>();
+  });
+
+  test("read entity collection", async () => {
+    const result = await LIBRARY_V2.Books().query().execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.d.results.length).toBeGreaterThan(0);
+    expect(result.data.d.results.map((book) => book.Title)).toContain("Der Prozess");
+
+    // `d.results` rather than V4's `value`
+    expectTypeOf(result).toEqualTypeOf<HttpResponseModel<ODataCollectionResponseV2<Books>>>();
+    expectTypeOf(result.data.d.results).toEqualTypeOf<Array<Books>>();
+  });
+
+  test("an unexpanded navigation property arrives as a deferred link", async () => {
+    // V4 simply omits what was not expanded. V2 puts a `__deferred` stand-in there instead, which is why
+    // the generated model types a navigation property as `T | DeferredContent`.
+    const result = await LIBRARY_V2.Books(BOOK_DER_PROZESS).query().execute();
+
+    expect(result.data.d.Copies).toStrictEqual({
+      __deferred: { uri: `${BASE_URL}/Books(guid'${BOOK_DER_PROZESS}')/Copies` },
+    });
+  });
+
+  test("read with unknown key yields 404", async () => {
+    await expectODataError(LIBRARY_V2.Books(UNKNOWN_ID).query().execute(), { status: 404, message: /Not Found/ });
+  });
+
+  test("create, read, update, patch and delete an entity", async () => {
+    const newBook: EditableBooks = {
+      Title: "Das Schloss",
+      Language: "de",
+      PageCount: 352,
+    };
+
+    // create
+    const created = await LIBRARY_V2.Books().create(newBook).execute();
+    expect(created.status).toBe(201);
+    expect(created.data.d).toMatchObject(newBook);
+    expectTypeOf(created).toEqualTypeOf<HttpResponseModel<ODataEntityModelResponseV2<Books>>>();
+
+    const id = created.data.d.Id;
+    expect(id).toBeDefined();
+
+    // read it back
+    const read = await LIBRARY_V2.Books(id).query().execute();
+    expect(read.status).toBe(200);
+    expect(read.data.d).toMatchObject(newBook);
+
+    // update replaces the whole entity - PUT, as in V4
+    const updated = await LIBRARY_V2.Books(id)
+      .update({ Title: "Das Schloss (2. Auflage)", Language: "de", PageCount: 353 })
+      .execute();
+    expect(updated.status).toBe(200);
+    expect((await LIBRARY_V2.Books(id).query().execute()).data.d.PageCount).toBe(353);
+
+    // patch is a MERGE here: V2 has no PATCH verb, so odata2ts tunnels it through POST + X-Http-Method
+    const patched = await LIBRARY_V2.Books(id).patch({ PageCount: 354 }).execute();
+    expect(patched.status).toBe(200);
+
+    const afterPatch = await LIBRARY_V2.Books(id).query().execute();
+    expect(afterPatch.data.d.PageCount).toBe(354);
+    // untouched properties survive a merge
+    expect(afterPatch.data.d.Title).toBe("Das Schloss (2. Auflage)");
+
+    // delete
+    const deleted = await LIBRARY_V2.Books(id).delete().execute();
+    expect(deleted.status).toBe(204);
+    expectTypeOf(deleted).toEqualTypeOf<HttpResponseModel<undefined>>();
+
+    await expectODataError(LIBRARY_V2.Books(id).query().execute(), { status: 404, message: /Not Found/ });
+  });
+
+  test("the adapter answers a write with a body that the V2 typing does not admit", async () => {
+    /*
+     * V2 prescribes 204 and no content for `update` and `patch`, and odata2ts types both as
+     * `HttpResponseModel<undefined>` accordingly - there is no `<true>` switch in V2 as there is in V4.
+     * This server answers 200 with the full entity instead, because that is what the V4 endpoint behind
+     * the adapter does. So the data is there at runtime while the compiler says it cannot be, and a caller
+     * who wants it has to re-read the entity or cast.
+     *
+     * Pinned rather than worked around: it is the one place where the V2 client's typing and this server
+     * disagree on a plain, everyday request.
+     */
+    const created = await LIBRARY_V2.Books().create({ Title: "Write Response Probe", Language: "de" }).execute();
+    const id = created.data.d.Id;
+
+    const patched = await LIBRARY_V2.Books(id).patch({ PageCount: 42 }).execute();
+
+    expect(patched.status).toBe(200);
+    expectTypeOf(patched).toEqualTypeOf<HttpResponseModel<undefined>>();
+    // ... and yet:
+    expect(patched.data).toBeDefined();
+
+    await LIBRARY_V2.Books(id).delete().execute();
+  });
+
+  test("deleting an unknown entity yields 404", async () => {
+    await expectODataError(LIBRARY_V2.Books(UNKNOWN_ID).delete().execute(), { status: 404, message: /Not Found/ });
+  });
+
+  test("an entity with a concurrency token can be created, and then never changed again", async () => {
+    /*
+     * `Copy.Condition` carries `@odata.etag`, so every write against a copy needs `If-Match`. That holds
+     * over V4 just as much - odata2ts has no ETag handling in either version, so `Copies` is create-only
+     * for this client, full stop.
+     *
+     * What V2 adds is that the metadata finally *says* so: `ConcurrencyMode="Fixed"` on the property, where
+     * the V4 document emits an empty `Core.OptimisticConcurrency` annotation that names nothing. The
+     * information a client would need to implement this is present here and absent there - which makes the
+     * gap odata2ts', not the server's.
+     */
+    const copy = await LIBRARY_V2.Copies()
+      .create({ MediumId: UNKNOWN_ID, InventoryNumber: 9821, IsLoanable: true, Condition: "1" })
+      .execute();
+    expect(copy.status).toBe(201);
+
+    const key = { MediumId: UNKNOWN_ID, InventoryNumber: 9821 };
+    // the token the client would have to echo, and the only trace of it in the payload
+    expect((await LIBRARY_V2.Copies(key).query().execute()).data.d.__metadata.etag).toMatch(/^W\//);
+
+    await expectODataError(LIBRARY_V2.Copies(key).patch({ IsLoanable: false }).execute(), {
+      status: 428,
+      message: /Precondition Required/,
+    });
+    await expectODataError(LIBRARY_V2.Copies(key).delete().execute(), {
+      status: 428,
+      message: /Precondition Required/,
+    });
+  });
+
+  test("a navigation property is addressable as a sub-resource", async () => {
+    const toMany = await LIBRARY_V2.Books(BOOK_DER_PROZESS).Copies().query().execute();
+    expect(toMany.status).toBe(200);
+    expect(toMany.data.d.results.length).toBeGreaterThan(0);
+    expect(toMany.data.d.results.every((copy) => copy.MediumId === BOOK_DER_PROZESS)).toBe(true);
+
+    const toOne = await LIBRARY_V2.Books(BOOK_DER_PROZESS).Publisher().query().execute();
+    expect(toOne.status).toBe(200);
+    expect(toOne.data.d.Name).toBe("Reclam");
+  });
+});

--- a/int-test/cap/test/v2/core/Operations.test.ts
+++ b/int-test/cap/test/v2/core/Operations.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "vitest";
+import { Library_Catalog_MediumStats } from "../../../src-generated/library-v2/LibraryV2Model.js";
+import { expectODataError } from "../../expectODataError.js";
+import { BASE_URL, BOOK_DER_PROZESS, LIBRARY_V2 } from "../LibraryV2TestConstants.js";
+
+/**
+ * Functions and actions over V2.
+ *
+ * V2 knows neither bound operations nor the `Namespace.Name(...)` call syntax: everything is a
+ * `FunctionImport` on the entity container, addressed by name with its arguments as query parameters, and
+ * `GET` vs. `POST` is the only distinction left between a function and an action. The adapter therefore
+ * flattens every bound operation into an import named `<EntitySet>_<Operation>` whose first parameter is
+ * the key of the entity it was bound to - `Books_LoanMetrics?Id=guid'...'`.
+ *
+ * odata2ts follows the metadata, so all 29 operations end up as methods on the *service* object rather than
+ * on an entity service. Reaching an operation therefore means naming its entity twice: once in the method
+ * and once in the key parameter.
+ *
+ * These require the server's custom handlers, which only load when the server is started through the full
+ * `cds` tooling (as the published Docker image does).
+ */
+describe("CAP Library V2: operations", () => {
+  test("an operation is an import on the container, with typed arguments", () => {
+    expect(decodeURIComponent(LIBRARY_V2.Search({ Term: "Prozess", MaxResults: 1 }).getUrl())).toBe(
+      `${BASE_URL}/Search?Term='Prozess'&MaxResults=1`,
+    );
+
+    // what was bound to an entity in V4 keeps its receiver as an ordinary parameter
+    expect(decodeURIComponent(LIBRARY_V2.Books_LoanMetrics({ Id: BOOK_DER_PROZESS }).getUrl())).toBe(
+      `${BASE_URL}/Books_LoanMetrics?Id=guid'${BOOK_DER_PROZESS}'`,
+    );
+  });
+
+  test("unbound function with params", async () => {
+    const result = await LIBRARY_V2.Search({ Term: "Prozess" }).execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.d.results.map((book) => book.Title)).toContain("Der Prozess");
+  });
+
+  test("unbound function returning a collection", async () => {
+    const result = await LIBRARY_V2.AllLanguages().execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.d.results.length).toBeGreaterThan(0);
+    expect(result.data.d.results).toContain("de");
+  });
+
+  test("unbound function returning an entity", async () => {
+    const result = await LIBRARY_V2.MostReadMedium().execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.d.Title).toBeDefined();
+    expect(result.data.d.__metadata.type).toBe("Library.Service.Books");
+  });
+
+  test("unbound action", async () => {
+    const result = await LIBRARY_V2.NextInventoryNumber().execute();
+
+    expect(result.status).toBe(200);
+    // a primitive result is keyed by the operation name - which is exactly what ODataValueResponseV2 says
+    expect(Number(result.data.d.NextInventoryNumber)).toBeGreaterThan(0);
+  });
+
+  test("void action", async () => {
+    const result = await LIBRARY_V2.ClosureDay({ Day: "2026-12-24" }).execute();
+
+    expect(result.status).toBe(204);
+    expect(result.data).toBeUndefined();
+  });
+
+  test("bound function, reached through its flattened import", async () => {
+    const result = await LIBRARY_V2.Books_LoanMetrics({ Id: BOOK_DER_PROZESS }).execute();
+
+    expect(result.status).toBe(200);
+    // the operation name wrapping a complex result is unwrapped by the generated response converter, so
+    // `d` carries the complex type's properties directly
+    const stats = result.data.d as unknown as Library_Catalog_MediumStats;
+    expect(stats.TotalLoanCount).toBeDefined();
+  });
+
+  test("bound function returning a collection", async () => {
+    const result = await LIBRARY_V2.Books_AvailableCopies({ Id: BOOK_DER_PROZESS }).execute();
+
+    expect(result.status).toBe(200);
+    expect(Array.isArray(result.data.d.results)).toBe(true);
+    expect(result.data.d.results.every((copy) => copy.MediumId === BOOK_DER_PROZESS)).toBe(true);
+  });
+
+  test("bound action", async () => {
+    const result = await LIBRARY_V2.Books_Reserve({ Id: BOOK_DER_PROZESS, MemberId: 1 }).execute();
+
+    expect(result.status).toBe(200);
+    expect(Number(result.data.d.Books_Reserve)).toBeGreaterThan(0);
+  });
+
+  test("an Edm.Int64 result arrives wrapped in an object the typing does not expect", async () => {
+    /*
+     * `ODataValueResponseV2<T>` says `d.<OperationName>` *is* the value, and that holds for the Int32 and
+     * the Decimal returning operations above. Not for this one: the adapter hands the V4 payload
+     * (`{"@odata.context": ..., "value": 19}`) through as a nested object instead of lifting the value out,
+     * so a caller reading `d.TotalMediaCount` gets `{ value, __metadata }` where the compiler promises a
+     * string. Pinned because nothing else makes this visible - the request itself succeeds.
+     */
+    const result = await LIBRARY_V2.TotalMediaCount().execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.d.TotalMediaCount as unknown).toStrictEqual({
+      value: expect.stringMatching(/^\d+$/),
+      __metadata: {},
+    });
+  });
+
+  test("a complex operation result carries a type name the metadata does not contain", async () => {
+    // `Library_Circulation_AnnualReport` in `$metadata`, `Library.Service.ion_AnnualReport` in the payload:
+    // the adapter mangles the flattened namespace when it builds `__metadata.type`. Harmless for odata2ts,
+    // which never reads that field, but it makes the payload unusable for anything that dispatches on the
+    // declared type.
+    const result = await LIBRARY_V2.YearEndClosing({ Year: 2024 }).execute();
+
+    expect(result.status).toBe(200);
+    expect((result.data.d as unknown as { __metadata: { type: string } }).__metadata.type).toBe(
+      "Library.Service.ion_AnnualReport",
+    );
+  });
+
+  test("an operation bound to a collection cannot be reached at all", async () => {
+    // `AvailableLanguages` is bound to `many $self` in CDS, i.e. to the *set* of books. The adapter still
+    // flattens it into a single-key import, so the only call the metadata allows is the one the V4 service
+    // underneath then refuses. There is no way to spell the intended call in V2.
+    await expectODataError(LIBRARY_V2.Books_AvailableLanguages({ Id: BOOK_DER_PROZESS }).execute(), {
+      status: 400,
+      message: /must be called on a collection of Library\.Service\.Books/,
+    });
+  });
+
+  test("an operation on an ETag-carrying entity demands a precondition odata2ts cannot send", async () => {
+    // `Copy.Condition` carries `@odata.etag`, so every write against a copy - this action included - needs
+    // `If-Match`. odata2ts sends none, in either version, so the operation stays unreachable over V4 as
+    // well. See core/CrudOperations.test.ts for what V2 does differently: it declares the token in the
+    // metadata, where V4 leaves the annotation empty.
+    await expectODataError(
+      LIBRARY_V2.Copies_CheckOut({ MediumId: BOOK_DER_PROZESS, InventoryNumber: 1001, MemberId: 1 }).execute(),
+      { status: 428, message: /Precondition Required/ },
+    );
+  });
+
+  test("a complex operation parameter has no V2 notation", async () => {
+    // V2 function imports take primitive parameters only. The reference model has one operation with a
+    // structured parameter, and odata2ts renders it as best it can - which the server cannot read back.
+    await expectODataError(LIBRARY_V2.LoanStatistics({ Period: { From: "2024-01-01", To: "2024-12-31" } }).execute(), {
+      status: 400,
+      message: /Invalid value: Period/,
+    });
+  });
+});

--- a/int-test/cap/test/v2/core/QueryFunctionality.test.ts
+++ b/int-test/cap/test/v2/core/QueryFunctionality.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, test } from "vitest";
+import { BOOK_DER_PROZESS, LIBRARY_V2 } from "../LibraryV2TestConstants.js";
+
+/**
+ * The system query options V2 knows, on read requests.
+ *
+ * The query builder is version-aware, so most of this reads like the V4 file - the differences are in what
+ * the builder is allowed to render and in what comes back:
+ *
+ * - counting is `$inlinecount=allpages` and the count arrives as a **string** in `d.__count`
+ * - `$expand` carries no nested options, so `expanding()` is a deep *select* and nothing more
+ * - `$search`, `$apply`/`groupBy` and the `$count` path segment do not exist in V2 and the builder does
+ *   not offer them
+ *
+ * What the builder does still offer, although V2 has no such thing, are the lambda operators - see the
+ * last two tests.
+ */
+describe("CAP Library V2: query functionality", () => {
+  test("$inlinecount instead of $count", async () => {
+    const cmd = LIBRARY_V2.Books().query((b) => b.count());
+    expect(decodeURIComponent(cmd.getUrl())).toContain("$inlinecount=allpages");
+
+    const result = await cmd.execute();
+
+    expect(result.status).toBe(200);
+    // a string, not a number - V2 serialises it as text and odata2ts hands it over unchanged
+    expect(result.data.d.__count).toMatch(/^\d+$/);
+    expect(Number(result.data.d.__count)).toBeGreaterThan(0);
+    expect(result.data.d.results.length).toBeGreaterThan(0);
+  });
+
+  test("$select", async () => {
+    const result = await LIBRARY_V2.Books(BOOK_DER_PROZESS)
+      .query((b) => b.select("Title", "Language"))
+      .execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.d.Title).toBe("Der Prozess");
+    expect(result.data.d.Language).toBe("de");
+    expect(result.data.d.ISBN).toBeUndefined();
+  });
+
+  test("$filter", async () => {
+    const result = await LIBRARY_V2.Books()
+      .query((b, q) => b.filter(q.Language.eq("de")))
+      .execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.d.results.length).toBeGreaterThan(0);
+    expect(result.data.d.results.every((book) => book.Language === "de")).toBe(true);
+  });
+
+  test("$filter with in", async () => {
+    const result = await LIBRARY_V2.Books()
+      .query((b, q) => b.filter(q.Language.in("de", "en")))
+      .execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.d.results.length).toBeGreaterThan(0);
+    expect(result.data.d.results.every((book) => book.Language === "de" || book.Language === "en")).toBe(true);
+  });
+
+  test("a string filter function is spelled the V2 way", async () => {
+    // V4's `contains(Title,'Prozess')` is `substringof('Prozess',Title)` in V2 - inverted arguments and a
+    // different name. The q-object knows that, so the same `contains()` call yields valid OData in both
+    // versions; nothing about it is visible to the caller.
+    const cmd = LIBRARY_V2.Books().query((b, q) => b.filter(q.Title.contains("Prozess")));
+    expect(decodeURIComponent(cmd.getUrl())).toContain("$filter=substringof('Prozess',Title)");
+
+    const result = await cmd.execute();
+    expect(result.status).toBe(200);
+    expect(result.data.d.results.map((book) => book.Title)).toStrictEqual(["Der Prozess"]);
+  });
+
+  test("$top and $skip", async () => {
+    const all = await LIBRARY_V2.Books()
+      .query((b, q) => b.orderBy(q.Title.asc()))
+      .execute();
+    expect(all.data.d.results.length).toBeGreaterThan(1);
+
+    const skipped = await LIBRARY_V2.Books()
+      .query((b, q) => b.orderBy(q.Title.asc()).skip(1).top(1))
+      .execute();
+
+    expect(skipped.data.d.results.length).toBe(1);
+    expect(skipped.data.d.results[0].Title).toBe(all.data.d.results[1].Title);
+  });
+
+  test("$orderby", async () => {
+    const ascending = await LIBRARY_V2.Books()
+      .query((b, q) => b.orderBy(q.Title.asc()))
+      .execute();
+    const descending = await LIBRARY_V2.Books()
+      .query((b, q) => b.orderBy(q.Title.desc()))
+      .execute();
+
+    const ascendingTitles = ascending.data.d.results.map((book) => book.Title);
+    const descendingTitles = descending.data.d.results.map((book) => book.Title);
+
+    expect(descendingTitles.length).toBeGreaterThan(1);
+    expect(descendingTitles).toStrictEqual([...ascendingTitles].reverse());
+  });
+
+  test("$expand", async () => {
+    const result = await LIBRARY_V2.Books(BOOK_DER_PROZESS)
+      .query((b) => b.select("Title").expand("Publisher"))
+      .execute();
+
+    expect(result.status).toBe(200);
+    // an expanded navigation property is the entity itself, where an unexpanded one is a `__deferred` link
+    expect(result.data.d.Publisher).toMatchObject({ Name: "Reclam" });
+  });
+
+  test("expanding() is a deep select, since $expand carries no options in V2", async () => {
+    // V4 would render `$expand=Publisher($select=Name)`. V2 cannot nest anything inside `$expand`, so the
+    // selection is lifted into the outer `$select` with a path - which is why `ExpandingQueryBuilderV2`
+    // offers `select` and nothing else.
+    const cmd = LIBRARY_V2.Books(BOOK_DER_PROZESS).query((b) => b.expanding("Publisher", (pb) => pb.select("Name")));
+
+    const url = decodeURIComponent(cmd.getUrl());
+    expect(url).toContain("$select=Publisher/Name");
+    expect(url).toContain("$expand=Publisher");
+
+    const result = await cmd.execute();
+    expect(result.status).toBe(200);
+    expect(result.data.d.Publisher).toMatchObject({ Name: "Reclam" });
+    // narrowed as asked: the publisher's other properties did not come along
+    expect((result.data.d.Publisher as unknown as Record<string, unknown>).Country).toBeUndefined();
+  });
+
+  test("a lambda over a navigation collection is rendered - and this server evaluates it", async () => {
+    /*
+     * `any()` is not part of OData V2, but the q-objects offer it in both versions, so the builder happily
+     * renders `Copies/any(a:a/IsLoanable eq true)` into a V2 URL. A strict V2 server would refuse that.
+     *
+     * This one does not: the adapter hands `$filter` through to the V4 endpoint unchanged, which parses it
+     * fine. So the request works *because* there is a V4 service underneath - not because it is valid V2.
+     * Asserted with the actual result, since a wrong filter that is silently ignored also answers 200.
+     */
+    const result = await LIBRARY_V2.Books()
+      .query((b, q) => b.select("Title").filter(q.Copies.any((copy) => copy.IsLoanable.eq(true))))
+      .execute();
+
+    expect(result.status).toBe(200);
+
+    const expanded = await LIBRARY_V2.Books()
+      .query((b) => b.select("Title").expand("Copies"))
+      .execute();
+    const expectedTitles = expanded.data.d.results
+      .filter((book) => (book.Copies as Array<{ IsLoanable: boolean }>).some((copy) => copy.IsLoanable))
+      .map((book) => book.Title)
+      .sort();
+
+    expect(expectedTitles.length).toBeGreaterThan(0);
+    expect(result.data.d.results.map((book) => book.Title).sort()).toStrictEqual(expectedTitles);
+  });
+
+  /**
+   * Skipped for the same reason as its V4 twin: it **takes the server down**. `$filter=Keywords/all(a:a ne
+   * 'X')` reaches the V4 endpoint through the adapter, where `@sap/cds` 10.0.3 throws an uncaught TypeError
+   * in its OData parser and the process exits - so running it would fail every test after it, in both
+   * folders, since all files share one server.
+   *
+   * Kept here to record that the adapter changes nothing about it: the crash is CAP's, and V2 is merely
+   * another way to reach it.
+   */
+  test.skip("$filter with all on a primitive collection", async () => {
+    const result = await LIBRARY_V2.Books()
+      .query((b, q) => b.select("Title").filter(q.Keywords.all((keyword) => keyword.it.ne("Nonexistent"))))
+      .execute();
+
+    expect(result.status).toBe(200);
+  });
+
+  test("an invalid query option is silently ignored here too", async () => {
+    const result = await LIBRARY_V2.Books()
+      .query((b) => b.top(-1))
+      .execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.d.results.length).toBeGreaterThan(0);
+  });
+});

--- a/int-test/cap/test/v2/core/Singleton.test.ts
+++ b/int-test/cap/test/v2/core/Singleton.test.ts
@@ -1,0 +1,83 @@
+import { HttpResponseModel } from "@odata2ts/http-client-api";
+import { ODataCollectionResponseV2, ODataEntityModelResponseV2 } from "@odata2ts/odata-core";
+import { describe, expect, expectTypeOf, test } from "vitest";
+import { MainBranch } from "../../../src-generated/library-v2/LibraryV2Model.js";
+import { BASE_URL, LIBRARY_V2 } from "../LibraryV2TestConstants.js";
+
+/**
+ * What the V4 model serves as the singleton `MainBranch`.
+ *
+ * OData V2 has no singletons - the concept arrived with V4 - so the adapter re-declares it as an ordinary
+ * `EntitySet` with a key. odata2ts follows that and generates the usual pair of services: a collection
+ * service for `MainBranch()` and an entity service for `MainBranch(id)`.
+ *
+ * At runtime the server does *not* follow its own metadata: `/MainBranch` answers with a single entity, the
+ * way a singleton does, not with a `results` array. So the collection service is typed for a payload this
+ * server never sends, while the entity service - which the metadata says is the addressable one - works.
+ * That split is the whole point of this file.
+ */
+describe("CAP Library V2: what was the singleton", () => {
+  test("it is an entity set here, so it has a key", () => {
+    expect(LIBRARY_V2.MainBranch().getPath()).toBe(`${BASE_URL}/MainBranch`);
+    expect(LIBRARY_V2.MainBranch(1).getPath()).toBe(`${BASE_URL}/MainBranch(1)`);
+  });
+
+  test("reading it by key works and yields a single entity", async () => {
+    const result = await LIBRARY_V2.MainBranch(1).query().execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.d.Name).toBeDefined();
+    expect(result.data.d.__metadata.uri).toBe(`${BASE_URL}/MainBranch(1)`);
+
+    expectTypeOf(result).toEqualTypeOf<HttpResponseModel<ODataEntityModelResponseV2<MainBranch>>>();
+  });
+
+  test("reading it without a key answers as a singleton, not as a collection", async () => {
+    // The metadata promises a collection, the server sends one entity. odata2ts believes the metadata, so
+    // `d.results` is typed as an array and is `undefined` at runtime - a caller iterating it gets a
+    // TypeError, with nothing in `$metadata` to warn them.
+    const result = await LIBRARY_V2.MainBranch().query().execute();
+
+    expect(result.status).toBe(200);
+    expectTypeOf(result).toEqualTypeOf<HttpResponseModel<ODataCollectionResponseV2<MainBranch>>>();
+
+    expect(result.data.d.results).toBeUndefined();
+    expect((result.data.d as unknown as MainBranch).Name).toBeDefined();
+  });
+
+  test("query options work on it", async () => {
+    const result = await LIBRARY_V2.MainBranch(1)
+      .query((builder) => builder.select("Name"))
+      .execute();
+
+    expect(result.data.d.Name).toBeDefined();
+    expect(result.data.d.LowestFloor).toBeUndefined();
+  });
+
+  test("patch the entity", async () => {
+    const original = (await LIBRARY_V2.MainBranch(1).query().execute()).data.d.Name;
+
+    const patched = await LIBRARY_V2.MainBranch(1).patch({ Name: "Main Branch (patched)" }).execute();
+    expect(patched.status).toBe(200);
+
+    expect((await LIBRARY_V2.MainBranch(1).query().execute()).data.d.Name).toBe("Main Branch (patched)");
+
+    await LIBRARY_V2.MainBranch(1).patch({ Name: original }).execute();
+  });
+
+  test("the address is flattened here as well", async () => {
+    // The adapter passes CAP's flat mode straight through: `Address_City`, not `Address/City`. Unlike the
+    // other structured elements of this model, which V2 *does* get as real complex types - see
+    // feature/DataTypes.test.ts.
+    const result = await LIBRARY_V2.MainBranch(1)
+      .query((builder) => builder.select("Address_City", "Address_Country"))
+      .execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.d.Address_City).toBeDefined();
+    expect(result.data.d.Name).toBeUndefined();
+
+    expectTypeOf<MainBranch>().toHaveProperty("Address_City");
+    expectTypeOf<MainBranch>().not.toHaveProperty("Address");
+  });
+});

--- a/int-test/cap/test/v2/feature/Blobs.test.ts
+++ b/int-test/cap/test/v2/feature/Blobs.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, expectTypeOf, test } from "vitest";
+import { Audiobooks, EBooks } from "../../../src-generated/library-v2/LibraryV2Model.js";
+import { AUDIOBOOK, BASE_URL, EBOOK, LIBRARY_V2 } from "../LibraryV2TestConstants.js";
+
+/**
+ * Binary content - odata2ts issue #149 - over V2, and the one feature where the two versions of the *client*
+ * differ rather than the two versions of the server.
+ *
+ * The server side is the better of the two here. V2 has no `Edm.Stream`, so the adapter re-expresses both
+ * carriers of binary content as what V2 does have: **media link entries**. `Audiobooks`, `AudiobookChapters`
+ * and `EBooks` come out as `m:HasStream="true"`, their content sits at `.../$value`, and every entity
+ * advertises it through `__metadata.media_src`. That is closer to the reference model, which declares
+ * `EBook` a media entity, than the V4 metadata of the same service, where CAP emits plain `Edm.Stream`
+ * properties and no `HasStream` at all.
+ *
+ * odata2ts cannot use any of it: `getBlob`/`updateBlob`/`getStream` and the media-entity service exist only
+ * in `@odata2ts/odata-service`'s v4 folder, and the V2 generator emits neither a stream service nor a media
+ * one. So this file asserts the gap from both sides - what the client does not offer, and what the server
+ * would have answered - rather than leaving the feature silently untested.
+ *
+ * The raw `fetch` calls below are deliberate and the only ones in this package: there is no generated client
+ * API to call instead, and that is precisely the finding.
+ */
+describe("CAP Library V2: binary content", () => {
+  const V4_BASE_URL = BASE_URL.replace("/v2/", "/v4/");
+
+  test("the stream property is gone from the model - the entity itself carries the content", () => {
+    // What is `content: Edm.Stream` in the V4 model has no property here at all. A caller migrating a V4
+    // client to V2 loses the property rather than getting a differently typed one.
+    expectTypeOf<EBooks>().not.toHaveProperty("content");
+    expectTypeOf<Audiobooks>().not.toHaveProperty("Sample");
+  });
+
+  test("the generated service offers no way to read or write that content", () => {
+    // The V4 client has `EBooks(id).content().getBlob()` and `Audiobooks(id).Sample().updateStream(...)`.
+    // Neither the property services nor a media-entity shortcut are generated for V2.
+    const ebook = LIBRARY_V2.EBooks(EBOOK) as unknown as Record<string, unknown>;
+
+    expect(ebook.content).toBeUndefined();
+    expect(ebook.getBlob).toBeUndefined();
+    expect(ebook.updateBlob).toBeUndefined();
+    expect(ebook.getStream).toBeUndefined();
+    expect((LIBRARY_V2.Audiobooks(AUDIOBOOK) as unknown as Record<string, unknown>).Sample).toBeUndefined();
+  });
+
+  test("the server does serve it, as a media link entry", async () => {
+    // Uploaded over V4, because that is the only version odata2ts can write it with. Read over V2, to show
+    // what the client would find there.
+    const content = "PK pretend-this-is-epub";
+    const uploaded = await fetch(`${V4_BASE_URL}/EBooks(${EBOOK})/content`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/epub+zip" },
+      body: content,
+    });
+    expect(uploaded.status).toBe(204);
+
+    const entity = await fetch(`${BASE_URL}/EBooks(guid'${EBOOK}')`).then((r) => r.json());
+    expect(entity.d.__metadata.media_src).toBe(`${BASE_URL}/EBooks(guid'${EBOOK}')/$value`);
+    expect(entity.d.__metadata.content_type).toBe("application/epub+zip");
+
+    const value = await fetch(entity.d.__metadata.media_src);
+    expect(value.status).toBe(200);
+    expect(value.headers.get("content-type")).toBe("application/epub+zip");
+    expect(await value.text()).toBe(content);
+  });
+
+  test("what the V4 model calls a named stream property is the entity's content here", async () => {
+    // Over V4 this is `.../Audiobooks(<id>)/Sample`. In V2 the whole entity is the stream, so the address
+    // is `$value` - which also means an entity can carry exactly one binary payload, and a model with two
+    // named streams on one entity could not be expressed at all.
+    const content = "ID3 pretend-this-is-mp3";
+    await fetch(`${V4_BASE_URL}/Audiobooks(${AUDIOBOOK})/Sample`, {
+      method: "PUT",
+      headers: { "Content-Type": "audio/mpeg" },
+      body: content,
+    });
+
+    const value = await fetch(`${BASE_URL}/Audiobooks(guid'${AUDIOBOOK}')/$value`);
+    expect(value.status).toBe(200);
+    expect(await value.text()).toBe(content);
+
+    // The old address still answers, since the adapter forwards anything it does not translate to the V4
+    // endpoint. That does not help a generated client: `Sample` is not in the V2 `$metadata`, so odata2ts
+    // has nothing to generate a service from - the working URL is unreachable by construction.
+    const byPropertyName = await fetch(`${BASE_URL}/Audiobooks(guid'${AUDIOBOOK}')/Sample`);
+    expect(byPropertyName.status).toBe(200);
+    expect(await byPropertyName.text()).toBe(content);
+  });
+});

--- a/int-test/cap/test/v2/feature/DataTypes.test.ts
+++ b/int-test/cap/test/v2/feature/DataTypes.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, expectTypeOf, test } from "vitest";
+import { Books, Copies, MainBranch } from "../../../src-generated/library-v2/LibraryV2Model.js";
+import { BOOK_DER_PROZESS, LIBRARY_V2 } from "../LibraryV2TestConstants.js";
+
+/**
+ * How the values themselves arrive over V2 - the part of this folder with the least in common with V4.
+ *
+ * V2's JSON format serialises the numeric types that do not fit a JavaScript number as **strings**, and
+ * timestamps as `/Date(<ticks>)/`. odata2ts models that: `Edm.Int64`, `Edm.Decimal`, `Edm.Double` and
+ * `Edm.Single` become `string`, and a date/time property becomes `string` as long as no converter is
+ * configured (this package configures none, on purpose - the raw wire format is what is under test).
+ *
+ * That mapping is right everywhere except for `Edm.Byte`/`Edm.SByte`, which the last test pins.
+ *
+ * The type system of the model also shrinks on the way: `Edm.Date`, `Edm.TimeOfDay` and `Edm.Duration` have
+ * no V2 counterparts and the adapter substitutes `Edm.DateTime`, `Edm.Time` and `Edm.String` for them.
+ */
+describe("CAP Library V2: data types", () => {
+  test("the numeric types that do not fit a JS number arrive as strings", async () => {
+    const book = (await LIBRARY_V2.Books(BOOK_DER_PROZESS).query().execute()).data.d;
+
+    // Edm.Double
+    expect(book.PopularityScore).toBe("87.5");
+    expectTypeOf<Books["PopularityScore"]>().toEqualTypeOf<string | null>();
+
+    const branch = (await LIBRARY_V2.MainBranch(1).query().execute()).data.d;
+    // Edm.Int64
+    expect(branch.Population).toBe("1841000");
+    expectTypeOf<MainBranch["Population"]>().toEqualTypeOf<string | null>();
+
+    const member = (await LIBRARY_V2.Members(1).query().execute()).data.d;
+    // Edm.Decimal - the whole reason for the string: 0.00 must not become 0
+    expect(member.Balance).toBe("0.00");
+
+    const copy = (await LIBRARY_V2.Copies({ MediumId: BOOK_DER_PROZESS, InventoryNumber: 1001 }).query().execute()).data
+      .d;
+    // Edm.Single
+    expect(copy.WeightKg).toBe("0.31");
+
+    // the ones that do fit stay numbers
+    expect(book.PageCount).toBe(224);
+    expectTypeOf<Books["PageCount"]>().toEqualTypeOf<number | null>();
+  });
+
+  test("a filter over a string-typed number is still written as a number", async () => {
+    // The value is a string in the model but a number in the URL - the q-object knows the difference, so a
+    // caller filtering on `PopularityScore` passes the string they read back and gets valid OData.
+    const cmd = LIBRARY_V2.Books().query((b, q) => b.filter(q.PopularityScore.gt("90")));
+    expect(decodeURIComponent(cmd.getUrl())).toContain("$filter=PopularityScore gt 90");
+
+    const result = await cmd.execute();
+    expect(result.status).toBe(200);
+    expect(result.data.d.results.every((book) => Number(book.PopularityScore) > 90)).toBe(true);
+  });
+
+  test("dates and timestamps arrive as ticks, not as ISO 8601", async () => {
+    const book = (await LIBRARY_V2.Books(BOOK_DER_PROZESS).query().execute()).data.d;
+
+    // Edm.Date in the V4 model, Edm.DateTime here - and a JSON value no one reads by eye
+    expect(book.PublicationDate).toBe("/Date(-1410134400000)/");
+    expect(new Date(-1410134400000).toISOString()).toBe("1925-04-26T00:00:00.000Z");
+    expectTypeOf<Books["PublicationDate"]>().toEqualTypeOf<string | null>();
+
+    // Edm.DateTimeOffset keeps its offset, appended to the ticks
+    const member = (await LIBRARY_V2.Members(1).query().execute()).data.d;
+    expect(member.ActiveSince).toMatch(/^\/Date\(\d+\+0000\)\/$/);
+
+    // Edm.TimeOfDay in the V4 model, Edm.Time here - which V2 serialises as a duration since midnight
+    const branch = (await LIBRARY_V2.MainBranch(1).query().execute()).data.d;
+    expect(branch.OpensAt).toBe("PT09H00M00S");
+
+    // Edm.Duration has no V2 counterpart at all and is declared Edm.String
+    const audiobook = (
+      await LIBRARY_V2.Audiobooks()
+        .query((b) => b.top(1))
+        .execute()
+    ).data.d.results[0];
+    expect(audiobook.Duration).toMatch(/^P/);
+  });
+
+  test("the value read back can be filtered on, in both notations", async () => {
+    // `datetime'/Date(...)/' ` is not the V2 URI literal format, but it is what a caller who round-trips the
+    // value they were given produces - and this server accepts it as readily as the canonical spelling.
+    const byTicks = await LIBRARY_V2.Books()
+      .query((b, q) => b.filter(q.PublicationDate.eq("/Date(-1410134400000)/")))
+      .execute();
+    const byLiteral = await LIBRARY_V2.Books()
+      .query((b, q) => b.filter(q.PublicationDate.eq("1925-04-26T00:00:00")))
+      .execute();
+
+    expect(byTicks.data.d.results.map((book) => book.Title)).toStrictEqual(["Der Prozess"]);
+    expect(byLiteral.data.d.results.map((book) => book.Title)).toStrictEqual(["Der Prozess"]);
+  });
+
+  test("a guid is bare in the payload and typed in the URL", async () => {
+    const book = (await LIBRARY_V2.Books(BOOK_DER_PROZESS).query().execute()).data.d;
+
+    expect(book.Id).toBe(BOOK_DER_PROZESS);
+    expect(
+      decodeURIComponent(
+        LIBRARY_V2.Books()
+          .query((b, q) => b.filter(q.Id.eq(BOOK_DER_PROZESS)))
+          .getUrl(),
+      ),
+    ).toContain(`$filter=Id eq guid'${BOOK_DER_PROZESS}'`);
+  });
+
+  test("Edm.Byte is typed as a string but delivered as a number", async () => {
+    /*
+     * The one place where odata2ts's V2 type mapping and this server disagree. odata2ts groups `Edm.Byte`
+     * and `Edm.SByte` with the string-serialised numeric types (`DataModelDigestionV2.mapODataType`), while
+     * V2's JSON format puts them among the plain JSON numbers - which is what arrives here.
+     *
+     * The consequence is quiet and easy to trip over: `book.AgeRating === "16"` is `false` although the
+     * compiler says both sides are strings, and any code doing string work on the value gets a number.
+     * Writing is unaffected, since the server accepts either.
+     */
+    const book = (await LIBRARY_V2.Books(BOOK_DER_PROZESS).query().execute()).data.d;
+
+    expectTypeOf<Books["AgeRating"]>().toEqualTypeOf<string | null>();
+    expect(typeof (book.AgeRating as unknown)).toBe("number");
+    expect(book.AgeRating as unknown).toBe(16);
+
+    // same for Edm.SByte
+    const branch = (await LIBRARY_V2.MainBranch(1).query().execute()).data.d;
+    expectTypeOf<MainBranch["LowestFloor"]>().toEqualTypeOf<string | null>();
+    expect(branch.LowestFloor as unknown).toBe(-2);
+
+    // and for a byte on another entity, to show it is the type and not the property
+    const copy = (await LIBRARY_V2.Copies({ MediumId: BOOK_DER_PROZESS, InventoryNumber: 1001 }).query().execute()).data
+      .d;
+    expectTypeOf<Copies["Condition"]>().toEqualTypeOf<string | null>();
+    expect(typeof (copy.Condition as unknown)).toBe("number");
+  });
+
+  test("a structured element survives as a real complex type", async () => {
+    // CAP's flat mode reaches V2 as it reaches V4 - `Address_City`, not `Address/City`. A collection of a
+    // structured type is the exception in both versions: it stays a complex type, because there is no flat
+    // spelling for it.
+    const member = (await LIBRARY_V2.Members(1).query().execute()).data.d;
+
+    expect(member.Address_City).toBe("Hamburg");
+    expect(member.PreviousAddresses[0]).toMatchObject({ Street: "Alte Gasse 9", City: "Bremen" });
+
+    const asComplex = await LIBRARY_V2.Members(1).PreviousAddresses().query().execute();
+    expect(asComplex.status).toBe(200);
+  });
+});

--- a/int-test/cap/test/v2/feature/DeepInsert.test.ts
+++ b/int-test/cap/test/v2/feature/DeepInsert.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "vitest";
+import { expectODataError } from "../../expectODataError.js";
+import { LIBRARY_V2, UNKNOWN_ID } from "../LibraryV2TestConstants.js";
+
+/**
+ * Deep insert - odata2ts issue #237 - over V2.
+ *
+ * V2 has no `@odata.bind` and no separate notation for a deep insert: a nested object in the payload *is*
+ * the deep insert, which is what odata2ts sends in both versions. The adapter passes it to the V4 endpoint,
+ * so the rule that decides the outcome is CAP's own and identical to the V4 case: deep operations run along
+ * **compositions**, never along associations.
+ *
+ * The four cases and their verdicts therefore mirror `test/feature/DeepInsert.test.ts` exactly - which is
+ * the point of testing them again here. What differs is only what comes back: V2 answers a create with the
+ * nested entity inlined, so the children are visible in the response instead of needing a re-read.
+ */
+describe("CAP Library V2: deep insert", () => {
+  test("a to-one composition is created along with the entity", async () => {
+    const uploadedAt = "2026-08-02T10:00:00Z";
+
+    const created = await LIBRARY_V2.Members()
+      .create({
+        Name: "V2 Deep Insert Member",
+        // no key: the server generates it, so it is no part of the editable model
+        IdDocument: { UploadedAt: uploadedAt },
+      })
+      .execute();
+
+    expect(created.status).toBe(201);
+
+    const read = await LIBRARY_V2.Members(created.data.d.Id)
+      .query((builder) => builder.expand("IdDocument"))
+      .execute();
+
+    const idDocument = read.data.d.IdDocument as { UploadedAt: string | null };
+    expect(idDocument).toBeDefined();
+    // V2 serialises a timestamp as ticks since the epoch, not as ISO 8601 - see feature/DataTypes.test.ts
+    expect(idDocument.UploadedAt).toBe(`/Date(${Date.parse(uploadedAt)}+0000)/`);
+  });
+
+  test("a to-many composition is created along with the entity", async () => {
+    // CAP does not generate this key, unlike the ones of the entity sets themselves
+    const chapterId = Math.floor(Math.random() * 1_000_000) + 900_000;
+
+    const created = await LIBRARY_V2.Audiobooks()
+      .create({
+        Title: "V2 Deep Insert Audiobook",
+        Language: "de",
+        // Edm.Duration has no V2 counterpart, so the adapter declares it Edm.String - the value is the same
+        Duration: "PT1H",
+        Narrator: "Some Narrator",
+        // up__Id is the backlink to the parent, which does not exist yet - CAP fills it in and overwrites
+        // whatever was sent, but the editable model demands it, since it is a plain required property
+        Chapters: [{ Id: chapterId, up__Id: UNKNOWN_ID, Title: "First chapter" }],
+      })
+      .execute();
+
+    expect(created.status).toBe(201);
+
+    const read = await LIBRARY_V2.Audiobooks(created.data.d.Id)
+      .query((builder) => builder.expand("Chapters"))
+      .execute();
+
+    const chapters = read.data.d.Chapters as Array<{ Title: string | null; up__Id: string }>;
+    expect(chapters).toHaveLength(1);
+    expect(chapters[0].Title).toBe("First chapter");
+    expect(chapters[0].up__Id).toBe(created.data.d.Id);
+  });
+
+  test("a to-many association is accepted and then dropped", async () => {
+    const created = await LIBRARY_V2.Books()
+      .create({
+        Title: "V2 Deep Insert Book",
+        Language: "de",
+        PageCount: 123,
+        AgeRating: "0",
+        ISBN: "9780000009811",
+        Copies: [
+          {
+            MediumId: UNKNOWN_ID,
+            InventoryNumber: 9811,
+            IsLoanable: true,
+          },
+        ],
+      })
+      .execute();
+
+    expect(created.status).toBe(201);
+
+    const read = await LIBRARY_V2.Books(created.data.d.Id)
+      .query((builder) => builder.expand("Copies"))
+      .execute();
+
+    expect(read.data.d.Copies).toStrictEqual([]);
+  });
+
+  test("a to-one association refuses everything but its key", async () => {
+    const branches = await LIBRARY_V2.Branches()
+      .query((builder) => builder.top(1))
+      .execute();
+    const branchId = branches.data.d.results[0].Id;
+
+    await expectODataError(
+      LIBRARY_V2.Copies()
+        .create({
+          MediumId: UNKNOWN_ID,
+          InventoryNumber: 9812,
+          IsLoanable: true,
+          Location: { Name: "Branch Created On The Fly" },
+        })
+        .execute(),
+      // the message reaches the client unchanged through the adapter
+      { status: 400, message: /Property "Name" does not exist in Location/ },
+    );
+
+    // the foreign key does what the nested object cannot
+    const created = await LIBRARY_V2.Copies()
+      .create({
+        MediumId: UNKNOWN_ID,
+        InventoryNumber: 9813,
+        IsLoanable: true,
+        Location_Id: branchId,
+      })
+      .execute();
+
+    expect(created.status).toBe(201);
+    expect(created.data.d.Location_Id).toBe(branchId);
+    // no cleanup: a copy carries a concurrency token here and cannot be deleted again over V2 at all,
+    // see core/CrudOperations.test.ts. Like its V4 twin, this file relies on the fresh server per run.
+  });
+});

--- a/int-test/cap/test/v2/feature/PropertyServices.test.ts
+++ b/int-test/cap/test/v2/feature/PropertyServices.test.ts
@@ -1,0 +1,130 @@
+import { HttpResponseModel } from "@odata2ts/http-client-api";
+import { ODataCollectionResponseV2, ODataValueResponseV2 } from "@odata2ts/odata-core";
+import { StringCollection } from "@odata2ts/odata-query-objects";
+import { afterAll, describe, expect, expectTypeOf, test } from "vitest";
+import { expectODataError } from "../../expectODataError.js";
+import { BASE_URL, BOOK_DER_PROZESS, LIBRARY_V2 } from "../LibraryV2TestConstants.js";
+
+/**
+ * Services for individual properties over V2 - the `enablePrimitivePropertyServices` feature.
+ *
+ * Reading works and is typed correctly. **Writing destroys data.** A `PUT` against a property URL is
+ * answered with 204 by this server and leaves the property `null` (or, for a collection-valued one, empty),
+ * whatever the payload says - the value sent never arrives. Verified directly against the server with every
+ * body shape V2 allows, so this is not odata2ts choosing the wrong one:
+ *
+ * - `{"Language": "en"}` (what odata2ts sends) - 204, value nulled
+ * - `{"d": {"Language": "en"}}` - 204, value nulled
+ * - `PUT .../Language/$value` with `text/plain` - 415
+ *
+ * The V4 endpoint of the same server honours all of these (see `test/feature/PropertyServices.test.ts`), so
+ * the loss is introduced by the adapter. It is the most dangerous finding in this folder: the client gets a
+ * success status for a write that silently deleted the value it was supposed to set. Every write below is
+ * therefore asserted through a read-back - the status alone would have looked fine.
+ *
+ * The way through that works is the entity-level `patch`, which is also what the cleanup here uses.
+ */
+describe("CAP Library V2: property services", () => {
+  const book = () => LIBRARY_V2.Books(BOOK_DER_PROZESS);
+  const SEED_KEYWORDS = ["Roman", "Klassiker", "Fragment"];
+
+  // the seed data is the contract the other files assert against, and the property writes below wipe it -
+  // so it is put back the only way that works here
+  afterAll(async () => {
+    await book().patch({ Language: "de", Keywords: SEED_KEYWORDS }).execute();
+  });
+
+  describe("primitive property", () => {
+    test("the property name is appended to the entity URL", () => {
+      expect(book().Title().getPath()).toBe(`${BASE_URL}/Books(guid'${BOOK_DER_PROZESS}')/Title`);
+    });
+
+    test("read a single value", async () => {
+      const result = await book().Title().getValue().execute();
+
+      expect(result.status).toBe(200);
+      // V2 keys the value by the property name inside `d`, where V4 uses a fixed `value` field
+      expect(result.data.d.Title).toBe("Der Prozess");
+
+      expectTypeOf(result).toEqualTypeOf<HttpResponseModel<ODataValueResponseV2<string>>>();
+    });
+
+    test("updating a single value reports success and deletes it", async () => {
+      const updated = await book().Language().updateValue("en").execute();
+      expect(updated.status).toBe(204);
+
+      // not "en", and not the previous "de" either: reading a null value answers 204 with no body
+      const read = await book().Language().getValue().execute();
+      expect(read.status).toBe(204);
+      expect(read.data).toBeUndefined();
+
+      // and the entity agrees - the value is gone, not merely hidden from the property resource
+      expect((await book().query().execute()).data.d.Language).toBeNull();
+    });
+
+    test("the entity-level patch is the way that works", async () => {
+      const patched = await book().patch({ Language: "en" }).execute();
+      expect(patched.status).toBe(200);
+
+      expect((await book().Language().getValue().execute()).data.d.Language).toBe("en");
+      expect((await book().query().execute()).data.d.Language).toBe("en");
+    });
+
+    test("delete a nullable value", async () => {
+      const deleted = await book().Language().deleteValue().execute();
+      expect(deleted.status).toBe(204);
+      expectTypeOf(deleted).toEqualTypeOf<HttpResponseModel<undefined>>();
+
+      const read = await book().Language().getValue().execute();
+      expect(read.status).toBe(204);
+      expect(read.data).toBeUndefined();
+    });
+
+    test("deleting a non-nullable value fails, and the server says so bluntly", async () => {
+      // Same 500 with the database constraint showing through as over V4 - the adapter forwards the error
+      // unchanged, so at least this one is not swallowed.
+      await expectODataError(book().Title().deleteValue().execute(), {
+        status: 500,
+        message: /NOT NULL constraint failed/,
+      });
+    });
+  });
+
+  describe("collection-valued property", () => {
+    test("reading it does not answer in the shape the generated service expects", async () => {
+      // odata2ts types a collection-valued property as a collection response (`d.results`), which is what a
+      // V2 server should send for `.../Keywords`. This one sends the value-response shape instead, keyed by
+      // the property name - so `d.results` is undefined and the values sit in `d.Keywords`.
+      await book().patch({ Keywords: SEED_KEYWORDS }).execute();
+
+      const result = await book().Keywords().query().execute();
+
+      expect(result.status).toBe(200);
+      expectTypeOf(result).toEqualTypeOf<HttpResponseModel<ODataCollectionResponseV2<StringCollection>>>();
+
+      expect(result.data.d.results).toBeUndefined();
+      expect((result.data.d as unknown as { Keywords: Array<string> }).Keywords).toStrictEqual(SEED_KEYWORDS);
+    });
+
+    test("replacing the whole collection empties it", async () => {
+      await book().patch({ Keywords: SEED_KEYWORDS }).execute();
+
+      const updated = await book().Keywords().update(["Testschlagwort"]).execute();
+      expect(updated.status).toBe(204);
+
+      // the same silent loss as for a primitive property - 204, and the collection is empty
+      expect((await book().query().execute()).data.d.Keywords).toStrictEqual([]);
+    });
+
+    test("adding a single entry is refused, without a word about why", async () => {
+      // CAP stores such a property as a plain array element rather than as an addressable collection
+      // resource, so a POST against that path has nowhere to go. Over V4 the server says as much ("Method
+      // POST is not allowed"); here the adapter answers 400 with an error body carrying no message at all,
+      // so what reaches the caller is the client's own fallback text.
+      await expectODataError(book().Keywords().add("Noch eins").execute(), {
+        status: 400,
+        message: /No error message/,
+      });
+    });
+  });
+});

--- a/int-test/cap/test/vitest.d.ts
+++ b/int-test/cap/test/vitest.d.ts
@@ -6,5 +6,7 @@ import "vitest";
 declare module "vitest" {
   export interface ProvidedContext {
     libraryBaseUrl: string;
+    /** The OData V2 endpoint of the same server, served by the V2 adapter middleware. */
+    libraryV2BaseUrl: string;
   }
 }

--- a/packages/odata-query-objects/src/operation/QFunction.ts
+++ b/packages/odata-query-objects/src/operation/QFunction.ts
@@ -42,7 +42,7 @@ function compileQueryParams(params: FunctionParams | undefined, notEncoded: bool
  *
  * This includes handling of entity id paths (same format as V4 functions).
  */
-export abstract class QFunction<ParamModel, ResponseStructure> {
+export abstract class QFunction<ParamModel, ResponseStructure = undefined> {
   public constructor(protected name: string) {}
 
   public abstract isV2(): boolean;

--- a/packages/odata-query-objects/src/operation/QFunctionV2.ts
+++ b/packages/odata-query-objects/src/operation/QFunctionV2.ts
@@ -6,7 +6,15 @@ import { QFunction } from "./QFunction";
  *
  * This includes handling of entity id paths (same format as V4 functions).
  */
-export abstract class QFunctionV2<ParamModel, ResponseStructure> extends QFunction<ParamModel, ResponseStructure> {
+/*
+ * `ResponseStructure` defaults to `undefined` because a V2 function import may return nothing at all -
+ * V2 has no separate notion of an action, so a void operation is a `FunctionImport` with
+ * `m:HttpMethod="POST"`. The generator then emits `QFunctionV2<Params>` with no second argument.
+ */
+export abstract class QFunctionV2<ParamModel, ResponseStructure = undefined> extends QFunction<
+  ParamModel,
+  ResponseStructure
+> {
   public constructor(
     name: string,
     protected responseConverter?: MainResponseConverter<

--- a/packages/odata-query-objects/src/operation/QFunctionV4.ts
+++ b/packages/odata-query-objects/src/operation/QFunctionV4.ts
@@ -6,7 +6,10 @@ import { QFunction } from "./QFunction";
  *
  * This includes handling of entity id paths (same format as V4 functions).
  */
-export abstract class QFunctionV4<ParamModel, ResponseStructure> extends QFunction<ParamModel, ResponseStructure> {
+export abstract class QFunctionV4<ParamModel, ResponseStructure = undefined> extends QFunction<
+  ParamModel,
+  ResponseStructure
+> {
   public constructor(
     name: string,
     protected responseConverter?: MainResponseConverter<


### PR DESCRIPTION
- `QFunctionV2`/`QFunctionV4` now default `ResponseStructure` to `undefined`, as `QAction` already did: V2 has no separate action, so a void operation is a `FunctionImport` with `m:HttpMethod="POST"`, and the generator emits `QFunctionV2<Params>` with one type argument - which did not compile
- `int-test/cap` generates a second client from `resource/library-v2.xml`, the snapshot of the V2 `$metadata` that `@cap-js-community/odata-v2-adapter` serves in front of the same CAP service
- `test/v2/` mirrors the V4 folders file by file, 66 tests - the first time the V2 client meets a running server anywhere in this repo
- `globalSetup` derives the V2 base URL from the V4 one instead of configuring it: one server, one port, only the version segment differs
- `feature/CrudQuery.test.ts` has no V2 counterpart - V2 has no `Prefer: return=representation`, so query options on write requests do not exist

What the V2 suite pins, beyond the usual CRUD/query/operation surface:

- a `PUT` against a property URL answers **204 and deletes the value**, in every payload shape V2 allows, while the V4 endpoint honours all of them - so every property write is asserted through a read-back
- `Edm.Byte`/`Edm.SByte` are mapped to `string` in `DataModelDigestionV2`, but V2's JSON format sends them as numbers - `book.AgeRating === "16"` is `false` although both sides are typed `string`. The other four string-serialised types are correct
- there is no binary-content API in V2 at all (`StreamServiceV4`/`MediaEntityServiceV4` have no counterpart), while the adapter exposes proper media link entries - the one feature where the server is ahead of the client
- `update`/`patch` are typed `HttpResponseModel<undefined>`, and this server answers 200 with the full entity
- requests the adapter does not translate are forwarded to the V4 endpoint and answered - lambdas, `$search`, `/$count` - including the `Keywords/all(...)` expression that takes the whole process down, so that test is `skip`ped here as well

The server side of the same investigation is odata2ts/test-server-cap#8.