### PR TITLE
fix(odata-query-objects): render a V2 datetime literal without a timezone

### DIFF
--- a/examples/main/test/dataTypes/DataTypeV2.test.ts
+++ b/examples/main/test/dataTypes/DataTypeV2.test.ts
@@ -60,14 +60,19 @@ describe("V2 Data Types & Converter Tests", function () {
   });
 
   test("v2: DateTime in URL", async () => {
-    const expected = "2006-11-05T00:00:00.000Z";
+    // V2's `datetime` literal is timezone-less - `Edm.DateTime` carries no offset and its ABNF has no
+    // place for one - so an ISO value handed in is normalised to UTC and the designator dropped. A
+    // strict V2 server answers 400 for the `...Z` form; verified against Apache Olingo in
+    // int-test/olingo-v2.
+    const given = "2006-11-05T00:00:00.000Z";
+    const expectedLiteral = "2006-11-05T00:00:00";
 
     await DATA_TYPE_SERVICE.oneOfEverything()
       .query((builder, qOoe) => {
-        return builder.filter(qOoe.dateTimeType.eq(expected));
+        return builder.filter(qOoe.dateTimeType.eq(given));
       })
       .execute();
 
-    expect(ODATA_CLIENT.lastUrl).toBe(`${ONE_OF_EVERYTHING_URL}?$filter=DateTimeType eq datetime'${expected}'`);
+    expect(ODATA_CLIENT.lastUrl).toBe(`${ONE_OF_EVERYTHING_URL}?$filter=DateTimeType eq datetime'${expectedLiteral}'`);
   });
 });

--- a/examples/main/test/dataTypes/DataTypeV2Converted.test.ts
+++ b/examples/main/test/dataTypes/DataTypeV2Converted.test.ts
@@ -62,7 +62,10 @@ describe("V2 Data Types & Converter Tests", function () {
   });
 
   test("v2: DateTime in URL", async () => {
+    // the converted case of the same rule: a DateTime renders as a timezone-less V2 literal, because
+    // that is the only form `Edm.DateTime` has - see the unconverted test next to this one
     const exampleDate = "2006-11-05T00:00:00.000Z";
+    const expectedLiteral = "2006-11-05T00:00:00";
 
     await DATA_TYPE_SERVICE.oneOfEverything()
       .query((builder, qOoe) => {
@@ -70,6 +73,6 @@ describe("V2 Data Types & Converter Tests", function () {
       })
       .execute();
 
-    expect(ODATA_CLIENT.lastUrl).toBe(`${ONE_OF_EVERYTHING_URL}?$filter=DateTimeType eq datetime'${exampleDate}'`);
+    expect(ODATA_CLIENT.lastUrl).toBe(`${ONE_OF_EVERYTHING_URL}?$filter=DateTimeType eq datetime'${expectedLiteral}'`);
   });
 });

--- a/int-test/cap/test/globalSetup.ts
+++ b/int-test/cap/test/globalSetup.ts
@@ -61,7 +61,7 @@ export default async function setup(project: TestProject) {
         `Is a Docker daemon running? Without Docker, run against a server you started yourself:\n` +
         `  LIBRARY_BASE_URL=http://localhost:4004${SERVICE_PATH} yarn int-test:cap\n` +
         `Original error: ${e instanceof Error ? e.message : String(e)}`,
-      { cause: e },
+      { cause: e as Error },
     );
   }
 

--- a/int-test/olingo-v2/README.md
+++ b/int-test/olingo-v2/README.md
@@ -50,6 +50,23 @@ The server holds its data in memory and rebuilds it per process, so a restart is
 nothing to deploy or seed. Test files still share one instance, so `fileParallelism` is off and anything
 written is put back.
 
+## Two generated clients
+
+The package generates the model **twice** from the same snapshot:
+
+| Service            | Output                            | Purpose                                             |
+| ------------------ | --------------------------------- | --------------------------------------------------- |
+| `library`          | `src-generated/library`           | no converters - pins what the server actually sends |
+| `libraryConverted` | `src-generated/library-converted` | Luxon, BigNumber, bigint, and `converter-v2-to-v4`  |
+
+V2 is where converters earn their keep: the format hands over every timestamp as `/Date(<ticks>)/` and
+every numeric type that does not fit a JS number as a string, so the raw model types all of those as
+`string`. Both halves are worth pinning, and neither is meaningful alone - `feature/DataTypes.test.ts`
+covers the wire format, `feature/Converters.test.ts` covers what the converters make of it.
+
+This is the first place converters meet a **running** V2 server at all; `examples/main` covers the
+converted V2 model only against a mock client.
+
 ## Generation
 
 The client is generated offline from `resource/library-v2.xml`, a committed snapshot of the server's
@@ -78,3 +95,26 @@ Where the server does not support something, the test asserts the rejection rath
 - **No binary content API.** The server declares two media link entries and serves them from `/$value`;
   `@odata2ts/odata-service` has no V2 counterpart to `StreamServiceV4`, so `feature/Blobs.test.ts`
   asserts the gap from both sides with the only raw `fetch` calls in this package.
+- **A query option on a write is refused with 405.** Olingo routes on the shape of the URI, so an entity
+  URI carrying `$select` is a route with no `PUT` handler. CAP honours the same request, so a query
+  option on a write does not port between V2 servers.
+- **Expanding a complex property is refused.** odata2ts widened `expand()` to accept complex properties
+  for V2, because V2 does not inline them the way V4 does - but this server takes navigation properties
+  only, and inlines its complex values anyway. `feature/ComplexTypes.test.ts` pins both rejections next
+  to the deep select through a _navigation_ property, which does work.
+- **A converted date cannot be filtered on.** The Luxon converter renders `datetime'…T00:00:00.000Z'`,
+  and V2's `Edm.DateTime` is timezone-less - its ABNF has no offset - so a strict server rejects it. The
+  raw client renders `datetime'…T00:00:00'` and is accepted. This one is odata2ts', not the server's.
+
+## Bugs this package found
+
+Three, all fixed in the same branch, none of which any existing suite could have caught:
+
+- `PrimitiveTypeServiceV2` destructured its converter (`{ convertFrom, convertTo }`), which strips `this`
+  - so any converter implemented as a class threw, and `ChainedConverter` is exactly that, produced as
+    soon as two converters are configured. `PrimitiveTypeServiceV4` never had the bug.
+- `QueryObjectGenerator` emitted a converter-mapped operation return type without importing it, so a
+  service with both converters and a `Edm.Decimal`-returning operation generated a q-object file that
+  did not compile.
+- The server's own `MostReadMedium` unboxed a nullable score and answered 500 once a client had created
+  an entity without it (fixed in test-server-olingo-v2).

--- a/int-test/olingo-v2/README.md
+++ b/int-test/olingo-v2/README.md
@@ -95,20 +95,21 @@ Where the server does not support something, the test asserts the rejection rath
 - **No binary content API.** The server declares two media link entries and serves them from `/$value`;
   `@odata2ts/odata-service` has no V2 counterpart to `StreamServiceV4`, so `feature/Blobs.test.ts`
   asserts the gap from both sides with the only raw `fetch` calls in this package.
