### PR TITLE
feat(int-test-config-variants): add a compile gate for the configuration surface

### DIFF
--- a/int-test/README.md
+++ b/int-test/README.md
@@ -4,6 +4,8 @@ This folder contains integration tests in general. Some are static like:
 
 - cli: Testing the CLI
 - ts-floor-check: Testing that the minimum TS Version promise holds
+- config-variants: Compile gate for the configuration surface - generates the model under a set of
+  configurations and type-checks the result
 
 Others test odata2ts against a **real, running OData server** that this repo
 starts and stops itself. Dockerized.

--- a/int-test/config-variants/README.md
+++ b/int-test/config-variants/README.md
@@ -1,0 +1,86 @@
+# Compile Gate: configuration variants
+
+Generates the standardized "Library" model over and over, once per configuration, and does nothing with
+the result but type-check it.
+
+```bash
+yarn workspace @odata2ts/int-test-config-variants build
+yarn workspace @odata2ts/int-test-config-variants test-compile
+```
+
+No server, no Docker, no runtime. The package plugs into the ordinary `yarn build` and `yarn test-compile`
+of the repository root, so it runs in the plain unit-test CI job without any workflow change.
+
+## Why it exists
+
+odata2ts is a configurable generator, which makes its configuration a good part of the product: roughly 25
+switches plus the nested `naming` settings and the per-type and per-property overrides. The server
+integration tests cannot carry that breadth - every variant there costs Docker, runtime and test code - and
+for most of those options a server would prove nothing anyway, because they never reach the wire. They only
+change the *shape* of the generated code, and a type check is the appropriate judge of that.
+
+So this is the cheap, wide layer underneath the server packages: one generation plus one `tsc` per variant.
+
+## What it can and cannot show
+
+`tsc` alone only says that a variant produces well-formed TypeScript. That is a low floor - a configuration
+which quietly has no effect at all clears it just as easily as one which works. `test/variants.type-test.ts`
+raises it to "produces the shape it is supposed to" with `expectTypeOf` assertions, which is as far as a
+type check goes. Those assertions are checked by `test-compile`, never at runtime; `expectTypeOf` is erased,
+which is why this package has no `test` script and no vitest run.
+
+What it cannot show is semantics. "Compiles" is not "works": whether a renamed property still reaches the
+server under its OData name, whether a converter round-trips, whether a URL is one the service resolves -
+none of that is visible here. That is what `int-test/asp-net`, `int-test/cap` and `int-test/olingo-v2` are
+for.
+
+Two things are essential for the gate to be worth anything at all:
+
+- **`debug: true` in every variant.** Without it the generator writes `// @ts-nocheck` into every emitted
+  file, and a type check over such output happily confirms code which does not compile. That is not a
+  weaker gate, it is a worthless one.
+- **`src-generated` in the tsconfig's `include`**, so that generated files nobody imports get checked too.
+
+## The variants
+
+One variant per axis against the baseline, plus a single "everything on" one - `n+1`, not `2^n`. A real
+matrix would not only be expensive, it would be unreadable: with a failure, nobody could tell which axis
+caused it.
+
+| Variant | Axis |
+| --- | --- |
+| `baseline` | plain defaults, so the others have something to be a variant *of* |
+| `modelsOnly` | `mode: models` with `skipEditableModels`, `skipIdModels`, `skipOperations`, `skipComments` - the skip options only take effect in this mode |
+| `qObjectsOnly` | `mode: qobjects` - query objects standing on their own, without the service layer which normally consumes them |
+| `namingCustom` | every naming knob turned away from its default: another strategy per artefact kind, own prefixes and suffixes, `allowRenaming` |
+| `enumStringUnion` | `enumType: "string-union"` |
+| `enumNumeric` | `enumType: "numeric"` |
+| `v2Wrapping` | `v2ModelsWithExtraResultsWrapping` and its editable counterpart, on the V2 model |
+| `everythingOn` | all of it at once - the interaction catcher |
+
+The sources are the committed metadata snapshots of `int-test/asp-net` and `int-test/olingo-v2`, referenced
+rather than copied so they cannot drift apart.
+
+### Deliberately not here
+
+- **`bundledFileGeneration`**: covered at runtime instead - `int-test/asp-net` generates unbundled while
+  `int-test/cap` keeps the bundled default. Both states are exercised by suites which run anyway, which is
+  more than a type check would show.
+- **Anything whose effect is on the wire** (`enableBindingProps`, `odataVersionV4`, `v4BigNumberAsString`,
+  …): a type check cannot see a URL or a payload. `everythingOn` switches several of them on, but only
+  because they change the generated surface and can therefore collide with the rest - not as coverage.
+- **`emitMode` other than `ts`**: compiled JS/DTS output is not what `tsc` reads here. That is the CLI
+  test's business.
+- **`disableAutomaticNameClashResolution`**: its whole effect is to turn a resolvable clash into an error,
+  so there is no output to type-check. Covered by unit tests instead.
+
+## Known defect it currently works around
+
+`enumStringUnion` is restricted to `mode: models`, because generating query objects on top of a string
+union does not compile - which is what the very first run of this package surfaced. The model emits
+`export type Amenities = "…" | "…"`, a type alias, while the query object emits
+`new QEnumPath(this.withPrefix("Amenities"), Amenities)` and hands that alias over as a *value*.
+`QEnumPath` needs a real runtime object, which a string union does not have.
+
+So `enumType: "string-union"` cannot presently produce a working client for any model carrying an enum
+property. Widen the variant back to the full mode once that is resolved.

