### PR TITLE
feat: read and write binary content over OData V2

### DIFF
--- a/int-test/README.md
+++ b/int-test/README.md
@@ -45,7 +45,7 @@ Test files follow the same scheme in every package, one concern per file:
 | `core/Operations.test.ts`             | functions and actions, bound and unbound                                       |
 | `core/Singleton.test.ts`              | the singleton: addressed by name, read and written like an entity              |
 | `feature/CrudQuery.test.ts`           | system query options on `create`/`add`/`update`/`patch`                        |
-| `feature/Blobs.test.ts`               | binary content: stream properties and media entities                           |
+| `feature/Blobs.test.ts`               | binary content: stream properties, media entities, V2's media link entries     |
 | `feature/Subtypes.test.ts`            | type cast segment and derived types' properties (ASP.NET only - CAP is flat)   |
 | `feature/PropertyServices.test.ts`    | services for individual properties (`enablePrimitivePropertyServices`)         |
 | `feature/DataTypes.test.ts`           | data types round tripped through the server (ASP.NET, and CAP's V2 suite)      |

--- a/int-test/cap/README.md
+++ b/int-test/cap/README.md
@@ -95,11 +95,11 @@ What belongs here is what the **client** does with it:
   among the plain numbers - so `book.AgeRating === "16"` is `false` although both sides are typed `string`.
   The other string-typed numbers (`Int64`, `Decimal`, `Double`, `Single`) are mapped correctly.
   Pinned in `test/v2/feature/DataTypes.test.ts`.
-- **There is no binary content API in V2.** `StreamServiceV4` and `MediaEntityServiceV4` have no V2
-  counterpart, and the V2 generator emits neither. The adapter exposes the content properly, as media link
-  entries with `$value` and `media_src` - so this is the one feature where the server is ahead of the
-  client. `test/v2/feature/Blobs.test.ts` asserts the gap from both sides, with the only raw `fetch` calls
-  in this package, since there is no generated API to call.
+- **Binary content changes shape between the versions.** What the V4 metadata declares as `Edm.Stream`
+  properties (`EBook.content`, `Audiobook.Sample`) the adapter re-expresses as media link entries, since
+  V2 has no stream type - so the same rows are reached as `EBooks(<id>)/content` over V4 and as
+  `EBooks(guid'<id>')/$value` over V2, and an entity can carry only one payload here.
+  `test/v2/feature/Blobs.test.ts` writes over one version and reads over the other to pin that they meet.
 - **No ETag handling.** Nothing reads `__metadata.etag`, nothing sends `If-Match`, so `Copies` is
   create-only - as it is over V4, except that the V2 metadata actually declares the token.
 - **A write answers with a body the typing does not admit.** V2 has no `Prefer: return=representation` and

--- a/int-test/cap/test/v2/feature/Blobs.test.ts
+++ b/int-test/cap/test/v2/feature/Blobs.test.ts
@@ -1,89 +1,197 @@
+import { HttpResponseModel } from "@odata2ts/http-client-api";
 import { describe, expect, expectTypeOf, test } from "vitest";
-import { Audiobooks, EBooks } from "../../../src-generated/library-v2/LibraryV2Model.js";
-import { AUDIOBOOK, BASE_URL, EBOOK, LIBRARY_V2 } from "../LibraryV2TestConstants.js";
+import { expectODataError } from "../../expectODataError.js";
+import { LIBRARY, AUDIOBOOK as V4_AUDIOBOOK, EBOOK as V4_EBOOK } from "../../LibraryTestConstants.js";
+import { AUDIOBOOK, BASE_URL, EBOOK, LIBRARY_V2, UNKNOWN_ID } from "../LibraryV2TestConstants.js";
 
 /**
- * Binary content - odata2ts issue #149 - over V2, and the one feature where the two versions of the *client*
- * differ rather than the two versions of the server.
+ * Binary content - odata2ts issue #149 - over V2, where the same server tells the same story differently.
  *
- * The server side is the better of the two here. V2 has no `Edm.Stream`, so the adapter re-expresses both
- * carriers of binary content as what V2 does have: **media link entries**. `Audiobooks`, `AudiobookChapters`
- * and `EBooks` come out as `m:HasStream="true"`, their content sits at `.../$value`, and every entity
- * advertises it through `__metadata.media_src`. That is closer to the reference model, which declares
- * `EBook` a media entity, than the V4 metadata of the same service, where CAP emits plain `Edm.Stream`
- * properties and no `HasStream` at all.
+ * V2 has no `Edm.Stream`, so the adapter re-expresses both of the V4 model's stream properties as what V2
+ * does have: **media link entries**. `EBooks`, `Audiobooks` and `AudiobookChapters` come out as
+ * `m:HasStream="true"`, their content sits at `.../$value`, and the property it used to be is gone from the
+ * model. Which means a single entity can carry exactly one binary payload here - a V4 model with two named
+ * streams on one entity could not be expressed at all.
  *
- * odata2ts cannot use any of it: `getBlob`/`updateBlob`/`getStream` and the media-entity service exist only
- * in `@odata2ts/odata-service`'s v4 folder, and the V2 generator emits neither a stream service nor a media
- * one. So this file asserts the gap from both sides - what the client does not offer, and what the server
- * would have answered - rather than leaving the feature silently untested.
- *
- * The raw `fetch` calls below are deliberate and the only ones in this package: there is no generated client
- * API to call instead, and that is precisely the finding.
+ * `EBooks(id).content()` therefore exists in both clients and means two different things: the stream
+ * property's service over V4, the media link entry's content over V2. That they end up at the same bytes is
+ * asserted below and is the point of testing this against one server that speaks both.
  */
 describe("CAP Library V2: binary content", () => {
-  const V4_BASE_URL = BASE_URL.replace("/v2/", "/v4/");
+  /** Reading a blob back as text keeps the assertions legible - the payloads here are text on purpose. */
+  async function textOf(blob: Blob | undefined) {
+    return blob === undefined ? undefined : blob.text();
+  }
 
-  test("the stream property is gone from the model - the entity itself carries the content", () => {
-    // What is `content: Edm.Stream` in the V4 model has no property here at all. A caller migrating a V4
-    // client to V2 loses the property rather than getting a differently typed one.
-    expectTypeOf<EBooks>().not.toHaveProperty("content");
-    expectTypeOf<Audiobooks>().not.toHaveProperty("Sample");
-  });
+  /** Same for a stream, which has to be consumed before anything can be asserted about it. */
+  async function textOfStream(stream: ReadableStream | undefined) {
+    return stream === undefined ? undefined : new Response(stream).text();
+  }
 
-  test("the generated service offers no way to read or write that content", () => {
-    // The V4 client has `EBooks(id).content().getBlob()` and `Audiobooks(id).Sample().updateStream(...)`.
-    // Neither the property services nor a media-entity shortcut are generated for V2.
-    const ebook = LIBRARY_V2.EBooks(EBOOK) as unknown as Record<string, unknown>;
+  describe("media link entry", () => {
+    const ebook = () => LIBRARY_V2.EBooks(EBOOK);
 
-    expect(ebook.content).toBeUndefined();
-    expect(ebook.getBlob).toBeUndefined();
-    expect(ebook.updateBlob).toBeUndefined();
-    expect(ebook.getStream).toBeUndefined();
-    expect((LIBRARY_V2.Audiobooks(AUDIOBOOK) as unknown as Record<string, unknown>).Sample).toBeUndefined();
-  });
-
-  test("the server does serve it, as a media link entry", async () => {
-    // Uploaded over V4, because that is the only version odata2ts can write it with. Read over V2, to show
-    // what the client would find there.
-    const content = "PK pretend-this-is-epub";
-    const uploaded = await fetch(`${V4_BASE_URL}/EBooks(${EBOOK})/content`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/epub+zip" },
-      body: content,
+    test("the URL is the entity's own plus $value", () => {
+      expect(ebook().content().getPath()).toBe(`${BASE_URL}/EBooks(guid'${EBOOK}')/$value`);
     });
-    expect(uploaded.status).toBe(204);
 
-    const entity = await fetch(`${BASE_URL}/EBooks(guid'${EBOOK}')`).then((r) => r.json());
-    expect(entity.d.__metadata.media_src).toBe(`${BASE_URL}/EBooks(guid'${EBOOK}')/$value`);
-    expect(entity.d.__metadata.content_type).toBe("application/epub+zip");
+    test("that URL is the one the entity itself advertises", async () => {
+      // V2's own way of pointing at the content - the client builds `$value` without having read the
+      // entity, so the two have to be checked against each other
+      const entity = await ebook().query().execute();
+      const metadata = entity.data.d.__metadata as unknown as Record<string, string>;
 
-    const value = await fetch(entity.d.__metadata.media_src);
-    expect(value.status).toBe(200);
-    expect(value.headers.get("content-type")).toBe("application/epub+zip");
-    expect(await value.text()).toBe(content);
+      expect(metadata.media_src).toBe(ebook().content().getPath());
+    });
+
+    test("upload and download round trip", async () => {
+      const content = "PK pretend-this-is-epub";
+
+      const updated = await ebook()
+        .updateBlob(new Blob([content], { type: "application/epub+zip" }))
+        .execute();
+      expect(updated.status).toBe(204);
+
+      const read = await ebook().getBlob().execute();
+
+      expect(read.status).toBe(200);
+      expect(await textOf(read.data)).toBe(content);
+      expect(read.data?.type).toBe("application/epub+zip");
+      expectTypeOf(read).toEqualTypeOf<HttpResponseModel<Blob | undefined>>();
+    });
+
+    test("deleting the content leaves the entity in place", async () => {
+      await ebook()
+        .updateBlob(new Blob(["to be removed"], { type: "application/epub+zip" }))
+        .execute();
+
+      const deleted = await ebook().deleteBlob().execute();
+      expect(deleted.status).toBe(204);
+
+      // 204 and no blob, *not* 404: the entity exists, it just has no content - which is the distinction
+      // a client needs to decide whether to upload
+      const read = await ebook().getBlob().execute();
+      expect(read.status).toBe(204);
+      expect(read.data).toBeUndefined();
+
+      const entity = await ebook().query().execute();
+      expect(entity.data.d.Title).toBe("Clean Code");
+    });
+
+    test("the entity's own properties are untouched by the content", async () => {
+      // A media link entry keeps ordinary properties, read and written as JSON. If the `$value` path
+      // leaked into the regular requests, this would address the bytes instead of the entity.
+      const patched = await ebook().patch({ Language: "en" }).execute();
+      expect(patched.status).toBe(200);
+
+      const entity = await ebook().query().execute();
+      expect(entity.data.d.Language).toBe("en");
+      expect(entity.data.d.FileFormat).toBe("EPUB");
+    });
+
+    test("an unknown entity has no content either", async () => {
+      // 404 rather than the 204 of an entity without content. The message is the client's fallback: it
+      // reads the response of a binary request as a blob, error responses included, so the server's
+      // `{"error":{"message":{"value":"Not Found"}}}` is never looked into - same as against Olingo.
+      await expectODataError(LIBRARY_V2.EBooks(UNKNOWN_ID).getBlob().execute(), {
+        status: 404,
+        message: /No error message/,
+      });
+    });
   });
 
   test("what the V4 model calls a named stream property is the entity's content here", async () => {
-    // Over V4 this is `.../Audiobooks(<id>)/Sample`. In V2 the whole entity is the stream, so the address
-    // is `$value` - which also means an entity can carry exactly one binary payload, and a model with two
-    // named streams on one entity could not be expressed at all.
+    // Over V4 this is `.../Audiobooks(<id>)/Sample`, a property among others. In V2 the whole entity is
+    // the media link entry, so the address is `$value` and the property does not exist.
     const content = "ID3 pretend-this-is-mp3";
-    await fetch(`${V4_BASE_URL}/Audiobooks(${AUDIOBOOK})/Sample`, {
-      method: "PUT",
-      headers: { "Content-Type": "audio/mpeg" },
-      body: content,
+    const audiobook = () => LIBRARY_V2.Audiobooks(AUDIOBOOK);
+
+    expect(audiobook().content().getPath()).toBe(`${BASE_URL}/Audiobooks(guid'${AUDIOBOOK}')/$value`);
+
+    await audiobook()
+      .updateBlob(new Blob([content], { type: "audio/mpeg" }))
+      .execute();
+    const read = await audiobook().getBlob().execute();
+
+    expect(read.status).toBe(200);
+    expect(await textOf(read.data)).toBe(content);
+  });
+
+  describe("the two versions address the same bytes", () => {
+    // The one thing only this server can show: the same rows, once as a stream property and once as a
+    // media link entry. If odata2ts built either URL wrongly, the two clients would not meet.
+    test("written over V2, read over V4", async () => {
+      const content = "PK written-over-v2";
+
+      await LIBRARY_V2.EBooks(EBOOK)
+        .updateBlob(new Blob([content], { type: "application/epub+zip" }))
+        .execute();
+
+      const read = await LIBRARY.EBooks(V4_EBOOK).content().getBlob().execute();
+      expect(await textOf(read.data)).toBe(content);
     });
 
-    const value = await fetch(`${BASE_URL}/Audiobooks(guid'${AUDIOBOOK}')/$value`);
-    expect(value.status).toBe(200);
-    expect(await value.text()).toBe(content);
+    test("written over V4, read over V2", async () => {
+      const content = "ID3 written-over-v4";
 
-    // The old address still answers, since the adapter forwards anything it does not translate to the V4
-    // endpoint. That does not help a generated client: `Sample` is not in the V2 `$metadata`, so odata2ts
-    // has nothing to generate a service from - the working URL is unreachable by construction.
-    const byPropertyName = await fetch(`${BASE_URL}/Audiobooks(guid'${AUDIOBOOK}')/Sample`);
-    expect(byPropertyName.status).toBe(200);
-    expect(await byPropertyName.text()).toBe(content);
+      await LIBRARY.Audiobooks(V4_AUDIOBOOK)
+        .Sample()
+        .updateBlob(new Blob([content], { type: "audio/mpeg" }))
+        .execute();
+
+      const read = await LIBRARY_V2.Audiobooks(AUDIOBOOK).getBlob().execute();
+      expect(await textOf(read.data)).toBe(content);
+    });
+  });
+
+  /**
+   * The same content over the same URLs, only never held in memory as a whole. Which is why these
+   * assertions look like the blob ones above: the transport differs, the result must not.
+   *
+   * Only the fetch client can do this - axios and jquery refuse the call - and that is what the
+   * int-tests run on.
+   */
+  describe("streamed transfer", () => {
+    const ebook = () => LIBRARY_V2.EBooks(EBOOK);
+
+    test("upload and download round trip", async () => {
+      const content = "PK pretend-this-is-a-large-epub";
+
+      const updated = await ebook()
+        .updateStream(new Blob([content]).stream(), "application/epub+zip")
+        .execute();
+      expect(updated.status).toBe(204);
+
+      const read = await ebook().getStream().execute();
+
+      expect(read.status).toBe(200);
+      expect(await textOfStream(read.data)).toBe(content);
+      expectTypeOf(read).toEqualTypeOf<HttpResponseModel<ReadableStream | undefined>>();
+    });
+
+    test("what was streamed up can be read as a blob and vice versa", async () => {
+      // The two ways of transferring must be interchangeable - the server stores bytes, not a shape.
+      const content = "streamed up, buffered down";
+
+      await ebook()
+        .updateStream(new Blob([content]).stream(), "application/epub+zip")
+        .execute();
+      expect(await textOf((await ebook().getBlob().execute()).data)).toBe(content);
+
+      await ebook()
+        .updateBlob(new Blob([content], { type: "application/epub+zip" }))
+        .execute();
+      expect(await textOfStream((await ebook().getStream().execute()).data)).toBe(content);
+    });
+
+    test("an empty content answers 204 without a stream", async () => {
+      await ebook().deleteBlob().execute();
+
+      const read = await ebook().getStream().execute();
+
+      // same distinction as with a blob: the entity is there, its content is not
+      expect(read.status).toBe(204);
+      expect(read.data).toBeUndefined();
+    });
   });
 });

--- a/int-test/olingo-v2/README.md
+++ b/int-test/olingo-v2/README.md
@@ -92,9 +92,10 @@ Where the server does not support something, the test asserts the rejection rath
 - **Deleting a property value answers 405.** Olingo's dispatcher has no route for `DELETE` on a property
   URL. Setting a value to null this way is a `MAY` in V1–V3.
 - **A side-effecting operation answers 201, not 200** — even when it creates nothing.
-- **No binary content API.** The server declares two media link entries and serves them from `/$value`;
-  `@odata2ts/odata-service` has no V2 counterpart to `StreamServiceV4`, so `feature/Blobs.test.ts`
-  asserts the gap from both sides with the only raw `fetch` calls in this package.
+- **A binary error response carries no message.** The client reads the response of a binary request as a
+  blob, error responses included, so the XML error body this server sends back for a `$value` on an
+  unknown entity is never looked into: the status is right, the message is the client's fallback.
+  Pinned in `feature/Blobs.test.ts`.
 - **A query option on a modification request is out of scope for V2.** System query options are defined
   for retrieval only, so there is no `$select` on a `PUT` for a service to honour. This server routes on
   the shape of the URI and answers 405; that is a conforming reaction to a request the protocol does not

--- a/int-test/olingo-v2/test/feature/Blobs.test.ts
+++ b/int-test/olingo-v2/test/feature/Blobs.test.ts
@@ -1,78 +1,184 @@
+import { HttpResponseModel } from "@odata2ts/http-client-api";
 import { describe, expect, expectTypeOf, test } from "vitest";
-import { AudiobookChapter, EBook } from "../../src-generated/library/LibraryModel.js";
-import { AUDIOBOOK_CHAPTER, BASE_URL, EBOOK_CLEAN_CODE, LIBRARY } from "../LibraryTestConstants.js";
+import { expectODataError } from "../expectODataError.js";
+import { AUDIOBOOK_CHAPTER, BASE_URL, EBOOK_CLEAN_CODE, LIBRARY, UNKNOWN_ID } from "../LibraryTestConstants.js";
 
 /**
- * Binary content - odata2ts issue #149 - and the one feature where the server is ahead of the client.
+ * Binary content - odata2ts issue #149 - the way V2 expresses it: as **media link entries** (`m:HasStream`).
  *
- * This server declares two media link entries (`m:HasStream="true"`): `EBook`, which is one *inside* the
- * inheritance hierarchy, and `AudiobookChapter`. Both serve their content from `.../$value` and advertise
- * it through `__metadata.media_src`, exactly as V2 prescribes.
+ * V2 has no `Edm.Stream`, so there is only one carrier of binary data, and the entity is it. This server
+ * declares two such entities: `EBook`, which sits *inside* the inheritance hierarchy, and `AudiobookChapter`,
+ * which does not. Both serve their content from `.../$value` and advertise it through `__metadata.media_src`.
  *
- * odata2ts cannot reach any of it: `StreamServiceV4` and `MediaEntityServiceV4` live in the v4 folder of
- * `@odata2ts/odata-service` and have no V2 counterpart, and the V2 generator emits neither. So this file
- * asserts the gap from both sides rather than leaving the feature untested - the same shape as the CAP
- * package's Blobs test, and for the same reason.
- *
- * The raw `fetch` calls are deliberate and the only ones here that could have been client calls.
+ * The `media_src` assertion is the one that matters most here: unlike V4, V2 never specified `$value` for a
+ * media resource - the entity is supposed to name its own content URL. odata2ts builds `$value` anyway,
+ * because that is where every implementation puts it, so the two have to be checked against each other.
  */
 describe("Olingo Library: binary content", () => {
-  test("the generated model has no property for the content", () => {
-    // A media link entry's content is the entity itself, so there is no property to type - in either
-    // version. What differs is that V4 would at least generate a media-entity service.
-    expectTypeOf<EBook>().not.toHaveProperty("content");
-    expectTypeOf<AudiobookChapter>().not.toHaveProperty("content");
-  });
+  /** Reading a blob back as text keeps the assertions legible - the payloads here are text on purpose. */
+  async function textOf(blob: Blob | undefined) {
+    return blob === undefined ? undefined : blob.text();
+  }
 
-  test("the generated service offers no way to read or write it", () => {
-    const ebook = LIBRARY.EBooks(EBOOK_CLEAN_CODE) as unknown as Record<string, unknown>;
+  /** Same for a stream, which has to be consumed before anything can be asserted about it. */
+  async function textOfStream(stream: ReadableStream | undefined) {
+    return stream === undefined ? undefined : new Response(stream).text();
+  }
 
-    expect(ebook.getBlob).toBeUndefined();
-    expect(ebook.updateBlob).toBeUndefined();
-    expect(ebook.getStream).toBeUndefined();
-    expect(
-      (LIBRARY.AudiobookChapters(AUDIOBOOK_CHAPTER) as unknown as Record<string, unknown>).getBlob,
-    ).toBeUndefined();
-  });
+  describe("media link entry", () => {
+    const ebook = () => LIBRARY.EBooks(EBOOK_CLEAN_CODE);
 
-  test("the entity advertises its content, and the server serves it", async () => {
-    const entity = await LIBRARY.EBooks(EBOOK_CLEAN_CODE).query().execute();
-
-    // `media_src` and `content_type` are V2's way of pointing at the content - and they are in the
-    // payload, reachable by a caller willing to leave the generated API behind
-    const metadata = entity.data.d.__metadata as unknown as Record<string, string>;
-    expect(metadata.media_src).toBe(`${BASE_URL}/EBooks(guid'${EBOOK_CLEAN_CODE}')/$value`);
-    expect(metadata.content_type).toBe("application/epub+zip");
-
-    const content = await fetch(metadata.media_src);
-    expect(content.status).toBe(200);
-    expect(content.headers.get("content-type")).toContain("application/epub+zip");
-    expect(await content.text()).toContain("epub");
-  });
-
-  test("a media link entry inside the inheritance hierarchy behaves like any other", async () => {
-    // `EBook` derives from the abstract `Medium` *and* carries a stream. The combination is what the
-    // reference model exists to probe, and it costs nothing here.
-    const entity = await LIBRARY.EBooks(EBOOK_CLEAN_CODE).query().execute();
-
-    expect(entity.data.d.__metadata.type).toBe("Library.Catalog.EBook");
-    expect(entity.data.d.Title).toBe("Clean Code"); // from Medium
-    expect(entity.data.d.FileFormat).toBe("EPUB"); // its own
-  });
-
-  test("the content can be replaced", async () => {
-    const url = `${BASE_URL}/AudiobookChapters(${AUDIOBOOK_CHAPTER})/$value`;
-    const content = "ID3 replaced-audio-content";
-
-    const written = await fetch(url, {
-      method: "PUT",
-      headers: { "Content-Type": "audio/mpeg" },
-      body: content,
+    test("the URL is the entity's own plus $value", () => {
+      expect(ebook().content().getPath()).toBe(`${BASE_URL}/EBooks(guid'${EBOOK_CLEAN_CODE}')/$value`);
     });
-    expect(written.status).toBe(204);
 
-    const read = await fetch(url);
-    expect(read.status).toBe(200);
-    expect(await read.text()).toBe(content);
+    test("that URL is the one the entity itself advertises", async () => {
+      // V2's own way of pointing at the content - if a server ever put it elsewhere, this is where the
+      // built URL and the advertised one would part ways
+      const entity = await ebook().query().execute();
+      const metadata = entity.data.d.__metadata as unknown as Record<string, string>;
+
+      expect(metadata.media_src).toBe(ebook().content().getPath());
+      expect(metadata.edit_media).toBe(ebook().content().getPath());
+    });
+
+    test("upload and download round trip", async () => {
+      const content = "PK pretend-this-is-epub";
+
+      const updated = await ebook()
+        .updateBlob(new Blob([content], { type: "application/epub+zip" }))
+        .execute();
+      expect(updated.status).toBe(204);
+
+      const read = await ebook().getBlob().execute();
+
+      expect(read.status).toBe(200);
+      expect(await textOf(read.data)).toBe(content);
+      // this server returns the MIME type it was given
+      expect(read.data?.type).toBe("application/epub+zip");
+      expectTypeOf(read).toEqualTypeOf<HttpResponseModel<Blob | undefined>>();
+    });
+
+    test("the MIME type can be overridden", async () => {
+      await ebook()
+        .updateBlob(new Blob(["whatever"]), "application/pdf")
+        .execute();
+
+      const read = await ebook().getBlob().execute();
+
+      expect(read.data?.type).toBe("application/pdf");
+    });
+
+    test("deleting the content leaves the entity in place", async () => {
+      await ebook()
+        .updateBlob(new Blob(["to be removed"], { type: "application/epub+zip" }))
+        .execute();
+
+      const deleted = await ebook().deleteBlob().execute();
+      expect(deleted.status).toBe(204);
+
+      // 204 and no blob, *not* 404: the entity exists, it just has no content - which is the distinction
+      // a client needs to decide whether to upload
+      const read = await ebook().getBlob().execute();
+      expect(read.status).toBe(204);
+      expect(read.data).toBeUndefined();
+
+      const entity = await ebook().query().execute();
+      expect(entity.data.d.Title).toBe("Clean Code");
+    });
+
+    test("the entity's own properties are untouched by the content", async () => {
+      // A media link entry keeps ordinary properties, read and written as JSON. If the `$value` path
+      // leaked into the regular requests, this would address the bytes instead of the entity.
+      const patched = await ebook().patch({ Language: "en" }).execute();
+      expect(patched.status).toBe(204);
+
+      const entity = await ebook().query().execute();
+      expect(entity.data.d.Language).toBe("en");
+      // still the media link entry it was, inheritance included
+      expect(entity.data.d.__metadata.type).toBe("Library.Catalog.EBook");
+      expect(entity.data.d.FileFormat).toBe("EPUB");
+    });
+
+    test("an unknown entity has no content either", async () => {
+      // 404 rather than the 204 of an entity without content. The message is the client's fallback: it
+      // reads the response of a binary request as a blob, error responses included, so the error body
+      // the server does send is never looked into - the same shows against CAP.
+      await expectODataError(LIBRARY.EBooks(UNKNOWN_ID).getBlob().execute(), {
+        status: 404,
+        message: /No error message/,
+      });
+    });
+  });
+
+  describe("media link entry outside the hierarchy", () => {
+    // `EBook` derives from the abstract `Medium`, `AudiobookChapter` from nothing at all, and it is keyed
+    // by an `Edm.Int32` rather than a guid. Same content access, differently built entity URL.
+    const chapter = () => LIBRARY.AudiobookChapters(AUDIOBOOK_CHAPTER);
+
+    test("upload and download round trip", async () => {
+      const content = "ID3 pretend-this-is-mp3";
+
+      expect(chapter().content().getPath()).toBe(`${BASE_URL}/AudiobookChapters(${AUDIOBOOK_CHAPTER})/$value`);
+
+      await chapter()
+        .updateBlob(new Blob([content], { type: "audio/mpeg" }))
+        .execute();
+      const read = await chapter().getBlob().execute();
+
+      expect(read.status).toBe(200);
+      expect(await textOf(read.data)).toBe(content);
+    });
+  });
+
+  /**
+   * The same content over the same URLs, only never held in memory as a whole. Which is why these
+   * assertions look like the blob ones above: the transport differs, the result must not.
+   *
+   * Only the fetch client can do this - axios and jquery refuse the call - and that is what the
+   * int-tests run on.
+   */
+  describe("streamed transfer", () => {
+    const ebook = () => LIBRARY.EBooks(EBOOK_CLEAN_CODE);
+
+    test("upload and download round trip", async () => {
+      const content = "PK pretend-this-is-a-large-epub";
+
+      const updated = await ebook()
+        .updateStream(new Blob([content]).stream(), "application/epub+zip")
+        .execute();
+      expect(updated.status).toBe(204);
+
+      const read = await ebook().getStream().execute();
+
+      expect(read.status).toBe(200);
+      expect(await textOfStream(read.data)).toBe(content);
+      expectTypeOf(read).toEqualTypeOf<HttpResponseModel<ReadableStream | undefined>>();
+    });
+
+    test("what was streamed up can be read as a blob and vice versa", async () => {
+      // The two ways of transferring must be interchangeable - the server stores bytes, not a shape.
+      const content = "streamed up, buffered down";
+
+      await ebook()
+        .updateStream(new Blob([content]).stream(), "application/epub+zip")
+        .execute();
+      expect(await textOf((await ebook().getBlob().execute()).data)).toBe(content);
+
+      await ebook()
+        .updateBlob(new Blob([content], { type: "application/epub+zip" }))
+        .execute();
+      expect(await textOfStream((await ebook().getStream().execute()).data)).toBe(content);
+    });
+
+    test("an empty content answers 204 without a stream", async () => {
+      await ebook().deleteBlob().execute();
+
+      const read = await ebook().getStream().execute();
+
+      // same distinction as with a blob: the entity is there, its content is not
+      expect(read.status).toBe(204);
+      expect(read.data).toBeUndefined();
+    });
   });
 });

--- a/packages/odata-service/src/StreamServiceBase.ts
+++ b/packages/odata-service/src/StreamServiceBase.ts
@@ -1,0 +1,105 @@
+import { ODataHttpClient, ODataHttpMethods } from "@odata2ts/http-client-api";
+import { ODataVersionV4 } from "@odata2ts/odata-core";
+import { ODataServiceOptionsInternal } from "./ODataServiceOptions";
+import {
+  BlobGetRequestCmd,
+  BlobUpdateRequestCmd,
+  StreamGetRequestCmd,
+  StreamUpdateRequestCmd,
+  UrlRequestCmd,
+} from "./request";
+import { ServiceStateHelper } from "./ServiceStateHelper.js";
+
+const DEFAULT_MIME_TYPE = "application/octet-stream";
+
+/**
+ * Access to binary data behind its own URL, shared by both OData versions.
+ *
+ * Binary data never travels within the entity's JSON payload - it has its own URL, and that URL is what
+ * this service is bound to. Which is also why the default headers are deliberately not sent here: they
+ * declare JSON. What the URL looks like is the versions' business, not this class's: V4 knows a stream
+ * property as well as a media entity's `$value`, V2 only the latter.
+ */
+export abstract class StreamServiceBase<out ClientType extends ODataHttpClient, V extends ODataVersionV4 = "4.0"> {
+  protected readonly __base: ServiceStateHelper<ClientType, V>;
+
+  public constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+    this.__base = new ServiceStateHelper(client, basePath, name, options);
+  }
+
+  public getPath() {
+    return this.__base.path;
+  }
+
+  /**
+   * Read the binary content.
+   *
+   * An entity which exists but has no content yet answers 204, so `data` is `undefined` - that is the
+   * distinction a client needs to decide whether to upload, and it must not be confused with 404.
+   */
+  public getBlob() {
+    const { client, path } = this.__base;
+
+    return new BlobGetRequestCmd<ClientType>(client, path);
+  }
+
+  /**
+   * Replace the binary content.
+   *
+   * The MIME type travels as `Content-Type` and defaults to the blob's own `type`; a blob constructed
+   * without one falls back to `application/octet-stream`. Servers differ in what they do with it: some
+   * store and return it, others answer with the MIME type declared in their model.
+   *
+   * @param data the binary content
+   * @param mimeType overrides the blob's own type
+   */
+  public updateBlob(data: Blob, mimeType?: string) {
+    const { client, path } = this.__base;
+
+    return new BlobUpdateRequestCmd<ClientType>(client, path, data, mimeType || data.type || DEFAULT_MIME_TYPE);
+  }
+
+  /**
+   * Read the binary content as a stream, so that it does not have to be held in memory as a whole.
+   *
+   * Same request as {@link getBlob}, only the response is not buffered. Reading a stream requires the
+   * fetch API, so the axios and the jquery client refuse this call - use `getBlob` with those.
+   *
+   * An entity which exists but has no content yet answers 204, so `data` is `undefined`.
+   */
+  public getStream() {
+    const { client, path } = this.__base;
+
+    return new StreamGetRequestCmd<ClientType>(client, path);
+  }
+
+  /**
+   * Replace the binary content from a stream, so that it does not have to be held in memory as a whole.
+   *
+   * Same request as {@link updateBlob}, only the body is streamed. Sending a stream requires the fetch
+   * API, so the axios and the jquery client refuse this call - use `updateBlob` with those.
+   *
+   * Unlike a blob a stream carries no MIME type of its own, hence the fallback to
+   * `application/octet-stream` when none is given.
+   *
+   * @param data the binary content
+   * @param mimeType the content's MIME type
+   */
+  public updateStream(data: ReadableStream, mimeType?: string) {
+    const { client, path } = this.__base;
+
+    return new StreamUpdateRequestCmd<ClientType>(client, path, data, mimeType || DEFAULT_MIME_TYPE);
+  }
+
+  /**
+   * Delete the binary content, leaving the entity itself in place.
+   *
+   * Support for this is not universal: a server may serve `GET` and `PUT` on a stream property and still
+   * refuse `DELETE` with 405, in which case the content can only be replaced, not removed.
+   */
+  public deleteBlob() {
+    const { client, path } = this.__base;
+
+    return new UrlRequestCmd<ClientType, undefined>(client, ODataHttpMethods.Delete, path);
+  }
+}

--- a/packages/odata-service/src/v2/MediaEntityServiceV2.ts
+++ b/packages/odata-service/src/v2/MediaEntityServiceV2.ts
@@ -1,0 +1,87 @@
+import { ODataHttpClient } from "@odata2ts/http-client-api";
+import { QueryObjectModel } from "@odata2ts/odata-query-objects";
+import { EntityTypeServiceV2 } from "./EntityTypeServiceV2";
+import { StreamServiceV2 } from "./StreamServiceV2";
+
+const VALUE_SEGMENT = "$value";
+
+/**
+ * Service for a media link entry (MLE), i.e. an entity type declared `m:HasStream="true"`: the entity
+ * points at a media resource (MR) which holds its binary content.
+ * Spec: {@link https://www.odata.org/documentation/odata-version-2-0/operations/} - 2.5 Creating Media Link Entries
+ *
+ * This is V2's answer to what V4 splits over two concepts: it has no `Edm.Stream`, so an entity carrying
+ * binary content *is* the media link entry, and the content is reachable by appending `$value` to its URL.
+ * Strictly speaking a client is supposed to take that URL from the entity's `__metadata.media_src` /
+ * `edit_media`, which is only known after reading the entity; every implementation puts the MR at `$value`,
+ * which is what makes the URL predictable enough to build without asking first.
+ *
+ * Everything an ordinary entity service does stays available - the media link entry still has regular
+ * properties, which are read and written as JSON; only its content is separate.
+ */
+export class MediaEntityServiceV2<
+  in out ClientType extends ODataHttpClient,
+  T,
+  EditableT,
+  Q extends QueryObjectModel,
+> extends EntityTypeServiceV2<ClientType, T, EditableT, Q> {
+  private _content?: StreamServiceV2<ClientType>;
+
+  /**
+   * The entity's content as its own service, bound to the `$value` URL.
+   */
+  public content(): StreamServiceV2<ClientType> {
+    if (!this._content) {
+      const { client, path, options } = this.__base;
+      this._content = new StreamServiceV2<ClientType>(client, path, VALUE_SEGMENT, options);
+    }
+
+    return this._content;
+  }
+
+  /**
+   * Read the entity's binary content. Shortcut for `content().getBlob()`.
+   */
+  public getBlob() {
+    return this.content().getBlob();
+  }
+
+  /**
+   * Replace the entity's binary content. Shortcut for `content().updateBlob(...)`.
+   *
+   * @param data the binary content
+   * @param mimeType overrides the blob's own type
+   */
+  public updateBlob(data: Blob, mimeType?: string) {
+    return this.content().updateBlob(data, mimeType);
+  }
+
+  /**
+   * Read the entity's binary content as a stream. Shortcut for `content().getStream()`.
+   */
+  public getStream() {
+    return this.content().getStream();
+  }
+
+  /**
+   * Replace the entity's binary content from a stream. Shortcut for `content().updateStream(...)`.
+   *
+   * @param data the binary content
+   * @param mimeType the content's MIME type
+   */
+  public updateStream(data: ReadableStream, mimeType?: string) {
+    return this.content().updateStream(data, mimeType);
+  }
+
+  /**
+   * Delete the entity's binary content, leaving the entity itself in place. Shortcut for
+   * `content().deleteBlob()`.
+   *
+   * V2 only specifies that deleting the media link entry deletes its media resource as well; emptying
+   * the content on its own is left to the implementation. Both reference servers answer 204 and keep the
+   * entity, but a server refusing this with 405 would be within the spec.
+   */
+  public deleteBlob() {
+    return this.content().deleteBlob();
+  }
+}

--- a/packages/odata-service/src/v2/StreamServiceV2.ts
+++ b/packages/odata-service/src/v2/StreamServiceV2.ts
@@ -1,0 +1,18 @@
+import { ODataHttpClient } from "@odata2ts/http-client-api";
+import { ODataServiceOptions } from "../ODataServiceOptions";
+import { StreamServiceBase } from "../StreamServiceBase.js";
+
+/**
+ * Access to the media resource of a media link entry, i.e. the binary content of an entity declared
+ * `m:HasStream="true"`.
+ * Spec: {@link https://www.odata.org/documentation/odata-version-2-0/operations/} - 2.7 Media Resources
+ *
+ * V2 knows no `Edm.Stream`, so unlike in V4 there is no second carrier of binary data: the only URL this
+ * service is ever bound to is the entity's `$value`, and an entity can carry exactly one such payload.
+ * That is also why it is not generated for any property - a V2 model has no way of declaring one.
+ */
+export class StreamServiceV2<out ClientType extends ODataHttpClient> extends StreamServiceBase<ClientType> {
+  public constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+    super(client, basePath, name, options);
+  }
+}

--- a/packages/odata-service/src/v2/index.ts
+++ b/packages/odata-service/src/v2/index.ts
@@ -3,3 +3,5 @@ export { EntityTypeServiceV2 } from "./EntityTypeServiceV2";
 export { CollectionServiceV2 } from "./CollectionServiceV2";
 export { PrimitiveTypeServiceV2 } from "./PrimitiveTypeServiceV2";
 export { ComplexTypeServiceV2 } from "./ComplexTypeServiceV2";
+export { StreamServiceV2 } from "./StreamServiceV2";
+export { MediaEntityServiceV2 } from "./MediaEntityServiceV2";

--- a/packages/odata-service/src/v4/StreamServiceV4.ts
+++ b/packages/odata-service/src/v4/StreamServiceV4.ts
@@ -1,105 +1,14 @@
-import { ODataHttpClient, ODataHttpMethods } from "@odata2ts/http-client-api";
+import { ODataHttpClient } from "@odata2ts/http-client-api";
 import { ODataVersionV4 } from "@odata2ts/odata-core";
-import { ODataServiceOptionsInternal } from "../ODataServiceOptions";
-import {
-  BlobGetRequestCmd,
-  BlobUpdateRequestCmd,
-  StreamGetRequestCmd,
-  StreamUpdateRequestCmd,
-  UrlRequestCmd,
-} from "../request";
-import { ServiceStateHelper } from "../ServiceStateHelper.js";
-
-const DEFAULT_MIME_TYPE = "application/octet-stream";
+import { StreamServiceBase } from "../StreamServiceBase.js";
 
 /**
  * Access to binary data: a stream property (`Edm.Stream`) or the content of a media entity.
  * Spec: {@link https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_ManagingStreamProperties}
  *
- * Binary data never travels within the entity's JSON payload - it has its own URL, the property name for
- * a stream property and `$value` for a media entity's content, and that URL is what this service is
- * bound to. Which is also why the default headers are deliberately not sent here: they declare JSON.
+ * The bound URL is the property name for a stream property and `$value` for a media entity's content.
  */
-export class StreamServiceV4<out ClientType extends ODataHttpClient, V extends ODataVersionV4 = "4.0"> {
-  protected readonly __base: ServiceStateHelper<ClientType, V>;
-
-  public constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
-    this.__base = new ServiceStateHelper(client, basePath, name, options);
-  }
-
-  public getPath() {
-    return this.__base.path;
-  }
-
-  /**
-   * Read the binary content.
-   *
-   * An entity which exists but has no content yet answers 204, so `data` is `undefined` - that is the
-   * distinction a client needs to decide whether to upload, and it must not be confused with 404.
-   */
-  public getBlob() {
-    const { client, path } = this.__base;
-
-    return new BlobGetRequestCmd<ClientType>(client, path);
-  }
-
-  /**
-   * Replace the binary content.
-   *
-   * The MIME type travels as `Content-Type` and defaults to the blob's own `type`; a blob constructed
-   * without one falls back to `application/octet-stream`. Servers differ in what they do with it: some
-   * store and return it, others answer with the MIME type declared in their model.
-   *
-   * @param data the binary content
-   * @param mimeType overrides the blob's own type
-   */
-  public updateBlob(data: Blob, mimeType?: string) {
-    const { client, path } = this.__base;
-
-    return new BlobUpdateRequestCmd<ClientType>(client, path, data, mimeType || data.type || DEFAULT_MIME_TYPE);
-  }
-
-  /**
-   * Read the binary content as a stream, so that it does not have to be held in memory as a whole.
-   *
-   * Same request as {@link getBlob}, only the response is not buffered. Reading a stream requires the
-   * fetch API, so the axios and the jquery client refuse this call - use `getBlob` with those.
-   *
-   * An entity which exists but has no content yet answers 204, so `data` is `undefined`.
-   */
-  public getStream() {
-    const { client, path } = this.__base;
-
-    return new StreamGetRequestCmd<ClientType>(client, path);
-  }
-
-  /**
-   * Replace the binary content from a stream, so that it does not have to be held in memory as a whole.
-   *
-   * Same request as {@link updateBlob}, only the body is streamed. Sending a stream requires the fetch
-   * API, so the axios and the jquery client refuse this call - use `updateBlob` with those.
-   *
-   * Unlike a blob a stream carries no MIME type of its own, hence the fallback to
-   * `application/octet-stream` when none is given.
-   *
-   * @param data the binary content
-   * @param mimeType the content's MIME type
-   */
-  public updateStream(data: ReadableStream, mimeType?: string) {
-    const { client, path } = this.__base;
-
-    return new StreamUpdateRequestCmd<ClientType>(client, path, data, mimeType || DEFAULT_MIME_TYPE);
-  }
-
-  /**
-   * Delete the binary content, leaving the entity itself in place.
-   *
-   * Support for this is not universal: a server may serve `GET` and `PUT` on a stream property and still
-   * refuse `DELETE` with 405, in which case the content can only be replaced, not removed.
-   */
-  public deleteBlob() {
-    const { client, path } = this.__base;
-
-    return new UrlRequestCmd<ClientType, undefined>(client, ODataHttpMethods.Delete, path);
-  }
-}
+export class StreamServiceV4<
+  out ClientType extends ODataHttpClient,
+  V extends ODataVersionV4 = "4.0",
+> extends StreamServiceBase<ClientType, V> {}

--- a/packages/odata-service/test/fixture/v2/PersonModelV2Service.ts
+++ b/packages/odata-service/test/fixture/v2/PersonModelV2Service.ts
@@ -5,6 +5,7 @@ import {
   CollectionServiceV2,
   EntitySetServiceV2,
   EntityTypeServiceV2,
+  MediaEntityServiceV2,
   ODataServiceOptions,
   PrimitiveTypeServiceV2,
   UrlRequestCmd,
@@ -65,6 +66,18 @@ export class PersonModelV2Service<ClientType extends ODataHttpClient> extends En
         mainResponseConverter: new EntityResponseConverterV2(qPersonV2),
       },
     );
+  }
+}
+
+/** Same entity, only declared `m:HasStream="true"` - which is all the generator does differently. */
+export class PersonModelV2MediaService<ClientType extends ODataHttpClient> extends MediaEntityServiceV2<
+  ClientType,
+  PersonModel,
+  EditablePersonModel,
+  QPersonV2
+> {
+  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+    super(client, basePath, name, new QPersonV2(), options);
   }
 }
 

--- a/packages/odata-service/test/v2/MediaEntityServiceV2.test.ts
+++ b/packages/odata-service/test/v2/MediaEntityServiceV2.test.ts
@@ -1,0 +1,91 @@
+import { HttpResponseModel } from "@odata2ts/http-client-api";
+import { beforeEach, describe, expect, expectTypeOf, test } from "vitest";
+import { PersonModelV2MediaService } from "../fixture/v2/PersonModelV2Service";
+import { MockClient } from "../mock/MockClient";
+
+describe("MediaEntityService V2 Test", () => {
+  const odataClient = new MockClient(true);
+  const BASE_URL = "path";
+  const NAME = "EBooks(guid'1')";
+  const ENTITY_PATH = `${BASE_URL}/${NAME}`;
+  const CONTENT_PATH = `${ENTITY_PATH}/$value`;
+
+  let service: PersonModelV2MediaService<MockClient>;
+
+  beforeEach(() => {
+    service = new PersonModelV2MediaService(odataClient, BASE_URL, NAME);
+  });
+
+  test("mediaEntity V2: the content lives at $value", () => {
+    // What the entity advertises as `__metadata.media_src` - only that it can be built without asking
+    expect(service.getPath()).toBe(ENTITY_PATH);
+    expect(service.content().getPath()).toBe(CONTENT_PATH);
+  });
+
+  test("mediaEntity V2: read the content", async () => {
+    const blob = new Blob(["epub"], { type: "application/epub+zip" });
+    odataClient.setBlobResponse(blob);
+
+    const response = await service.getBlob().execute();
+
+    expect(odataClient.lastUrl).toBe(CONTENT_PATH);
+    expect(odataClient.lastOperation).toBe("GET");
+    expect(response.data).toBe(blob);
+    expectTypeOf(response).toEqualTypeOf<HttpResponseModel<Blob | undefined>>();
+  });
+
+  test("mediaEntity V2: write the content", async () => {
+    const blob = new Blob(["epub"], { type: "application/epub+zip" });
+
+    await service.updateBlob(blob).execute();
+
+    expect(odataClient.lastUrl).toBe(CONTENT_PATH);
+    // PUT, not V2's MERGE-through-POST: that tunneling applies to entity updates, not to the raw content
+    expect(odataClient.lastOperation).toBe("PUT");
+    expect(odataClient.lastData).toBe(blob);
+    expect(odataClient.lastMimeType).toBe("application/epub+zip");
+  });
+
+  test("mediaEntity V2: read the content as a stream", async () => {
+    const stream = new Blob(["epub"]).stream();
+    odataClient.setStreamResponse(stream);
+
+    const response = await service.getStream().execute();
+
+    expect(odataClient.lastUrl).toBe(CONTENT_PATH);
+    expect(odataClient.lastOperation).toBe("GET");
+    expect(response.data).toBe(stream);
+    expectTypeOf(response).toEqualTypeOf<HttpResponseModel<ReadableStream | undefined>>();
+  });
+
+  test("mediaEntity V2: write the content from a stream", async () => {
+    const stream = new Blob(["epub"]).stream();
+
+    await service.updateStream(stream, "application/epub+zip").execute();
+
+    expect(odataClient.lastUrl).toBe(CONTENT_PATH);
+    expect(odataClient.lastOperation).toBe("PUT");
+    expect(odataClient.lastData).toBe(stream);
+    expect(odataClient.lastMimeType).toBe("application/epub+zip");
+  });
+
+  test("mediaEntity V2: delete the content", async () => {
+    await service.deleteBlob().execute();
+
+    expect(odataClient.lastUrl).toBe(CONTENT_PATH);
+    expect(odataClient.lastOperation).toBe("DELETE");
+  });
+
+  test("mediaEntity V2: the entity itself is still addressed without $value", async () => {
+    // The decisive one: a media link entry keeps ordinary properties, read and written as JSON. If the
+    // content path leaked into the entity requests, every regular operation would address the bytes.
+    await service.patch({ userName: "tester" }).execute();
+
+    expect(odataClient.lastUrl).toBe(ENTITY_PATH);
+    // V2 tunnels the partial update through POST
+    expect(odataClient.lastOperation).toBe("POST");
+    expect(odataClient.lastData).toStrictEqual({ UserName: "tester" });
+
+    expect(service.query().getUrl()).toBe(ENTITY_PATH);
+  });
+});

--- a/packages/odata-service/test/v2/StreamServiceV2.test.ts
+++ b/packages/odata-service/test/v2/StreamServiceV2.test.ts
@@ -1,0 +1,137 @@
+import { HttpResponseModel } from "@odata2ts/http-client-api";
+import { beforeEach, describe, expect, expectTypeOf, test } from "vitest";
+import { RequestInfo, StreamServiceV2 } from "../../src/";
+import { MockClient } from "../mock/MockClient";
+
+describe("StreamService V2 Test", () => {
+  const odataClient = new MockClient(true);
+  const BASE_URL = "path/EBooks(guid'1')";
+  const NAME = "$value";
+  const EXPECTED_PATH = `${BASE_URL}/${NAME}`;
+  const MIME_TYPE = "application/epub+zip";
+
+  let service: StreamServiceV2<MockClient>;
+
+  beforeEach(() => {
+    service = new StreamServiceV2<MockClient>(odataClient, BASE_URL, NAME);
+  });
+
+  test("stream V2: base tests", () => {
+    expect(service.getPath()).toBe(EXPECTED_PATH);
+  });
+
+  test("stream V2: get blob", async () => {
+    const request = service.getBlob();
+    const result = request.getInfo();
+
+    expectTypeOf(result).toEqualTypeOf<RequestInfo>();
+
+    expect(result.url).toBe(EXPECTED_PATH);
+    expect(result.data).toBeUndefined();
+    expect(result.method).toBe("GET");
+    // the JSON default headers must not be sent here: the response is binary. V2's are the ones which
+    // would ask for `application/json`, which the media resource is not
+    expect(result.headers).toBeUndefined();
+
+    const blob = new Blob(["epub"], { type: MIME_TYPE });
+    odataClient.setBlobResponse(blob);
+    const response = await request.execute();
+
+    expect(odataClient.lastUrl).toBe(EXPECTED_PATH);
+    expect(odataClient.lastOperation).toBe("GET");
+    expect(response.data).toBe(blob);
+    expectTypeOf(response).toEqualTypeOf<HttpResponseModel<Blob | undefined>>();
+  });
+
+  test("stream V2: an empty media resource answers 204, so no blob", async () => {
+    // The entity exists, its content does not - a client deciding whether to upload depends on the
+    // distinction, so `undefined` must survive instead of becoming an error.
+    const response = await service.getBlob().execute();
+
+    expect(response.data).toBeNull();
+    expectTypeOf(response).toEqualTypeOf<HttpResponseModel<Blob | undefined>>();
+  });
+
+  test("stream V2: update blob", async () => {
+    const blob = new Blob(["epub"], { type: MIME_TYPE });
+    const request = service.updateBlob(blob);
+    const result = request.getInfo();
+
+    expect(result.url).toBe(EXPECTED_PATH);
+    expect(result.method).toBe("PUT");
+    // the blob itself, not a serialized version of it
+    expect(result.data).toBe(blob);
+
+    await request.execute();
+
+    expect(odataClient.lastOperation).toBe("PUT");
+    expect(odataClient.lastData).toBe(blob);
+    expect(odataClient.lastMimeType).toBe(MIME_TYPE);
+    expectTypeOf(request.getInfo()).toEqualTypeOf<RequestInfo<Blob>>();
+  });
+
+  test("stream V2: the MIME type can be overridden", async () => {
+    const blob = new Blob(["epub"], { type: MIME_TYPE });
+
+    await service.updateBlob(blob, "application/x-custom").execute();
+
+    expect(odataClient.lastMimeType).toBe("application/x-custom");
+  });
+
+  test("stream V2: a blob without a type falls back to octet-stream", async () => {
+    await service.updateBlob(new Blob(["epub"])).execute();
+
+    expect(odataClient.lastMimeType).toBe("application/octet-stream");
+  });
+
+  test("stream V2: get stream", async () => {
+    const stream = new Blob(["epub"], { type: MIME_TYPE }).stream();
+    odataClient.setStreamResponse(stream);
+
+    const response = await service.getStream().execute();
+
+    expect(odataClient.lastUrl).toBe(EXPECTED_PATH);
+    expect(odataClient.lastOperation).toBe("GET");
+    // the stream itself, not a buffered copy of it
+    expect(response.data).toBe(stream);
+    expectTypeOf(response).toEqualTypeOf<HttpResponseModel<ReadableStream | undefined>>();
+  });
+
+  test("stream V2: update stream", async () => {
+    const stream = new Blob(["epub"], { type: MIME_TYPE }).stream();
+    const request = service.updateStream(stream, MIME_TYPE);
+    const result = request.getInfo();
+
+    expect(result.url).toBe(EXPECTED_PATH);
+    expect(result.method).toBe("PUT");
+    expect(result.data).toBe(stream);
+
+    await request.execute();
+
+    expect(odataClient.lastOperation).toBe("PUT");
+    expect(odataClient.lastData).toBe(stream);
+    expect(odataClient.lastMimeType).toBe(MIME_TYPE);
+    expectTypeOf(request.getInfo()).toEqualTypeOf<RequestInfo<ReadableStream>>();
+  });
+
+  test("stream V2: a stream without a MIME type falls back to octet-stream", async () => {
+    // unlike a blob a stream carries no type of its own, so there is nothing else to fall back to
+    await service.updateStream(new Blob(["epub"], { type: MIME_TYPE }).stream()).execute();
+
+    expect(odataClient.lastMimeType).toBe("application/octet-stream");
+  });
+
+  test("stream V2: delete blob", async () => {
+    const request = service.deleteBlob();
+    const result = request.getInfo();
+
+    expectTypeOf(result).toEqualTypeOf<RequestInfo>();
+
+    expect(result.url).toBe(EXPECTED_PATH);
+    expect(result.data).toBeUndefined();
+    expect(result.method).toBe("DELETE");
+
+    expectTypeOf(await request.execute()).toEqualTypeOf<HttpResponseModel<undefined>>();
+    expect(odataClient.lastOperation).toBe("DELETE");
+  });
+});

--- a/packages/odata2ts/src/data-model/DataModelDigestion.ts
+++ b/packages/odata2ts/src/data-model/DataModelDigestion.ts
@@ -110,6 +110,14 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
    */
   protected abstract mapODataType(type: string): TypeModel;
 
+  /**
+   * Whether the entity's own representation is binary content: a media entity in V4, a media link entry
+   * in V2. Both versions know the same marker, V2 puts it into the metadata namespace though.
+   */
+  protected isMediaEntity(entityType: ET): boolean {
+    return ifTrue(entityType.$.HasStream);
+  }
+
   public async digest(): Promise<DataModel> {
     this.digestEntityTypesAndOperations();
 
@@ -278,8 +286,8 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
         keys: [], // postprocess required to include props from base classes
         getKeyUnion: () => keyNames.join(" | "),
         subtypes: new Set(),
-        // postprocess required as well: HasStream is inherited from base types
-        hasStream: ifTrue((model as EntityType).$.HasStream),
+        // postprocess required as well: the media entity marker is inherited from base types
+        hasStream: this.isMediaEntity(model),
       });
     }
   }