-- **A query option on a write is refused with 405.** Olingo routes on the shape of the URI, so an entity
-  URI carrying `$select` is a route with no `PUT` handler. CAP honours the same request, so a query
-  option on a write does not port between V2 servers.
+- **A query option on a modification request is out of scope for V2.** System query options are defined
+  for retrieval only, so there is no `$select` on a `PUT` for a service to honour. This server routes on
+  the shape of the URI and answers 405; that is a conforming reaction to a request the protocol does not
+  describe. The client lets it be expressed because the command type is shared with the read path.
 - **Expanding a complex property is refused.** odata2ts widened `expand()` to accept complex properties
   for V2, because V2 does not inline them the way V4 does - but this server takes navigation properties
   only, and inlines its complex values anyway. `feature/ComplexTypes.test.ts` pins both rejections next
   to the deep select through a _navigation_ property, which does work.
-- **A converted date cannot be filtered on.** The Luxon converter renders `datetime'…T00:00:00.000Z'`,
-  and V2's `Edm.DateTime` is timezone-less - its ABNF has no offset - so a strict server rejects it. The
-  raw client renders `datetime'…T00:00:00'` and is accepted. This one is odata2ts', not the server's.
+- **Filtering on a converted date works**, and did not before: V2's `Edm.DateTime` literal is
+  timezone-less while a converter hands back a full ISO string, so `QDateTimeV2Path` now normalises to
+  UTC and drops the designator. A strict V2 server rejects the ISO form outright.
 
 ## Bugs this package found
 
-Three, all fixed in the same branch, none of which any existing suite could have caught:
+Four, all fixed in the same branch, none of which any existing suite could have caught:
 
 - `PrimitiveTypeServiceV2` destructured its converter (`{ convertFrom, convertTo }`), which strips `this`
   - so any converter implemented as a class threw, and `ChainedConverter` is exactly that, produced as
@@ -116,5 +117,8 @@ Three, all fixed in the same branch, none of which any existing suite could have
 - `QueryObjectGenerator` emitted a converter-mapped operation return type without importing it, so a
   service with both converters and a `Edm.Decimal`-returning operation generated a q-object file that
   did not compile.
+- `QDateTimeV2Path` and `QDateTimeV2Param` wrapped a converted value into `datetime'...'` verbatim, so a
+  converted date produced `datetime'...T00:00:00.000Z'` - a literal V2 does not define, since
+  `Edm.DateTime` carries no timezone. Filtering on a date was therefore impossible with converters on.
 - The server's own `MostReadMedium` unboxed a nullable score and answered 500 once a client had created
   an entity without it (fixed in test-server-olingo-v2).

--- a/int-test/olingo-v2/odata2ts.config.ts
+++ b/int-test/olingo-v2/odata2ts.config.ts
@@ -25,6 +25,35 @@ const config: ConfigFileOptions = {
       source: "resource/library-v2.xml",
       output: "src-generated/library",
     },
+    /**
+     * The same model a second time, with converters switched on.
+     *
+     * V2 is where converters matter most: its JSON format hands over every timestamp as
+     * `/Date(<ticks>)/` and every numeric type that does not fit a JS number as a string, so the raw
+     * model types those as `string` and leaves the caller to parse them. The converters turn that into
+     * `DateTime`, `BigNumber` and `bigint` on the way in and back on the way out.
+     *
+     * Generated separately rather than replacing the raw client, because both halves are worth testing:
+     * `feature/DataTypes.test.ts` pins what the server actually sends, and `feature/Converters.test.ts`
+     * pins what the converters make of it. Neither is meaningful without the other.
+     */
+    libraryConverted: {
+      serviceName: "LibraryConverted",
+      source: "resource/library-v2.xml",
+      output: "src-generated/library-converted",
+      enablePrimitivePropertyServices: true,
+      converters: [
+        // maps V2's own spellings onto the V4 ones, so a date is an ISO string before anything else
+        // touches it - the base every other converter here builds on
+        "@odata2ts/converter-v2-to-v4",
+        "@odata2ts/converter-luxon",
+        "@odata2ts/converter-big-number",
+        {
+          module: "@odata2ts/converter-common",
+          use: ["int64ToBigIntConverter"],
+        },
+      ],
+    },
   },
 };
 

--- a/int-test/olingo-v2/package.json
+++ b/int-test/olingo-v2/package.json
@@ -14,11 +14,18 @@
     "test-compile": "node ../../node_modules/.bin/tsc"
   },
   "dependencies": {
+    "@odata2ts/converter-big-number": "^0.2.8",
+    "@odata2ts/converter-common": "^0.3.7",
+    "@odata2ts/converter-luxon": "^0.2.7",
+    "@odata2ts/converter-v2-to-v4": "^0.5.7",
     "@odata2ts/http-client-fetch": "^0.11.0",
-    "@odata2ts/odata-service": "workspace:^"
+    "@odata2ts/odata-service": "workspace:^",
+    "bignumber.js": "^9.1.2",
+    "luxon": "^3.7.2"
   },
   "devDependencies": {
     "@odata2ts/odata2ts": "workspace:^",
+    "@types/luxon": "^3.7.2",
     "testcontainers": "^12.0.4"
   }
 }

--- a/int-test/olingo-v2/test/LibraryConvertedConstants.ts
+++ b/int-test/olingo-v2/test/LibraryConvertedConstants.ts
@@ -1,0 +1,11 @@
+import { FetchClient } from "@odata2ts/http-client-fetch";
+import { inject } from "vitest";
+import { LibraryConvertedService } from "../src-generated/library-converted/LibraryConvertedService.js";
+
+/**
+ * The same server through the converter-enabled client.
+ *
+ * Deliberately a second service instance rather than a replacement: `LibraryTestConstants` drives the raw
+ * client, which is what pins the wire format, and this one pins what the converters make of it.
+ */
+export const CONVERTED = new LibraryConvertedService(new FetchClient(), inject("libraryBaseUrl"));