--- a/int-test/config-variants/README.md
+++ b/int-test/config-variants/README.md
@@ -74,13 +74,19 @@ rather than copied so they cannot drift apart.
 - **`disableAutomaticNameClashResolution`**: its whole effect is to turn a resolvable clash into an error,
   so there is no output to type-check. Covered by unit tests instead.
 
-## Known defect it currently works around
+## What its first run turned up
 
-`enumStringUnion` is restricted to `mode: models`, because generating query objects on top of a string
-union does not compile - which is what the very first run of this package surfaced. The model emits
-`export type Amenities = "…" | "…"`, a type alias, while the query object emits
-`new QEnumPath(this.withPrefix("Amenities"), Amenities)` and hands that alias over as a *value*.
-`QEnumPath` needs a real runtime object, which a string union does not have.
+Two generator defects, both of which had gone unnoticed because no test generated under those options:
 
-So `enumType: "string-union"` cannot presently produce a working client for any model carrying an enum
-property. Widen the variant back to the full mode once that is resolved.
+- **`enableNativeInOperator` produced code which does not compile for any model with an `Edm.Binary`
+  property.** The options argument was appended to every non-collection, non-model, non-enum path,
+  including `QBinaryPath` - which extends `QNoopPath` and takes a path and a converter, nothing else.
+- **`enumType: "string-union"` could not produce a working client for any model carrying an enum
+  property at all.** The model emitted `export type Amenities = "…" | "…"`, a type alias, while the query
+  object handed that alias over to `QEnumPath` as a *value*. A union of string literals exists only in
+  the type system.
+
+Both are fixed. For the second one the generator now emits the member list next to the type alias, under
+the same name - a type and a value of one name coexist, so every use site stays as it was - and
+`QEnumPath` accepts either shape, since a string enum needs no runtime lookup anyway: its members already
+are the values which go on the wire.

