### PR TITLE
feat(odata2ts): generate index files for every build

### DIFF
--- a/packages/odata2ts/src/app.ts
+++ b/packages/odata2ts/src/app.ts
@@ -107,5 +107,10 @@ export async function runApp(metadataJson: ODataEdmxModelBase<any>, options: Run
   }
 
   // await Promise.all(promises);
+
+  // barrels come last: they list what has actually been written
+  await project.generateIndexFiles();
+  console.log("Successfully generated index files!");
+
   console.log("Successfully finished!");
 }

--- a/packages/odata2ts/src/project/ProjectManager.ts
+++ b/packages/odata2ts/src/project/ProjectManager.ts
@@ -1,6 +1,7 @@
 import * as path from "path";
+import { camelCase } from "change-case";
 import { mkdirp } from "mkdirp";
-import { CompilerOptions, Project, SourceFile } from "ts-morph";
+import { CompilerOptions, ExportDeclarationStructure, OptionalKind, Project, SourceFile } from "ts-morph";
 import { firstCharLowerCase } from "xml2js/lib/processors.js";
 import { DataModel } from "../data-model/DataModel.js";
 import { EntityType } from "../data-model/DataTypeModel.js";
@@ -11,6 +12,16 @@ import { FileHandler } from "./FileHandler.js";
 import { FileFormatter } from "./formatter/FileFormatter.js";
 import { createFormatter } from "./formatter/index.js";
 import { loadTsMorphCompilerOptions } from "./TsMorphHelper.js";
