### PR TITLE
chore: reformat with prettier

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,21 +8,6 @@ on:
     types: [assigned, opened, synchronize, reopened]
 
 jobs:
-  format:
-    name: Formatting
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-      - name: Install packages
-        run: yarn --immutable
-      # Nothing else enforces prettier - no format script ran on commit, no hook - so the formatting only
-      # ever reached the files someone happened to touch. This keeps it from drifting again.
-      - name: Check formatting
-        run: yarn check-format
-
   test:
     name: Unit Tests With Coverage
     runs-on: ubuntu-latest
@@ -41,6 +26,8 @@ jobs:
         run: yarn build
       - name: Type Test
         run: yarn test-compile
+      - name: Check formatting
+        run: yarn check-format
       - name: Check Circular Deps
         run: yarn check-circular-deps
       - name: Run Tests

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,6 +8,21 @@ on:
     types: [assigned, opened, synchronize, reopened]
 
 jobs:
+  format:
+    name: Formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Install packages
+        run: yarn --immutable
+      # Nothing else enforces prettier - no format script ran on commit, no hook - so the formatting only
+      # ever reached the files someone happened to touch. This keeps it from drifting again.
+      - name: Check formatting
+        run: yarn check-format
+
   test:
     name: Unit Tests With Coverage
     runs-on: ubuntu-latest

--- a/.prettierignore
+++ b/.prettierignore
@@ -18,3 +18,7 @@ CHANGELOG.md
 # Reformatting them would make them stop being a snapshot.
 int-test/*/resource/
 examples/*/resource/
+
+# Generated clients: the generator formats them itself (option `prettier`), and they are gitignored -
+# checking them would only make the result depend on whether a build has run.
+src-generated

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -17,23 +17,23 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
+- Focusing on what is best not just for us as individuals, but for the
   overall community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
+- The use of sexualized language or imagery, and sexual attention or
   advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
   address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement Responsibilities
@@ -106,7 +106,7 @@ Violating these terms may lead to a permanent ban.
 ### 4. Permanent Ban
 
 **Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
+standards, including sustained inappropriate behavior, harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
 **Consequence**: A permanent ban from any sort of public interaction within

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,1 @@
-module.exports = { extends: ["@commitlint/config-conventional"] }
+module.exports = { extends: ["@commitlint/config-conventional"] };

--- a/examples/test-converters/README.md
+++ b/examples/test-converters/README.md
@@ -2,18 +2,23 @@
 
 # odata2ts Converter API
 
-Defines the API of converters and converter packages as they are used in 
+Defines the API of converters and converter packages as they are used in
 [`@odat2ts`](https://github.com/odata2ts/odata2ts).
 
 ## Installation
+
 Via npm:
+
 ```
 npm install --save @odata2ts/converter-api
 ```
+
 Via yarn:
+
 ```
 yarn add @odata2ts/converter-api
 ```
 
 ## API usage
+
 TODO

--- a/int-test/asp-net/README.md
+++ b/int-test/asp-net/README.md
@@ -85,7 +85,7 @@ The model is generated a **second** time, into `src-generated/library-renamed`, 
 This is the only place that option meets a running server, and `test/feature/Renaming.test.ts` is the only
 file which uses the resulting client.
 
-Generated separately rather than replacing the raw one, because the point is the *mapping* between the two
+Generated separately rather than replacing the raw one, because the point is the _mapping_ between the two
 name forms, and a mapping is only observable where both ends are visible: with a single, renamed client a
 wrongly built URL and a broken name mapping look exactly alike. The test writes through the renamed client
 and reads back through the raw one, which is what pins down that the value really landed under the OData

--- a/int-test/cli/tsconfig.json
+++ b/int-test/cli/tsconfig.json
@@ -4,7 +4,5 @@
     "rootDir": ".",
     "noEmit": true
   },
-  "include": [
-    "test"
-  ]
+  "include": ["test"]
 }

--- a/int-test/config-variants/README.md
+++ b/int-test/config-variants/README.md
@@ -17,7 +17,7 @@ odata2ts is a configurable generator, which makes its configuration a good part 
 switches plus the nested `naming` settings and the per-type and per-property overrides. The server
 integration tests cannot carry that breadth - every variant there costs Docker, runtime and test code - and
 for most of those options a server would prove nothing anyway, because they never reach the wire. They only
-change the *shape* of the generated code, and a type check is the appropriate judge of that.
+change the _shape_ of the generated code, and a type check is the appropriate judge of that.
 
 So this is the cheap, wide layer underneath the server packages: one generation plus one `tsc` per variant.
 