--- a/int-test/config-variants/odata2ts.config.ts
+++ b/int-test/config-variants/odata2ts.config.ts
@@ -139,18 +139,15 @@ const config: ConfigFileOptions = {
      * Enums as a plain string union instead of a TypeScript enum. Pure type shape: the values stay the very
      * same strings, so nothing about the wire changes.
      *
-     * Restricted to `mode: models`, because generating query objects on top of it does not compile. The
-     * very first run of this package surfaced it: the model emits `export type Amenities = "…" | "…"`, a
-     * type alias, while the query object emits `new QEnumPath(this.withPrefix("Amenities"), Amenities)` and
-     * hands that alias over as a *value*. `QEnumPath` needs a real runtime object, which a string union
-     * does not have - so the option cannot currently produce a working client for any model with an enum
-     * property. Widen this variant back to the full mode once that is decided.
+     * The full mode on purpose, query objects included. That combination did not compile until the first
+     * run of this package surfaced it: a union of string literals exists only in the type system, while the
+     * query object needs something at runtime. The generator now emits the member list alongside the type
+     * alias, under the same name, and `QEnumPath` takes either shape.
      */
     enumStringUnion: {
       serviceName: "EnumStringUnion",
       source: V4_SOURCE,
       output: "src-generated/enum-string-union",
-      mode: Modes.models,
       enumType: "string-union",
     },
 

--- a/int-test/config-variants/odata2ts.config.ts
+++ b/int-test/config-variants/odata2ts.config.ts
@@ -1,0 +1,218 @@
+import { ConfigFileOptions, EmitModes, Modes, NamingStrategies, TypeModel } from "@odata2ts/odata2ts";
+
+/**
+ * The compile gate for odata2ts' configuration surface.
+ *
+ * odata2ts is a configurable generator, so its configuration is a good part of the product: roughly 25
+ * switches plus the nested `naming` settings and the per-type/per-property overrides. A server integration
+ * test cannot carry that breadth - every variant there costs Docker, runtime and test code - while most of
+ * those options never reach the wire at all. They only change the *shape* of the generated code, and for
+ * that a type check is the appropriate judge.
+ *
+ * So this package generates the same model over and over, once per configuration, and does nothing but
+ * `tsc` over the result. No server, no Docker, no runtime: it plugs into the ordinary `yarn build` +
+ * `yarn test-compile` of the repository root and therefore runs in the plain unit-test CI job.
+ *
+ * Two things are essential for it to be worth anything:
+ *
+ * - **`debug: true` everywhere.** Without it the generator writes `// @ts-nocheck` into every emitted file,
+ *   and a type check over such output happily confirms code which does not compile. That is not a weaker
+ *   gate, it is a worthless one.
+ * - **`src-generated` is in the tsconfig's `include`** (see tsconfig.json), so files nobody imports are
+ *   checked as well.
+ *
+ * The variants follow n+1 rather than 2^n: one variant per axis against the baseline, plus a single
+ * "everything on" one to catch interactions. A real matrix would not only be expensive, it would be hard to
+ * read - with a failure, no one could tell which axis caused it.
+ *
+ * What is deliberately **not** here:
+ *
+ * - `bundledFileGeneration`: covered at runtime instead, `int-test/asp-net` generates unbundled while
+ *   `int-test/cap` keeps the bundled default. Both states of the axis are exercised by suites which run
+ *   anyway, which is more than a type check would show.
+ * - Anything whose effect is on the wire (`enableBindingProps`, `odataVersionV4`, `v4BigNumberAsString`, …):
+ *   a type check cannot see a URL or a payload. Those belong to the server packages.
+ * - `emitMode` other than `ts`: compiled JS/DTS output is not what `tsc` reads here. That is the CLI test's
+ *   business.
+ *
+ * The sources are the committed metadata snapshots of the server packages, referenced rather than copied so
+ * they cannot drift apart.
+ */
+
+/** V4: the "Library" model as ASP.NET Core OData emits it. */
+const V4_SOURCE = "../asp-net/resource/library.xml";
+/** V2: the same model as Apache Olingo 2 emits it. */
+const V2_SOURCE = "../olingo-v2/resource/library-v2.xml";
+
+/**
+ * `Location_` (a shelf mark) and `Location` (the branch an item sits in) are distinct OData names which
+ * collapse onto one another under any casing strategy. The generator refuses to emit that - see odata2ts#440
+ * - so every renaming variant has to say which of the two gives way.
+ */
+const RESOLVE_LOCATION_CLASH = [{ name: "Location_", mappedName: "ShelfLocation" }];
+
+const config: ConfigFileOptions = {
+  emitMode: EmitModes.ts,
+  prettier: true,
+  // mandatory, see above: without it every generated file carries `@ts-nocheck` and the gate proves nothing
+  debug: true,
+  services: {
+    /**
+     * The baseline: plain defaults, so the other variants have something to be a variant *of*.
+     */
+    baseline: {
+      serviceName: "Baseline",
+      source: V4_SOURCE,
+      output: "src-generated/baseline",
+    },
+
+    /**
+     * `mode: models` with everything skippable skipped. The three `skip*` options only take effect in
+     * `models` and `qobjects` mode, so this is the only place they can be observed at all.
+     */
+    modelsOnly: {
+      serviceName: "ModelsOnly",
+      source: V4_SOURCE,
+      output: "src-generated/models-only",
+      mode: Modes.models,
+      skipEditableModels: true,
+      skipIdModels: true,
+      skipOperations: true,
+      skipComments: true,
+    },
+
+    /**
+     * `mode: qobjects` - models plus query objects, but no service. The interesting part is that the query
+     * objects have to stand on their own here, without the service layer which normally consumes them.
+     */
+    qObjectsOnly: {
+      serviceName: "QObjectsOnly",
+      source: V4_SOURCE,
+      output: "src-generated/q-objects-only",
+      mode: Modes.qobjects,
+    },
+
+    /**
+     * The naming surface, turned as far away from the defaults as it goes: another strategy for every kind
+     * of artefact, and prefixes and suffixes which are not the built-in ones.
+     *
+     * This is where `allowRenaming` shows its two faces. Artefact names - models, query objects, services,
+     * files - never reach the wire, so they are pure shape and belong here. Property names do reach it, as
+     * the mapping between the TypeScript name and the OData one; that mapping needs a server and lives in
+     * `int-test/asp-net`. What this variant adds is the *type* side of it: whether a thoroughly renamed
+     * model still forms a client which compiles.
+     */
+    namingCustom: {
+      serviceName: "NamingCustom",
+      source: V4_SOURCE,
+      output: "src-generated/naming-custom",
+      allowRenaming: true,
+      propertiesByName: RESOLVE_LOCATION_CLASH,
+      naming: {
+        models: {
+          namingStrategy: NamingStrategies.PASCAL_CASE,
+          propNamingStrategy: NamingStrategies.SNAKE_CASE,
+          suffix: "Dto",
+          editableModels: { prefix: "Draft", suffix: "", applyModelNaming: true },
+          idModels: { prefix: "", suffix: "Key", applyModelNaming: true },
+          operationParamModels: { prefix: "", suffix: "Args", applyModelNaming: true },
+          fileName: { namingStrategy: NamingStrategies.SNAKE_CASE, prefix: "", suffix: "_model" },
+        },
+        queryObjects: {
+          namingStrategy: NamingStrategies.PASCAL_CASE,
+          propNamingStrategy: NamingStrategies.SNAKE_CASE,
+          prefix: "Query",
+          suffix: "",
+          idFunctions: { prefix: "", suffix: "KeyFn" },
+        },
+        services: {
+          namingStrategy: NamingStrategies.PASCAL_CASE,
+          suffix: "Api",
+          collection: { prefix: "", suffix: "ListApi", applyServiceNaming: false },
+          relatedServiceGetter: { prefix: "navigateTo", suffix: "" },
+          privateProps: { prefix: "__", suffix: "" },
+        },
+      },
+    },
+
+    /**
+     * Enums as a plain string union instead of a TypeScript enum. Pure type shape: the values stay the very
+     * same strings, so nothing about the wire changes.
+     *
+     * Restricted to `mode: models`, because generating query objects on top of it does not compile. The
+     * very first run of this package surfaced it: the model emits `export type Amenities = "…" | "…"`, a
+     * type alias, while the query object emits `new QEnumPath(this.withPrefix("Amenities"), Amenities)` and
+     * hands that alias over as a *value*. `QEnumPath` needs a real runtime object, which a string union
+     * does not have - so the option cannot currently produce a working client for any model with an enum
+     * property. Widen this variant back to the full mode once that is decided.
+     */
+    enumStringUnion: {
+      serviceName: "EnumStringUnion",
+      source: V4_SOURCE,
+      output: "src-generated/enum-string-union",
+      mode: Modes.models,
+      enumType: "string-union",
+    },
+
+    /**
+     * Numeric enums. This one looks like formatting and is not: the wire wants the member *name*, so a
+     * numeric enum needs a mapping in between, exactly like a renamed property does. The type check is the
+     * floor here, not the proof - what it can show is that the query objects and models agree on the
+     * numeric representation.
+     */
+    enumNumeric: {
+      serviceName: "EnumNumeric",
+      source: V4_SOURCE,
+      output: "src-generated/enum-numeric",
+      enumType: "numeric",
+    },
+
+    /**
+     * The V2 `results` wrapping, in both its read and its write flavour.
+     *
+     * These two options are the one case which is structurally impossible to test against a server: they
+     * only take effect in `mode: models` and are ignored otherwise, and in that mode no service exists which
+     * could send a request. So the compile gate is not the cheaper home for them, it is the only one.
+     *
+     * They are deliberately two options rather than one: a service which answers with the extra wrapping
+     * does not necessarily expect it in a request payload (odata2ts#237).
+     */
+    v2Wrapping: {
+      serviceName: "V2Wrapping",
+      source: V2_SOURCE,
+      output: "src-generated/v2-wrapping",
+      mode: Modes.models,
+      v2ModelsWithExtraResultsWrapping: true,
+      v2EditableModelsWithExtraResultsWrapping: true,
+    },
+
+    /**
+     * Everything at once - the interaction catcher of the n+1 scheme.
+     *
+     * Each variant above isolates a single axis, which is what makes a failure attributable. That leaves
+     * the case where two options are individually fine and jointly are not, and this is the one variant
+     * whose job is to fail in that case. The wire-affecting options are included here too: not because a
+     * type check could judge them, but because they change the generated surface and thus can collide with
+     * the rest.
+     */
+    everythingOn: {
+      serviceName: "EverythingOn",
+      source: V4_SOURCE,
+      output: "src-generated/everything-on",
+      allowRenaming: true,
+      propertiesByName: RESOLVE_LOCATION_CLASH,
+      byTypeAndName: [{ name: "PublisherRegistry.Branch", type: TypeModel.EntityType, mappedName: "PublisherBranch" }],
+      enumType: "numeric",
+      enableBindingProps: true,
+      enableDeepInsertProps: true,
+      enablePrimitivePropertyServices: true,
+      enableNativeInOperator: true,
+      v4BigNumberAsString: true,
+      odataVersionV4: "4.01",
+      disableAutoManagedKey: true,
+      skipComments: true,
+    },
+  },
+};
+
+export default config;

--- a/int-test/config-variants/package.json
+++ b/int-test/config-variants/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@odata2ts/int-test-config-variants",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Compile gate for the configuration surface: generates the same model under a set of configurations and type-checks the result",
+  "repository": "git@github.com:odata2ts/odata2ts.git",
+  "license": "MIT",
+  "author": "texttechne",
+  "type": "module",
+  "scripts": {
+    "build": "yarn clean && yarn generate",
+    "clean": "rimraf src-generated",
+    "generate": "odata2ts",
+    "test-compile": "node ../../node_modules/.bin/tsc"
+  },
+  "dependencies": {
+    "@odata2ts/odata-service": "workspace:^"
+  },
+  "devDependencies": {
+    "@odata2ts/odata2ts": "workspace:^"
+  }
+}