+
+/**
+ * Name of the generated barrel files. Not configurable: "index" is what every module resolution
+ * understands as the entry point of a folder, so a different name would defeat the purpose.
+ */
+const INDEX_FILE_NAME = "index";
+
+function exportAll(moduleSpecifier: string): OptionalKind<ExportDeclarationStructure> {
+  return { moduleSpecifier };
+}
 
 export interface ProjectManagerOptions {
   usePrettier?: boolean;
@@ -56,6 +67,13 @@ export class ProjectManager {
 
   private readonly cachedFiles: Map<string, SourceFile> | undefined;
 
+  /**
+   * Every file that was actually written, by the folder it lives in. This is the basis for the barrel
+   * files, so that they list what has really been emitted - which depends on the generation mode as well
+   * as on whether a main file ended up with any content at all.
+   */
+  private readonly writtenFiles = new Map<string, Array<string>>();
+
   constructor(
     protected outputDir: string,
     protected emitMode: EmitModes,
@@ -88,7 +106,13 @@ export class ProjectManager {
     return this.cachedFiles!;
   }
 
-  private async writeFile(fileHandler: FileHandler) {
+  private async writeFile(fileHandler: FileHandler, trackForIndex = true) {
+    if (trackForIndex) {
+      const folderFiles = this.writtenFiles.get(fileHandler.path) || [];
+      folderFiles.push(fileHandler.fileName);
+      this.writtenFiles.set(fileHandler.path, folderFiles);
+    }
+
     if (this.options.noOutput) {
       await fileHandler.write(this.emitMode, true);
       this.cachedFiles!.set(fileHandler.getFullFilePath(), fileHandler.getFile());
@@ -273,5 +297,92 @@ export class ProjectManager {
     ) {
       await this.writeFile(file);
     }
+  }
+
+  /**
+   * Generates the barrel files, re-exporting everything that has been generated: one index file per folder
+   * which holds generated files, one per namespace above those, and one at the root of the output directory.
+   *
+   * The root barrel re-exports the files on root level flatly, but each namespace under its own name
+   * ({@code export * as libraryCatalog from "./library-catalog/index.js"}). OData allows the same type name
+   * in two namespaces, and unbundled generation keeps those names as they are - a flat re-export would make
+   * both of them unreachable. With only a single namespace that cannot happen, so there it stays flat.
+   *
+   * Bundled file generation only ever emits files on root level, so there the root barrel is all there is.
+   *
+   * Must run after all other files have been written, since the barrels list what was actually emitted.
+   */
+  public async generateIndexFiles() {
+    const folderPaths = [...this.writtenFiles.keys()].filter((folderPath) => folderPath !== "").sort();
+
+    // one barrel per folder holding generated files
+    const barreledFolders: Array<string> = [];
+    for (const folderPath of folderPaths) {
+      if (await this.writeIndexFile(folderPath, this.getFileSpecifiers(folderPath).map(exportAll))) {
+        barreledFolders.push(folderPath);
+      }
+    }
+
+    // one barrel per namespace, re-exporting the folders below it
+    const foldersByNamespace = barreledFolders.reduce((collector, folderPath) => {
+      const namespace = folderPath.includes("/") ? folderPath.split("/")[0] : "";
+      collector.set(namespace, [...(collector.get(namespace) || []), folderPath]);
+      return collector;
+    }, new Map<string, Array<string>>());
+
+    const barreledNamespaces: Array<string> = [];
+    for (const [namespace, namespaceFolders] of foldersByNamespace) {
+      if (!namespace) {
+        continue;
+      }
+      const specifiers = namespaceFolders.map(
+        (folderPath) => `./${folderPath.substring(namespace.length + 1)}/${INDEX_FILE_NAME}.js`,
+      );
+      if (await this.writeIndexFile(namespace, specifiers.map(exportAll))) {
+        barreledNamespaces.push(namespace);
+      }
+    }
+
+    await this.writeIndexFile("", [
+      ...this.getFileSpecifiers("").map(exportAll),
+      // folders without a namespace level of their own are addressed directly
+      ...(foldersByNamespace.get("") || []).map((folderPath) => exportAll(`./${folderPath}/${INDEX_FILE_NAME}.js`)),
+      ...barreledNamespaces.map((namespace) => {
+        const moduleSpecifier = `./${namespace}/${INDEX_FILE_NAME}.js`;
+        return barreledNamespaces.length === 1
+          ? exportAll(moduleSpecifier)
+          : { moduleSpecifier, namespaceExport: camelCase(namespace) };
+      }),
+    ]);
+  }
+
+  private getFileSpecifiers(folderPath: string) {
+    return (this.writtenFiles.get(folderPath) || [])
+      .slice()
+      .sort()
+      .map((fileName) => `./${fileName}.js`);
+  }
+
+  /**
+   * @return whether the barrel was written - it is skipped if a generated file already occupies the name
+   */
+  private async writeIndexFile(
+    folderPath: string,
+    exportDeclarations: Array<OptionalKind<ExportDeclarationStructure>>,
+  ): Promise<boolean> {
+    if (this.writtenFiles.get(folderPath)?.includes(INDEX_FILE_NAME)) {
+      console.warn(
+        `Skipping index file for "${folderPath || "."}": a generated artefact is already named "${INDEX_FILE_NAME}"!`,
+      );
+      return false;
+    }
+
+    // barrels are trivially correct, so they are type checked regardless of the debug option: an ambiguous
+    // re-export is a real problem and should surface instead of being hidden behind @ts-nocheck
+    const fileHandler = this.createFile(INDEX_FILE_NAME, undefined, folderPath, true);
+    fileHandler.getFile().addExportDeclarations(exportDeclarations);
+
+    await this.writeFile(fileHandler, false);
+    return true;
   }
 }

--- a/packages/odata2ts/src/project/ProjectManager.ts
+++ b/packages/odata2ts/src/project/ProjectManager.ts
@@ -300,8 +300,13 @@ export class ProjectManager {
   }
 
   /**
-   * Generates the barrel files, re-exporting everything that has been generated: one index file per folder
-   * which holds generated files, one per namespace above those, and one at the root of the output directory.
+   * Generates the barrel files, re-exporting everything that has been generated: one index file per
+   * namespace and one at the root of the output directory.
+   *
+   * The files of a folder are always re-exported by the index of its <em>parent</em> - the namespace level
+   * for the model folders, the output root for everything else. Model folders therefore get no index of
+   * their own, which means no generated artefact can ever collide with one: a model literally named "index"
+   * is simply re-exported like any other.
    *
    * The root barrel re-exports the files on root level flatly, but each namespace under its own name
    * ({@code export * as libraryCatalog from "./library-catalog/index.js"}). OData allows the same type name
@@ -315,38 +320,29 @@ export class ProjectManager {
   public async generateIndexFiles() {
     const folderPaths = [...this.writtenFiles.keys()].filter((folderPath) => folderPath !== "").sort();
 
-    // one barrel per folder holding generated files
-    const barreledFolders: Array<string> = [];
-    for (const folderPath of folderPaths) {
-      if (await this.writeIndexFile(folderPath, this.getFileSpecifiers(folderPath).map(exportAll))) {
-        barreledFolders.push(folderPath);
-      }
-    }
+    // collect the files of each folder under the folder which is to re-export them
+    const specifiersByParent = new Map<string, Array<string>>();
+    folderPaths.forEach((folderPath) => {
+      const lastSlash = folderPath.lastIndexOf("/");
+      const parent = lastSlash < 0 ? "" : folderPath.substring(0, lastSlash);
+      const folderName = lastSlash < 0 ? folderPath : folderPath.substring(lastSlash + 1);
+      const specifiers = this.getWrittenFileNames(folderPath).map((fileName) => `./${folderName}/${fileName}.js`);
 
-    // one barrel per namespace, re-exporting the folders below it
-    const foldersByNamespace = barreledFolders.reduce((collector, folderPath) => {
-      const namespace = folderPath.includes("/") ? folderPath.split("/")[0] : "";
-      collector.set(namespace, [...(collector.get(namespace) || []), folderPath]);
-      return collector;
-    }, new Map<string, Array<string>>());
+      specifiersByParent.set(parent, [...(specifiersByParent.get(parent) || []), ...specifiers]);
+    });
 
+    // one barrel per namespace
     const barreledNamespaces: Array<string> = [];
-    for (const [namespace, namespaceFolders] of foldersByNamespace) {
-      if (!namespace) {
-        continue;
-      }
-      const specifiers = namespaceFolders.map(
-        (folderPath) => `./${folderPath.substring(namespace.length + 1)}/${INDEX_FILE_NAME}.js`,
-      );
-      if (await this.writeIndexFile(namespace, specifiers.map(exportAll))) {
+    for (const [namespace, specifiers] of specifiersByParent) {
+      if (namespace && (await this.writeIndexFile(namespace, specifiers.map(exportAll)))) {
         barreledNamespaces.push(namespace);
       }
     }
 
     await this.writeIndexFile("", [
       ...this.getFileSpecifiers("").map(exportAll),
-      // folders without a namespace level of their own are addressed directly
-      ...(foldersByNamespace.get("") || []).map((folderPath) => exportAll(`./${folderPath}/${INDEX_FILE_NAME}.js`)),
+      // folders without a namespace level of their own are re-exported by the root itself
+      ...(specifiersByParent.get("") || []).map(exportAll),
       ...barreledNamespaces.map((namespace) => {
         const moduleSpecifier = `./${namespace}/${INDEX_FILE_NAME}.js`;
         return barreledNamespaces.length === 1
@@ -356,15 +352,19 @@ export class ProjectManager {
     ]);
   }
 
+  private getWrittenFileNames(folderPath: string) {
+    return (this.writtenFiles.get(folderPath) || []).slice().sort();
+  }
+
   private getFileSpecifiers(folderPath: string) {
-    return (this.writtenFiles.get(folderPath) || [])
-      .slice()
-      .sort()
-      .map((fileName) => `./${fileName}.js`);
+    return this.getWrittenFileNames(folderPath).map((fileName) => `./${fileName}.js`);
   }
 
   /**
-   * @return whether the barrel was written - it is skipped if a generated file already occupies the name
+   * Only ever relevant for the root barrel: no generated file lives on a namespace level, and model folders
+   * get no barrel at all. The root file names are configurable, though, so one of them may occupy the name.
+   *
+   * @return whether the barrel was written
    */
   private async writeIndexFile(
     folderPath: string,

--- a/packages/odata2ts/test/app.test.ts
+++ b/packages/odata2ts/test/app.test.ts
@@ -39,8 +39,11 @@ describe("App Test", () => {
   let logInfoSpy: MockInstance;
 
   beforeAll(async () => {
-    // @ts-ignore
-    createPmSpy = vi.spyOn(ProjectManager, "createProjectManager").mockResolvedValue(vi.fn());
+    createPmSpy = vi
+      .spyOn(ProjectManager, "createProjectManager")
+      // runApp calls the barrel generation on the project manager itself
+      // @ts-ignore
+      .mockResolvedValue(Object.assign(vi.fn(), { generateIndexFiles: vi.fn() }));
 
     logInfoSpy = vi.spyOn(console, "log").mockImplementation(() => vi.fn());
   });
@@ -162,7 +165,8 @@ describe("App Test", () => {
     await doRunApp();
 
     expect(logInfoSpy).toHaveBeenNthCalledWith(1, "Successfully generated models!");
-    expect(logInfoSpy).toHaveBeenNthCalledWith(2, "Successfully finished!");
+    expect(logInfoSpy).toHaveBeenNthCalledWith(2, "Successfully generated index files!");
+    expect(logInfoSpy).toHaveBeenNthCalledWith(3, "Successfully finished!");
   });
 
   test("App: generate only models", async () => {

--- a/packages/odata2ts/test/project/ProjectManager.test.ts
+++ b/packages/odata2ts/test/project/ProjectManager.test.ts
@@ -2,7 +2,7 @@ import path from "path";
 import { ODataTypesV4 } from "@odata2ts/odata-core";
 import { mkdirp } from "mkdirp";
 import { EmitResult } from "ts-morph";
-import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, MockInstance, test, vi } from "vitest";
 import { DataModel } from "../../src/data-model/DataModel.js";
 import { digest } from "../../src/data-model/DataModelDigestionV4.js";
 import { NamingHelper } from "../../src/data-model/NamingHelper.js";
@@ -65,8 +65,11 @@ describe("ProjectManager Test", () => {
     return `${NAMESPACE}.${name}`;
   }
 
+  let logWarnSpy: MockInstance;
+
   beforeAll(() => {
     vi.spyOn(console, "log").mockImplementation(() => {});
+    logWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
   beforeEach(() => {
@@ -463,6 +466,136 @@ describe("ProjectManager Test", () => {
     await pm.finalizeServices();
 
     expect(pm.getCachedFiles().size).toBe(1);
+  });
+
+  function getExports(pm: Awaited<ReturnType<typeof createProjectManager>>, filePath: string) {
+    return pm
+      .getCachedFiles()
+      .get(filePath)!
+      .getExportDeclarations()
+      .map((exportDecl) => exportDecl.getModuleSpecifierValue());
+  }
+
+  /** the name each export is re-exported under, undefined where it is a flat `export *` */
+  function getNamespaceAliases(pm: Awaited<ReturnType<typeof createProjectManager>>, filePath: string) {
+    return pm
+      .getCachedFiles()
+      .get(filePath)!
+      .getExportDeclarations()
+      .map((exportDecl) => exportDecl.getNamespaceExport()?.getName());
+  }
+
+  test("Index file for bundled generation", async () => {
+    // given all three bundled files
+    noOutput = true;
+    useExhaustiveDataModel(modelBuilder);
+    const pm = await doCreateProjectManager();
+
+    pm.initModels();
+    await pm.finalizeModels();
+    pm.initQObjects();
+    await pm.finalizeQObjects();
+    pm.initServices();
+    await pm.finalizeServices();
+
+    // when generating the barrels
+    await pm.generateIndexFiles();
+
+    // then there's exactly one: bundled generation only ever emits on root level
+    expect([...pm.getCachedFiles().keys()]).toEqual([
+      MAIN_FILE_NAMES.model,
+      MAIN_FILE_NAMES.qObject,
+      MAIN_FILE_NAMES.service,
+      "index",
+    ]);
+    // and it re-exports all of them
+    expect(getExports(pm, "index")).toEqual([
+      `./${MAIN_FILE_NAMES.qObject}.js`,
+      `./${MAIN_FILE_NAMES.model}.js`,
+      `./${MAIN_FILE_NAMES.service}.js`,
+    ]);
+  });
+
+  test("Index files for unbundled generation", async () => {
+    // given one model in its own folder and the main service file on root level
+    noOutput = true;
+    bundledFileGeneration = false;
+    const pm = await doCreateProjectManager();
+
+    await pm.finalizeFile(pm.createOrGetModelFile(ENTITY_FOLDER_PATH, ENTITY_NAME));
+    pm.initServices();
+    await pm.finalizeServices();
+
+    // when generating the barrels
+    await pm.generateIndexFiles();
+
+    // then the model folder has one of its own
+    expect(getExports(pm, `${ENTITY_FOLDER_PATH}/index`)).toEqual([`./${ENTITY_NAME}.js`]);
+    // and so has the namespace above it
+    expect(getExports(pm, "ns-1-example/index")).toEqual(["./my-entity/index.js"]);
+    // and the root one points at the root level file and at the namespace - flatly, since there's only one
+    expect(getExports(pm, "index")).toEqual([`./${MAIN_FILE_NAMES.service}.js`, "./ns-1-example/index.js"]);
+    expect(getNamespaceAliases(pm, "index")).toEqual([undefined, undefined]);
+  });
+
+  test("Index file re-exports several namespaces under their own name", async () => {
+    // given models in two different namespaces
+    noOutput = true;
+    bundledFileGeneration = false;
+    const pm = await doCreateProjectManager();
+
+    await pm.finalizeFile(pm.createOrGetModelFile("ns-1-example/my-entity", ENTITY_NAME));
+    await pm.finalizeFile(pm.createOrGetModelFile("other-ns/my-complex", COMPLEX_NAME));
+    pm.initServices();
+    await pm.finalizeServices();
+
+    // when generating the barrels
+    await pm.generateIndexFiles();
+
+    // then the root barrel keeps them apart: the same type name may legitimately occur in both
+    expect(getExports(pm, "index")).toEqual([
+      `./${MAIN_FILE_NAMES.service}.js`,
+      "./ns-1-example/index.js",
+      "./other-ns/index.js",
+    ]);
+    // the underscore keeps the alias a valid identifier, as the namespace segment starts with a digit
+    expect(getNamespaceAliases(pm, "index")).toEqual([undefined, "ns_1Example", "otherNs"]);
+  });
+
+  test("Index file only lists what has been written", async () => {
+    noOutput = true;
+    bundledFileGeneration = false;
+    const pm = await doCreateProjectManager();
+
+    // the main model file stays empty here, so it never gets written ...
+    pm.createOrGetMainModelFile();
+    await pm.finalizeModels();
+    // ... while the main service file always is
+    pm.initServices();
+    await pm.finalizeServices();
+
+    await pm.generateIndexFiles();
+
+    expect(getExports(pm, "index")).toEqual([`./${MAIN_FILE_NAMES.service}.js`]);
+  });
+
+  test("Index file is skipped where an artefact occupies the name", async () => {
+    // given a model which is literally named "index"
+    noOutput = true;
+    bundledFileGeneration = false;
+    const pm = await doCreateProjectManager();
+
+    await pm.finalizeFile(pm.createOrGetModelFile(ENTITY_FOLDER_PATH, "index"));
+    pm.initServices();
+    await pm.finalizeServices();
+
+    // when generating the barrels
+    await pm.generateIndexFiles();
+
+    // then that folder gets none and the user is told about it
+    expect(logWarnSpy).toHaveBeenCalledWith(expect.stringContaining(ENTITY_FOLDER_PATH));
+    // and the root barrel doesn't reference the folder either
+    expect(getExports(pm, "index")).toEqual([`./${MAIN_FILE_NAMES.service}.js`]);
   });
 
   // test("ProjectManager: create and write model file", async () => {

--- a/packages/odata2ts/test/project/ProjectManager.test.ts
+++ b/packages/odata2ts/test/project/ProjectManager.test.ts
@@ -2,7 +2,7 @@ import path from "path";
 import { ODataTypesV4 } from "@odata2ts/odata-core";
 import { mkdirp } from "mkdirp";
 import { EmitResult } from "ts-morph";
-import { afterAll, beforeAll, beforeEach, describe, expect, MockInstance, test, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { DataModel } from "../../src/data-model/DataModel.js";
 import { digest } from "../../src/data-model/DataModelDigestionV4.js";
 import { NamingHelper } from "../../src/data-model/NamingHelper.js";
@@ -65,11 +65,8 @@ describe("ProjectManager Test", () => {
     return `${NAMESPACE}.${name}`;
   }
 
-  let logWarnSpy: MockInstance;
-
   beforeAll(() => {
     vi.spyOn(console, "log").mockImplementation(() => {});
-    logWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
   beforeEach(() => {
@@ -529,10 +526,9 @@ describe("ProjectManager Test", () => {
     // when generating the barrels
     await pm.generateIndexFiles();
 
-    // then the model folder has one of its own
-    expect(getExports(pm, `${ENTITY_FOLDER_PATH}/index`)).toEqual([`./${ENTITY_NAME}.js`]);
-    // and so has the namespace above it
-    expect(getExports(pm, "ns-1-example/index")).toEqual(["./my-entity/index.js"]);
+    // then the namespace re-exports the files of the model folder - which has no barrel of its own
+    expect(getExports(pm, "ns-1-example/index")).toEqual([`./my-entity/${ENTITY_NAME}.js`]);
+    expect(pm.getCachedFiles().has(`${ENTITY_FOLDER_PATH}/index`)).toBe(false);
     // and the root one points at the root level file and at the namespace - flatly, since there's only one
     expect(getExports(pm, "index")).toEqual([`./${MAIN_FILE_NAMES.service}.js`, "./ns-1-example/index.js"]);
     expect(getNamespaceAliases(pm, "index")).toEqual([undefined, undefined]);
@@ -552,7 +548,10 @@ describe("ProjectManager Test", () => {
     // when generating the barrels
     await pm.generateIndexFiles();
 
-    // then the root barrel keeps them apart: the same type name may legitimately occur in both
+    // then each namespace re-exports its own files
+    expect(getExports(pm, "ns-1-example/index")).toEqual([`./my-entity/${ENTITY_NAME}.js`]);
+    expect(getExports(pm, "other-ns/index")).toEqual([`./my-complex/${COMPLEX_NAME}.js`]);
+    // and the root barrel keeps them apart: the same type name may legitimately occur in both
     expect(getExports(pm, "index")).toEqual([
       `./${MAIN_FILE_NAMES.service}.js`,
       "./ns-1-example/index.js",
@@ -579,7 +578,7 @@ describe("ProjectManager Test", () => {
     expect(getExports(pm, "index")).toEqual([`./${MAIN_FILE_NAMES.service}.js`]);
   });
 
-  test("Index file is skipped where an artefact occupies the name", async () => {
+  test("An artefact named like the index file is no special case", async () => {
     // given a model which is literally named "index"
     noOutput = true;
     bundledFileGeneration = false;
@@ -592,10 +591,9 @@ describe("ProjectManager Test", () => {
     // when generating the barrels
     await pm.generateIndexFiles();
 
-    // then that folder gets none and the user is told about it
-    expect(logWarnSpy).toHaveBeenCalledWith(expect.stringContaining(ENTITY_FOLDER_PATH));
-    // and the root barrel doesn't reference the folder either
-    expect(getExports(pm, "index")).toEqual([`./${MAIN_FILE_NAMES.service}.js`]);
+    // then it is re-exported like any other: model folders hold no barrel it could collide with
+    expect(getExports(pm, "ns-1-example/index")).toEqual(["./my-entity/index.js"]);
+    expect(getExports(pm, "index")).toEqual([`./${MAIN_FILE_NAMES.service}.js`, "./ns-1-example/index.js"]);
   });
 
   // test("ProjectManager: create and write model file", async () => {


### PR DESCRIPTION
- generate barrel files on every run: one `index.ts` per namespace and one at the root of the output directory — the files of a folder are re-exported by the index of its parent, so model folders hold none of their own
- bundled file generation only ever emits on root level, so there the root barrel is all there is: the three main files
- the root barrel re-exports root level files flatly, but each namespace under its own name (`export * as libraryCatalog from "./library-catalog/index.js"`) 
- the barrels list what has actually been written, so they follow `mode` automatically and leave out main files that ended up empty