--- a/int-test/olingo-v2/test/core/ServiceApi.test.ts
+++ b/int-test/olingo-v2/test/core/ServiceApi.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "vitest";
+import { expectODataError } from "../expectODataError.js";
+import { BASE_URL, BOOK_DER_PROZESS, COPY_KEY, LIBRARY } from "../LibraryTestConstants.js";
+
+/**
+ * Parts of the generated service's own API that no other file here exercises: key handling, adding
+ * query options to a command after the fact, and the select wildcard.
+ *
+ * None of them is server behaviour - they are the client's, and they would be equally true against any
+ * V2 service. They are covered here because every request still goes out for real, so a rendering that
+ * the server would reject shows up rather than being asserted against a mock.
+ */
+describe("Olingo Library: service API", () => {
+  test("createKey and parseKey round trip a simple key", () => {
+    const key = LIBRARY.Books().createKey(BOOK_DER_PROZESS);
+
+    // typed, as everywhere in V2 - and relative, so it can be appended to a service root
+    expect(key).toBe(`Books(guid'${BOOK_DER_PROZESS}')`);
+    expect(LIBRARY.Books().parseKey(key)).toBe(BOOK_DER_PROZESS);
+  });
+
+  test("createKey and parseKey round trip a composite key", () => {
+    // the more interesting case, and the one with no counterpart in examples/main: two key properties
+    // of different types, each carrying its own V2 literal notation
+    const key = LIBRARY.Copies().createKey(COPY_KEY);
+
+    expect(key).toBe(`Copies(MediumId=guid'${BOOK_DER_PROZESS}',InventoryNumber=1001)`);
+    expect(LIBRARY.Copies().parseKey(key)).toStrictEqual(COPY_KEY);
+  });
+
+  test("getKeySpec describes the key", () => {
+    expect(
+      LIBRARY.Books()
+        .getKeySpec()
+        .map((param) => param.getName()),
+    ).toStrictEqual(["Id"]);
+    expect(
+      LIBRARY.Copies()
+        .getKeySpec()
+        .map((param) => param.getName()),
+    ).toStrictEqual(["MediumId", "InventoryNumber"]);
+  });
+
+  test("a parsed key addresses the entity it came from", async () => {
+    // the round trip is only worth anything if the result is usable, so it is used
+    const parsed = LIBRARY.Copies().parseKey(LIBRARY.Copies().createKey(COPY_KEY));
+    const result = await LIBRARY.Copies(parsed).query().execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.d.InventoryNumber).toBe(1001);
+  });
+
+  test("addToQuery adds options to a command that already exists", async () => {
+    // written against a throwaway entity on purpose: `update` is a PUT, so it resets every property it
+    // does not carry, and the seed data is what the other files assert against
+    const created = await LIBRARY.Books().create({ Title: "addToQuery probe", Language: "de" }).execute();
+    const id = created.data.d.Id;
+
+    // `update` returns a builder-backed command, so query options can be attached after the payload -
+    // which is the only way to reach them for the write verbs, whose signatures take no query function
+    const cmd = LIBRARY.Books(id)
+      .update({ Title: "addToQuery probe", Language: "de" })
+      .addToQuery((builder) => builder.select("Title"));
+
+    expect(decodeURIComponent(cmd.getUrl())).toBe(`${BASE_URL}/Books(guid'${id}')?$select=Title`);
+
+    /*
+     * And this server refuses it. Olingo routes on the shape of the URI, so an entity URI carrying a
+     * query option is a different route - one with no PUT handler - and the answer is 405 rather than
+     * the option simply being ignored.
+     *
+     * Worth pinning because the failure mode is unhelpful: the write is rejected wholesale for the sake
+     * of an option that could not have changed anything. CAP takes the same request and honours the
+     * write, so a query option on a write is not portable between V2 servers at all.
+     */
+    await expectODataError(cmd.execute(), {
+      status: 405,
+      message: /does not allow the HTTP method/,
+    });
+
+    // without the option the very same write succeeds
+    const plain = LIBRARY.Books(id).update({ Title: "addToQuery probe", Language: "de" });
+    expect((await plain.execute()).status).toBe(204);
+
+    await LIBRARY.Books(id).delete().execute();
+  });
+
+  test("the select wildcard", async () => {
+    const cmd = LIBRARY.Books().query((builder) => builder.select("*"));
+    expect(decodeURIComponent(cmd.getUrl())).toContain("$select=*");
+
+    const result = await cmd.execute();
+    expect(result.status).toBe(200);
+    // everything comes back, unlike a narrowed select
+    expect(result.data.d.results[0].ISBN).toBeDefined();
+  });
+
+  test("the select wildcard inside expanding flattens to a path", async () => {
+    // `$select=Location/*` - the nested spelling, which only exists because V2 has to flatten what V4
+    // would nest inside `$expand`
+    const cmd = LIBRARY.Copies(COPY_KEY).query((builder) =>
+      builder.expanding("Location", (branch) => branch.select("*")),
+    );
+    const url = decodeURIComponent(cmd.getUrl());
+    expect(url).toContain("$select=Location/*");
+    expect(url).toContain("$expand=Location");
+
+    const result = await cmd.execute();
+    expect(result.status).toBe(200);
+    expect((result.data.d.Location as unknown as { Name: string }).Name).toBeDefined();
+  });
+});

--- a/int-test/olingo-v2/test/core/ServiceApi.test.ts
+++ b/int-test/olingo-v2/test/core/ServiceApi.test.ts
@@ -51,36 +51,48 @@ describe("Olingo Library: service API", () => {
   });
 
   test("addToQuery adds options to a command that already exists", async () => {
-    // written against a throwaway entity on purpose: `update` is a PUT, so it resets every property it
-    // does not carry, and the seed data is what the other files assert against
-    const created = await LIBRARY.Books().create({ Title: "addToQuery probe", Language: "de" }).execute();
+    // `query()` takes its options up front, but a command can also be widened afterwards - which is what
+    // `addToQuery` is for, and it composes with what the query function already set
+    const cmd = LIBRARY.Books()
+      .query((builder, q) => builder.filter(q.Language.eq("de")))
+      .addToQuery((builder) => builder.select("Title").top(1));
+
+    const url = decodeURIComponent(cmd.getUrl());
+    expect(url).toContain("$filter=Language eq 'de'");
+    expect(url).toContain("$select=Title");
+    expect(url).toContain("$top=1");
+
+    const result = await cmd.execute();
+    expect(result.status).toBe(200);
+    expect(result.data.d.results).toHaveLength(1);
+    expect(result.data.d.results[0].ISBN).toBeUndefined();
+  });
+
+  test("a query option on a modification request is out of scope for V2", async () => {
+    /*
+     * `addToQuery` is available on the write commands too, because the command type is shared - but V2
+     * defines system query options for retrieval only. There is no `$select` on a `PUT` to honour, and
+     * nothing in [MS-ODATA] says what a service should do with one.
+     *
+     * This server routes on the shape of the URI, so an entity URI carrying a query option is simply a
+     * route with no `PUT` handler and the answer is 405. That is a conforming reaction to a request the
+     * protocol does not describe; the interesting part is only that the client lets it be expressed.
+     */
+    const created = await LIBRARY.Books().create({ Title: "write option probe", Language: "de" }).execute();
     const id = created.data.d.Id;
 
-    // `update` returns a builder-backed command, so query options can be attached after the payload -
-    // which is the only way to reach them for the write verbs, whose signatures take no query function
-    const cmd = LIBRARY.Books(id)
-      .update({ Title: "addToQuery probe", Language: "de" })
-      .addToQuery((builder) => builder.select("Title"));
+    await expectODataError(
+      LIBRARY.Books(id)
+        .update({ Title: "write option probe", Language: "de" })
+        .addToQuery((builder) => builder.select("Title"))
+        .execute(),
+      { status: 405, message: /does not allow the HTTP method/ },
+    );
 
-    expect(decodeURIComponent(cmd.getUrl())).toBe(`${BASE_URL}/Books(guid'${id}')?$select=Title`);
-
-    /*
-     * And this server refuses it. Olingo routes on the shape of the URI, so an entity URI carrying a
-     * query option is a different route - one with no PUT handler - and the answer is 405 rather than
-     * the option simply being ignored.
-     *
-     * Worth pinning because the failure mode is unhelpful: the write is rejected wholesale for the sake
-     * of an option that could not have changed anything. CAP takes the same request and honours the
-     * write, so a query option on a write is not portable between V2 servers at all.
-     */
-    await expectODataError(cmd.execute(), {
-      status: 405,
-      message: /does not allow the HTTP method/,
-    });
-
-    // without the option the very same write succeeds
-    const plain = LIBRARY.Books(id).update({ Title: "addToQuery probe", Language: "de" });
-    expect((await plain.execute()).status).toBe(204);
+    // the same write without the option is an ordinary V2 request and succeeds
+    expect((await LIBRARY.Books(id).update({ Title: "write option probe", Language: "de" }).execute()).status).toBe(
+      204,
+    );
 
     await LIBRARY.Books(id).delete().execute();
   });