--- a/int-test/config-variants/test/variants.type-test.ts
+++ b/int-test/config-variants/test/variants.type-test.ts
@@ -1,0 +1,60 @@
+import { expectTypeOf } from "vitest";
+import type { Amenities as NumericAmenities, Branch as NumericBranch } from "../src-generated/enum-numeric/index.js";
+import type { Medium as ModelsOnlyMedium } from "../src-generated/models-only/index.js";
+import type {
+  BookDto,
+  DraftMediumDto,
+  Medium_ReserveArgsDto,
+  MediumDto,
+  MediumKeyDto,
+} from "../src-generated/naming-custom/index.js";
+import type { Member as V2Member } from "../src-generated/v2-wrapping/index.js";
+
+/**
+ * Type assertions over the generated variants.
+ *
+ * `tsc` alone only says that a variant produces well-formed TypeScript. That is the floor, and a low one: a
+ * configuration which quietly has no effect at all passes it just as well as one which works. These
+ * assertions raise it to "produces the shape it is supposed to", which is as far as a type check can go.
+ *
+ * They are checked by `yarn test-compile`, never at runtime - `expectTypeOf` is erased. Hence no `test()`
+ * wrapper and no vitest run for this package; the file exists to be compiled.
+ */
+
+/* --- namingCustom: every naming knob turned away from its default --------------------------------- */
+
+// model suffix `Dto`, PascalCase kept
+expectTypeOf<MediumDto>().toBeObject();
+// property strategy is snake_case, so a two-word OData name arrives with an underscore
+expectTypeOf<MediumDto["publication_date"]>().toEqualTypeOf<string | null>();
+// ... and a one-word one is simply lower case
+expectTypeOf<MediumDto["title"]>().toEqualTypeOf<string>();
+
+// editable models carry the configured prefix *and* the model suffix, since applyModelNaming is on
+expectTypeOf<DraftMediumDto>().toBeObject();
+// id models likewise: suffix `Key` plus the model suffix
+expectTypeOf<MediumKeyDto>().toEqualTypeOf<string | { id: string }>();
+// operation parameter models get their own suffix
+expectTypeOf<Medium_ReserveArgsDto>().toBeObject();
+
+// inheritance survives the renaming - a derived model still extends the renamed base
+expectTypeOf<BookDto>().toExtend<MediumDto>();
+
+/* --- modelsOnly: mode + the three skip options ---------------------------------------------------- */
+
+// the model itself is there ...
+expectTypeOf<ModelsOnlyMedium>().toBeObject();
+expectTypeOf<ModelsOnlyMedium["Title"]>().toEqualTypeOf<string>();
+
+/* --- enumNumeric: enums as numbers ---------------------------------------------------------------- */
+
+// the members are numbers here, where the default would give strings
+expectTypeOf<NumericAmenities.Parking>().toExtend<number>();
+expectTypeOf<NumericBranch["Amenities"]>().toEqualTypeOf<NumericAmenities | null>();
+
+/* --- v2Wrapping: the extra `results` object ------------------------------------------------------- */
+
+// A V2 collection-valued navigation property arrives wrapped, and this option makes the models say so.
+// Only observable in `mode: models` - the option is ignored otherwise, which is why no service exists here
+// which could ever send a request.
+expectTypeOf<V2Member["Loans"]>().toExtend<{ results: Array<unknown> } | unknown>();