--- a/packages/odata2ts/src/data-model/DataModelDigestionV2.ts
+++ b/packages/odata2ts/src/data-model/DataModelDigestionV2.ts
@@ -120,6 +120,10 @@ class DigesterV3 extends Digester<SchemaV3, EntityTypeV3, ComplexTypeV3> {
     return [];
   }
 
+  protected isMediaEntity(entityType: EntityTypeV3): boolean {
+    return entityType.$["m:HasStream"] === "true";
+  }
+
   // in V2 all we have & need is the FunctionImport: Function & Action elements are only known in V4.
   protected digestOperations(schema: SchemaV3) {}
 

--- a/packages/odata2ts/src/data-model/edmx/ODataEdmxModelBase.ts
+++ b/packages/odata2ts/src/data-model/edmx/ODataEdmxModelBase.ts
@@ -48,7 +48,9 @@ export interface EntityType {
     OpenType?: "true" | "false";
     /**
      * Marks a media entity, i.e. an entity whose own representation is binary content, addressed by
-     * appending `$value` to its URL. V4 only, and inherited by derived types.
+     * appending `$value` to its URL. Inherited by derived types.
+     *
+     * V4 spelling; V2 knows the same marker as `m:HasStream` and calls such an entity a media link entry.
      */
     HasStream?: "true" | "false";
   };