@@ -47,16 +47,16 @@ One variant per axis against the baseline, plus a single "everything on" one - `
 matrix would not only be expensive, it would be unreadable: with a failure, nobody could tell which axis
 caused it.
 
-| Variant | Axis |
-| --- | --- |
-| `baseline` | plain defaults, so the others have something to be a variant *of* |
-| `modelsOnly` | `mode: models` with `skipEditableModels`, `skipIdModels`, `skipOperations`, `skipComments` - the skip options only take effect in this mode |
-| `qObjectsOnly` | `mode: qobjects` - query objects standing on their own, without the service layer which normally consumes them |
-| `namingCustom` | every naming knob turned away from its default: another strategy per artefact kind, own prefixes and suffixes, `allowRenaming` |
-| `enumStringUnion` | `enumType: "string-union"` |
-| `enumNumeric` | `enumType: "numeric"` |
-| `v2Wrapping` | `v2ModelsWithExtraResultsWrapping` and its editable counterpart, on the V2 model |
-| `everythingOn` | all of it at once - the interaction catcher |
+| Variant           | Axis                                                                                                                                        |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `baseline`        | plain defaults, so the others have something to be a variant _of_                                                                           |
+| `modelsOnly`      | `mode: models` with `skipEditableModels`, `skipIdModels`, `skipOperations`, `skipComments` - the skip options only take effect in this mode |
+| `qObjectsOnly`    | `mode: qobjects` - query objects standing on their own, without the service layer which normally consumes them                              |
+| `namingCustom`    | every naming knob turned away from its default: another strategy per artefact kind, own prefixes and suffixes, `allowRenaming`              |
+| `enumStringUnion` | `enumType: "string-union"`                                                                                                                  |
+| `enumNumeric`     | `enumType: "numeric"`                                                                                                                       |
+| `v2Wrapping`      | `v2ModelsWithExtraResultsWrapping` and its editable counterpart, on the V2 model                                                            |
+| `everythingOn`    | all of it at once - the interaction catcher                                                                                                 |
 
 The sources are the committed metadata snapshots of `int-test/asp-net` and `int-test/olingo-v2`, referenced
 rather than copied so they cannot drift apart.
@@ -83,7 +83,7 @@ Two generator defects, both of which had gone unnoticed because no test generate
   including `QBinaryPath` - which extends `QNoopPath` and takes a path and a converter, nothing else.
 - **`enumType: "string-union"` could not produce a working client for any model carrying an enum
   property at all.** The model emitted `export type Amenities = "…" | "…"`, a type alias, while the query
-  object handed that alias over to `QEnumPath` as a *value*. A union of string literals exists only in
+  object handed that alias over to `QEnumPath` as a _value_. A union of string literals exists only in
   the type system.
 
 Both are fixed. For the second one the generator now emits the member list next to the type alias, under

--- a/package.json
+++ b/package.json
@@ -15,8 +15,10 @@
   "scripts": {
     "build": "yarn clean && yarn workspaces foreach -A -pt run build",
     "check-circular-deps": "yarn workspaces foreach -A -p run check-circular-deps",
+    "check-format": "prettier --check .",
     "clean": "rimraf coverage",
     "coverage": "vitest run --coverage",
+    "format": "prettier --write .",
     "int-test": "yarn workspaces foreach -A -p --include 'int-test/*' run test",
     "int-test:asp-net": "yarn workspace @odata2ts/int-test-asp-net test",
     "int-test:cap": "yarn workspace @odata2ts/int-test-cap test",

--- a/packages/odata-core/README.md
+++ b/packages/odata-core/README.md
@@ -1,33 +1,37 @@
 [![npm (scoped)](https://img.shields.io/npm/v/@odata2ts/odata-core?style=for-the-badge)](https://www.npmjs.com/package/@odata2ts/odata-core)
 
 # OData Core
+
 Bundles central and constant information about OData as protocol, like the versions or data types.
 As such this package has no dependencies and can be used for any purpose.
 
-Contains enumerations of 
-* the main OData versions, i.e. V2 and V4
-* all V2 data types
-* all V4 data types
+Contains enumerations of
+
+- the main OData versions, i.e. V2 and V4
+- all V2 data types
+- all V4 data types
 
 Contains interfaces for
-* V2 Response Models
-* V4 Response Models
+
+- V2 Response Models
+- V4 Response Models
 
 ## Installation
+
 ```
 npm install --save @odata2ts/odata-core
 ```
 
 ## V4 Data Types
 
-| OData V4 Type      | Description                                                         | URL format | URL Example                                         | JSON type             |                                                                                             
-|--------------------|---------------------------------------------------------------------|------------|:----------------------------------------------------|-----------------------|
+| OData V4 Type      | Description                                                         | URL format | URL Example                                         | JSON type             |
+| ------------------ | ------------------------------------------------------------------- | ---------- | :-------------------------------------------------- | --------------------- |
 | Edm.Boolean        | boolean value                                                       | literal    | true<br/>false                                      | boolean               |
 | Edm.String         | string value                                                        | quoted     | 'Some Test'                                         | string                |
 | Edm.Byte           | unsigned 8-bit integer value                                        | literal    | 1                                                   | number                |
-| Edm.SByte          | signed 8-bit integer value                                          | literal    | -1                                                  | number                | 
-| Edm.Int16          | signed 16-bit integer value                                         | literal    | 123                                                 | number                | 
-| Edm.Int32          | signed 32-bit integer value                                         | literal    | 123                                                 | number                | 
+| Edm.SByte          | signed 8-bit integer value                                          | literal    | -1                                                  | number                |
+| Edm.Int16          | signed 16-bit integer value                                         | literal    | 123                                                 | number                |
+| Edm.Int32          | signed 32-bit integer value                                         | literal    | 123                                                 | number                |
 | Edm.Int64          | signed 64-bit integer value                                         | literal    | 123                                                 | number                |
 | Edm.Single         | floating point number with 7 digits precision                       | literal    | 1.1                                                 | number                |
 | Edm.Double         | floating point number with 15 digits precision                      | literal    | 1.2                                                 | number                |
@@ -35,69 +39,72 @@ npm install --save @odata2ts/odata-core
 | Edm.Guid           | 16-byte (128-bit) unique identifier value                           | literal    | ...                                                 | string                |
 | Edm.Duration       | duration                                                            | literal    | PT12H59M10S<br/> P1Y<br/> PT12.123S                 | string                |
 | Edm.TimeOfDay      | specific time of day                                                | literal    | 12:59:10<br/>12:15<br/> 12:15:03.123                | string                |
-| Edm.Date           | specific day                                                        | literal    | 2022-12-31                                          | string                | 
-| Edm.DateTimeOffset | specific point in time                                              | literal    | 2022-12-31T23:59:59Z<br/> 2022-12-31T23:59:59+02:00 | string                | 
+| Edm.Date           | specific day                                                        | literal    | 2022-12-31                                          | string                |
+| Edm.DateTimeOffset | specific point in time                                              | literal    | 2022-12-31T23:59:59Z<br/> 2022-12-31T23:59:59+02:00 | string                |
 | Edm.Binary         | fixed or variable length binary data                                |            |                                                     | base64 encoded string |
 | Edm.Stream         | most filter operations don't work here<br/> also exclusive handling |            |                                                     |                       |
 | Edm.Geography.*    |                                                                     |            |                                                     |                       |
 | Edm.Geometry.*     |                                                                     |            |                                                     |                       |
 
-
 ## V2 Data Types
 
 The special thing about V2 OData services is, that we have to differentiate between using
 OData types in the URL or in JSON, since they are formatted differently:
-* URL: values in filter queries ($filter) or function parameters (which are query parameters)
-* JSON: values in request or response bodies
+
+- URL: values in filter queries ($filter) or function parameters (which are query parameters)
+- JSON: values in request or response bodies
 
 The following table lists information about all V2 data types according to the official resources used.
 
-For URL usage, see chapter 6 "Primitive Data Types" of the 
+For URL usage, see chapter 6 "Primitive Data Types" of the
 [V2 overview document](https://www.odata.org/documentation/odata-version-2-0/overview/).
 This is the most authoritative resource despite it's lack of being a true specification.
 
-For JSON usage, see chapter 4 "Primitive Types" of the document about the 
+For JSON usage, see chapter 4 "Primitive Types" of the document about the
 [V2 JSON format](https://www.odata.org/documentation/odata-version-2-0/json-format/).
 
-| OData V2 Type      | Description                                      | URL format                   | URL example                          | JSON type             | JSON example             |                                                                                             
-|--------------------|--------------------------------------------------|------------------------------|:-------------------------------------|-----------------------|--------------------------| 
-| Edm.Boolean        | boolean value                                    | literal                      | true                                 | boolean               | true                     |
-| Edm.String         | string value                                     | quoted                       | 'test'                               | string                | "test"                   |
-| Edm.Byte           | unsigned 8-bit integer value                     | literal                      | 1                                    | string                | "1"                      |
-| Edm.SByte          | signed 8-bit integer value                       | literal                      | -1                                   | string                | "-1"                     | 
-| Edm.Int16          | signed 16-bit integer value                      | literal                      | 123                                  | number                | 123                      | 
-| Edm.Int32          | signed 32-bit integer value                      | literal                      | 123                                  | number                | 123                      | 
-| Edm.Int64          | signed 64-bit integer value                      | type suffix "L"              | 123L                                 | string                | "123"                    |
-| Edm.Single         | floating point number with 7 digits precision    | type suffix "f"              | 1.1f                                 | string                | "1.1"                    |
-| Edm.Double         | floating point number with 15 digits precision   | type suffix "d"              | 1.2d                                 | string                | "1.2"                    |
-| Edm.Decimal        | numeric values with arbitrary precision and scale | type suffix "M" or "m"       | 12.22M                               | string                | "12.22                   | 
-| Edm.Guid           | 16-byte (128-bit) unique identifier value        | type prefix "guid"           | guid'xxx...'                         | string                | "xxx..."                 |
-| Edm.Time           | day time duration representing time of day       | type prefix "time"           | time'PT12H59M10S'                    | string                | "PT12H59M10S"            |
-| Edm.DateTime       | specific point in time                           | type prefix "datetime"       | datetime'2022-12-31T23:59:59'        | string                | "/Date(123...)/"         |
-| Edm.DateTimeOffset | specific point in time                           | type prefix "datetimeoffset" | datetimeoffset'2022-12-31T23:59:59Z' | string                | "2022-12-31T23:59:59+01:00" |
-| Edm.Binary         | fixed or variable length binary data             | type prefix "X" or "binary"  | binary'23A'                          | base64 encoded string | "..."                    |
+| OData V2 Type      | Description                                       | URL format                   | URL example                          | JSON type             | JSON example                |
+| ------------------ | ------------------------------------------------- | ---------------------------- | :----------------------------------- | --------------------- | --------------------------- |
+| Edm.Boolean        | boolean value                                     | literal                      | true                                 | boolean               | true                        |
+| Edm.String         | string value                                      | quoted                       | 'test'                               | string                | "test"                      |
+| Edm.Byte           | unsigned 8-bit integer value                      | literal                      | 1                                    | string                | "1"                         |
+| Edm.SByte          | signed 8-bit integer value                        | literal                      | -1                                   | string                | "-1"                        |
+| Edm.Int16          | signed 16-bit integer value                       | literal                      | 123                                  | number                | 123                         |
+| Edm.Int32          | signed 32-bit integer value                       | literal                      | 123                                  | number                | 123                         |
+| Edm.Int64          | signed 64-bit integer value                       | type suffix "L"              | 123L                                 | string                | "123"                       |
+| Edm.Single         | floating point number with 7 digits precision     | type suffix "f"              | 1.1f                                 | string                | "1.1"                       |
+| Edm.Double         | floating point number with 15 digits precision    | type suffix "d"              | 1.2d                                 | string                | "1.2"                       |
+| Edm.Decimal        | numeric values with arbitrary precision and scale | type suffix "M" or "m"       | 12.22M                               | string                | "12.22                      |
+| Edm.Guid           | 16-byte (128-bit) unique identifier value         | type prefix "guid"           | guid'xxx...'                         | string                | "xxx..."                    |
+| Edm.Time           | day time duration representing time of day        | type prefix "time"           | time'PT12H59M10S'                    | string                | "PT12H59M10S"               |
+| Edm.DateTime       | specific point in time                            | type prefix "datetime"       | datetime'2022-12-31T23:59:59'        | string                | "/Date(123...)/"            |
+| Edm.DateTimeOffset | specific point in time                            | type prefix "datetimeoffset" | datetimeoffset'2022-12-31T23:59:59Z' | string                | "2022-12-31T23:59:59+01:00" |
+| Edm.Binary         | fixed or variable length binary data              | type prefix "X" or "binary"  | binary'23A'                          | base64 encoded string | "..."                       |
 
 Edm.DateTime is quite special in multiple ways:
-1) URL and JSON representation are completely different
-2) the JSON representation has quite a unique format
-3) Edm.DateTime is not really consistent with Edm.DateTimeOffset
 
-Another oddity is Edm.Time, since it is defined as duration (by the way, the static "P" stands for "period"). 
-Now the "spec" states, that it should represent a specific time of day and refers to the "day time duration" as 
+1. URL and JSON representation are completely different
+2. the JSON representation has quite a unique format
+3. Edm.DateTime is not really consistent with Edm.DateTimeOffset
+
+Another oddity is Edm.Time, since it is defined as duration (by the way, the static "P" stands for "period").
+Now the "spec" states, that it should represent a specific time of day and refers to the "day time duration" as
 definition.
 
-I think that the definition is flawed for two reasons. 
+I think that the definition is flawed for two reasons.
 First, ["day time duration"](https://www.w3.org/TR/xmlschema11-2/#nt-duDTFrag) also allows for specifying
 a period of days, which doesn't overlap with time of day.
-Second, a duration might be able to represent a time of day, in the sense that a duration of 6 hours and 
-12 minutes might also represent "06:12", but both data types usually have different restrictions. 
-Time of day requires the specification of hours and minutes, while duration might specify any of its 
+Second, a duration might be able to represent a time of day, in the sense that a duration of 6 hours and
+12 minutes might also represent "06:12", but both data types usually have different restrictions.
+Time of day requires the specification of hours and minutes, while duration might specify any of its
 parts, e.g. only seconds "PT12S".
 
 ## Documentation
+
 No further documentation currently.
 
 ## Support, Feedback, Contributing
+
 This project is open to feature requests, suggestions, bug reports, usage questions etc.
 via [GitHub issues](https://github.com/odata2ts/odata2ts/issues).
 
@@ -106,5 +113,5 @@ Contributions and feedback are encouraged and always welcome.
 See the [contribution guidelines](https://github.com/odata2ts/odata2ts/blob/main/CONTRIBUTING.md) for further information.
 
 ## License
-MIT - see [License](./LICENSE).
 
+MIT - see [License](./LICENSE).

--- a/packages/odata-query-builder/README.md
+++ b/packages/odata-query-builder/README.md
@@ -8,7 +8,7 @@ The query builder depends on generated models and q-objects to offer a powerful 
 These models and q-objects are generated via [odata2ts](https://github.com/odata2ts/odata2ts) out of an existing OData service.
 
 The query builder offers operations which you probably know from SQL:
-`select`, `filter`, `count`, `skip`, `top`. 
+`select`, `filter`, `count`, `skip`, `top`.
 You also get the ability to expand related entities which in turn can be
 filtered, selected or further expanded.
 
@@ -23,29 +23,28 @@ A complex query could look like this:
 
 ```ts
 import { createUriBuilderV4 } from "@odata2ts/odata-uri-builder";
