### PR TITLE
feat(odata2ts)!: state a binding by the key of the entity, not by its URL

### DIFF
--- a/int-test/asp-net/README.md
+++ b/int-test/asp-net/README.md
@@ -70,4 +70,6 @@ OData really emits, not the idealized reference model: it has no `TypeDefinition
 attributes and no `SRID` facets, none of which the model builder can express. The server's
 `FEATURE-COVERAGE.md` records why.
 
-`enableBindingProps` is switched on, since proving the binding notations is the point of this package.
+`enableBindingProps` is switched on, since proving the binding notations is the point of this package. A
+binding is stated by the key of the entity to bind; the URL the query objects build from it is only worth
+anything if a real server resolves it.

--- a/int-test/asp-net/test/feature/Binding.test.ts
+++ b/int-test/asp-net/test/feature/Binding.test.ts
@@ -9,13 +9,13 @@ import { BASE_URL, BOOK_DER_PROZESS, BRANCH_CENTRAL, BRANCH_SUBURBAN, LIBRARY } 
  * the feature was only ever proven at generator level, against fixtures. A fixture cannot show that the
  * link actually moved on the other side.
  *
- * The client is generated for OData 4.0, so the generated property is `Nav@odata.bind` carrying a URL.
- * The 4.01 spelling - a nested `{"@id": …}` - is sent by hand in the last test, since a 4.0 client does
- * not emit it.
+ * The client is generated as a service, so a binding is stated by the key of the entity to bind
+ * (`{"@id": key}`) and the query objects turn it into what goes on the wire - here, for OData 4.0,
+ * `Nav@odata.bind` carrying the URL. That translation is the very thing under test: whether the URL the
+ * client assembles is one this server actually resolves. The 4.01 spelling of the payload is sent by
+ * hand in the last test, since a 4.0 client does not emit it.
  */
 describe("ASP.NET Library: binding existing entities", () => {
-  const branchUrl = (id: number) => `${BASE_URL}/Branches(${id})`;
-
   /** Copies only this file touches, so re-binding cannot race the other test files. */
   const BOUND_ON_CREATE = 4001;
   const BOUND_TO_CONSTRAINED_NAV = 4002;
@@ -42,7 +42,7 @@ describe("ASP.NET Library: binding existing entities", () => {
         Condition: 1,
         IsLoanable: true,
         WeightKg: 0.4,
-        "Location@odata.bind": branchUrl(BRANCH_CENTRAL),
+        Location: { "@id": BRANCH_CENTRAL },
       })
       .execute();
 
@@ -57,7 +57,7 @@ describe("ASP.NET Library: binding existing entities", () => {
   test("patching the binding re-points the link", async () => {
     const copy = LIBRARY.Copies(copyKey(BOUND_ON_CREATE));
 
-    const patched = await copy.patch({ "Location@odata.bind": branchUrl(BRANCH_SUBURBAN) }).execute();
+    const patched = await copy.patch({ Location: { "@id": BRANCH_SUBURBAN } }).execute();
     expect(patched.status).toBe(204);
 
     const location = await copy.Location().query().execute();
@@ -84,7 +84,7 @@ describe("ASP.NET Library: binding existing entities", () => {
   test("binding to null clears the link", async () => {
     const copy = LIBRARY.Copies(copyKey(BOUND_ON_CREATE));
 
-    const patched = await copy.patch({ "Location@odata.bind": null }).execute();
+    const patched = await copy.patch({ Location: null }).execute();
     expect(patched.status).toBe(204);
 
     // the link is gone, so the navigation target is not there any more - and this server sends no error
@@ -103,7 +103,7 @@ describe("ASP.NET Library: binding existing entities", () => {
         Condition: 1,
         IsLoanable: true,
         WeightKg: 0.4,
-        "Medium@odata.bind": `${BASE_URL}/Media(${BOOK_DER_PROZESS})`,
+        Medium: { "@id": BOOK_DER_PROZESS },
       })
       .execute();
 
@@ -124,7 +124,7 @@ describe("ASP.NET Library: binding existing entities", () => {
         MediumId: BOOK_DER_PROZESS,
         InventoryNumber: BOUND_WITH_401_NOTATION,
         Condition: 1,
-        Location: { "@id": branchUrl(BRANCH_SUBURBAN) },
+        Location: { "@id": `${BASE_URL}/Branches(${BRANCH_SUBURBAN})` },
       }),
     });
 

--- a/int-test/asp-net/test/feature/DeepInsert.test.ts
+++ b/int-test/asp-net/test/feature/DeepInsert.test.ts
@@ -2,7 +2,7 @@ import { HttpResponseModel } from "@odata2ts/http-client-api";
 import { ODataModelResponseV4 } from "@odata2ts/odata-core";
 import { describe, expect, expectTypeOf, test } from "vitest";
 import { Book, Member } from "../../src-generated/library/LibraryModel.js";
-import { BASE_URL, LIBRARY } from "../LibraryTestConstants.js";
+import { LIBRARY } from "../LibraryTestConstants.js";
 
 /**
  * Deep insert - odata2ts issue #237 - against a server that actually stores the nested entities.
@@ -12,8 +12,9 @@ import { BASE_URL, LIBRARY } from "../LibraryTestConstants.js";
  * entities have to be *created and linked* on the other side, which is what a fixture cannot show and
  * these tests can.
  *
- * The client is generated for OData 4.0, so a binding is spelled `Nav@odata.bind` and stays a separate
- * property - a deep insert and a binding can therefore be sent side by side, which the last test does.
+ * A binding is stated by the key of the entity to bind (`{"@id": key}`) and therefore shares the property
+ * with the deep insert; the `"@id"` tells the two apart. Sending both for one entity is what the last
+ * test does - for OData 4.0 the query objects split them into two properties again.
  */
 describe("ASP.NET Library: deep insert", () => {
   /** The server assigns the keys here, so each test reads back what it created rather than a fixture id. */
@@ -109,7 +110,7 @@ describe("ASP.NET Library: deep insert", () => {
             Condition: 1,
             IsLoanable: true,
             WeightKg: 0.5,
-            "Location@odata.bind": `${BASE_URL}/Branches(${branchId})`,
+            Location: { "@id": branchId },
           },
         ],
       })

--- a/int-test/cap/odata2ts.config.ts
+++ b/int-test/cap/odata2ts.config.ts
@@ -28,6 +28,10 @@ const config: ConfigFileOptions = {
   // on, because a deep insert can only be proven against a server that actually stores the nested
   // entities: see test/feature/DeepInsert.test.ts
   enableDeepInsertProps: true,
+  // on, because a binding by key is only proven when a server resolves the URL the query objects build
+  // from it - and this is the only V2 server we have: see test/feature/Binding.test.ts and
+  // test/v2/feature/Binding.test.ts
+  enableBindingProps: true,
   services: {
     library: {
       serviceName: "Library",

--- a/int-test/cap/test/feature/Binding.test.ts
+++ b/int-test/cap/test/feature/Binding.test.ts
@@ -1,0 +1,96 @@
+import { afterAll, describe, expect, test } from "vitest";
+import { EditableBooks } from "../../src-generated/library/LibraryModel.js";
+import { LIBRARY } from "../LibraryTestConstants.js";
+
+/**
+ * Binding an already existing entity to a navigation property - odata2ts issue #38 - against CAP.
+ *
+ * The client states a binding by the key of the entity to bind (`{"@id": key}`); the query objects turn
+ * that key into the URL of the referenced entity and, since this client targets OData 4.0, into the
+ * `Nav@odata.bind` property. Whether that URL is one the server resolves is exactly what a fixture
+ * cannot show and these tests can.
+ *
+ * `Book/Publisher` is an **association**, which is the case CAP refuses for a deep insert of anything
+ * but the key (see DeepInsert.test.ts) - a binding is the supported way to point it somewhere. It also
+ * has to be an entity without an ETag: `Copies` carries `@odata.etag`, so every write against it needs
+ * `If-Match`, which odata2ts does not send (see test/v2/core/CrudOperations.test.ts).
+ */
+describe("CAP Library: binding existing entities", () => {
+  const createdBooks: Array<string> = [];
+
+  async function createBook(title: string, editable: Omit<EditableBooks, "Title">) {
+    const created = await LIBRARY.Books()
+      .create({ Title: title, ...editable })
+      .execute();
+    createdBooks.push(created.data.Id);
+    return created;
+  }
+
+  async function anyTwoPublisherIds() {
+    const publishers = await LIBRARY.Publishers()
+      .query((builder, qPublisher) => builder.select("Id").orderBy(qPublisher.Id.asc()).top(2))
+      .execute();
+    return publishers.data.value.map((publisher) => publisher.Id);
+  }
+
+  afterAll(async () => {
+    for (const id of createdBooks) {
+      await LIBRARY.Books(id).delete().execute();
+    }
+  });
+
+  test("create with a binding links the entity", async () => {
+    const [publisherId] = await anyTwoPublisherIds();
+
+    const created = await createBook("Bound On Create", { Publisher: { "@id": publisherId } });
+    expect(created.status).toBe(201);
+
+    const publisher = await LIBRARY.Books(created.data.Id).Publisher().query().execute();
+    expect(publisher.data.Id).toBe(publisherId);
+  });
+
+  test("patching the binding re-points the link", async () => {
+    const [firstPublisher, secondPublisher] = await anyTwoPublisherIds();
+
+    const created = await createBook("Bound On Patch", { Publisher: { "@id": firstPublisher } });
+    const book = LIBRARY.Books(created.data.Id);
+
+    const patched = await book.patch({ Publisher: { "@id": secondPublisher } }).execute();
+    expect(patched.status).toBe(200);
+
+    const publisher = await book.Publisher().query().execute();
+    expect(publisher.data.Id).toBe(secondPublisher);
+
+    // The decisive assertion. Re-pointing a reference must not write the new key into the previously
+    // linked publisher, which would leave two entities with the same key behind - and still answer 200.
+    const publishers = await LIBRARY.Publishers()
+      .query((builder, qPublisher) => builder.select("Id").orderBy(qPublisher.Id.asc()).top(2))
+      .execute();
+    expect(publishers.data.value.map((p) => p.Id)).toStrictEqual([firstPublisher, secondPublisher]);
+  });
+
+  test("the key may be stated in its long form as well", async () => {
+    const [publisherId] = await anyTwoPublisherIds();
+
+    // `PublishersId` is a single-key id model, so it accepts the value on its own or the object - both
+    // have to end up as the same URL
+    const created = await createBook("Bound By Long Key", { Publisher: { "@id": { Id: publisherId } } });
+    expect(created.status).toBe(201);
+
+    const publisher = await LIBRARY.Books(created.data.Id).Publisher().query().execute();
+    expect(publisher.data.Id).toBe(publisherId);
+  });
+
+  test("binding to null clears the link", async () => {
+    const [publisherId] = await anyTwoPublisherIds();
+
+    const created = await createBook("Bound Then Cleared", { Publisher: { "@id": publisherId } });
+    const book = LIBRARY.Books(created.data.Id);
+
+    const patched = await book.patch({ Publisher: null }).execute();
+    expect(patched.status).toBe(200);
+
+    const read = await book.query((builder) => builder.expanding("Publisher", (publisher) => publisher)).execute();
+    expect(read.data.Publisher).toBeNull();
+  });
+});

--- a/int-test/cap/test/v2/feature/Binding.test.ts
+++ b/int-test/cap/test/v2/feature/Binding.test.ts
@@ -1,0 +1,83 @@
+import { afterAll, describe, expect, test } from "vitest";
+import { BASE_URL, LIBRARY_V2 } from "../LibraryV2TestConstants.js";
+
+/**
+ * Binding an already existing entity to a navigation property - odata2ts issue #38 - over V2.
+ *
+ * The client states a binding by the key of the entity to bind, exactly as the V4 one does; only what the
+ * query objects make of it differs, since V2 has no `@odata.bind`: the navigation property carries
+ * `{"__metadata": {"uri": "Publishers(1)"}}` instead.
+ *
+ * This is where that notation runs into a wall. The V2 adapter accepts such a payload with 201 and does
+ * not link anything - no error, no hint. The counter-test below sends the very same body by hand, so the
+ * verdict is pinned on the adapter rather than on what odata2ts assembles; and the foreign key, which
+ * works, shows that the request itself was fine. `test/feature/Binding.test.ts` proves the same client
+ * feature against the V4 endpoint of this very server, where it does link.
+ *
+ * `int-test/olingo-v2` holds the other half of the V2 picture: a genuine V2 server refuses the very same
+ * payload with a loud 501 instead of dropping it in silence.
+ */
+describe("CAP Library V2: binding existing entities", () => {
+  const createdBooks: Array<string> = [];
+
+  async function anyPublisherId() {
+    const publishers = await LIBRARY_V2.Publishers()
+      .query((builder, qPublisher) => builder.select("Id").orderBy(qPublisher.Id.asc()).top(1))
+      .execute();
+    return publishers.data.d.results[0].Id;
+  }
+
+  async function publisherIdOf(bookId: string) {
+    const read = await LIBRARY_V2.Books(bookId)
+      .query((builder) => builder.expand("Publisher"))
+      .execute();
+    return (read.data.d.Publisher as { Id: number } | null)?.Id ?? null;
+  }
+
+  test("a binding is accepted and then dropped", async () => {
+    const publisherId = await anyPublisherId();
+
+    const created = await LIBRARY_V2.Books()
+      .create({ Title: "V2 Bound On Create", Publisher: { "@id": publisherId } })
+      .execute();
+    createdBooks.push(created.data.d.Id);
+
+    expect(created.status).toBe(201);
+    // the link was never made - the adapter says nothing about it
+    expect(await publisherIdOf(created.data.d.Id)).toBeNull();
+  });
+
+  test("the same body sent by hand fares no better, while the foreign key works", async () => {
+    const publisherId = await anyPublisherId();
+
+    // Byte for byte what the query objects assemble from `{"@id": publisherId}`. Sent without odata2ts,
+    // so this is the adapter's verdict on the V2 binding notation, not the client's.
+    const byHand = await fetch(`${BASE_URL}/Books`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify({
+        Title: "V2 Bound By Hand",
+        Publisher: { __metadata: { uri: `Publishers(${publisherId})` } },
+      }),
+    });
+    const byHandBody = (await byHand.json()) as { d: { Id: string; Publisher_Id: number | null } };
+    createdBooks.push(byHandBody.d.Id);
+
+    expect(byHand.status).toBe(201);
+    expect(byHandBody.d.Publisher_Id).toBeNull();
+
+    // the foreign key is the way through over V2 here, and it proves the request itself was well-formed
+    const viaForeignKey = await LIBRARY_V2.Books()
+      .create({ Title: "V2 Bound By Foreign Key", Publisher_Id: publisherId })
+      .execute();
+    createdBooks.push(viaForeignKey.data.d.Id);
+
+    expect(await publisherIdOf(viaForeignKey.data.d.Id)).toBe(publisherId);
+  });
+
+  afterAll(async () => {
+    for (const id of createdBooks) {
+      await LIBRARY_V2.Books(id).delete().execute();
+    }
+  });
+});

--- a/int-test/olingo-v2/odata2ts.config.ts
+++ b/int-test/olingo-v2/odata2ts.config.ts
@@ -19,6 +19,10 @@ const config: ConfigFileOptions = {
   // on, because the property services are a generator feature of their own and otherwise never
   // meet a real server: see test/feature/PropertyServices.test.ts
   enablePrimitivePropertyServices: true,
+  // on, because this is the only genuine OData V2 server we have - the one place where the V2 binding
+  // notation the query objects build can be held against a real deserializer:
+  // see test/feature/Binding.test.ts
+  enableBindingProps: true,
   services: {
     library: {
       serviceName: "Library",

--- a/int-test/olingo-v2/test/core/CrudOperations.test.ts
+++ b/int-test/olingo-v2/test/core/CrudOperations.test.ts
@@ -112,20 +112,26 @@ describe("Olingo Library: CRUD operations", () => {
     });
   });
 
-  test("a deep insert is refused outright", async () => {
-    // Olingo's ListsProcessor creates one entity from one payload; a nested collection has nowhere to
-    // go and the request is answered 501. The CAP server accepts the same payload along compositions,
-    // so this is the one write shape where the two V2 servers differ fundamentally.
-    await expectODataError(
-      LIBRARY.Books()
-        .create({
-          Title: "Deep Insert Book",
-          Language: "de",
-          Copies: [{ MediumId: UNKNOWN_ID, InventoryNumber: 9901, IsLoanable: true }],
-        } as EditableBook)
-        .execute(),
-      { status: 501, message: /[Nn]ot implemented/ },
-    );
+  test("a deep insert creates the nested entities and links them", async () => {
+    // Olingo's ListsProcessor runs a create payload through `createInlinedEntities`, which creates each
+    // nested entity and then links it - so the foreign key the client sent is overwritten with the key
+    // of the parent that did not exist yet when the payload was written.
+    const created = await LIBRARY.Books()
+      .create({
+        Title: "Deep Insert Book",
+        Language: "de",
+        Copies: [{ MediumId: UNKNOWN_ID, InventoryNumber: 9901, IsLoanable: true }],
+      } as EditableBook)
+      .execute();
+
+    expect(created.status).toBe(201);
+
+    const copies = await LIBRARY.Books(created.data.d.Id).Copies().query().execute();
+    expect(copies.data.d.results.map((copy) => [copy.MediumId, copy.InventoryNumber])).toStrictEqual([
+      [created.data.d.Id, 9901],
+    ]);
+
+    await LIBRARY.Books(created.data.d.Id).delete().execute();
   });
 
   test("an entity with a concurrency token demands a precondition odata2ts cannot send", async () => {

--- a/int-test/olingo-v2/test/feature/Binding.test.ts
+++ b/int-test/olingo-v2/test/feature/Binding.test.ts
@@ -1,0 +1,135 @@
+import { HttpResponseModel } from "@odata2ts/http-client-api";
+import { ODataEntityModelResponseV2 } from "@odata2ts/odata-core";
+import { afterAll, describe, expect, expectTypeOf, test } from "vitest";
+import { Book } from "../../src-generated/library/LibraryModel.js";
+import { expectODataError } from "../expectODataError.js";
+import { LIBRARY, UNKNOWN_ID } from "../LibraryTestConstants.js";
+
+/**
+ * Binding an already existing entity to a navigation property - odata2ts issue #38 - against Olingo 2.
+ *
+ * This is the only genuine OData V2 server we have, and therefore the only place where the V2 notation
+ * the query objects build from `{"@id": key}` - `{"__metadata": {"uri": "Publishers(1)"}}` - meets a real
+ * V2 deserializer. Everything the client assembles is under test here: that the URL points at the right
+ * entity set, that a relative URL is resolved, and that the server ends up moving the link.
+ *
+ * `Book/Publisher` is the navigation used throughout, because `Copies` carries a concurrency token and
+ * odata2ts sends no `If-Match` - see test/core/CrudOperations.test.ts.
+ */
+describe("Olingo Library: binding existing entities", () => {
+  const createdBooks: Array<string> = [];
+
+  async function publisherIds() {
+    const publishers = await LIBRARY.Publishers()
+      .query((builder, qPublisher) => builder.select("Id").orderBy(qPublisher.Id.asc()).top(2))
+      .execute();
+    return publishers.data.d.results.map((publisher) => publisher.Id);
+  }
+
+  async function publisherOf(bookId: string) {
+    const read = await LIBRARY.Books(bookId)
+      .query((builder) => builder.expand("Publisher"))
+      .execute();
+    return read.data.d.Publisher as { Id: number; Name: string };
+  }
+
+  async function createBook(title: string, publisherId: number) {
+    const created = await LIBRARY.Books()
+      .create({ Title: title, Publisher: { "@id": publisherId } })
+      .execute();
+    createdBooks.push(created.data.d.Id);
+    return created;
+  }
+
+  afterAll(async () => {
+    for (const id of createdBooks) {
+      await LIBRARY.Books(id).delete().execute();
+    }
+  });
+
+  test("create with a binding links the entity", async () => {
+    const [publisherId] = await publisherIds();
+
+    const created = await createBook("Bound On Create", publisherId);
+
+    expect(created.status).toBe(201);
+    expectTypeOf(created).toEqualTypeOf<HttpResponseModel<ODataEntityModelResponseV2<Book>>>();
+    expect((await publisherOf(created.data.d.Id)).Id).toBe(publisherId);
+  });
+
+  test("the key may be stated in its long form as well", async () => {
+    const [publisherId] = await publisherIds();
+
+    // `PublisherId` is a single-key id model, so it accepts the value on its own or the object - both
+    // have to end up as the same URL
+    const created = await LIBRARY.Books()
+      .create({ Title: "Bound By Long Key", Publisher: { "@id": { Id: publisherId } } })
+      .execute();
+    createdBooks.push(created.data.d.Id);
+
+    expect(created.status).toBe(201);
+    expect((await publisherOf(created.data.d.Id)).Id).toBe(publisherId);
+  });
+
+  test("patching the binding re-points the link", async () => {
+    const [firstPublisher, secondPublisher] = await publisherIds();
+
+    const created = await createBook("Bound On Patch", firstPublisher);
+    const book = LIBRARY.Books(created.data.d.Id);
+
+    const patched = await book.patch({ Publisher: { "@id": secondPublisher } }).execute();
+    expect(patched.status).toBe(204);
+    expect((await publisherOf(created.data.d.Id)).Id).toBe(secondPublisher);
+
+    // The decisive assertion. Re-pointing a reference must not write the new key into the previously
+    // linked publisher, which would leave two entities with the same key behind - and still answer 204.
+    const publishers = await LIBRARY.Publishers()
+      .query((builder, qPublisher) => builder.select("Id").orderBy(qPublisher.Id.asc()).top(2))
+      .execute();
+    expect(publishers.data.d.results.map((publisher) => publisher.Id)).toStrictEqual([firstPublisher, secondPublisher]);
+  });
+
+  test("a binding to an entity that does not exist is refused", async () => {
+    const [publisherId] = await publisherIds();
+    const created = await createBook("Bound Then Refused", publisherId);
+    const book = LIBRARY.Books(created.data.d.Id);
+
+    // 9999 is no publisher of this model - the server resolves the URL before it writes anything
+    await expectODataError(book.patch({ Publisher: { "@id": 9999 } }).execute(), {
+      status: 404,
+      message: /could not be found/,
+    });
+
+    // and the link that was there is untouched
+    expect((await publisherOf(created.data.d.Id)).Id).toBe(publisherId);
+  });
+
+  test("an update without the navigation property leaves the link alone", async () => {
+    const [publisherId] = await publisherIds();
+    const created = await createBook("Bound And Renamed", publisherId);
+    const book = LIBRARY.Books(created.data.d.Id);
+
+    const patched = await book.patch({ Title: "Renamed" }).execute();
+    expect(patched.status).toBe(204);
+
+    const read = await LIBRARY.Books(created.data.d.Id)
+      .query((builder) => builder.expand("Publisher"))
+      .execute();
+    expect(read.data.d.Title).toBe("Renamed");
+    expect((read.data.d.Publisher as { Id: number }).Id).toBe(publisherId);
+  });
+
+  test("a binding on an entity that does not exist is a 404 of its own", async () => {
+    const [publisherId] = await publisherIds();
+
+    await expectODataError(
+      LIBRARY.Books(UNKNOWN_ID)
+        .patch({ Publisher: { "@id": publisherId } })
+        .execute(),
+      {
+        status: 404,
+        message: /could not be found/,
+      },
+    );
+  });
+});

--- a/packages/odata-query-objects/src/QueryObject.ts
+++ b/packages/odata-query-objects/src/QueryObject.ts
@@ -239,11 +239,11 @@ export class QueryObject<T extends object = any> implements QueryObjectModel<T> 
     const result = models.map((model) => {
       const typeByCi = getTypeControlInfo(model);
       return Object.entries(model).reduce((collector, [key, value]) => {
-        let prop = this[key as keyof this] as QValuePathModel | undefined;
+        let prop = this[key as keyof this] as unknown as QValuePathModel | undefined;
         let finalKey = prop?.getPath();
         if (typeByCi && typeof this.__subtypeMapping !== "undefined") {
           const qName = this.__subtypeMapping[typeByCi];
-          const subProp = this[`${qName}_${key}` as keyof this] as QValuePathModel | undefined;
+          const subProp = this[`${qName}_${key}` as keyof this] as unknown as QValuePathModel | undefined;
           if (subProp) {
             prop = subProp;
             finalKey = subProp.getPath().replace(new RegExp(`^${typeByCi}/`), "");

--- a/packages/odata-query-objects/src/QueryObject.ts
+++ b/packages/odata-query-objects/src/QueryObject.ts
@@ -1,3 +1,4 @@
+import { QBinding } from "./path/QBinding";
 import { QEntityPathModel, QValuePathModel } from "./path/QPathModel";
 import { FlexibleConversionModel, QueryObjectModel } from "./QueryObjectModel";
 
@@ -27,6 +28,72 @@ function getMapping(q: QueryObject) {
  */
 function getTypeControlInfo(model: any): string | undefined {
   return (model["@odata.type"] ?? model["@type"])?.replace(/^#/, "");
+}
+
+/**
+ * The property by which the editable models state a binding to an already existing entity, carrying its
+ * key. It is the 4.01 spelling, but with the key in place of the URL - see {@link QBinding}.
+ */
+const BINDING_PROP = "@id";
+
+function isBinding(value: any): value is Record<typeof BINDING_PROP, any> {
+  return !!value && typeof value === "object" && !Array.isArray(value) && BINDING_PROP in value;
+}
+
+/**
+ * Writes a navigation property which may carry bindings to already existing entities, deep insert
+ * payloads, or - for a collection valued property - both at once.
+ *
+ * Where the notation keeps a binding apart from the payload (4.0: {@code "Nav@odata.bind"}), a mixed
+ * collection ends up as two properties; the other notations state both under the name of the navigation
+ * property itself and therefore keep the order of the given array.
+ */
+function convertNavProp(
+  collector: Record<string, any>,
+  odataName: string,
+  value: any,
+  entity: QueryObject,
+  binding: QBinding<any>,
+) {
+  // null clears the link, which is the one operation that has no payload counterpart
+  if (value === null || value === undefined) {
+    collector[binding.getKey(odataName)] = value;
+    return;
+  }
+
+  // some V2 services expect collections wrapped in an extra results object, see issue #237
+  const wrapped = !Array.isArray(value) && typeof value === "object" && Array.isArray(value.results);
+  const items: Array<any> | undefined = Array.isArray(value) ? value : wrapped ? value.results : undefined;
+
+  if (!items) {
+    if (isBinding(value)) {
+      collector[binding.getKey(odataName)] = binding.format(value[BINDING_PROP]);
+    } else {
+      collector[odataName] = entity.convertToOData(value);
+    }
+    return;
+  }
+
+  const rewrap = (list: Array<any>) => (wrapped ? { results: list } : list);
+  const bindingKey = binding.getKey(odataName);
+
+  if (bindingKey === odataName) {
+    collector[odataName] = rewrap(
+      items.map((item) => (isBinding(item) ? binding.format(item[BINDING_PROP]) : entity.convertToOData(item))),
+    );
+    return;
+  }
+
+  const payloads = items.filter((item) => !isBinding(item));
+  const bindings = items.filter(isBinding);
+
+  if (bindings.length) {
+    collector[bindingKey] = bindings.map((item) => binding.format(item[BINDING_PROP]));
+  }
+  // an empty array is meaningful on its own, so it is only dropped when the bindings took its place
+  if (payloads.length || !bindings.length) {
+    collector[odataName] = rewrap(payloads.map((item) => entity.convertToOData(item)));
+  }
 }
 
 export const ENUMERABLE_PROP_DEFINITION = { enumerable: true };
@@ -185,7 +252,12 @@ export class QueryObject<T extends object = any> implements QueryObjectModel<T> 
         const asEntity = prop as QEntityPathModel<any>;
         if (typeof asEntity?.getEntity === "function") {
           const entity = asEntity.getEntity();
-          collector[finalKey!] = entity.convertToOData(value);
+          const binding = asEntity.getBinding?.();
+          if (binding) {
+            convertNavProp(collector, finalKey!, value, entity, binding);
+          } else {
+            collector[finalKey!] = entity.convertToOData(value);
+          }
         } else if (prop) {
           collector[finalKey!] = prop.converter ? prop.converter.convertTo(value) : value;
         }

--- a/packages/odata-query-objects/src/index.ts
+++ b/packages/odata-query-objects/src/index.ts
@@ -54,6 +54,7 @@ export { QComplexPath } from "./path/QComplexPath";
 export { QComplexCollectionPath } from "./path/QComplexCollectionPath";
 export { QEntityPath } from "./path/QEntityPath";
 export { QEntityCollectionPath } from "./path/QEntityCollectionPath";
+export { QBinding, type BindingNotation } from "./path/QBinding";
 export * from "./path/QPathModel";
 
 export { QEnumPath } from "./path/enum/QEnumPath";

--- a/packages/odata-query-objects/src/path/QBinding.ts
+++ b/packages/odata-query-objects/src/path/QBinding.ts
@@ -1,0 +1,65 @@
+import { QId } from "../operation/QId";
+
+/**
+ * How a binding to an already existing entity is spelled in a request payload.
+ *
+ * - {@code 4.0} keeps the binding apart from the payload: {@code "Location@odata.bind": "Branches(1)"}
+ * - {@code 4.01} states it inline, by the very name of the navigation property: {@code "Location": {"@id": "Branches(1)"}}
+ * - {@code V2} does the same, in the notation of its own: {@code "Location": {"__metadata": {"uri": "Branches(1)"}}}
+ */
+export type BindingNotation = "V2" | "4.0" | "4.01";
+
+/**
+ * Turns the key of an entity into the binding notation of the targeted OData version.
+ *
+ * The user facing models state a binding by key ({@code {"@id": 1}}), since the key is what the user has at
+ * hand - the URL of the entity is something they would have to assemble themselves. That URL is built here,
+ * by the id function of the entity set the navigation property points to, which is known from the
+ * NavigationPropertyBinding (V4) or the AssociationSet (V2) of the metadata.
+ *
+ * The URL is relative to the service root, which is what the spec asks for and what spares this object any
+ * knowledge about the actual service location.
+ */
+export class QBinding<Id> {
+  /**
+   * @param idFunctionFn returns the id function of the *target* entity set; a factory, so that a query
+   *                     object and the id function of the entity it points to may live in the same module
+   * @param notation the spelling of the targeted OData version
+   */
+  constructor(
+    private idFunctionFn: () => QId<Id>,
+    private notation: BindingNotation = "4.0",
+  ) {
+    if (!idFunctionFn || typeof idFunctionFn !== "function") {
+      throw new Error("Function which returns the id function must be supplied!");
+    }
+  }
+
+  public getNotation(): BindingNotation {
+    return this.notation;
+  }
+
+  /**
+   * The property name the binding goes by, which is the navigation property itself in every version but
+   * 4.0 - meaning that in those versions a binding and a deep insert share one property.
+   */
+  public getKey(odataPropName: string): string {
+    return this.notation === "4.0" ? `${odataPropName}@odata.bind` : odataPropName;
+  }
+
+  /**
+   * The value of the binding property: the URL of the referenced entity, wrapped as the notation demands.
+   */
+  public format(id: Id): unknown {
+    const url = this.idFunctionFn().buildUrl(id);
+
+    switch (this.notation) {
+      case "V2":
+        return { __metadata: { uri: url } };
+      case "4.01":
+        return { "@id": url };
+      default:
+        return url;
+    }
+  }
+}

--- a/packages/odata-query-objects/src/path/QModelBasePath.ts
+++ b/packages/odata-query-objects/src/path/QModelBasePath.ts
@@ -1,10 +1,12 @@
 import { QueryObject } from "../QueryObject";
+import { QBinding } from "./QBinding";
 import { QEntityPathModel } from "./QPathModel";
 
 export class QModelBasePath<Q extends QueryObject> implements QEntityPathModel<Q> {
   constructor(
     protected path: string,
     protected qEntityFn: () => new (prefix?: string) => Q,
+    protected binding?: QBinding<any>,
   ) {
     if (!path || !path.trim()) {
       throw new Error("Path must be supplied!");
@@ -16,6 +18,10 @@ export class QModelBasePath<Q extends QueryObject> implements QEntityPathModel<Q
 
   public getPath(): string {
     return this.path;
+  }
+
+  public getBinding(): QBinding<any> | undefined {
+    return this.binding;
   }
 
   public getEntity(withPrefix: boolean = false): Q {

--- a/packages/odata-query-objects/src/path/QModelCollectionBasePath.ts
+++ b/packages/odata-query-objects/src/path/QModelCollectionBasePath.ts
@@ -3,12 +3,14 @@ import { QFilterExpression } from "../QFilterExpression";
 import { QOrderByExpression } from "../QOrderByExpression";
 import { QueryObject } from "../QueryObject";
 import { LambdaOperatorType } from "./base/LambdaOperatorType";
+import { QBinding } from "./QBinding";
 import { QEntityPathModel } from "./QPathModel";
 
 export class QModelCollectionBasePath<Q extends QueryObject> implements QEntityPathModel<Q> {
   constructor(
     private path: string,
     private qEntityFn: () => new (prefix?: string) => Q,
+    private binding?: QBinding<any>,
   ) {
     if (!path || !path.trim()) {
       throw new Error("Path must be supplied!");
@@ -20,6 +22,10 @@ export class QModelCollectionBasePath<Q extends QueryObject> implements QEntityP
 
   public getPath(): string {
     return this.path;
+  }
+
+  public getBinding(): QBinding<any> | undefined {
+    return this.binding;
   }
 
   public getEntity(withPrefix: boolean = false): Q {

--- a/packages/odata-query-objects/src/path/QPathModel.ts
+++ b/packages/odata-query-objects/src/path/QPathModel.ts
@@ -1,4 +1,5 @@
 import { ValueConverter } from "@odata2ts/converter-api";
+import { QBinding } from "./QBinding";
 
 export interface QPathModel {
   getPath(): string;
@@ -11,4 +12,10 @@ export interface QValuePathModel extends QPathModel {
 export interface QEntityPathModel<Q> extends QPathModel {
   getEntity(withPrefix?: boolean): Q;
   isCollectionType(): boolean;
+  /**
+   * The binding of this navigation property, if it points at an entity set which is known from the
+   * metadata and the client was generated with binding props enabled. Only then a key can be turned into
+   * the URL a binding is made of.
+   */
+  getBinding?(): QBinding<any> | undefined;
 }

--- a/packages/odata-query-objects/test/QBinding.test.ts
+++ b/packages/odata-query-objects/test/QBinding.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "vitest";
+import { QBinding } from "../src";
+import { QAuthorId, QBookV2, QBookV40, QBookV401 } from "./fixture/BindingModel";
+
+/**
+ * Binding an already existing entity to a navigation property, stated by the key of that entity.
+ *
+ * The user facing models spell it as {@code {"@id": key}} in every OData version - assembling the URL of
+ * the referenced entity is exactly what they are spared. Turning that key into the notation the targeted
+ * version asks for happens here, on the way out.
+ */
+describe("QBinding: binding by key", () => {
+  const qBook40 = new QBookV40();
+  const qBook401 = new QBookV401();
+  const qBookV2 = new QBookV2();
+
+  test("4.0 keeps the binding apart from the payload", () => {
+    const result = qBook40.convertToOData({ id: 1, author: { "@id": 3 } });
+
+    expect(result).toStrictEqual({ ID: 1, "Author@odata.bind": "Authors(3)" });
+  });
+
+  test("4.01 states the binding by the navigation property itself", () => {
+    const result = qBook401.convertToOData({ id: 1, author: { "@id": 3 } });
+
+    expect(result).toStrictEqual({ ID: 1, Author: { "@id": "Authors(3)" } });
+  });
+
+  test("V2 states the binding in the metadata notation", () => {
+    const result = qBookV2.convertToOData({ id: 1, author: { "@id": 3 } });
+
+    expect(result).toStrictEqual({ ID: 1, Author: { __metadata: { uri: "Authors(3)" } } });
+  });
+
+  test("the key is accepted in its long form as well", () => {
+    const result = qBook40.convertToOData({ author: { "@id": { id: 3 } } });
+
+    expect(result).toStrictEqual({ "Author@odata.bind": "Authors(ID=3)" });
+  });
+
+  test("null clears the link, under the property carrying the binding", () => {
+    expect(qBook40.convertToOData({ author: null })).toStrictEqual({ "Author@odata.bind": null });
+    expect(qBook401.convertToOData({ author: null })).toStrictEqual({ Author: null });
+  });
+
+  test("a deep insert is converted as it always was", () => {
+    const result = qBook40.convertToOData({ id: 1, author: { id: 3, name: "Kafka" } });
+
+    expect(result).toStrictEqual({ ID: 1, Author: { ID: 3, NAME: "Kafka" } });
+  });
+
+  test("4.0 splits a mixed collection into two properties", () => {
+    const result = qBook40.convertToOData({
+      relatedAuthors: [{ "@id": 3 }, { id: 4, name: "Kafka" }, { "@id": { id: 5 } }],
+    });
+
+    // the notation has a name of its own for the binding, so both shapes cannot share one array
+    expect(result).toStrictEqual({
+      "RelatedAuthors@odata.bind": ["Authors(3)", "Authors(ID=5)"],
+      RelatedAuthors: [{ ID: 4, NAME: "Kafka" }],
+    });
+  });
+
+  test("4.01 keeps a mixed collection in one array, in the given order", () => {
+    const result = qBook401.convertToOData({
+      relatedAuthors: [{ "@id": 3 }, { id: 4, name: "Kafka" }],
+    });
+
+    expect(result).toStrictEqual({
+      RelatedAuthors: [{ "@id": "Authors(3)" }, { ID: 4, NAME: "Kafka" }],
+    });
+  });
+
+  test("4.0 leaves out the payload property when the collection only binds", () => {
+    const result = qBook40.convertToOData({ relatedAuthors: [{ "@id": 3 }] });
+
+    expect(result).toStrictEqual({ "RelatedAuthors@odata.bind": ["Authors(3)"] });
+  });
+
+  test("an empty collection survives, since it is meaningful on its own", () => {
+    expect(qBook40.convertToOData({ relatedAuthors: [] })).toStrictEqual({ RelatedAuthors: [] });
+    expect(qBook401.convertToOData({ relatedAuthors: [] })).toStrictEqual({ RelatedAuthors: [] });
+  });
+
+  test("V2 keeps the extra results wrapping of a collection", () => {
+    // @ts-expect-error: the wrapping is opt-in via v2EditableModelsWithExtraResultsWrapping
+    const result = qBookV2.convertToOData({ relatedAuthors: { results: [{ "@id": 3 }, { id: 4, name: "Kafka" }] } });
+
+    expect(result).toStrictEqual({
+      RelatedAuthors: { results: [{ __metadata: { uri: "Authors(3)" } }, { ID: 4, NAME: "Kafka" }] },
+    });
+  });
+
+  test("the binding is not applied on the way back", () => {
+    // a response never carries a binding: the service answers with the entity itself
+    const result = qBook40.convertFromOData({ ID: 1, Author: { ID: 3, NAME: "Kafka" } });
+
+    expect(result).toStrictEqual({ id: 1, author: { id: 3, name: "Kafka" } });
+  });
+
+  test("fail: id function must be supplied", () => {
+    // @ts-expect-error
+    expect(() => new QBinding()).toThrow("Function which returns the id function must be supplied!");
+    // @ts-expect-error
+    expect(() => new QBinding(new QAuthorId("Authors"))).toThrow(
+      "Function which returns the id function must be supplied!",
+    );
+  });
+
+  test("4.0 is the notation by default", () => {
+    expect(new QBinding(() => new QAuthorId("Authors")).getNotation()).toBe("4.0");
+  });
+});

--- a/packages/odata-query-objects/test/fixture/BindingModel.ts
+++ b/packages/odata-query-objects/test/fixture/BindingModel.ts
@@ -1,0 +1,89 @@
+import {
+  QBinding,
+  QEntityCollectionPath,
+  QEntityPath,
+  QId,
+  QNumberParam,
+  QNumberPath,
+  QStringPath,
+  QueryObject,
+} from "../../src";
+import { QParamModel } from "../../src/param/QParamModel";
+
+export interface Author {
+  id: number;
+  name: string;
+}
+
+export type AuthorId = number | { id: number };
+
+export interface Book {
+  id?: number;
+  author?: EditableAuthor | { "@id": AuthorId } | null;
+  relatedAuthors?: Array<EditableAuthor | { "@id": AuthorId }>;
+}
+
+export interface EditableAuthor {
+  id: number;
+  name?: string;
+}
+
+export class QAuthor extends QueryObject<Author> {
+  public readonly id = new QNumberPath(this.withPrefix("ID"));
+  public readonly name = new QStringPath(this.withPrefix("NAME"));
+}
+
+export class QAuthorId extends QId<AuthorId> {
+  getParams(): Array<QParamModel<any, any>> {
+    return [new QNumberParam("ID", "id")];
+  }
+}
+
+/**
+ * The navigation properties are named differently than their OData counterparts on purpose: a binding
+ * ends up on the wire by the OData name, while the user states it by the mapped one.
+ *
+ * One class per notation, since that is what the generator bakes into a query object - the notation is
+ * decided at generation time, from the OData version the client targets.
+ */
+export class QBookV40 extends QueryObject<Book> {
+  public readonly id = new QNumberPath(this.withPrefix("ID"));
+  public readonly author = new QEntityPath(
+    this.withPrefix("Author"),
+    () => QAuthor,
+    new QBinding(() => new QAuthorId("Authors"), "4.0"),
+  );
+  public readonly relatedAuthors = new QEntityCollectionPath(
+    this.withPrefix("RelatedAuthors"),
+    () => QAuthor,
+    new QBinding(() => new QAuthorId("Authors"), "4.0"),
+  );
+}
+
+export class QBookV401 extends QueryObject<Book> {
+  public readonly id = new QNumberPath(this.withPrefix("ID"));
+  public readonly author = new QEntityPath(
+    this.withPrefix("Author"),
+    () => QAuthor,
+    new QBinding(() => new QAuthorId("Authors"), "4.01"),
+  );
+  public readonly relatedAuthors = new QEntityCollectionPath(
+    this.withPrefix("RelatedAuthors"),
+    () => QAuthor,
+    new QBinding(() => new QAuthorId("Authors"), "4.01"),
+  );
+}
+
+export class QBookV2 extends QueryObject<Book> {
+  public readonly id = new QNumberPath(this.withPrefix("ID"));
+  public readonly author = new QEntityPath(
+    this.withPrefix("Author"),
+    () => QAuthor,
+    new QBinding(() => new QAuthorId("Authors"), "V2"),
+  );
+  public readonly relatedAuthors = new QEntityCollectionPath(
+    this.withPrefix("RelatedAuthors"),
+    () => QAuthor,
+    new QBinding(() => new QAuthorId("Authors"), "V2"),
+  );
+}

--- a/packages/odata2ts/src/FactoryFunctionModel.ts
+++ b/packages/odata2ts/src/FactoryFunctionModel.ts
@@ -33,6 +33,7 @@ export type DigesterFunction<S extends Schema<any, any>> = (
 
 export type GeneratorFunctionOptions = Pick<
   RunOptions,
+  | "mode"
   | "bundledFileGeneration"
   | "skipEditableModels"
   | "skipIdModels"

--- a/packages/odata2ts/src/OptionModel.ts
+++ b/packages/odata2ts/src/OptionModel.ts
@@ -298,11 +298,25 @@ export interface ConfigFileOptions extends Omit<CliOptions, "sourceUrl" | "sourc
    */
   odataVersionV4?: "4.0" | "4.01";
   /**
-   * Adds one property per navigation property to the editable models, which allows to bind an already
-   * existing entity to it, in the notation of the targeted OData version, e.g. {@code "Author@odata.bind"}
-   * for 4.0.
+   * Allows to bind an already existing entity to a navigation property of the editable models.
    *
-   * Opt-in, so by default no such property is generated.
+   * Where a service is generated (mode {@code service} or {@code all}), the binding goes by the
+   * navigation property itself and states the entity to bind by its key:
+   * {@code { Author: { "@id": 1 } }}. The key is typed as the id model of the related entity, so its
+   * short form is accepted just as well as the full one. The query objects turn that key into the URL
+   * of the entity - relative to the service root - and into the notation of the targeted OData version,
+   * which is why a service is needed for it: {@code "Author@odata.bind"} for 4.0,
+   * {@code {"@id": …}} for 4.01 and {@code {"__metadata": {"uri": …}}} for V2.
+   *
+   * Since that URL is built from the entity set the navigation property points to, a binding is only
+   * generated for navigation properties whose target is known from the metadata - a
+   * NavigationPropertyBinding in V4, an AssociationSet in V2 - and whose related entity has an id model
+   * ({@code skipIdModels} therefore takes it away).
+   *
+   * Without a service the binding is stated as it goes on the wire, by the OData name of the navigation
+   * property and carrying the URL itself, e.g. {@code "Author@odata.bind": "People(1)"} for 4.0.
+   *
+   * Opt-in, so by default no binding is generated.
    */
   enableBindingProps?: boolean;
   /**
@@ -312,9 +326,10 @@ export interface ConfigFileOptions extends Omit<CliOptions, "sourceUrl" | "sourc
    * own.
    *
    * Together with <code>enableBindingProps</code> a navigation property accepts either shape - a new
-   * entity or a reference to an existing one. In V2 and OData 4.01 a binding goes by the very name of the
-   * navigation property, so there the property is typed as the union of both; 4.0 has a name of its own
-   * for it ({@code "Author@odata.bind"}) and therefore keeps them apart.
+   * entity or a reference to an existing one. Where a service is generated both go by the navigation
+   * property itself and the {@code "@id"} property tells them apart; without one, the binding is spelled
+   * as it goes on the wire, which shares the property in V2 and OData 4.01 but keeps it apart in 4.0
+   * ({@code "Author@odata.bind"}).
    *
    * Opt-in, so by default the editable models contain no navigation property at all.
    */

--- a/packages/odata2ts/src/data-model/DataModel.ts
+++ b/packages/odata2ts/src/data-model/DataModel.ts
@@ -65,6 +65,7 @@ export class DataModel {
   private readonly namespace2Alias: { [ns: string]: string };
   private aliases: Record<string, string> = {};
   private container: EntityContainerModel = { entitySets: {}, singletons: {}, functions: {}, actions: {} };
+  private navPropBindings?: Map<string, EntitySetType>;
 
   constructor(
     namespaces: Array<NamespaceWithAlias>,
@@ -268,6 +269,76 @@ export class DataModel {
 
   public getEntityContainer() {
     return this.container;
+  }
+
+  /**
+   * The entity set a navigation property points to, as stated by the NavigationPropertyBinding of an
+   * entity set or singleton (V4) or by the AssociationSet (V2). Knowing it is what makes a binding
+   * expressible by key: the URL of the referenced entity is built from that entity set.
+   *
+   * Bindings are declared per entity set, while the models are generated per entity type, so a navigation
+   * property realized by more than one entity set with differing targets can only be served by one of
+   * them - the first one wins. Paths of more than one segment (a binding declared for a nested or a
+   * derived navigation property) are left out: they do not address a navigation property of this very
+   * entity type.
+   *
+   * A binding of an inherited navigation property is registered for the base type declaring it as well,
+   * since that is the model the property is generated into.
+   */
+  public getNavPropBindingTarget(fqEntityTypeName: string, navPropOdataName: string): EntitySetType | undefined {
+    if (!this.navPropBindings) {
+      this.navPropBindings = new Map();
+
+      const entitySets = Object.values(this.container.entitySets);
+      const bindingSources: Array<EntitySetType | SingletonType> = [
+        ...entitySets,
+        ...Object.values(this.container.singletons),
+      ];
+
+      for (const source of bindingSources) {
+        for (const { path, target } of source.navPropBinding ?? []) {
+          if (path.includes("/")) {
+            continue;
+          }
+          // the target may be stated qualified by the entity container it lives in
+          const targetName = target.split("/").pop()!.split(".").pop()!;
+          const targetSet = entitySets.find((es) => es.odataName === targetName);
+          if (!targetSet) {
+            continue;
+          }
+
+          for (const owner of this.collectTypeHierarchy(source.entityType)) {
+            const key = `${owner}|${path}`;
+            if (!this.navPropBindings.has(key)) {
+              this.navPropBindings.set(key, targetSet);
+            }
+          }
+        }
+      }
+    }
+
+    return this.navPropBindings.get(`${fqEntityTypeName}|${navPropOdataName}`);
+  }
+
+  /**
+   * The fully qualified names of an entity type and of all its base types.
+   */
+  private collectTypeHierarchy(entityType: EntityType): Array<string> {
+    const result: Array<string> = [];
+    const visited = new Set<string>();
+    const queue: Array<string> = [entityType.fqName];
+
+    while (queue.length) {
+      const fqName = queue.shift()!;
+      if (visited.has(fqName)) {
+        continue;
+      }
+      visited.add(fqName);
+      result.push(fqName);
+      queue.push(...(this.getEntityType(fqName)?.baseClasses ?? []));
+    }
+
+    return result;
   }
 
   public getConverter(dataType: ODataTypesV2 | ODataTypesV4 | string) {

--- a/packages/odata2ts/src/generator/ModelGenerator.ts
+++ b/packages/odata2ts/src/generator/ModelGenerator.ts
@@ -4,6 +4,7 @@ import { DataModel } from "../data-model/DataModel.js";
 import { ComplexType, DataTypes, EntityType, OperationType, PropertyModel } from "../data-model/DataTypeModel.js";
 import { NamingHelper } from "../data-model/NamingHelper.js";
 import { EntityBasedGeneratorFunction, GeneratorFunctionOptions } from "../FactoryFunctionModel.js";
+import { Modes } from "../OptionModel.js";
 import { FileHandler } from "../project/FileHandler.js";
 import { ProjectManager } from "../project/ProjectManager.js";
 import { CoreImports } from "./import/ImportObjects.js";
@@ -256,6 +257,7 @@ class ModelGenerator {
     const complexProps = allProps.filter((p) => p.dataType === DataTypes.ComplexType);
     const navProps = this.generateNavProps(
       file.getImports(),
+      model.fqName,
       allProps.filter((p) => p.dataType === DataTypes.ModelType),
     );
 
@@ -284,14 +286,38 @@ class ModelGenerator {
   }
 
   /**
+   * Whether a binding is stated by the key of the referenced entity instead of by its URL, which is only
+   * possible where a service is generated: the URL is assembled at runtime, by the query objects, and
+   * those only take part in a request when there is a service to issue it.
+   */
+  private bindsByKey() {
+    return this.options.mode === Modes.service || this.options.mode === Modes.all;
+  }
+
+  /**
    * A navigation property can be bound to an already existing entity, as long as that entity is
    * addressable by a URL - which requires it to have a key.
+   *
+   * Where the binding is stated by key, two more things have to be in place: the id model, which is the
+   * shape of that key, and the entity set the navigation property points to, since the URL is built from
+   * it. Neither is inferable, so a navigation property missing one of them gets no binding at all.
    */
-  private isBindableNavProp(prop: PropertyModel) {
-    if (!this.options.enableBindingProps) {
+  private isBindableNavProp(ownerFqName: string, prop: PropertyModel) {
+    if (!this.options.enableBindingProps || prop.dataType !== DataTypes.ModelType) {
       return false;
     }
-    return prop.dataType === DataTypes.ModelType && !!this.dataModel.getEntityType(prop.fqType)?.keyNames.length;
+    const target = this.dataModel.getEntityType(prop.fqType);
+    if (!target?.keyNames.length) {
+      return false;
+    }
+    if (!this.bindsByKey()) {
+      return true;
+    }
+    return (
+      !this.options.skipIdModels &&
+      target.generateId &&
+      !!this.dataModel.getNavPropBindingTarget(ownerFqName, prop.odataName)
+    );
   }
 
   /**
@@ -300,26 +326,32 @@ class ModelGenerator {
    * - binding an existing entity to the navigation property (issue #38)
    * - deep insert / deep update, i.e. the related entity travelling within this entity's payload (#237)
    *
-   * They meet in V2 and 4.01, where a binding goes by the very name of the navigation property, so the
-   * property has to accept either shape there. 4.0 spells a binding as {@code "Category@odata.bind"} and
-   * therefore keeps the two apart.
+   * Where a service is generated, both go by the mapped name of the navigation property and are told
+   * apart by the {@code "@id"} property, which carries the key of the entity to bind. The query objects
+   * turn that key into the notation of the targeted OData version when the request is converted, so the
+   * user never has to spell out a URL they would have to assemble themselves.
    *
-   * A binding is addressed by the OData name, since that notation ends up on the wire as it is - it is
-   * passed through the query object untouched. A deep insert is addressed by the mapped name instead:
-   * its payload *is* converted, so the property has to be the one the query object knows.
+   * Without a service there is nothing to do that conversion, so the binding is stated as it goes on the
+   * wire: by the OData name, since that notation is passed through the query object untouched. It meets
+   * the deep insert in V2 and 4.01, where a binding goes by the very name of the navigation property, so
+   * the property accepts either shape there; 4.0 spells it as {@code "Category@odata.bind"} and therefore
+   * keeps the two apart. A deep insert is addressed by the mapped name in either case: its payload *is*
+   * converted, so the property has to be the one the query object knows.
    */
   private generateNavProps(
     imports: ImportContainer,
+    ownerFqName: string,
     props: Array<PropertyModel>,
   ): Array<OptionalKind<PropertySignatureStructure>> {
     const isV2 = this.version === ODataVersions.V2;
     const isV401 = !isV2 && this.options.odataVersionV4 === "4.01";
     // in these versions a binding has no name of its own, so it shares the property with a deep insert
     const bindingByPropName = isV2 || isV401;
+    const byKey = this.bindsByKey();
 
     return props.flatMap((prop) => {
       const deepInsert = this.options.enableDeepInsertProps;
-      const bindable = this.isBindableNavProp(prop);
+      const bindable = this.isBindableNavProp(ownerFqName, prop);
 
       // one entry per resulting property name, so that renaming cannot merge what belongs apart
       const byName = new Map<string, { shapes: Array<string>; docs: Array<string>; binds: boolean }>();
@@ -341,12 +373,23 @@ class ModelGenerator {
         );
       }
       if (bindable) {
-        collect(
-          bindingByPropName ? prop.odataName : `${prop.odataName}@odata.bind`,
-          isV2 ? `{ __metadata: { uri: string } }` : isV401 ? `{ "@id": string }` : "string",
-          `Bind "${prop.name}" to an already existing entity by its URL.`,
-          true,
-        );
+        if (byKey) {
+          const target = this.dataModel.getEntityType(prop.fqType)!;
+          const idName = imports.addGeneratedModel(prop.fqType, target.id.modelName);
+          collect(
+            prop.name,
+            `{ "@id": ${idName} }`,
+            `Bind "${prop.name}" to an already existing entity by its key.`,
+            true,
+          );
+        } else {
+          collect(
+            bindingByPropName ? prop.odataName : `${prop.odataName}@odata.bind`,
+            isV2 ? `{ __metadata: { uri: string } }` : isV401 ? `{ "@id": string }` : "string",
+            `Bind "${prop.name}" to an already existing entity by its URL.`,
+            true,
+          );
+        }
       }
 
       return [...byName.entries()].map(([name, { shapes, docs, binds }]) => {

--- a/packages/odata2ts/src/generator/QueryObjectGenerator.ts
+++ b/packages/odata2ts/src/generator/QueryObjectGenerator.ts
@@ -20,6 +20,7 @@ import {
 } from "../data-model/DataTypeModel.js";
 import { NamingHelper } from "../data-model/NamingHelper.js";
 import { EntityBasedGeneratorFunction, GeneratorFunctionOptions } from "../FactoryFunctionModel.js";
+import { Modes } from "../OptionModel.js";
 import { FileHandler } from "../project/FileHandler.js";
 import { ProjectManager } from "../project/ProjectManager.js";
 import { QueryObjectImports } from "./import/ImportObjects.js";
@@ -150,7 +151,7 @@ class QueryObjectGenerator {
         name: model.qName,
         isExported: true,
         extends: this.getExtendsClauseForQObjects(model, imports),
-        properties: this.generateQueryObjectProps(file.getImports(), model.props),
+        properties: this.generateQueryObjectProps(file.getImports(), model.fqName, model.props),
       });
     } else {
       // base class used for extension needs an own file
@@ -159,7 +160,7 @@ class QueryObjectGenerator {
         name: model.qBaseName,
         isExported: true,
         extends: this.getExtendsClauseForQObjects(model, baseFile.getImports()),
-        properties: this.generateQueryObjectProps(baseFile.getImports(), model.props),
+        properties: this.generateQueryObjectProps(baseFile.getImports(), model.fqName, model.props),
       });
       this.project.finalizeFile(baseFile);
 
@@ -237,6 +238,7 @@ class QueryObjectGenerator {
 
   private generateQueryObjectProps(
     importContainer: ImportContainer,
+    ownerFqName: string,
     allProps: Array<PropertyModel>,
   ): Array<OptionalKind<PropertyDeclarationStructure>> {
     // stream properties get no q-path: filtering, ordering and the like do not apply to binary content,
@@ -266,13 +268,15 @@ class QueryObjectGenerator {
             ? importContainer.addGeneratedModel(prop.fqType, prop.type, false)
             : importContainer.addQObject(prop.qObject!);
 
-        qPathInit = `new ${qPath}(this.withPrefix("${odataName}"), ${isEnumType(prop) ? qObject : `() => ${qObject}`})`;
+        const binding = isEnumType(prop) ? "" : this.generateBindingStmt(importContainer, ownerFqName, prop);
+        qPathInit = `new ${qPath}(this.withPrefix("${odataName}"), ${isEnumType(prop) ? qObject : `() => ${qObject}`}${binding})`;
       } else {
         // add import for data type
         const qPath = importContainer.addQObject(prop.qPath);
         if (isModelType(prop)) {
           const qObject = importContainer.addGeneratedQObject(prop.fqType, prop.qObject!);
-          qPathInit = `new ${qPath}(this.withPrefix("${odataName}"), () => ${qObject})`;
+          const binding = this.generateBindingStmt(importContainer, ownerFqName, prop);
+          qPathInit = `new ${qPath}(this.withPrefix("${odataName}"), () => ${qObject}${binding})`;
         } else if (isEnumType(prop)) {
           const qObject = importContainer.addGeneratedModel(prop.fqType, prop.type, false);
           qPathInit = `new ${qPath}(this.withPrefix("${odataName}"), ${qObject})`;
@@ -294,6 +298,40 @@ class QueryObjectGenerator {
         initializer: qPathInit,
       } as OptionalKind<PropertyDeclarationStructure>;
     });
+  }
+
+  /**
+   * The binding of a navigation property, which is what allows the editable models to state a binding by
+   * the key of the referenced entity: the query object turns that key into the URL the wire notation asks
+   * for, using the id function of the entity set the navigation property points to.
+   *
+   * Only generated where a service is generated - without one nothing would ever call the conversion, and
+   * the models state the binding as it goes on the wire instead (see the model generator).
+   *
+   * @returns the constructor argument including its leading comma, or an empty string
+   */
+  private generateBindingStmt(importContainer: ImportContainer, ownerFqName: string, prop: PropertyModel): string {
+    const generatesService = this.options.mode === Modes.service || this.options.mode === Modes.all;
+    if (
+      !generatesService ||
+      !this.options.enableBindingProps ||
+      this.options.skipIdModels ||
+      prop.dataType !== DataTypes.ModelType
+    ) {
+      return "";
+    }
+
+    const target = this.dataModel.getEntityType(prop.fqType);
+    const targetSet = this.dataModel.getNavPropBindingTarget(ownerFqName, prop.odataName);
+    if (!target?.generateId || !target.keyNames.length || !targetSet) {
+      return "";
+    }
+
+    const qBinding = importContainer.addQObject(QueryObjectImports.QBinding);
+    const qId = importContainer.addGeneratedQObject(target.id.fqName, target.id.qName);
+    const notation = this.version === ODataVersions.V2 ? "V2" : this.options.odataVersionV4 === "4.01" ? "4.01" : "4.0";
+
+    return `, new ${qBinding}(() => new ${qId}("${targetSet.odataName}"), "${notation}")`;
   }
 
   private generateConverterStmt(importContainer: ImportContainer, converters: Array<ValueConverterImport> | undefined) {

--- a/packages/odata2ts/src/generator/import/ImportObjects.ts
+++ b/packages/odata2ts/src/generator/import/ImportObjects.ts
@@ -37,6 +37,7 @@ export enum QueryObjectImports {
   QueryObject = "QueryObject",
   ENUMERABLE_PROP_DEFINITION = "ENUMERABLE_PROP_DEFINITION",
   QId = "QId",
+  QBinding = "QBinding",
   QFunctionV2 = "QFunctionV2",
   QFunctionV4 = "QFunctionV4",
   QAction = "QAction",

--- a/packages/odata2ts/test/fixture/generator/model/entity-relationships-binding-by-key-v2.ts
+++ b/packages/odata2ts/test/fixture/generator/model/entity-relationships-binding-by-key-v2.ts
@@ -1,0 +1,22 @@
+import type { DeferredContent } from "@odata2ts/odata-core";
+
+export interface Author {
+  id: number;
+}
+
+export type AuthorId = number | { id: number };
+
+export interface EditableAuthor extends Pick<Author, "id"> {}
+
+export interface Book {
+  id: number;
+  author: Author | DeferredContent;
+  relatedAuthors: Array<Author> | DeferredContent;
+}
+
+export type BookId = number | { id: number };
+
+export interface EditableBook extends Pick<Book, "id"> {
+  author?: { "@id": AuthorId };
+  relatedAuthors?: Array<{ "@id": AuthorId }>;
+}

--- a/packages/odata2ts/test/fixture/generator/model/entity-relationships-binding-by-key.ts
+++ b/packages/odata2ts/test/fixture/generator/model/entity-relationships-binding-by-key.ts
@@ -1,0 +1,23 @@
+export interface Author {
+  id: number;
+  name: boolean | null;
+}
+
+export type AuthorId = number | { id: number };
+
+export interface EditableAuthor extends Pick<Author, "id">, Partial<Pick<Author, "name">> {}
+
+export interface Book {
+  id: number;
+  author?: Author;
+  altAuthor?: Author | null;
+  relatedAuthors?: Array<Author>;
+}
+
+export type BookId = number | { id: number };
+
+export interface EditableBook extends Pick<Book, "id"> {
+  author?: { "@id": AuthorId };
+  altAuthor?: { "@id": AuthorId } | null;
+  relatedAuthors?: Array<{ "@id": AuthorId }>;
+}

--- a/packages/odata2ts/test/fixture/generator/model/entity-relationships-deep-insert-binding-by-key-v2.ts
+++ b/packages/odata2ts/test/fixture/generator/model/entity-relationships-deep-insert-binding-by-key-v2.ts
@@ -1,0 +1,22 @@
+import type { DeferredContent } from "@odata2ts/odata-core";
+
+export interface Author {
+  id: number;
+}
+
+export type AuthorId = number | { id: number };
+
+export interface EditableAuthor extends Pick<Author, "id"> {}
+
+export interface Book {
+  id: number;
+  author: Author | DeferredContent;
+  relatedAuthors: Array<Author> | DeferredContent;
+}
+
+export type BookId = number | { id: number };
+
+export interface EditableBook extends Pick<Book, "id"> {
+  author?: EditableAuthor | { "@id": AuthorId };
+  relatedAuthors?: Array<EditableAuthor | { "@id": AuthorId }>;
+}

--- a/packages/odata2ts/test/fixture/generator/model/entity-relationships-deep-insert-binding-by-key.ts
+++ b/packages/odata2ts/test/fixture/generator/model/entity-relationships-deep-insert-binding-by-key.ts
@@ -1,0 +1,23 @@
+export interface Author {
+  id: number;
+  name: boolean | null;
+}
+
+export type AuthorId = number | { id: number };
+
+export interface EditableAuthor extends Pick<Author, "id">, Partial<Pick<Author, "name">> {}
+
+export interface Book {
+  id: number;
+  author?: Author;
+  altAuthor?: Author | null;
+  relatedAuthors?: Array<Author>;
+}
+
+export type BookId = number | { id: number };
+
+export interface EditableBook extends Pick<Book, "id"> {
+  author?: EditableAuthor | { "@id": AuthorId };
+  altAuthor?: EditableAuthor | { "@id": AuthorId } | null;
+  relatedAuthors?: Array<EditableAuthor | { "@id": AuthorId }>;
+}

--- a/packages/odata2ts/test/fixture/generator/qobject/entity-binding-unbound.ts
+++ b/packages/odata2ts/test/fixture/generator/qobject/entity-binding-unbound.ts
@@ -1,0 +1,40 @@
+import {
+  QEntityCollectionPath,
+  QEntityPath,
+  QId,
+  QNumberParam,
+  QNumberPath,
+  QueryObject,
+} from "@odata2ts/odata-query-objects";
+// @ts-ignore
+import type { AuthorId, BookId } from "./TesterModel.js";
+
+export class QAuthor extends QueryObject {
+  public readonly id = new QNumberPath(this.withPrefix("id"));
+}
+
+export const qAuthor = new QAuthor();
+
+export class QAuthorId extends QId<AuthorId> {
+  private readonly params = [new QNumberParam("id")];
+
+  getParams() {
+    return this.params;
+  }
+}
+
+export class QBook extends QueryObject {
+  public readonly id = new QNumberPath(this.withPrefix("id"));
+  public readonly author = new QEntityPath(this.withPrefix("author"), () => QAuthor);
+  public readonly relatedAuthors = new QEntityCollectionPath(this.withPrefix("relatedAuthors"), () => QAuthor);
+}
+
+export const qBook = new QBook();
+
+export class QBookId extends QId<BookId> {
+  private readonly params = [new QNumberParam("id")];
+
+  getParams() {
+    return this.params;
+  }
+}

--- a/packages/odata2ts/test/fixture/generator/qobject/entity-binding.ts
+++ b/packages/odata2ts/test/fixture/generator/qobject/entity-binding.ts
@@ -1,0 +1,49 @@
+import {
+  QBinding,
+  QEntityCollectionPath,
+  QEntityPath,
+  QId,
+  QNumberParam,
+  QNumberPath,
+  QueryObject,
+} from "@odata2ts/odata-query-objects";
+// @ts-ignore
+import type { AuthorId, BookId } from "./TesterModel.js";
+
+export class QAuthor extends QueryObject {
+  public readonly id = new QNumberPath(this.withPrefix("id"));
+}
+
+export const qAuthor = new QAuthor();
+
+export class QAuthorId extends QId<AuthorId> {
+  private readonly params = [new QNumberParam("id")];
+
+  getParams() {
+    return this.params;
+  }
+}
+
+export class QBook extends QueryObject {
+  public readonly id = new QNumberPath(this.withPrefix("id"));
+  public readonly author = new QEntityPath(
+    this.withPrefix("author"),
+    () => QAuthor,
+    new QBinding(() => new QAuthorId("Authors"), "4.0"),
+  );
+  public readonly relatedAuthors = new QEntityCollectionPath(
+    this.withPrefix("relatedAuthors"),
+    () => QAuthor,
+    new QBinding(() => new QAuthorId("Authors"), "4.0"),
+  );
+}
+
+export const qBook = new QBook();
+
+export class QBookId extends QId<BookId> {
+  private readonly params = [new QNumberParam("id")];
+
+  getParams() {
+    return this.params;
+  }
+}

--- a/packages/odata2ts/test/generator/v2/ModelGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v2/ModelGenerator.test.ts
@@ -2,7 +2,7 @@ import { ODataTypesV2, ODataVersions } from "@odata2ts/odata-core";
 import { beforeAll, beforeEach, describe, test } from "vitest";
 import { digest } from "../../../src/data-model/DataModelDigestionV2.js";
 import { generateModels } from "../../../src/generator/index.js";
-import { EmitModes } from "../../../src/index.js";
+import { EmitModes, Modes } from "../../../src/index.js";
 import { createProjectManager } from "../../../src/project/ProjectManager.js";
 import { ODataModelBuilderV2 } from "../../data-model/builder/v2/ODataModelBuilderV2.js";
 import {
@@ -105,9 +105,10 @@ describe("Model Generator Tests V2", () => {
           .addNavProp("relatedAuthors", withNs("Author"), "Book_RelatedAuthors", "*"),
       );
 
-    // when generating
+    // when generating without a service
     // then the editable model uses the __metadata uri notation
     await generateAndCompare("entity-relationships-binding-v2.ts", {
+      mode: Modes.models,
       enableBindingProps: true,
       skipEditableModels: false,
       skipIdModels: false,
@@ -180,6 +181,58 @@ describe("Model Generator Tests V2", () => {
     // then the navigation property accepts either shape, since V2 addresses a binding by the very name
     // of the navigation property
     await generateAndCompare("entity-relationships-deep-insert-binding-v2.ts", {
+      mode: Modes.models,
+      enableDeepInsertProps: true,
+      enableBindingProps: true,
+      skipEditableModels: false,
+      skipIdModels: false,
+      disableAutoManagedKey: true,
+    });
+  });
+  /**
+   * The entity sets, plus the AssociationSets which state by which of them the ends of the associations
+   * are realized - the V2 counterpart of a NavigationPropertyBinding. Without them a binding cannot be
+   * expressed by key, since the URL of the referenced entity is built from that entity set.
+   */
+  function addRelatedEntitySets() {
+    odataBuilder
+      .addEntitySet("Books", withNs(ENTITY_NAME))
+      .addEntitySet("Authors", withNs("Author"))
+      .addAssociationSet("Book_Author_Set", "Book_Author", [
+        { role: "Book_Author", entitySet: "Books" },
+        { role: "Author_Book", entitySet: "Authors" },
+      ])
+      .addAssociationSet("Book_RelatedAuthors_Set", "Book_RelatedAuthors", [
+        { role: "Book_Author", entitySet: "Books" },
+        { role: "Author_Book", entitySet: "Authors" },
+      ]);
+  }
+
+  test(`${TEST_SUITE_NAME}: binding props by key`, async () => {
+    // given entities related to each other, reachable through entity sets
+    addRelatedEntities();
+    addRelatedEntitySets();
+
+    // when opting into the binding props while a service is generated
+    // then the binding goes by the navigation property itself and carries the key of the entity to bind,
+    // which the query objects turn into the __metadata uri notation
+    await generateAndCompare("entity-relationships-binding-by-key-v2.ts", {
+      enableBindingProps: true,
+      skipEditableModels: false,
+      skipIdModels: false,
+      disableAutoManagedKey: true,
+    });
+  });
+
+  test(`${TEST_SUITE_NAME}: deep insert and binding props share the property when bound by key`, async () => {
+    // given entities related to each other, reachable through entity sets
+    addRelatedEntities();
+    addRelatedEntitySets();
+
+    // when opting into both while a service is generated
+    // then the navigation property accepts either shape - a new entity or the key of an existing one -
+    // and the "@id" property tells them apart
+    await generateAndCompare("entity-relationships-deep-insert-binding-by-key-v2.ts", {
       enableDeepInsertProps: true,
       enableBindingProps: true,
       skipEditableModels: false,

--- a/packages/odata2ts/test/generator/v4/ModelGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/ModelGenerator.test.ts
@@ -2,7 +2,7 @@ import { ODataTypesV4, ODataVersions } from "@odata2ts/odata-core";
 import { beforeAll, beforeEach, describe, test } from "vitest";
 import { digest } from "../../../src/data-model/DataModelDigestionV4.js";
 import { generateModels } from "../../../src/generator/index.js";
-import { EmitModes } from "../../../src/index.js";
+import { EmitModes, Modes } from "../../../src/index.js";
 import { createProjectManager } from "../../../src/project/ProjectManager.js";
 import { ODataModelBuilderV4 } from "../../data-model/builder/v4/ODataModelBuilderV4.js";
 import {
@@ -247,9 +247,10 @@ describe("Model Generator Tests V4", () => {
           .addProp("relatedAuthors", `Collection(${withNs("Author")})`),
       );
 
-    // when generating for 4.01
+    // when generating for 4.01 without a service
     // then the editable model uses the short form instead of the @odata.bind notation
     await generateAndCompare("entity-relationships-v401.ts", {
+      mode: Modes.models,
       enableBindingProps: true,
       odataVersionV4: "4.01",
       skipEditableModels: false,
@@ -297,9 +298,10 @@ describe("Model Generator Tests V4", () => {
           .addProp("relatedAuthors", `Collection(${withNs("Author")})`),
       );
 
-    // when opting into the binding props
+    // when opting into the binding props without a service
     // then the editable model allows to bind an existing entity via the @odata.bind notation
     await generateAndCompare("entity-relationships-binding.ts", {
+      mode: Modes.models,
       enableBindingProps: true,
       skipEditableModels: false,
       skipIdModels: false,
@@ -320,6 +322,66 @@ describe("Model Generator Tests V4", () => {
           .addProp("relatedAuthors", `Collection(${withNs("Author")})`),
       );
   }
+
+  /**
+   * The entity sets, plus the NavigationPropertyBindings which state where the navigation properties of
+   * a book point to. Without them a binding cannot be expressed by key, since the URL of the referenced
+   * entity is built from the entity set it lives in.
+   */
+  function addRelatedEntitySets() {
+    odataBuilder.addEntitySet("Authors", withNs("Author")).addEntitySet("Books", withNs(ENTITY_NAME), [
+      { path: "author", target: "Authors" },
+      { path: "altAuthor", target: "Authors" },
+      { path: "relatedAuthors", target: "Authors" },
+    ]);
+  }
+
+  test(`${TEST_SUITE_NAME}: binding props by key`, async () => {
+    // given entities related to each other, reachable through entity sets
+    addRelatedEntities();
+    addRelatedEntitySets();
+
+    // when opting into the binding props while a service is generated
+    // then the binding goes by the navigation property itself and carries the key of the entity to bind,
+    // which the query objects turn into the URL the wire notation asks for
+    await generateAndCompare("entity-relationships-binding-by-key.ts", {
+      enableBindingProps: true,
+      skipEditableModels: false,
+      skipIdModels: false,
+      disableAutoManagedKey: true,
+    });
+  });
+
+  test(`${TEST_SUITE_NAME}: deep insert and binding props share the property when bound by key`, async () => {
+    // given entities related to each other, reachable through entity sets
+    addRelatedEntities();
+    addRelatedEntitySets();
+
+    // when opting into both while a service is generated
+    // then the navigation property accepts either shape - a new entity or the key of an existing one -
+    // and the "@id" property tells them apart
+    await generateAndCompare("entity-relationships-deep-insert-binding-by-key.ts", {
+      enableDeepInsertProps: true,
+      enableBindingProps: true,
+      skipEditableModels: false,
+      skipIdModels: false,
+      disableAutoManagedKey: true,
+    });
+  });
+
+  test(`${TEST_SUITE_NAME}: no binding props by key without a NavigationPropertyBinding`, async () => {
+    // given entities related to each other, but no entity set stating where the navigation leads
+    addRelatedEntities();
+
+    // when opting into the binding props while a service is generated
+    // then no binding prop at all: the URL of the referenced entity could not be built
+    await generateAndCompare("entity-relationships.ts", {
+      enableBindingProps: true,
+      skipEditableModels: false,
+      skipIdModels: false,
+      disableAutoManagedKey: true,
+    });
+  });
 
   test(`${TEST_SUITE_NAME}: deep insert props`, async () => {
     // given entities related to each other
@@ -343,6 +405,7 @@ describe("Model Generator Tests V4", () => {
     // when opting into both
     // then both show up separately, since 4.0 spells a binding with a name of its own
     await generateAndCompare("entity-relationships-deep-insert-binding.ts", {
+      mode: Modes.models,
       enableDeepInsertProps: true,
       enableBindingProps: true,
       skipEditableModels: false,
@@ -359,6 +422,7 @@ describe("Model Generator Tests V4", () => {
     // then the navigation property accepts either shape: a new entity or a reference to an existing one,
     // because 4.01 addresses a binding by the very name of the navigation property
     await generateAndCompare("entity-relationships-deep-insert-binding-v401.ts", {
+      mode: Modes.models,
       enableDeepInsertProps: true,
       enableBindingProps: true,
       odataVersionV4: "4.01",

--- a/packages/odata2ts/test/generator/v4/QueryObjectGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/QueryObjectGenerator.test.ts
@@ -1,7 +1,6 @@
 import { ODataTypesV4, ODataVersions } from "@odata2ts/odata-core";
 import { beforeAll, beforeEach, describe, test } from "vitest";
 import { digest } from "../../../src/data-model/DataModelDigestionV4.js";
-import { DigestionOptions } from "../../../src/FactoryFunctionModel.js";
 import { generateQueryObjects } from "../../../src/generator/index.js";
 import { EmitModes } from "../../../src/index.js";
 import { createProjectManager } from "../../../src/project/ProjectManager.js";
@@ -11,6 +10,7 @@ import {
   EntityBasedGeneratorFunctionWithoutVersion,
   FixtureComparatorHelper,
 } from "../comparator/FixtureComparatorHelper.js";
+import { TestOptions } from "../TestTypes.js";
 import { createEntityBasedGenerationTests, ENTITY_NAME, SERVICE_NAME } from "./EntityBasedGenerationTests.js";
 
 describe("Query Object Generator Tests V4", () => {
@@ -39,7 +39,7 @@ describe("Query Object Generator Tests V4", () => {
 
   async function generateAndCompare(
     fixturePath: string,
-    genOptions?: Partial<DigestionOptions>,
+    genOptions?: TestOptions,
     fileToInspect = MODEL_FILE,
   ) {
     await fixtureComparatorHelper.generateAndCompare(fileToInspect, fixturePath, odataBuilder.getSchemas(), genOptions);
@@ -241,6 +241,46 @@ describe("Query Object Generator Tests V4", () => {
       },
       `${SERVICE_NAME.toLowerCase()}/${ENTITY_NAME.toLowerCase()}/Q${ENTITY_NAME}`,
     );
+  });
+
+  function addRelatedEntities() {
+    odataBuilder
+      .addEntityType("Author", undefined, (builder) => builder.addKeyProp("id", ODataTypesV4.Int32))
+      .addEntityType(ENTITY_NAME, undefined, (builder) =>
+        builder
+          .addKeyProp("id", ODataTypesV4.Int32)
+          .addProp("author", withNs("Author"), false)
+          .addProp("relatedAuthors", `Collection(${withNs("Author")})`),
+      );
+  }
+
+  test(`${TEST_SUITE_NAME}: binding of a navigation property`, async () => {
+    // given entities related to each other, reachable through entity sets
+    addRelatedEntities();
+    odataBuilder.addEntitySet("Authors", withNs("Author")).addEntitySet("Books", withNs(ENTITY_NAME), [
+      { path: "author", target: "Authors" },
+      { path: "relatedAuthors", target: "Authors" },
+    ]);
+
+    // when opting into the binding props
+    // then the q-paths carry the id function of the entity set they point to, which is what turns the
+    // key stated in an editable model into the URL of the referenced entity
+    await generateAndCompare("entity-binding.ts", {
+      enableBindingProps: true,
+      skipIdModels: false,
+    });
+  });
+
+  test(`${TEST_SUITE_NAME}: no binding without a NavigationPropertyBinding`, async () => {
+    // given entities related to each other, but no entity set stating where the navigation leads
+    addRelatedEntities();
+
+    // when opting into the binding props
+    // then the q-paths stay as they are: the URL of the referenced entity could not be built
+    await generateAndCompare("entity-binding-unbound.ts", {
+      enableBindingProps: true,
+      skipIdModels: false,
+    });
   });
 
   test(`${TEST_SUITE_NAME}: stream property gets no q-path`, async () => {


### PR DESCRIPTION
- where a service is generated, `enableBindingProps` states a binding by the navigation property itself, carrying the key of the entity to bind: `Location?: EditableBranch | { "@id": BranchId } | null` instead of `"Location@odata.bind": string`
- the key is typed as the generated id model, so its short form (`{ "@id": 3 }`) is accepted just as well as the full one (`{ "@id": { Id: 3 } }`)
- deep insert and binding now share one property in every OData version and are told apart by `"@id"`, which is what makes the two features compose instead of needing a property each
- the translation into the wire notation happens in the query objects, on the way out: `Nav@odata.bind` for 4.0, `{"@id": url}` for 4.01, `{"__metadata": {"uri": url}}` for V2 — new `QBinding` in `odata-query-objects`, handed to `QEntityPath` / `QEntityCollectionPath` and resolved by `convertToOData`
- the URL is relative and built from the entity set the navigation property points to, taken from the `NavigationPropertyBinding` (V4) or the `AssociationSet` (V2)
- a collection accepts bindings and deep-insert payloads side by side; 4.0 splits them into two properties again, the other notations keep one array in the given order
- `null` clears a link and is written under the property that carries the binding
- without a service nothing changed: the models keep stating a binding as it goes on the wire, since no query object would be there to convert it
- a navigation property gets no binding at all when its target entity set is not declared in the metadata, or when the related entity has no id model (`skipIdModels`)
- `int-test/cap` and `int-test/olingo-v2` generate binding props now; the CAP V2 adapter drops the notation in silence, which is recorded as a limit where it shows