--- a/packages/odata2ts/src/data-model/edmx/ODataEdmxModelV3.ts
+++ b/packages/odata2ts/src/data-model/edmx/ODataEdmxModelV3.ts
@@ -16,6 +16,13 @@ export interface SchemaV3 extends Schema<EntityTypeV3, ComplexTypeV3> {
 }
 
 export interface EntityTypeV3 extends EntityType {
+  $: EntityType["$"] & {
+    /**
+     * Marks a media link entry, i.e. an entity pointing at a media resource which holds its binary
+     * content. Same marker as V4's `HasStream`, only in the metadata namespace.
+     */
+    "m:HasStream"?: "true" | "false";
+  };
   NavigationProperty?: Array<NavigationProperty>;
 }
 

--- a/packages/odata2ts/src/generator/ServiceGenerator.ts
+++ b/packages/odata2ts/src/generator/ServiceGenerator.ts
@@ -298,8 +298,9 @@ class ServiceGenerator {
     const props = [...model.baseProps, ...model.props];
 
     // a media entity's own representation is binary content, reachable via `$value` - that access is
-    // what the specialized base class adds on top of the regular entity service
-    const isMediaEntity = this.version === ODataVersions.V4 && !isComplexType && (model as EntityType).hasStream;
+    // what the specialized base class adds on top of the regular entity service. V2 calls the same thing
+    // a media link entry and addresses it the same way.
+    const isMediaEntity = !isComplexType && (model as EntityType).hasStream;
 
     const entityServiceType = importContainer.addServiceObject(
       this.version,

--- a/packages/odata2ts/src/generator/import/ImportObjects.ts
+++ b/packages/odata2ts/src/generator/import/ImportObjects.ts
@@ -92,7 +92,8 @@ export const VERSIONED_SERVICE_IMPORTS = [
   ServiceImports.CollectionService,
   ServiceImports.EntitySetService,
   ServiceImports.ComplexTypeService,
-  // V4 only in fact - streams are an OData V4 concept, so these are never requested for V2
-  ServiceImports.StreamService,
   ServiceImports.MediaEntityService,
+  // V4 only in fact - a stream *property* is an OData V4 concept, and V2's only binary content is the
+  // media link entry's own, which MediaEntityServiceV2 reaches on its own
+  ServiceImports.StreamService,
 ];

--- a/packages/odata2ts/test/data-model/builder/CommonEntityAndComplexBuilderBase.ts
+++ b/packages/odata2ts/test/data-model/builder/CommonEntityAndComplexBuilderBase.ts
@@ -4,7 +4,7 @@ export interface EntityOrComplexBuilderOptions {
   baseType?: string;
   abstract?: boolean;
   open?: boolean;
-  /** Media entity: only meaningful on entity types, and only in V4. */
+  /** Media entity (V4) resp. media link entry (V2): only meaningful on entity types. */
   hasStream?: boolean;
 }
 

--- a/packages/odata2ts/test/data-model/builder/v2/ODataEntityTypeBuilderV2.ts
+++ b/packages/odata2ts/test/data-model/builder/v2/ODataEntityTypeBuilderV2.ts
@@ -5,7 +5,14 @@ export class ODataEntityTypeBuilderV2 extends ODataEntityTypeBuilderBase<EntityT
   private associations: Array<Association> = [];
 
   protected createVersionedEntityType(): EntityTypeV3 {
-    return this.createEntityType();
+    const entityType = this.createEntityType();
+    // V2 spells the media entity marker in the metadata namespace
+    const { HasStream, ...attributes } = entityType.$;
+
+    return {
+      ...entityType,
+      $: { ...attributes, ...(HasStream ? { "m:HasStream": HasStream } : {}) },
+    };
   }
 
   public getAssociations() {

--- a/packages/odata2ts/test/data-model/v2/EntityTypeDigestion.test.ts
+++ b/packages/odata2ts/test/data-model/v2/EntityTypeDigestion.test.ts
@@ -489,4 +489,29 @@ describe("V2: EntityTypeDigestion Test", () => {
       required: false,
     } as PropertyModel);
   });
+
+  test("EntityTypes: media link entry", async () => {
+    // V2's counterpart of V4's media entity, only that the marker sits in the metadata namespace:
+    // `m:HasStream="true"`. Reading the V4 spelling instead would silently find nothing.
+    odataBuilder.addEntityType("Book", undefined, (builder) => builder.addKeyProp("id", ODataTypesV2.Guid));
+    odataBuilder.addEntityType("EBook", { hasStream: true }, (builder) => builder.addKeyProp("id", ODataTypesV2.Guid));
+
+    const result = await doDigest();
+
+    expect(result.getEntityType(withNs("EBook"))!.hasStream).toBe(true);
+    expect(result.getEntityType(withNs("Book"))!.hasStream).toBeFalsy();
+  });
+
+  test("EntityTypes: media link entry trait is inherited", async () => {
+    // Same as in V4: a type derived from a media link entry has its content at the same place, so the
+    // flag has to survive the base class.
+    odataBuilder.addEntityType("Medium", { hasStream: true }, (builder) => builder.addKeyProp("id", ODataTypesV2.Guid));
+    odataBuilder.addEntityType("EBook", { baseType: withNs("Medium") }, (builder) =>
+      builder.addProp("fileFormat", ODataTypesV2.String),
+    );
+
+    const result = await doDigest();
+
+    expect(result.getEntityType(withNs("EBook"))!.hasStream).toBe(true);
+  });
 });