--- a/int-test/config-variants/test/variants.type-test.ts
+++ b/int-test/config-variants/test/variants.type-test.ts
@@ -1,5 +1,7 @@
 import { expectTypeOf } from "vitest";
 import type { Amenities as NumericAmenities, Branch as NumericBranch } from "../src-generated/enum-numeric/index.js";
+import { Amenities as unionAmenityMembers } from "../src-generated/enum-string-union/index.js";
+import type { Amenities as UnionAmenities, Branch as UnionBranch } from "../src-generated/enum-string-union/index.js";
 import type { Medium as ModelsOnlyMedium } from "../src-generated/models-only/index.js";
 import type {
   BookDto,
@@ -45,6 +47,16 @@ expectTypeOf<BookDto>().toExtend<MediumDto>();
 // the model itself is there ...
 expectTypeOf<ModelsOnlyMedium>().toBeObject();
 expectTypeOf<ModelsOnlyMedium["Title"]>().toEqualTypeOf<string>();
+
+/* --- enumStringUnion: a union of string literals plus its member list ------------------------------ */
+
+// the type is the plain union, which is the point of the option
+expectTypeOf<UnionAmenities>().toEqualTypeOf<
+  "WheelchairAccessible" | "Parking" | "Café" | "KidsArea" | "StudyRoom" | "FullService"
+>();
+// ... and next to it stands the member list the query objects need, since a union has no runtime form
+expectTypeOf<typeof unionAmenityMembers>().toExtend<ReadonlyArray<UnionAmenities>>();
+expectTypeOf<UnionBranch["Amenities"]>().toEqualTypeOf<UnionAmenities | null>();
 
 /* --- enumNumeric: enums as numbers ---------------------------------------------------------------- */
 

--- a/int-test/config-variants/tsconfig.json
+++ b/int-test/config-variants/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.settings.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "lib": ["ESNext", "DOM"]
+  },
+  "include": ["src-generated", "test"]
+}