--- a/int-test/olingo-v2/test/feature/ComplexTypes.test.ts
+++ b/int-test/olingo-v2/test/feature/ComplexTypes.test.ts
@@ -77,14 +77,25 @@ describe("Olingo Library: complex types", () => {
   });
 
   test("deep select into a complex property is refused as well", async () => {
-    // `expanding()` renders V2's flattened deep select, `$select=Address/City&$expand=Address`. Same
-    // story: valid for some V2 services, not for this one.
+    /*
+     * `expanding()` renders V2's flattened deep select, `$select=Address/City&$expand=Address`. Same
+     * story: valid for some V2 services, not for this one.
+     *
+     * The request is malformed twice over for this server - the expand names a complex property and the
+     * select traverses one - and Olingo reports whichever of the two validations happens to run first.
+     * Both spellings are accepted here rather than pinning one, because which arrives is an ordering
+     * detail inside the server: the file on its own yields "Invalid segment", the full suite yields the
+     * navigation-property message. The refusal is the finding; its wording is not.
+     */
     const cmd = LIBRARY.Members(1).query((b) => b.expanding("Address", (address) => address.select("City")));
     const url = decodeURIComponent(cmd.getUrl());
     expect(url).toContain("$select=Address/City");
     expect(url).toContain("$expand=Address");
 
-    await expectODataError(cmd.execute(), { status: 400, message: /Invalid segment: 'Address\/City'/ });
+    await expectODataError(cmd.execute(), {
+      status: 400,
+      message: /Invalid segment: 'Address\/City'|must be a navigation property/,
+    });
   });
 
   test("deep select through a navigation property does work", async () => {

--- a/int-test/olingo-v2/test/feature/ComplexTypes.test.ts
+++ b/int-test/olingo-v2/test/feature/ComplexTypes.test.ts
@@ -1,0 +1,100 @@
+import { HttpResponseModel } from "@odata2ts/http-client-api";
+import { ODataValueResponseV2 } from "@odata2ts/odata-core";
+import { describe, expect, expectTypeOf, test } from "vitest";
+import { PostalAddress } from "../../src-generated/library/LibraryModel.js";
+import { expectODataError } from "../expectODataError.js";
+import { BASE_URL, COPY_KEY, LIBRARY } from "../LibraryTestConstants.js";
+
+/**
+ * Complex-typed properties, and the service odata2ts generates for them.
+ *
+ * This is the first V2 server in the integration tests with a real complex property: CAP flattens
+ * `Address` into `Address_City`, `Address_Street` and so on, so `int-test/cap` had nothing to point a
+ * `ComplexTypeServiceV2` at. Here `Member.Address` is a `PostalAddress`, itself derived from an abstract
+ * `Address` - complex type inheritance, which V2 allows and V4's own model uses too.
+ */
+describe("Olingo Library: complex types", () => {
+  test("a complex property is addressable as a sub-resource", async () => {
+    // `ComplexTypeServiceV2`, generated because the property is complex-typed rather than primitive
+    expect(LIBRARY.Members(1).Address().getPath()).toBe(`${BASE_URL}/Members(1)/Address`);
+
+    const result = await LIBRARY.Members(1).Address().query().execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.d).toMatchObject({
+      Street: "Lindenweg 4",
+      City: "Hamburg",
+      PostalCode: "22765",
+      Country: "DE",
+    });
+  });
+
+  test("the complex value names its own type, including the derived one", async () => {
+    const result = await LIBRARY.Members(1).Address().query().execute();
+
+    // `PostalAddress` derives from the abstract `Address`, and the payload says so - V2 marks a complex
+    // value with its type where V4 leaves it unannotated
+    expect((result.data.d as unknown as { __metadata: { type: string } }).__metadata.type).toBe(
+      "Library.Catalog.PostalAddress",
+    );
+
+    expectTypeOf<PostalAddress>().toHaveProperty("PostalCode"); // its own
+    expectTypeOf<PostalAddress>().toHaveProperty("Street"); // from the abstract Address
+  });
+
+  test("a property of the complex value is addressable one level further down", async () => {
+    const result = await LIBRARY.Members(1).Address().City().getValue().execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.d.City).toBe("Hamburg");
+    expectTypeOf(result).toEqualTypeOf<HttpResponseModel<ODataValueResponseV2<string>>>();
+  });
+
+  test("the complex value arrives inline without being asked for", async () => {
+    // Which is why the two rejections below cost nothing here: there is no need to expand what is
+    // already in the payload. A V2 service is free to do it either way.
+    const member = (await LIBRARY.Members(1).query().execute()).data.d;
+
+    expect(member.Address).toMatchObject({ City: "Hamburg" });
+  });
+
+  test("expanding a complex property is refused by this server", async () => {
+    /*
+     * odata2ts widened `expand()` to accept complex properties for V2, because V2 does not inline them
+     * the way V4 does and some services require the expand. This one does not accept it: `$expand` here
+     * takes navigation properties only.
+     *
+     * So the client can express something the server rejects, and a caller porting a query from another
+     * V2 service would hit a 400 with no hint from `$metadata`. Asserted rather than avoided.
+     */
+    const cmd = LIBRARY.Members(1).query((b) => b.expand("Address"));
+    expect(decodeURIComponent(cmd.getUrl())).toContain("$expand=Address");
+
+    await expectODataError(cmd.execute(), {
+      status: 400,
+      message: /must be a navigation property/,
+    });
+  });
+
+  test("deep select into a complex property is refused as well", async () => {
+    // `expanding()` renders V2's flattened deep select, `$select=Address/City&$expand=Address`. Same
+    // story: valid for some V2 services, not for this one.
+    const cmd = LIBRARY.Members(1).query((b) => b.expanding("Address", (address) => address.select("City")));
+    const url = decodeURIComponent(cmd.getUrl());
+    expect(url).toContain("$select=Address/City");
+    expect(url).toContain("$expand=Address");
+
+    await expectODataError(cmd.execute(), { status: 400, message: /Invalid segment: 'Address\/City'/ });
+  });
+
+  test("deep select through a navigation property does work", async () => {
+    // The distinction that matters: it is the complex *property* the server will not traverse, not the
+    // deep select itself. Through a navigation property the very same mechanism is fine.
+    const cmd = LIBRARY.Copies(COPY_KEY).query((b) => b.expanding("Location", (branch) => branch.select("Name")));
+    expect(decodeURIComponent(cmd.getUrl())).toContain("$select=Location/Name");
+
+    const result = await cmd.execute();
+    expect(result.status).toBe(200);
+    expect((result.data.d.Location as unknown as { Name: string }).Name).toBeDefined();
+  });
+});

--- a/int-test/olingo-v2/test/feature/Converters.test.ts
+++ b/int-test/olingo-v2/test/feature/Converters.test.ts
@@ -76,30 +76,31 @@ describe("Olingo Library: value converters", () => {
     expect(typeof copy.Condition).toBe("number");
   });
 