--- a/packages/odata2ts/test/fixture/generator/service/v2/media-entity.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/media-entity.ts
@@ -1,0 +1,43 @@
+import type { ODataHttpClient } from "@odata2ts/http-client-api";
+import { EntitySetServiceV2, MediaEntityServiceV2, ODataService, ODataServiceOptions } from "@odata2ts/odata-service";
+// @ts-ignore
+import type { QEBook } from "./QTester.js";
+// @ts-ignore
+import { qEBook, QEBookId } from "./QTester.js";
+// @ts-ignore
+import type { EBook, EBookId, EditableEBook } from "./TesterModel.js";
+
+export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
+  public eBooks(): EBookCollectionService<ClientType>;
+  public eBooks(id: EBookId): EBookService<ClientType>;
+  public eBooks(id?: EBookId | undefined) {
+    const fieldName = "EBooks";
+    const { client, path, options, isUrlNotEncoded } = this.__base;
+    return typeof id === "undefined" || id === null
+      ? new EBookCollectionService(client, path, fieldName, options)
+      : new EBookService(client, path, new QEBookId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+  }
+}
+
+export class EBookService<in out ClientType extends ODataHttpClient> extends MediaEntityServiceV2<
+  ClientType,
+  EBook,
+  EditableEBook,
+  QEBook
+> {
+  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+    super(client, basePath, name, qEBook, options);
+  }
+}
+
+export class EBookCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV2<
+  ClientType,
+  EBook,
+  EditableEBook,
+  QEBook,
+  EBookId
+> {
+  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+    super(client, basePath, name, qEBook, new QEBookId(name), options);
+  }
+}