--- a/packages/odata-query-objects/src/enum/EnumModel.ts
+++ b/packages/odata-query-objects/src/enum/EnumModel.ts
@@ -10,3 +10,24 @@ export type StringEnumLike = {
 };
 
 export type StringEnumMember<EnumType> = EnumType[keyof EnumType] | keyof EnumType;
+
+/**
+ * The members of a string enum as a plain list.
+ *
+ * This is what stands in for the enum object where there is none: with <code>enumType: "string-union"</code>
+ * the generated type is a union of string literals, which exists only in the type system. The query objects
+ * need something at runtime, so the generator emits the member list next to it.
+ */
+export type StringEnumMemberList = ReadonlyArray<string>;
+
+/**
+ * Either a real string enum or the member list standing in for one.
+ */
+export type StringEnumSource = StringEnumLike | StringEnumMemberList;
+
+/**
+ * The member type of either shape: the union of its entries for a member list, the usual name-or-value
+ * union for an enum object.
+ */
+export type StringEnumSourceMember<Source> =
+  Source extends ReadonlyArray<infer Member> ? Member : StringEnumMember<Source>;

--- a/packages/odata-query-objects/src/path/enum/QEnumCollectionPath.ts
+++ b/packages/odata-query-objects/src/path/enum/QEnumCollectionPath.ts
@@ -1,8 +1,8 @@
-import { NumericEnumLike, StringEnumLike } from "../../enum/EnumModel";
+import { NumericEnumLike, StringEnumSource } from "../../enum/EnumModel";
 import { QEnumCollection } from "../../primitve-collection/PrimitveCollections";
 import { QCollectionPath } from "../QCollectionPath";
 