-  test("a converted date cannot be filtered on: the literal it renders is not valid V2", async () => {
+  test("a converted date can be filtered on", async () => {
     /*
-     * The direction that had never been tested, and it does not work. Going *out*, the converter renders
-     * a `DateTime` as `datetime'1925-04-26T00:00:00.000Z'` - with fractional seconds and a `Z`. V2's
-     * `Edm.DateTime` is timezone-less and its ABNF has no offset, so that literal is invalid and a strict
-     * server refuses it.
-     *
-     * The raw client, handed the same instant as a plain string, renders `datetime'1925-04-26T00:00:00'`
-     * and gets 200. So converters make reading a date pleasant and filtering on one impossible, and the
-     * workaround is to drop back to the unconverted client for that one query.
-     *
-     * Recorded as a client-side defect, not a server one: it is odata2ts that emits the literal.
+     * The direction that had never been tested: a `DateTime` going *out*. V2's `Edm.DateTime` literal is
+     * timezone-less - its ABNF has no offset - while a converter hands back a full ISO string, `Z` and
+     * all. `QDateTimeV2Path` therefore normalises the value to UTC and drops the designator, so what
+     * reaches the server is a literal it accepts.
      */
     const cmd = CONVERTED.Books().query((b, q) =>
       b.filter(q.PublicationDate.eq(DateTime.fromISO("1925-04-26T00:00:00", { zone: "utc" }))),
     );
-    expect(decodeURIComponent(cmd.getUrl())).toContain("datetime'1925-04-26T00:00:00.000Z'");
+    expect(decodeURIComponent(cmd.getUrl())).toContain("$filter=PublicationDate eq datetime'1925-04-26T00:00:00'");
 
-    await expectODataError(cmd.execute(), { status: 400, message: /Invalid filter expression/ });
+    const result = await cmd.execute();
+    expect(result.data.d.results.map((book) => book.Title)).toStrictEqual(["Der Prozess"]);
+  });
 
-    // what the raw client sends for the same instant, and what the server wants
-    const raw = LIBRARY.Books().query((b, q) => b.filter(q.PublicationDate.eq("1925-04-26T00:00:00")));
-    expect(decodeURIComponent(raw.getUrl())).toContain("datetime'1925-04-26T00:00:00'");
-    expect((await raw.execute()).data.d.results.map((book) => book.Title)).toStrictEqual(["Der Prozess"]);
+  test("a date given in another zone is normalised to the same instant", async () => {
+    // the normalisation has to shift, not truncate: 02:00+02:00 is the same instant as 00:00Z, and the
+    // literal V2 wants is the UTC one
+    const cmd = CONVERTED.Books().query((b, q) =>
+      b.filter(q.PublicationDate.eq(DateTime.fromISO("1925-04-26T02:00:00+02:00", { setZone: true }))),
+    );
+    expect(decodeURIComponent(cmd.getUrl())).toContain("datetime'1925-04-26T00:00:00'");
+
+    expect((await cmd.execute()).data.d.results.map((book) => book.Title)).toStrictEqual(["Der Prozess"]);
   });
 
   test("a converted value survives a write and comes back converted", async () => {

--- a/int-test/olingo-v2/test/feature/Converters.test.ts
+++ b/int-test/olingo-v2/test/feature/Converters.test.ts
@@ -1,0 +1,134 @@
+import { BigNumber } from "bignumber.js";
+import { DateTime } from "luxon";
+import { describe, expect, expectTypeOf, test } from "vitest";
+import { Book, Branch, Copy, Member } from "../../src-generated/library-converted/LibraryConvertedModel.js";
+import { expectODataError } from "../expectODataError.js";
+import { CONVERTED } from "../LibraryConvertedConstants.js";
+import { BOOK_DER_PROZESS, COPY_KEY, LIBRARY } from "../LibraryTestConstants.js";
+
+/**
+ * Value converters against a running V2 server - the combination that had never been tested anywhere.
+ *
+ * V2 is where converters earn their keep. Its JSON format hands over every timestamp as
+ * `/Date(<ticks>)/` and every numeric type that does not fit a JS number as a string, so the raw client
+ * types all of those as `string` and leaves the caller to parse them - which is exactly what
+ * `feature/DataTypes.test.ts` pins. This file drives the same server through the converter-enabled
+ * client generated from the second service configuration, and asserts what comes out instead.
+ *
+ * Both halves matter. `examples/main` covers the converted V2 model, but only against a mock client, so
+ * until now nothing checked that a converted value survives a real request in either direction.
+ */
+describe("Olingo Library: value converters", () => {
+  test("a timestamp becomes a DateTime rather than a tick count", async () => {
+    const raw = (await LIBRARY.Books(BOOK_DER_PROZESS).query().execute()).data.d;
+    const converted = (await CONVERTED.Books(BOOK_DER_PROZESS).query().execute()).data.d;
+
+    // the same property, the same request, the two clients side by side
+    expect(raw.PublicationDate).toBe("/Date(-1410134400000)/");
+    expect(DateTime.isDateTime(converted.PublicationDate)).toBe(true);
+    expect(converted.PublicationDate!.toUTC().toISO()).toContain("1925-04-26");
+
+    expectTypeOf<Book["PublicationDate"]>().toEqualTypeOf<DateTime | null>();
+  });
+
+  test("the numeric types V2 sends as strings become numbers, BigNumber and bigint", async () => {
+    const book = (await CONVERTED.Books(BOOK_DER_PROZESS).query().execute()).data.d;
+    // Edm.Double - fits a JS number once parsed
+    expect(book.PopularityScore).toBe(87.5);
+    expectTypeOf<Book["PopularityScore"]>().toEqualTypeOf<number | null>();
+
+    const member = (await CONVERTED.Members(1).query().execute()).data.d;
+    // Edm.Decimal - the one that must not become a number, or 0.00 stops being 0.00
+    expect(BigNumber.isBigNumber(member.Balance)).toBe(true);
+    expect(member.Balance!.toFixed(2)).toBe("0.00");
+    expectTypeOf<Member["Balance"]>().toEqualTypeOf<BigNumber | null>();
+
+    const branch = (await CONVERTED.Branches(1).query().execute()).data.d;
+    // Edm.Int64 - beyond a JS number's safe range in general, so a bigint
+    expect(branch.Population).toBe(BigInt("1841000"));
+    expectTypeOf<Branch["Population"]>().toEqualTypeOf<bigint | null>();
+
+    const copy = (await CONVERTED.Copies(COPY_KEY).query().execute()).data.d;
+    // Edm.Single
+    expect(copy.WeightKg).toBeCloseTo(0.31, 5);
+  });
+
+  test("the converters correct the Edm.Byte mapping the raw client gets wrong", async () => {
+    /*
+     * `feature/DataTypes.test.ts` pins the raw client's divergence: `Edm.Byte` and `Edm.SByte` are typed
+     * `string` by `DataModelDigestionV2` while V2's JSON format puts them among the plain numbers, so
+     * the value that arrives is a number the compiler calls a string.
+     *
+     * With `@odata2ts/converter-v2-to-v4` in place the model says `number` and the value is a number, so
+     * type and runtime agree again. Worth knowing which way round that is: the converter is not adding a
+     * conversion here so much as repairing a mapping.
+     */
+    const book = (await CONVERTED.Books(BOOK_DER_PROZESS).query().execute()).data.d;
+    expectTypeOf<Book["AgeRating"]>().toEqualTypeOf<number | null>();
+    expect(book.AgeRating).toBe(16);
+
+    const branch = (await CONVERTED.Branches(1).query().execute()).data.d;
+    expectTypeOf<Branch["LowestFloor"]>().toEqualTypeOf<number | null>();
+    expect(branch.LowestFloor).toBe(-2);
+
+    const copy = (await CONVERTED.Copies(COPY_KEY).query().execute()).data.d;
+    expectTypeOf<Copy["Condition"]>().toEqualTypeOf<number | null>();
+    expect(typeof copy.Condition).toBe("number");
+  });
+
+  test("a converted date cannot be filtered on: the literal it renders is not valid V2", async () => {
+    /*
+     * The direction that had never been tested, and it does not work. Going *out*, the converter renders
+     * a `DateTime` as `datetime'1925-04-26T00:00:00.000Z'` - with fractional seconds and a `Z`. V2's
+     * `Edm.DateTime` is timezone-less and its ABNF has no offset, so that literal is invalid and a strict
+     * server refuses it.
+     *
+     * The raw client, handed the same instant as a plain string, renders `datetime'1925-04-26T00:00:00'`
+     * and gets 200. So converters make reading a date pleasant and filtering on one impossible, and the
+     * workaround is to drop back to the unconverted client for that one query.
+     *
+     * Recorded as a client-side defect, not a server one: it is odata2ts that emits the literal.
+     */
+    const cmd = CONVERTED.Books().query((b, q) =>
+      b.filter(q.PublicationDate.eq(DateTime.fromISO("1925-04-26T00:00:00", { zone: "utc" }))),
+    );
+    expect(decodeURIComponent(cmd.getUrl())).toContain("datetime'1925-04-26T00:00:00.000Z'");
+
+    await expectODataError(cmd.execute(), { status: 400, message: /Invalid filter expression/ });
+
+    // what the raw client sends for the same instant, and what the server wants
+    const raw = LIBRARY.Books().query((b, q) => b.filter(q.PublicationDate.eq("1925-04-26T00:00:00")));
+    expect(decodeURIComponent(raw.getUrl())).toContain("datetime'1925-04-26T00:00:00'");
+    expect((await raw.execute()).data.d.results.map((book) => book.Title)).toStrictEqual(["Der Prozess"]);
+  });
+
+  test("a converted value survives a write and comes back converted", async () => {
+    // the full round trip: DateTime in, ticks on the wire, DateTime out again
+    const publicationDate = DateTime.fromISO("2001-02-03T00:00:00", { zone: "utc" });
+
+    const created = await CONVERTED.Books()
+      .create({ Title: "Converted Round Trip", Language: "de", PublicationDate: publicationDate })
+      .execute();
+    expect(created.status).toBe(201);
+
+    const id = created.data.d.Id;
+    const read = await CONVERTED.Books(id).query().execute();
+    expect(read.data.d.PublicationDate!.toUTC().toISO()).toContain("2001-02-03");
+
+    // and the raw client sees the ticks the server actually stored
+    const raw = await LIBRARY.Books(id).query().execute();
+    expect(raw.data.d.PublicationDate).toBe(`/Date(${publicationDate.toMillis()})/`);
+
+    await CONVERTED.Books(id).delete().execute();
+  });
+
+  test("a converted primitive property service converts too", async () => {
+    // the property services are generated for the converted service as well, and go through the same
+    // converter - so `getValue()` on a date yields a DateTime, not a tick string
+    const result = await CONVERTED.Books(BOOK_DER_PROZESS).PublicationDate().getValue().execute();
+
+    expect(result.status).toBe(200);
+    expect(DateTime.isDateTime(result.data.d.PublicationDate)).toBe(true);
+    expect(result.data.d.PublicationDate!.toUTC().toISO()).toContain("1925-04-26");
+  });
+});

--- a/packages/odata-query-objects/src/index.ts
+++ b/packages/odata-query-objects/src/index.ts
@@ -38,7 +38,7 @@ export { QDateTimeOffsetParam } from "./param/v4/QDateTimeOffsetParam";
 
 export { QGuidV2Param } from "./param/v2/QGuidV2Param";
 export { QBinaryV2Param } from "./param/v2/QBinaryV2Param";
-export { QDateTimeV2Param } from "./param/v2/QDateTimeV2Param";
+export { QDateTimeV2Param, toDateTimeV2UrlValue } from "./param/v2/QDateTimeV2Param";
 export { QDateTimeOffsetV2Param } from "./param/v2/QDateTimeOffsetV2Param";
 export { QStringNumberV2Param } from "./param/v2/QStringNumberV2Param";
 export { QDecimalV2Param } from "./param/v2/QDecimalV2Param";

--- a/packages/odata-query-objects/src/param/v2/QDateTimeV2Param.ts
+++ b/packages/odata-query-objects/src/param/v2/QDateTimeV2Param.ts
@@ -4,8 +4,41 @@ import { UrlParamValueFormatter, UrlParamValueParser } from "../UrlParamModel";
 
 export const DATE_TIME_V2_TYPE_PREFIX = "datetime";
 
+const ZONE_DESIGNATOR = /(?:Z|[+-]\d{2}:?\d{2})$/;
+
+/**
+ * Brings an ISO-8601 value into the shape V2's `datetime` literal allows.
+ *
+ * `Edm.DateTime` is timezone-less in V2 - its ABNF has no offset at all, so `Z` and `+02:00` are both
+ * invalid inside `datetime'...'` and a strict server answers 400. A converter, however, maps the value
+ * onto a real date type and hands back a full ISO string, designator included. Rather than asking every
+ * converter to know about V2 URL syntax, the designator is resolved here: a value carrying one is
+ * normalised to UTC and the designator dropped, so the instant is preserved.
+ *
+ * Values without a designator are passed through untouched, which covers the unconverted case where the
+ * caller supplies the literal body themselves.
+ */
+export function toDateTimeV2UrlValue(value: string): string {
+  if (!ZONE_DESIGNATOR.test(value)) {
+    return value;
+  }
+  const asUtc = new Date(value);
+  if (isNaN(asUtc.getTime())) {
+    return value.replace(ZONE_DESIGNATOR, "");
+  }
+  // toISOString always ends in "Z" and always carries milliseconds; V2 allows fractional seconds but
+  // they are noise when zero, and some servers are picky about them
+  return asUtc
+    .toISOString()
+    .replace(/\.000Z$/, "")
+    .replace(/Z$/, "");
+}
+
 const getUrlConformValue: UrlParamValueFormatter<string> = (value) => {
-  return formatParamWithTypePrefix(DATE_TIME_V2_TYPE_PREFIX, value);
+  return formatParamWithTypePrefix(
+    DATE_TIME_V2_TYPE_PREFIX,
+    typeof value === "string" ? toDateTimeV2UrlValue(value) : value,
+  );
 };
 
 const parseValueFromUrl: UrlParamValueParser<string> = (urlConformValue) => {

--- a/packages/odata-query-objects/src/path/v2/QDateTimeV2Path.ts
+++ b/packages/odata-query-objects/src/path/v2/QDateTimeV2Path.ts
@@ -1,11 +1,13 @@
 import { formatWithTypePrefix } from "../../param/UrlParamHelper";
-import { DATE_TIME_V2_TYPE_PREFIX } from "../../param/v2/QDateTimeV2Param";
+import { DATE_TIME_V2_TYPE_PREFIX, toDateTimeV2UrlValue } from "../../param/v2/QDateTimeV2Param";
 import { QBasePath } from "../base/QBasePath";
 import { dayFn, hourFn, minuteFn, monthFn, secondFn, yearFn } from "./DateTimeFunctions";
 
 export class QDateTimeV2Path<ConvertedType = string> extends QBasePath<string, ConvertedType> {
   protected formatValue(value: string): string {
-    return formatWithTypePrefix(DATE_TIME_V2_TYPE_PREFIX, value);
+    // see toDateTimeV2UrlValue: a converted value arrives as a full ISO string, and V2's datetime
+    // literal admits no timezone designator
+    return formatWithTypePrefix(DATE_TIME_V2_TYPE_PREFIX, toDateTimeV2UrlValue(value));
   }
 
   public year = yearFn(this.getPath());

--- a/packages/odata-query-objects/test/param/v2/QDateTimeV2Param.test.ts
+++ b/packages/odata-query-objects/test/param/v2/QDateTimeV2Param.test.ts
@@ -2,6 +2,9 @@ import { FIXED_DATE, FIXED_STRING, fixedDateConverter } from "@odata2ts/test-con
 import { describe, expect, test } from "vitest";
 import { QDateTimeV2Param } from "../../../src";
 
+/** The same instant as FIXED_STRING, in the timezone-less form V2's `datetime` literal requires. */
+const FIXED_STRING_URL = FIXED_STRING.replace(/\.000Z$/, "").replace(/Z$/, "");
+
 describe("QDateTimeV2Param Tests", () => {
   const name = "T3st_bbb";
   const toTest = new QDateTimeV2Param(name);
@@ -37,7 +40,12 @@ describe("QDateTimeV2Param Tests", () => {
     expect(toTest.formatUrlValue(null)).toBe("null");
     expect(toTest.formatUrlValue(undefined)).toBe(undefined);
 
-    expect(toTestWithConverter.formatUrlValue(new Date())).toBe(`datetime'${FIXED_STRING}'`);
+    /*
+     * The converted value arrives as a full ISO string, but V2's `datetime` literal is timezone-less -
+     * its ABNF has no offset - so the designator is dropped on the way into the URL and the instant is
+     * normalised to UTC. A strict V2 server answers 400 for the ISO form.
+     */
+    expect(toTestWithConverter.formatUrlValue(new Date())).toBe(`datetime'${FIXED_STRING_URL}'`);
   });
 
   test("parseUrlValue", () => {

--- a/packages/odata-query-objects/test/param/v2/QDateTimeV2Param.test.ts
+++ b/packages/odata-query-objects/test/param/v2/QDateTimeV2Param.test.ts
@@ -1,6 +1,6 @@
 import { FIXED_DATE, FIXED_STRING, fixedDateConverter } from "@odata2ts/test-converters";
 import { describe, expect, test } from "vitest";
-import { QDateTimeV2Param } from "../../../src";
+import { QDateTimeV2Param, toDateTimeV2UrlValue } from "../../../src";
 
 /** The same instant as FIXED_STRING, in the timezone-less form V2's `datetime` literal requires. */
 const FIXED_STRING_URL = FIXED_STRING.replace(/\.000Z$/, "").replace(/Z$/, "");
@@ -46,6 +46,41 @@ describe("QDateTimeV2Param Tests", () => {
      * normalised to UTC. A strict V2 server answers 400 for the ISO form.
      */
     expect(toTestWithConverter.formatUrlValue(new Date())).toBe(`datetime'${FIXED_STRING_URL}'`);
+  });
+
+  describe("toDateTimeV2UrlValue", () => {
+    /*
+     * V2's `datetime` literal is timezone-less: `Edm.DateTime` carries no offset and its ABNF has no
+     * place for one, so anything a converter hands back has to be brought into that shape before it is
+     * wrapped. These cover the four ways a value can arrive.
+     */
+    test("a value without a designator is passed through", () => {
+      // the unconverted case: the caller supplies the literal body themselves
+      expect(toDateTimeV2UrlValue("2006-11-05T00:00:00")).toBe("2006-11-05T00:00:00");
+      expect(toDateTimeV2UrlValue("2006-11-05T00:00:00.123")).toBe("2006-11-05T00:00:00.123");
+    });
+
+    test("a UTC designator is dropped, and so are zero milliseconds", () => {
+      expect(toDateTimeV2UrlValue("2006-11-05T00:00:00Z")).toBe("2006-11-05T00:00:00");
+      expect(toDateTimeV2UrlValue("2006-11-05T00:00:00.000Z")).toBe("2006-11-05T00:00:00");
+      // non-zero milliseconds are kept: V2 allows fractional seconds, it is only the zone that cannot stay
+      expect(toDateTimeV2UrlValue("2006-11-05T00:00:00.123Z")).toBe("2006-11-05T00:00:00.123");
+    });
+
+    test("an offset is resolved rather than truncated", () => {
+      // the instant has to survive: 02:00+02:00 is 00:00 UTC, not 02:00
+      expect(toDateTimeV2UrlValue("2006-11-05T02:00:00+02:00")).toBe("2006-11-05T00:00:00");
+      expect(toDateTimeV2UrlValue("2006-11-04T21:00:00-03:00")).toBe("2006-11-05T00:00:00");
+      // the compact spelling of an offset counts too
+      expect(toDateTimeV2UrlValue("2006-11-05T02:00:00+0200")).toBe("2006-11-05T00:00:00");
+    });
+
+    test("a value that carries a designator but cannot be parsed keeps its body", () => {
+      // nothing sensible can be computed, so the designator is removed and the rest left alone -
+      // better a literal the server can reject than a crash inside the client
+      expect(toDateTimeV2UrlValue("not-a-date-at-allZ")).toBe("not-a-date-at-all");
+      expect(toDateTimeV2UrlValue("2006-13-45T99:99:99Z")).toBe("2006-13-45T99:99:99");
+    });
   });
 
   test("parseUrlValue", () => {

--- a/packages/odata-query-objects/test/path/v2/QDateTimePath.test.ts
+++ b/packages/odata-query-objects/test/path/v2/QDateTimePath.test.ts
@@ -9,6 +9,9 @@ import {
   EXAMPLE_PATH_NAME,
 } from "./DateTimeBaseTests";
 
+/** The same instant as FIXED_STRING, in the timezone-less form V2's `datetime` literal requires. */
+const FIXED_STRING_URL = FIXED_STRING.replace(/\.000Z$/, "").replace(/Z$/, "");
+
 describe("QDateTimeV2Path test", () => {
   const toTest = new QDateTimeV2Path(EXAMPLE_PATH_NAME);
   const exampleResult = `datetime'${EXAMPLE_DATE_TIME}'`;
@@ -27,7 +30,8 @@ describe("QDateTimeV2Path test", () => {
   test("with converter", () => {
     const testWithConv = new QDateTimeV2Path(EXAMPLE_PATH_NAME, fixedDateConverter);
 
-    expect(testWithConv.gt(FIXED_DATE).toString()).toBe(`createdAt gt datetime'${FIXED_STRING}'`);
+    // V2's datetime literal carries no timezone designator, so the converted ISO value is normalised
+    expect(testWithConv.gt(FIXED_DATE).toString()).toBe(`createdAt gt datetime'${FIXED_STRING_URL}'`);
   });
 
   createBaseDateTimeTests(toTest, EXAMPLE_DATE_TIME, exampleResult);

--- a/packages/odata-service/src/v2/PrimitiveTypeServiceV2.ts
+++ b/packages/odata-service/src/v2/PrimitiveTypeServiceV2.ts
@@ -1,4 +1,4 @@
-import { ValueConverter } from "@odata2ts/converter-api";
+import { ConverterOptions, ValueConverter } from "@odata2ts/converter-api";
 import { ODataHttpClient, ODataHttpMethods } from "@odata2ts/http-client-api";
 import { ODataValueResponseV2 } from "@odata2ts/odata-core";
 import {
@@ -35,14 +35,21 @@ export class PrimitiveTypeServiceV2<in out ClientType extends ODataHttpClient, T
     client: ClientType,
     basePath: string,
     name: string,
-    { convertTo, convertFrom }: ValueConverter<any, T> = getIdentityConverter(),
+    converter: ValueConverter<any, T> = getIdentityConverter(),
     mappedName?: string,
     options?: ODataServiceOptions,
   ) {
     this.__base = new ServiceStateHelper(client, basePath, name, options);
+    /*
+     * The two conversion methods are delegated to rather than pulled off the converter, because a
+     * converter may be a class with instance state: destructuring `{ convertFrom, convertTo }` strips
+     * `this`, and `ChainedConverter` - which is what a configuration with more than one converter
+     * produces - then throws on its own `this.converter2`. PrimitiveTypeServiceV4 keeps the object as
+     * it is for the same reason.
+     */
     this.__converter = {
-      convertFrom,
-      convertTo,
+      convertFrom: (value, converterOptions?: ConverterOptions) => converter.convertFrom(value, converterOptions),
+      convertTo: (value, converterOptions?: ConverterOptions) => converter.convertTo(value, converterOptions),
       getName() {
         return name;
       },

--- a/packages/odata-service/test/v2/PrimitiveTypeServiceV2.test.ts
+++ b/packages/odata-service/test/v2/PrimitiveTypeServiceV2.test.ts
@@ -50,6 +50,39 @@ describe("PrimitiveTypeService V2 Test", () => {
     expect(converter.getMappedName()).toBe("mappedUserName");
   });
 
+  test("primitiveType V2: the converter is delegated to, not taken apart", async () => {
+    /*
+     * Both directions go through the converter object itself rather than through methods pulled off it.
+     * That matters for any converter implemented as a class - `ChainedConverter`, which is what a
+     * configuration with more than one converter produces, keeps its state in `this` and throws once its
+     * methods are detached. The V4 service has always kept the object; this asserts that V2 does too.
+     */
+    const stateful = new (class {
+      public readonly id = "Stateful";
+      public readonly from = "string" as const;
+      public readonly to = "string" as const;
+      private readonly marker = "!";
+      convertFrom(value: string | null | undefined) {
+        return value === null || value === undefined ? value : `from${this.marker}${value}`;
+      }
+      convertTo(value: string | null | undefined) {
+        return value === null || value === undefined ? value : `to${this.marker}${value}`;
+      }
+    })();
+
+    const service = new PrimitiveTypeServiceV2<MockClient, string>(
+      odataClient,
+      BASE_URL,
+      NAME,
+      stateful as any,
+      PROPERTY_NAME,
+    );
+    const converter = (service as any).__converter;
+
+    expect(converter.convertFrom("value")).toBe("from!value");
+    expect(converter.convertTo("value")).toBe("to!value");
+  });
+
   test("primitiveType V2: get value", async () => {
     const request = testService.getValue();
     const result = request.getInfo();

--- a/packages/odata2ts/src/generator/QueryObjectGenerator.ts
+++ b/packages/odata2ts/src/generator/QueryObjectGenerator.ts
@@ -403,7 +403,12 @@ class QueryObjectGenerator {
       ? undefined
       : returnType.type && returnType.dataType !== DataTypes.PrimitiveType
         ? imports.addGeneratedModel(returnType.fqType, returnType.type)
-        : returnType.type;
+        : // a converter may map a primitive onto a type that lives in a module of its own (BigNumber,
+          // DateTime, ...); without this the name is emitted but never imported and the q-object file
+          // does not compile. Same handling as ModelGenerator applies to a converted property.
+          returnType.typeModule
+          ? imports.addCustomType(returnType.typeModule, returnType.type, true)
+          : returnType.type;
     const responseStructure = returnType ? importReturnType(this.version, imports, returnType) : undefined;
     const completeResponseStructure = responseStructure && rtType ? `${responseStructure}<${rtType}>` : undefined;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -669,9 +669,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@odata2ts/int-test-olingo-v2@workspace:int-test/olingo-v2"
   dependencies:
+    "@odata2ts/converter-big-number": "npm:^0.2.8"
+    "@odata2ts/converter-common": "npm:^0.3.7"
+    "@odata2ts/converter-luxon": "npm:^0.2.7"
+    "@odata2ts/converter-v2-to-v4": "npm:^0.5.7"
     "@odata2ts/http-client-fetch": "npm:^0.11.0"
     "@odata2ts/odata-service": "workspace:^"
     "@odata2ts/odata2ts": "workspace:^"
+    "@types/luxon": "npm:^3.7.2"
+    bignumber.js: "npm:^9.1.2"
+    luxon: "npm:^3.7.2"
     testcontainers: "npm:^12.0.4"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Follow-up to #434, which closed the coverage gaps against `examples/main`. Two odata2ts defects and one protocol correction came out of it.

- **`QDateTimeV2Path` / `QDateTimeV2Param` produced an invalid V2 literal.** `Edm.DateTime` carries no timezone — its ABNF has no place for an offset — but a converter maps the value onto a real date type and hands back a full ISO string, so the literal came out as `datetime'2006-11-05T00:00:00.000Z'` and a strict V2 service answers 400. Filtering on a date was impossible as soon as converters were configured. The value is now normalised to **UTC** and the designator dropped, so an instant given in any zone yields the literal V2 defines. `Edm.DateTimeOffset` is untouched — there the offset belongs.
- **`PrimitiveTypeServiceV2` destructured its converter.** `{ convertFrom, convertTo }` strips `this`, so any converter implemented as a class threw on first use — and `ChainedConverter` is exactly that, produced as soon as two converters are configured. Every converted primitive property service was broken. `PrimitiveTypeServiceV4` keeps the object and never had it.
- **`QueryObjectGenerator` emitted a converter-mapped operation return type without importing it**, so a service with converters plus an `Edm.Decimal`-returning operation generated a q-object file that did not compile. `ModelGenerator` already handled this for properties via `typeModule`.

`int-test/olingo-v2` grows from 55 to 77 tests, closing what `examples/main` covered and the V2 suites did not:

- a **second generated client** (`libraryConverted`) applying Luxon, BigNumber, `int64ToBigIntConverter` and `converter-v2-to-v4` to the same model — the first time converters meet a running V2 server at all, since `examples/main` only tests them against a mock
- the complex-type property service (`Members(1).Address()`), which CAP could not host because it flattens complex properties
- `createKey`/`parseKey`/`getKeySpec`, `addToQuery`, and both select wildcards

**Why the datetime bug survived this long:** `examples/main` *did* cover it, in two "DateTime in URL" tests — and asserted the invalid form. The behaviour was pinned wrong, so the suite defended the bug. Both assertions are corrected here, and `int-test/olingo-v2` now proves the literal against Apache Olingo rather than a mock.

**One correction to #434:** system query options are defined for retrieval only in V2, so attaching one to a modification request is outside the protocol. `addToQuery` is now demonstrated on a read; the write case is kept as the out-of-scope request it is, rather than being framed as a server incompatibility.

Also carries the `cause: e as Error` cast in `int-test/cap/test/globalSetup.ts`.