-import { qPerson } from "../generated-src/QTrippin.ts"
+import { qPerson } from "../generated-src/QTrippin.ts";
 
 // In this minimal example the path ("People") as well as the q-object (qPerson) are provided manually.
 // When using the generated service you will be provided with the builder and the proper q-object
 createQueryBuilderV4("People", qPerson)
-  .select("lastName", "age")                            // typesafe: only model attributes are allowed
-  .filter(qPerson.userName.equals("russellwhyte"))      // typesafe: only string values are allowed for comparison with string props
-  .expand("homeAddress")                                // typesafe: only expandable properties are allowed
-  .expanding("trips", (builder, qTrip) => {             // typesafe: only expandable properties are allowed
-    builder
-      .select("tripId", "budget", "description")
-      .top(1)
-      .filter(qTrip.budget.gt(1000));
+  .select("lastName", "age") // typesafe: only model attributes are allowed
+  .filter(qPerson.userName.equals("russellwhyte")) // typesafe: only string values are allowed for comparison with string props
+  .expand("homeAddress") // typesafe: only expandable properties are allowed
+  .expanding("trips", (builder, qTrip) => {
+    // typesafe: only expandable properties are allowed
+    builder.select("tripId", "budget", "description").top(1).filter(qTrip.budget.gt(1000));
   })
   .build();
-
 ```
+
 Result without encoding:<br>
 `/People?$select=LastName,Age`<br>
 `&$filter=UserName eq 'russellwhyte'`<br>
 `&$expand=HomeAddress,Trips($select=TripId,Budget,Description;top=5;$filter=Budget gt 1000)`
 
 ## Server Capabilities
+
 Be aware that the OData service you use does not have to implement all querying capabilities.
 
 When using an unsupported operation, then the server should respond with `501: Not Implemented`
@@ -55,6 +54,7 @@ Some OData services advertise their capabilities via annotations, but this is no
 the OData spec. In any case `odata2ts` doesn't support annotations currently.
 
 ## Inspiration
+
 The approach of generating certain objects to provide type-specific and type-safe query capabilities is by no means an
 invention of `odata2ts`. On the contrary, `odata2ts` has been built in order to realize this approach for the domain
 of OData queries.
@@ -66,19 +66,22 @@ database queries: [QueryDsl](https://querydsl.com/) and [jOOQ](https://www.jooq.
 especially when it comes to filtering.
 
 ## Documentation
+
 [Query Builder Documentation](https://odata2ts.github.io/docs/query-builder/overview-and-setup)
 
 Main documentation for the odata2ts eco system:
 [https://odata2ts.github.io](https://odata2ts.github.io/)
 
 ## Tests
-See folder [test](https://github.com/odata2ts/odata2ts/tree/main/packages/odata-query-builder/test) 
+
+See folder [test](https://github.com/odata2ts/odata2ts/tree/main/packages/odata-query-builder/test)
 for unit tests.
 
 The [example packages](https://github.com/odata2ts/odata2ts/tree/main/examples) also contain some
 integration tests for querying.
 
 ## Support, Feedback, Contributing
+
 This project is open to feature requests, suggestions, bug reports, usage questions etc.
 via [GitHub issues](https://github.com/odata2ts/odata2ts/issues).
 
@@ -87,15 +90,17 @@ Contributions and feedback are encouraged and always welcome.
 See the [contribution guidelines](https://github.com/odata2ts/odata2ts/blob/main/CONTRIBUTING.md) for further information.
 
 ## Spirit
+
 This project and this module have been created and are maintained in the following spirit:
 
-* adhere to the **OData specification** as much as possible
-  * support any OData service implementation which conforms to the spec
-  * allow to work around faulty implementations if possible
-* stability matters
-  * exercise Test Driven Development
-  * bomb the place with unit tests (code coverage > 95%)
-  * ensure that assumptions & understanding are correct by creating integration tests
+- adhere to the **OData specification** as much as possible
+  - support any OData service implementation which conforms to the spec
+  - allow to work around faulty implementations if possible
+- stability matters
+  - exercise Test Driven Development
+  - bomb the place with unit tests (code coverage > 95%)
+  - ensure that assumptions & understanding are correct by creating integration tests
 
 ## License
+
 MIT - see [License](./LICENSE).

--- a/packages/odata-query-builder/src/ODataQueryBuilderModel.ts
+++ b/packages/odata-query-builder/src/ODataQueryBuilderModel.ts
@@ -83,8 +83,7 @@ export type ExpandingFunction<Prop> =
   | Nullable;
 
 export type ExpandingFunctionV2<Prop> =
-  | ((expBuilder: ExpandingQueryBuilderV2<EntityExtractor<Prop>>, qObject: EntityExtractor<Prop>) => void)
-  | Nullable;
+  ((expBuilder: ExpandingQueryBuilderV2<EntityExtractor<Prop>>, qObject: EntityExtractor<Prop>) => void) | Nullable;
 
 export interface ODataQueryBuilderConfig {
   expandingBuilder?: boolean;
@@ -305,7 +304,8 @@ export type V2ExpandResult = { selects: Array<string>; expands: Array<string> };
  * exposes the full set of system query options.
  */
 export interface CollectionQueryBuilderV2<Q extends QueryObjectModel>
-  extends Pick<ODataQueryBuilderModel<Q, CollectionQueryBuilderV2<Q>>, V2CollectionOps>,
+  extends
+    Pick<ODataQueryBuilderModel<Q, CollectionQueryBuilderV2<Q>>, V2CollectionOps>,
     V2ExpandingFunction<Q, CollectionQueryBuilderV2<Q>>,
     V2ExpandFunction<Q, CollectionQueryBuilderV2<Q>> {
   /**
@@ -319,7 +319,8 @@ export interface CollectionQueryBuilderV2<Q extends QueryObjectModel>
  * only select/expand/expanding are meaningful.
  */
 export interface ModelQueryBuilderV2<Q extends QueryObjectModel>
-  extends Pick<ODataQueryBuilderModel<Q, ModelQueryBuilderV2<Q>>, V2ModelOps>,
+  extends
+    Pick<ODataQueryBuilderModel<Q, ModelQueryBuilderV2<Q>>, V2ModelOps>,
     V2ExpandingFunction<Q, ModelQueryBuilderV2<Q>>,
     V2ExpandFunction<Q, ModelQueryBuilderV2<Q>> {
   /**
@@ -329,7 +330,8 @@ export interface ModelQueryBuilderV2<Q extends QueryObjectModel>
 }
 
 export interface ExpandingQueryBuilderV2<Q extends QueryObjectModel>
-  extends Pick<ODataQueryBuilderModel<Q, ExpandingQueryBuilderV2<Q>>, V2ExpandingOps>,
+  extends
+    Pick<ODataQueryBuilderModel<Q, ExpandingQueryBuilderV2<Q>>, V2ExpandingOps>,
     V2ExpandingFunction<Q, ExpandingQueryBuilderV2<Q>>,
     V2ExpandFunction<Q, ExpandingQueryBuilderV2<Q>> {
   /**
@@ -343,8 +345,10 @@ export interface ExpandingQueryBuilderV2<Q extends QueryObjectModel>
  * Contract for ODataQueryBuilder for V4, bound to a collection of models:
  * exposes the full set of system query options.
  */
-export interface CollectionQueryBuilderV4<Q extends QueryObjectModel>
-  extends Pick<ODataQueryBuilderModel<Q, CollectionQueryBuilderV4<Q>>, V4CollectionOps> {
+export interface CollectionQueryBuilderV4<Q extends QueryObjectModel> extends Pick<
+  ODataQueryBuilderModel<Q, CollectionQueryBuilderV4<Q>>,
+  V4CollectionOps
+> {
   /**
    * Creates a new builder with the identical state (deep copy).
    */
@@ -355,16 +359,22 @@ export interface CollectionQueryBuilderV4<Q extends QueryObjectModel>
  * Contract for ODataQueryBuilder for V4, bound to a single model (EntityType or ComplexType instance):
  * only select/expand/expanding are meaningful.
  */
-export interface ModelQueryBuilderV4<Q extends QueryObjectModel>
-  extends Pick<ODataQueryBuilderModel<Q, ModelQueryBuilderV4<Q>>, V4ModelOps> {
+export interface ModelQueryBuilderV4<Q extends QueryObjectModel> extends Pick<
+  ODataQueryBuilderModel<Q, ModelQueryBuilderV4<Q>>,
+  V4ModelOps
+> {
   /**
    * Creates a new builder with the identical state (deep copy).
    */
   clone: () => ModelQueryBuilderV4<Q>;
 }
 
-export interface ExpandingCollectionQueryBuilderV4<Q extends QueryObjectModel>
-  extends Pick<ODataQueryBuilderModel<Q, ExpandingCollectionQueryBuilderV4<Q>>, V4CollectionExpandingOps> {}
+export interface ExpandingCollectionQueryBuilderV4<Q extends QueryObjectModel> extends Pick<
+  ODataQueryBuilderModel<Q, ExpandingCollectionQueryBuilderV4<Q>>,
+  V4CollectionExpandingOps
+> {}
 
-export interface ExpandingModelQueryBuilderV4<Q extends QueryObjectModel>
-  extends Pick<ODataQueryBuilderModel<Q, ExpandingModelQueryBuilderV4<Q>>, V4ModelExpandingOps> {}
+export interface ExpandingModelQueryBuilderV4<Q extends QueryObjectModel> extends Pick<
+  ODataQueryBuilderModel<Q, ExpandingModelQueryBuilderV4<Q>>,
+  V4ModelExpandingOps
+> {}

--- a/packages/odata-query-objects/README.md
+++ b/packages/odata-query-objects/README.md
@@ -7,16 +7,19 @@ They are the counterpart to the typescript model interfaces and allow for comple
 renaming and type conversion.
 
 ## Documentation
+
 [Q-Objects Documentation](https://odata2ts.github.io/docs/category/q-objects)
 
 Main documentation for the odata2ts eco system:
 [https://odata2ts.github.io](https://odata2ts.github.io/)
 
 ## Tests
+
 See folder [test](https://github.com/odata2ts/odata2ts/tree/main/packages/odata-query-objects/test)
 for unit tests.
 
 ## Support, Feedback, Contributing
+
 This project is open to feature requests, suggestions, bug reports, usage questions etc.
 via [GitHub issues](https://github.com/odata2ts/odata2ts/issues).
 
@@ -25,15 +28,16 @@ Contributions and feedback are encouraged and always welcome.
 See the [contribution guidelines](https://github.com/odata2ts/odata2ts/blob/main/CONTRIBUTING.md) for further information.
 
 ## Spirit
+
 This project and this module have been created and are maintained in the following spirit:
 
-* adhere to the **OData specification** as much as possible
-  * support any OData service implementation which conforms to the spec
-  * allow to work around faulty implementations if possible
-* stability matters
-  * exercise Test Driven Development
-  * bomb the place with unit tests (code coverage > 95%)
-  * ensure that assumptions & understanding are correct by creating integration tests
+- adhere to the **OData specification** as much as possible
+  - support any OData service implementation which conforms to the spec
+  - allow to work around faulty implementations if possible
+- stability matters
+  - exercise Test Driven Development
+  - bomb the place with unit tests (code coverage > 95%)
+  - ensure that assumptions & understanding are correct by creating integration tests
 
 ## Inspiration
 
@@ -41,7 +45,5 @@ The base idea for generating and using "Query Objects" stems from [QueryDsl](htt
 [Jooq](https://www.jooq.org/) also works this way.
 
 ## License
+
 MIT - see [License](./LICENSE).
-
-
-

--- a/packages/odata-query-objects/src/enum/NumericEnumConverter.ts
+++ b/packages/odata-query-objects/src/enum/NumericEnumConverter.ts
@@ -1,9 +1,10 @@
 import { ParamValueModel, ValueConverter } from "@odata2ts/converter-api";
 import { NumericEnumLike, NumericEnumMember } from "./EnumModel";
 
-export class NumericEnumConverter<EnumType extends NumericEnumLike>
-  implements ValueConverter<string, NumericEnumMember<EnumType>>
-{
+export class NumericEnumConverter<EnumType extends NumericEnumLike> implements ValueConverter<
+  string,
+  NumericEnumMember<EnumType>
+> {
   public from = "Edm.EnumType";
   public id = "NumericEnumConverter";
   public to = "enum";

--- a/packages/odata-query-objects/src/param/QParam.ts
+++ b/packages/odata-query-objects/src/param/QParam.ts
@@ -6,9 +6,10 @@ import { UrlParamValueFormatter, UrlParamValueParser } from "./UrlParamModel";
 
 export type PrimitiveParamType = string | number | boolean;
 
-export abstract class QParam<Type extends PrimitiveParamType, ConvertedType>
-  implements QParamModel<Type, ConvertedType>
-{
+export abstract class QParam<Type extends PrimitiveParamType, ConvertedType> implements QParamModel<
+  Type,
+  ConvertedType
+> {
   constructor(
     protected name: string,
     protected mappedName?: string,

--- a/packages/odata-query-objects/src/param/UrlParamModel.ts
+++ b/packages/odata-query-objects/src/param/UrlParamModel.ts
@@ -29,7 +29,7 @@ export type UrlValueModel = string | undefined;
  * Useful for function parameter values.
  */
 export type UrlParamValueFormatter<Type extends boolean | number | string> = (
-  value: ParamValueModel<Type>
+  value: ParamValueModel<Type>,
 ) => UrlValueModel;
 
 /**
@@ -42,5 +42,5 @@ export type UrlParamValueFormatter<Type extends boolean | number | string> = (
  * @param parsingRegExp the regular expression to use to parse the value
  */
 export type UrlParamValueParser<Type extends boolean | number | string> = (
-  urlConformValue: UrlValueModel
+  urlConformValue: UrlValueModel,
 ) => ParamValueModel<Type>;

--- a/packages/odata-query-objects/src/primitve-collection/PrimitiveCollectionModel.ts
+++ b/packages/odata-query-objects/src/primitve-collection/PrimitiveCollectionModel.ts
@@ -11,8 +11,4 @@ export type EnumCollection<T> = PrimitiveCollectionType<T>;
 export type NumericEnumCollection<T> = PrimitiveCollectionType<T>;
 
 export type PrimitiveCollection =
-  | StringCollection
-  | NumberCollection
-  | BooleanCollection
-  | EnumCollection<any>
-  | NumericEnumCollection<any>;
+  StringCollection | NumberCollection | BooleanCollection | EnumCollection<any> | NumericEnumCollection<any>;

--- a/packages/odata-query-objects/src/response/ResponseDataConverter.ts
+++ b/packages/odata-query-objects/src/response/ResponseDataConverter.ts
@@ -5,8 +5,7 @@ import { QueryObjectModel } from "../QueryObjectModel";
  * The main ResponseDataConverter interface, which allows to convert from the OData model to the user model.
  */
 export type ResponseDataConverter<ConvertedType> =
-  | Pick<QParamModel<any, ConvertedType>, "convertFrom">
-  | Pick<QueryObjectModel<ConvertedType>, "convertFromOData">;
+  Pick<QParamModel<any, ConvertedType>, "convertFrom"> | Pick<QueryObjectModel<ConvertedType>, "convertFromOData">;
 
 /**
  * OData V2 responds to value queries with a partial entity model only consisting of the given property.

--- a/packages/odata-query-objects/test/fixture/SimpleEntityWithConverter.ts
+++ b/packages/odata-query-objects/test/fixture/SimpleEntityWithConverter.ts
@@ -1,5 +1,4 @@
 import { booleanToNumberConverter, fixedDateConverter, numberToStringConverter } from "@odata2ts/test-converters";
-
 import {
   QBooleanCollection,
   QBooleanPath,
@@ -43,11 +42,11 @@ export class QTestEntity extends QueryObject<TestEntity> {
   public readonly simpleEntity = new QEntityPath(this.withPrefix("simple"), () => QSimpleEntityWithConverter);
   public readonly simpleEntities = new QEntityCollectionPath(
     this.withPrefix("simpleList"),
-    () => QSimpleEntityWithConverter
+    () => QSimpleEntityWithConverter,
   );
   public readonly options = new QCollectionPath(
     this.withPrefix("options"),
     () => QBooleanCollection,
-    booleanToNumberConverter
+    booleanToNumberConverter,
   );
 }

--- a/packages/odata-query-objects/test/fixture/operation/IdFunction.ts
+++ b/packages/odata-query-objects/test/fixture/operation/IdFunction.ts
@@ -1,5 +1,4 @@
 import { booleanToNumberConverter } from "@odata2ts/test-converters";
-
 import { QBooleanParam, QGuidParam, QGuidV2Param, QId, QStringParam } from "../../../src";
 
 export type BookIdModel =

--- a/packages/odata-service/README.md
+++ b/packages/odata-service/README.md
@@ -1,19 +1,22 @@
 [![npm (scoped)](https://img.shields.io/npm/v/@odata2ts/odata-service?style=for-the-badge)](https://www.npmjs.com/package/@odata2ts/odata-service)
 
 # OData Service
+
 Main runtime dependency of [odata2ts](https://github.com/odata2ts/odata2ts) when using
 the generated full-fledged odata client.
 
 This module provides the base classes for the generated services and pulls in all other dependencies
-like `odata-query-builder` and `odata-query-objects`. 
+like `odata-query-builder` and `odata-query-objects`.
 
 ## Documentation
+
 [Main Service Documentation](https://odata2ts.github.io/docs/category/main-service)
 
 Main documentation for the odata2ts eco system:
 [https://odata2ts.github.io](https://odata2ts.github.io/)
 
 ## Tests
+
 See folder [test](https://github.com/odata2ts/odata2ts/tree/main/packages/odata-service/test)
 for unit tests.
 
@@ -21,6 +24,7 @@ See [example packages](https://github.com/odata2ts/odata2ts/tree/main/examples) 
 using the generated services.
 
 ## Support, Feedback, Contributing
+
 This project is open to feature requests, suggestions, bug reports, usage questions etc.
 via [GitHub issues](https://github.com/odata2ts/odata2ts/issues).
 
@@ -29,15 +33,17 @@ Contributions and feedback are encouraged and always welcome.
 See the [contribution guidelines](https://github.com/odata2ts/odata2ts/blob/main/CONTRIBUTING.md) for further information.
 
 ## Spirit
+
 This project and this module have been created and are maintained in the following spirit:
 
-* adhere to the **OData specification** as much as possible
-  * support any OData service implementation which conforms to the spec
-  * allow to work around faulty implementations if possible
-* stability matters
-  * exercise Test Driven Development
-  * bomb the place with unit tests (code coverage > 95%)
-  * ensure that assumptions & understanding are correct by creating integration tests
+- adhere to the **OData specification** as much as possible
+  - support any OData service implementation which conforms to the spec
+  - allow to work around faulty implementations if possible
+- stability matters
+  - exercise Test Driven Development
+  - bomb the place with unit tests (code coverage > 95%)
+  - ensure that assumptions & understanding are correct by creating integration tests
 
 ## License
+
 MIT - see [License](./LICENSE).

--- a/packages/odata-service/src/request/converter/RequestConverter.ts
+++ b/packages/odata-service/src/request/converter/RequestConverter.ts
@@ -15,5 +15,4 @@ export type RequestConverter<UserType, ODataType = UserType> = (
  * The end user can supply custom request converters.
  */
 export type MainRequestConverter<UserType, ODataType = UserType> =
-  | Pick<QueryObjectModel<UserType>, "convertToOData">
-  | Pick<QParamModel<ODataType, UserType>, "convertTo">;
+  Pick<QueryObjectModel<UserType>, "convertToOData"> | Pick<QParamModel<ODataType, UserType>, "convertTo">;

--- a/packages/odata-service/test/v2/ComplexTypeServiceV2.test.ts
+++ b/packages/odata-service/test/v2/ComplexTypeServiceV2.test.ts
@@ -41,9 +41,7 @@ describe("ComplexTypeService V2 Test", () => {
     expect(result.method).toBe("GET");
     expect(result.data).toBeUndefined();
 
-    expectTypeOf(await request.execute()).toEqualTypeOf<
-      HttpResponseModel<ODataComplexModelResponseV2<PersonModel>>
-    >();
+    expectTypeOf(await request.execute()).toEqualTypeOf<HttpResponseModel<ODataComplexModelResponseV2<PersonModel>>>();
   });
 
   test("complexType: query with select", async () => {

--- a/packages/odata2ts/src/cli/processConfigFile.ts
+++ b/packages/odata2ts/src/cli/processConfigFile.ts
@@ -1,6 +1,5 @@
 import { cosmiconfig } from "cosmiconfig";
 import { TypeScriptLoader } from "cosmiconfig-typescript-loader";
-
 import { ConfigFileOptions } from "../OptionModel.js";
 import { logFilePath } from "../project/logger/logFilePath.js";
 

--- a/packages/odata2ts/src/data-model/DataModel.ts
+++ b/packages/odata2ts/src/data-model/DataModel.ts
@@ -1,6 +1,5 @@
 import { MappedConverterChains } from "@odata2ts/converter-runtime";
 import { ODataTypesV2, ODataTypesV4 } from "@odata2ts/odata-core";
-
 import {
   ActionImportType,
   ComplexType,
@@ -70,7 +69,7 @@ export class DataModel {
   constructor(
     namespaces: Array<NamespaceWithAlias>,
     private version: ODataVersion,
-    converters: MappedConverterChains = new Map()
+    converters: MappedConverterChains = new Map(),
   ) {
     this.converters = converters;
     this.namespace2Alias = namespaces.reduce<Record<string, string>>((col, [ns, alias]) => {

--- a/packages/odata2ts/src/data-model/ServiceConfigHelper.ts
+++ b/packages/odata2ts/src/data-model/ServiceConfigHelper.ts
@@ -122,7 +122,7 @@ export class ServiceConfigHelper {
           const regExp = new RegExp(`^${source}$`, ignoreCase ? "i" : "");
           mapping.regExps.push(
             // @ts-ignore: too generic
-            [regExp, ent]
+            [regExp, ent],
           );
           break;
         default:
@@ -135,7 +135,7 @@ export class ServiceConfigHelper {
   private getByName<T extends TypeBasedGenerationOptions>(
     mapping: Record<string, TypeBasedGenerationOptions>,
     namespace: NamespaceWithAlias,
-    nameToMap: string
+    nameToMap: string,
   ) {
     const [ns, alias] = namespace;
     const hayStack = { ...this.mapping.Any.names, ...mapping };
@@ -172,7 +172,7 @@ export class ServiceConfigHelper {
   private findConfig<T extends TypeBasedGenerationOptions>(
     mapping: MappingType<T>,
     namespace: NamespaceWithAlias,
-    name: string
+    name: string,
   ) {
     const stringEnt = this.getByName(mapping.names, namespace, name);
     const reEnt = this.getByRegExp(mapping.regExps, namespace, name);
@@ -182,33 +182,33 @@ export class ServiceConfigHelper {
 
   public findEntityTypeConfig(
     namespace: NamespaceWithAlias,
-    name: string
+    name: string,
   ): WithoutName<EntityTypeGenerationOptions> | undefined {
     return this.findConfig<EntityTypeGenerationOptions>(this.mapping.EntityType, namespace, name);
   }
   public findComplexTypeConfig(
     namespace: NamespaceWithAlias,
-    name: string
+    name: string,
   ): WithoutName<ComplexTypeGenerationOptions> | undefined {
     return this.findConfig(this.mapping.ComplexType, namespace, name);
   }
   public findEnumTypeConfig(
     namespace: NamespaceWithAlias,
-    name: string
+    name: string,
   ): WithoutName<GenericTypeGenerationOptions> | undefined {
     return this.findConfig(this.mapping.EnumType, namespace, name);
   }
 
   public findOperationTypeConfig(
     namespace: NamespaceWithAlias,
-    name: string
+    name: string,
   ): WithoutName<GenericTypeGenerationOptions> | undefined {
     return this.findConfig(this.mapping.OperationType, namespace, name);
   }
 
   public findOperationImportConfig(
     namespace: string,
-    name: string
+    name: string,
   ): WithoutName<GenericTypeGenerationOptions> | undefined {
     return this.findConfig(this.mapping.OperationImportType, [namespace], name);
   }

--- a/packages/odata2ts/src/data-model/validation/NameClashValidator.ts
+++ b/packages/odata2ts/src/data-model/validation/NameClashValidator.ts
@@ -3,8 +3,10 @@ import { TypeModel } from "../../TypeModel.js";
 import { OperationTypes } from "../DataTypeModel.js";
 import { NameValidator, ValidationError } from "./NameValidator.js";
 
-export interface NameValidatorOptions
-  extends Pick<ConfigFileOptions, "disableAutomaticNameClashResolution" | "bundledFileGeneration"> {}
+export interface NameValidatorOptions extends Pick<
+  ConfigFileOptions,
+  "disableAutomaticNameClashResolution" | "bundledFileGeneration"
+> {}
 
 export class NameClashValidator implements NameValidator {
   private entityContainer = new Map<string, ValidationError>();

--- a/packages/odata2ts/src/project/FileHandler.ts
+++ b/packages/odata2ts/src/project/FileHandler.ts
@@ -1,7 +1,5 @@
 import { writeFile } from "fs/promises";
-
 import { SourceFile } from "ts-morph";
-
 import { ImportContainer } from "../generator/ImportContainer.js";
 import { EmitModes } from "../OptionModel.js";
 import { FileFormatter } from "./formatter/FileFormatter.js";
@@ -13,7 +11,7 @@ export class FileHandler {
     protected readonly file: SourceFile,
     protected readonly importContainer: ImportContainer,
     protected formatter: FileFormatter | undefined,
-    public readonly allowTypeChecking: boolean
+    public readonly allowTypeChecking: boolean,
   ) {}
 
   public getFullFilePath() {

--- a/packages/odata2ts/src/project/formatter/BaseFormatter.ts
+++ b/packages/odata2ts/src/project/formatter/BaseFormatter.ts
@@ -1,5 +1,4 @@
 import { ManipulationSettings } from "ts-morph";
-
 import { FileFormatter } from "./FileFormatter.js";
 
 /**

--- a/packages/odata2ts/src/project/formatter/PrettierFormatter.ts
+++ b/packages/odata2ts/src/project/formatter/PrettierFormatter.ts
@@ -1,6 +1,5 @@
 import prettier from "prettier";
 import { IndentationText, NewLineKind, QuoteKind } from "ts-morph";
-
 import { BaseFormatter } from "./BaseFormatter.js";
 
 export class PrettierFormatter extends BaseFormatter {

--- a/packages/odata2ts/test/generator/v4/QueryObjectGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/QueryObjectGenerator.test.ts
@@ -37,11 +37,7 @@ describe("Query Object Generator Tests V4", () => {
 
   createEntityBasedGenerationTests(TEST_SUITE_NAME, FIXTURE_BASE_PATH, MODEL_FILE, GENERATE);
 
-  async function generateAndCompare(
-    fixturePath: string,
-    genOptions?: TestOptions,
-    fileToInspect = MODEL_FILE,
-  ) {
+  async function generateAndCompare(fixturePath: string, genOptions?: TestOptions, fileToInspect = MODEL_FILE) {
     await fixtureComparatorHelper.generateAndCompare(fileToInspect, fixturePath, odataBuilder.getSchemas(), genOptions);
   }
 


### PR DESCRIPTION
- a repository-wide `prettier --write` over all tracked files, no behavioural change
- what it touches: trailing commas, blank lines between import groups (the sort-imports plugin), and the line-break style of a few generic type arguments
- 28 files, all of them pre-existing drift — none of it is code written for this PR
- adds a `check-format` script and a small CI job running it, plus a `format` script for the write side
- generated clients are excluded from the check: the generator formats them itself via its `prettier` option, and they are gitignored, so checking them would make the result depend on whether a build has run
- verified: full build, 1734 unit tests green, and `prettier --check .` — the exact command CI runs — passes

The drift accumulated because nothing enforced the formatting: no format script, no lint-staged hook, no CI check, so prettier only ever reached the files someone happened to run it on. The new job is what keeps it from coming back.