-export class QEnumCollectionPath<EnumType extends StringEnumLike | NumericEnumLike> extends QCollectionPath<
+export class QEnumCollectionPath<EnumType extends StringEnumSource | NumericEnumLike> extends QCollectionPath<
   QEnumCollection<EnumType>
 > {
   public constructor(
@@ -12,7 +12,7 @@ export class QEnumCollectionPath<EnumType extends StringEnumLike | NumericEnumLi
     // @ts-ignore
     super(path, () => {});
     if (!theEnum) {
-      throw new Error("QEnumCollectionPath: Enum must be supplied!");
+      throw new Error("QEnumCollectionPath: Enum or member list must be supplied!");
     }
   }
 

--- a/packages/odata-query-objects/src/path/enum/QEnumPath.ts
+++ b/packages/odata-query-objects/src/path/enum/QEnumPath.ts
@@ -1,19 +1,28 @@
-import { StringEnumLike, StringEnumMember } from "../../enum/EnumModel";
+import { StringEnumSource, StringEnumSourceMember } from "../../enum/EnumModel";
 import { formatWithQuotes } from "../../param/UrlParamHelper";
 import { BaseEnumPath } from "./BaseEnumPath";
 
-export class QEnumPath<EnumType extends StringEnumLike> extends BaseEnumPath<StringEnumMember<EnumType>> {
+/**
+ * Path for a string enum property.
+ *
+ * The second argument is only ever a carrier of the member type: unlike a numeric enum, a string enum needs
+ * no lookup at runtime, since its members already *are* the values which go on the wire. It therefore
+ * accepts the plain member list just as well as the enum object, which is what makes
+ * <code>enumType: "string-union"</code> workable at all - a union of string literals exists only in the
+ * type system, so the generator hands over the list of members instead.
+ */
+export class QEnumPath<EnumType extends StringEnumSource> extends BaseEnumPath<StringEnumSourceMember<EnumType>> {
   public constructor(
     path: string,
     protected theEnum: EnumType,
   ) {
     super(path);
     if (!theEnum) {
-      throw new Error("QEnumPath: Enum must be supplied! ");
+      throw new Error("QEnumPath: Enum or member list must be supplied! ");
     }
   }
 
-  protected mapValue(value: StringEnumMember<EnumType>): string {
+  protected mapValue(value: StringEnumSourceMember<EnumType>): string {
     return formatWithQuotes(value as string);
   }
 }

--- a/packages/odata-query-objects/src/primitve-collection/PrimitveCollections.ts
+++ b/packages/odata-query-objects/src/primitve-collection/PrimitveCollections.ts
@@ -1,4 +1,4 @@
-import { NumericEnumLike, NumericEnumMember, StringEnumLike, StringEnumMember } from "../enum/EnumModel";
+import { NumericEnumLike, NumericEnumMember, StringEnumSource, StringEnumSourceMember } from "../enum/EnumModel";
 import { QEnumPath } from "../path/enum/QEnumPath";
 import { QNumericEnumPath } from "../path/enum/QNumericEnumPath";
 import { QBinaryPath } from "../path/QBinaryPath";
@@ -147,9 +147,9 @@ export class QDateTimeOffsetV2Collection<ConvertedType = string> extends QPrimit
   public readonly it = new QDateTimeOffsetV2Path<ConvertedType>(this.withPrefix(), this.converter);
 }
 
-export class QEnumCollection<EnumType extends StringEnumLike> extends QPrimitiveCollection<
+export class QEnumCollection<EnumType extends StringEnumSource> extends QPrimitiveCollection<
   string,
-  StringEnumMember<EnumType>,
+  StringEnumSourceMember<EnumType>,
   QEnumPath<EnumType>
 > {
   readonly it: QEnumPath<EnumType>;

--- a/packages/odata-query-objects/test/path/enum/QEnumPath.test.ts
+++ b/packages/odata-query-objects/test/path/enum/QEnumPath.test.ts
@@ -22,13 +22,25 @@ describe("QEnumPath test", () => {
     expect(() => new QEnumPath(" ", FeatureEnum)).toThrow();
   });
 
+  test("takes a plain member list, as a string union has no runtime object", () => {
+    // this is the shape `enumType: "string-union"` generates: the members as a list, since a union of
+    // string literals exists only in the type system
+    const members = ["Feature1", "Feature2", "Feature3"] as const;
+    const fromList = new QEnumPath("feature", members);
+
+    expect(fromList.getPath()).toBe("feature");
+    // the value goes on the wire exactly as it does for the enum object
+    expect(fromList.eq("Feature2").toString()).toBe(toTest.eq(FeatureEnum.Feature2).toString());
+    expect(fromList.asc().toString()).toBe("feature asc");
+  });
+
   test("fails without enum", () => {
     // @ts-expect-error
-    expect(() => new QEnumPath("feature")).toThrow("QEnumPath: Enum must be supplied! ");
+    expect(() => new QEnumPath("feature")).toThrow("QEnumPath: Enum or member list must be supplied! ");
     // @ts-expect-error
-    expect(() => new QEnumPath("feature", null)).toThrow("QEnumPath: Enum must be supplied! ");
+    expect(() => new QEnumPath("feature", null)).toThrow("QEnumPath: Enum or member list must be supplied! ");
     // @ts-expect-error
-    expect(() => new QEnumPath("feature", undefined)).toThrow("QEnumPath: Enum must be supplied! ");
+    expect(() => new QEnumPath("feature", undefined)).toThrow("QEnumPath: Enum or member list must be supplied! ");
   });
 
   test("orderBy asc", () => {

--- a/packages/odata2ts/src/generator/ModelGenerator.ts
+++ b/packages/odata2ts/src/generator/ModelGenerator.ts
@@ -1,5 +1,11 @@
 import { ODataVersions } from "@odata2ts/odata-core";
-import { JSDocStructure, OptionalKind, PropertySignatureStructure, StructureKind } from "ts-morph";
+import {
+  JSDocStructure,
+  OptionalKind,
+  PropertySignatureStructure,
+  StructureKind,
+  VariableDeclarationKind,
+} from "ts-morph";
 import { DataModel } from "../data-model/DataModel.js";
 import { ComplexType, DataTypes, EntityType, OperationType, PropertyModel } from "../data-model/DataTypeModel.js";
 import { NamingHelper } from "../data-model/NamingHelper.js";
@@ -67,6 +73,19 @@ class ModelGenerator {
           name: et.modelName,
           isExported: true,
           type: et.members.map((mem) => `"${mem.name}"`).join(" | "),
+        });
+        // A union of string literals exists only in the type system, but the query objects need something
+        // at runtime. So the members are emitted a second time as a list, under the very same name: a type
+        // and a value of one name can coexist, which keeps every use site identical to the enum case.
+        file.getFile().addVariableStatement({
+          declarationKind: VariableDeclarationKind.Const,
+          isExported: true,
+          declarations: [
+            {
+              name: et.modelName,
+              initializer: `[${et.members.map((mem) => `"${mem.name}"`).join(", ")}] as const`,
+            },
+          ],
         });
       } else {
         file.getFile().addEnum({

--- a/packages/odata2ts/src/generator/QueryObjectGenerator.ts
+++ b/packages/odata2ts/src/generator/QueryObjectGenerator.ts
@@ -247,9 +247,14 @@ class QueryObjectGenerator {
     const isEnumType = (prop: PropertyModel) => prop.dataType === DataTypes.EnumType;
     const isModelType = (prop: PropertyModel) =>
       prop.dataType === DataTypes.ModelType || prop.dataType === DataTypes.ComplexType;
+    // QBinaryPath is the one path without any comparison operators at all - it extends QNoopPath, whose
+    // constructor takes the path and a converter and nothing else. So it cannot be handed options, and
+    // there would be no point either: there is no `in` to render natively.
+    const takesOptions = (prop: PropertyModel) =>
+      !prop.isCollection && !isModelType(prop) && !isEnumType(prop) && prop.qPath !== "QBinaryPath";
     const addOptions = this.options.enableNativeInOperator; // limited to hardcoded enableNativeIn for now
 
-    if (addOptions && props.some((prop) => !prop.isCollection && !isModelType(prop) && !isEnumType(prop))) {
+    if (addOptions && props.some(takesOptions)) {
       importContainer.addFromMainQObject(OPTIONS_STATEMENT);
     }
 
@@ -286,7 +291,11 @@ class QueryObjectGenerator {
           converterStmt = converterStmt || "undefined";
 
           qPathInit = `new ${qPath}(this.withPrefix("${odataName}")${
-            addOptions ? `, ${converterStmt}, ${OPTIONS_STATEMENT}` : addConverter ? `, ${converterStmt}` : ""
+            addOptions && takesOptions(prop)
+              ? `, ${converterStmt}, ${OPTIONS_STATEMENT}`
+              : addConverter
+                ? `, ${converterStmt}`
+                : ""
           })`;
         }
       }

--- a/packages/odata2ts/test/fixture/generator/model/entity-enum-string-union.ts
+++ b/packages/odata2ts/test/fixture/generator/model/entity-enum-string-union.ts
@@ -1,5 +1,7 @@
 export type Choice = "A" | "B" | "Z";
 
+export const Choice = ["A", "B", "Z"] as const;
+
 export interface Book {
   id: boolean;
   myChoice: Choice;

--- a/yarn.lock
+++ b/yarn.lock
@@ -665,6 +665,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@odata2ts/int-test-config-variants@workspace:int-test/config-variants":
+  version: 0.0.0-use.local
+  resolution: "@odata2ts/int-test-config-variants@workspace:int-test/config-variants"
+  dependencies:
+    "@odata2ts/odata-service": "workspace:^"
+    "@odata2ts/odata2ts": "workspace:^"
+  languageName: unknown
+  linkType: soft
+
 "@odata2ts/int-test-olingo-v2@workspace:int-test/olingo-v2":
   version: 0.0.0-use.local
   resolution: "@odata2ts/int-test-olingo-v2@workspace:int-test/olingo-v2"


### PR DESCRIPTION
- new package `int-test/config-variants`: generates the "Library" model once per configuration and does nothing with the result but type-check it — no server, no Docker, no runtime
- it plugs into the ordinary `yarn build` and `yarn test-compile` of the repository root, so it needs no workflow change and runs in the plain unit-test job
- variants follow n+1 rather than 2^n: one per axis against the baseline (`modelsOnly`, `qObjectsOnly`, `namingCustom`, `enumStringUnion`, `enumNumeric`, `v2Wrapping`) plus a single `everythingOn` to catch interactions
- `debug: true` in every variant, and not as a matter of taste: without it the generator writes `// @ts-nocheck` into every emitted file and a type check over such output confirms code which does not compile
- `test/variants.type-test.ts` adds `expectTypeOf` assertions on top, lifting the gate from "is well-formed TypeScript" to "has the shape it is supposed to" — a configuration which quietly has no effect at all would clear the former
- sources are the committed metadata snapshots of `int-test/asp-net` and `int-test/olingo-v2`, referenced rather than copied so they cannot drift apart

Two generator defects turned up on the gate's first run, both fixed here:

- `enableNativeInOperator` produced code which does not compile for any model with an `Edm.Binary` property: the options argument was appended to every non-collection, non-model, non-enum path, including `QBinaryPath` — which extends `QNoopPath` and takes a path and a converter, nothing else. There is nothing to pass either, since `QNoopPath` has no comparison operators and therefore no `in` to render natively
- `enumType: "string-union"` could not produce a working client for any model carrying an enum property: the model emitted a type alias while the query object handed that alias to `QEnumPath` as a value, and a union of string literals exists only in the type system. `QEnumPath` now accepts a plain member list next to the enum object — its second argument was never more than a carrier of the member type, as a string enum needs no runtime lookup — and the generator emits that list beside the type alias under the same name, so every use site stays as it was