--- a/packages/odata2ts/test/generator/v2/ServiceGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v2/ServiceGenerator.test.ts
@@ -239,4 +239,19 @@ describe("Service Generator Tests V2", () => {
     // NOTE: it's irrelevant that the OpenEntityService has no keys defined as long as it's not referenced via EntitySet or NavProp
     await compareMainService("abstract-and-open-types.ts");
   });
+
+  test("Service Generator: media link entry", async () => {
+    // given a media link entry, i.e. an entity pointing at the binary content which is its own
+    odataBuilder
+      .addEntityType("EBook", { hasStream: true }, (builder) =>
+        builder.addKeyProp("id", ODataTypesV2.Guid).addProp("title", ODataTypesV2.String, false),
+      )
+      .addEntitySet("EBooks", withNs("EBook"));
+
+    // when generating
+    await doGenerate();
+
+    // then its service extends the media entity service, which adds the $value access
+    await compareMainService("media-entity.ts");
+  });
 });


### PR DESCRIPTION
- `MediaEntityServiceV2` for entity types marked `m:HasStream`: `content()` plus the `getBlob`/`updateBlob`/`getStream`/`updateStream`/`deleteBlob` shortcuts, mirroring `MediaEntityServiceV4`
- `StreamServiceV2` bound to the entity's `$value`; V2 has no `Edm.Stream`, so a media link entry's own content is the only binary payload there is, and an entity can carry exactly one
- `StreamServiceBase` holds what both versions share; `StreamServiceV4` is now a thin subclass of it, with its public API unchanged
- the V2 digestion reads the marker as `m:HasStream` — it lives in the metadata namespace, unlike V4's plain `HasStream` — via an overridable `isMediaEntity()`; inheritance over base types already worked version-neutrally
- `ServiceGenerator` no longer restricts media entity services to V4
- no subtype options for V2, since it knows no type cast segments in URLs
- integration tests against both V2 servers assert the built `$value` URL against the `__metadata.media_src` the entity advertises — V2 never specified `$value` for a media resource, the entity is supposed to name its own content URL
- the CAP tests write over one protocol version and read over the other: the same rows arrive as an `Edm.Stream` property over V4 and as a media link entry over V2
- both `Blobs.test.ts` files replace the ones that documented the gap; READMEs updated accordingly

Known limitation, not V2-specific and left as is: an error response to a binary request is read as a blob, so the server's error message never reaches the caller. Both tests pin the client's fallback message for now; the fix belongs in the `http-client` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)