### PR TITLE
chore(int-test-cap): cover the native in operator and V4 converters

### DIFF
--- a/int-test/asp-net/test/core/QueryFunctionality.test.ts
+++ b/int-test/asp-net/test/core/QueryFunctionality.test.ts
@@ -88,12 +88,18 @@ describe("ASP.NET Library: query functionality", () => {
 
     expect(response.status).toBe(200);
   });
-  test("$filter with in", async () => {
-    const result = await LIBRARY.Media()
-      .query((builder, qMedium) => {
-        builder.filter(qMedium.Language.in("de", "en"));
-      })
-      .execute();
+  test("$filter with in, rolled out as equals-expressions", async () => {
+    // This client keeps the default, which emulates `in` - `int-test/cap` is generated with
+    // `enableNativeInOperator` and covers the other state. Both spellings yield the same rows, so the URL
+    // is the assertion which tells them apart at all.
+    const request = LIBRARY.Media().query((builder, qMedium) => {
+      builder.filter(qMedium.Language.in("de", "en"));
+    });
+
+    // decoded, since the query string travels percent-encoded
+    expect(decodeURIComponent(request.getUrl())).toContain("$filter=(Language eq 'de' or Language eq 'en')");
+
+    const result = await request.execute();
 
     expect(result.status).toBe(200);
     expect(result.data.value.length).toBeGreaterThan(0);

--- a/int-test/cap/README.md
+++ b/int-test/cap/README.md
@@ -53,6 +53,22 @@ A second client is generated the same way from `resource/library-v2.xml`, the sn
 `/odata/v2/library/$metadata`. It is not a second model: the adapter translates the one service on the
 fly, so that file is the translation, and testing against it is what makes the translation visible.
 
+A third client, `src-generated/library-converted`, is the V4 model once more with value converters and
+`v4BigNumberAsString`. Converters had only ever met a running server as V2, through `int-test/olingo-v2`,
+and V2 is a different problem: there a timestamp arrives as `/Date(<ticks>)/` and every wide numeric type
+as a string, so the raw client types them as `string` and the converter has something obvious to parse.
+V4 sends real ISO values - and types `Edm.Decimal` and `Edm.Int64` as `number`, which is exactly where
+precision disappears unnoticed. `v4BigNumberAsString` therefore belongs with the converters rather than
+being a variant of its own: it asks the server for those two types as strings, and only then is there
+anything left to preserve. See `test/feature/Converters.test.ts`, which writes through the converted
+client and reads back through the raw one.
+
+`enableNativeInOperator` is on for the V4 client, while `int-test/asp-net` keeps the emulating default.
+The option has two states and both are worth having against a real server, so they are split across the
+two V4 packages instead of duplicating a suite. Both `test/core/QueryFunctionality.test.ts` files assert
+the URL, because the emulated and the native spelling return the same rows - the result alone would not
+tell them apart.
+
 Assertions use the fixed seed data from `db/data/*.csv` in the server repo.
 
 ## Observed CAP behaviour

--- a/int-test/cap/odata2ts.config.ts
+++ b/int-test/cap/odata2ts.config.ts
@@ -37,6 +37,40 @@ const config: ConfigFileOptions = {
       serviceName: "Library",
       source: "resource/library.xml",
       output: "src-generated/library",
+      // V4 only, and on here rather than in `int-test/asp-net`, which keeps the emulating default: the
+      // option has exactly two states and both are worth having against a real server, so they are split
+      // across the two V4 packages instead of duplicating a suite. `test/core/QueryFunctionality.test.ts`
+      // covers it on either side - the assertion differs only in the URL that reaches the server.
+      enableNativeInOperator: true,
+    },
+    /**
+     * The V4 model a second time, with converters switched on.
+     *
+     * Converters had only ever met a real server as V2, through `int-test/olingo-v2`, and V2 is a
+     * different problem: there every timestamp arrives as `/Date(<ticks>)/` and every wide numeric type as
+     * a string, so the raw client types them as `string` and the converter has something to parse. V4 hands
+     * over real ISO values - and types `Edm.Decimal` and `Edm.Int64` as `number`, which is precisely where
+     * precision goes missing without anyone noticing.
+     *
+     * `v4BigNumberAsString` belongs with them rather than being its own variant: it asks the server for
+     * those two types as strings (`IEEE754Compatible` in accept and content-type). Without it the converter
+     * would be handed a number which has already lost its precision, and converting that is pointless. The
+     * two options only mean anything together.
+     *
+     * Generated separately rather than replacing the raw client, because both halves are the point: the raw
+     * one shows what the server actually sends, the converted one what the converters make of it. See
+     * test/feature/Converters.test.ts.
+     */
+    libraryConverted: {
+      serviceName: "LibraryConverted",
+      source: "resource/library.xml",
+      output: "src-generated/library-converted",
+      v4BigNumberAsString: true,
+      converters: [
+        "@odata2ts/converter-luxon",
+        "@odata2ts/converter-big-number",
+        { module: "@odata2ts/converter-common", use: ["int64ToBigIntConverter"] },
+      ],
     },
     libraryV2: {
       serviceName: "LibraryV2",

--- a/int-test/cap/package.json
+++ b/int-test/cap/package.json
@@ -14,11 +14,17 @@
     "test-compile": "node ../../node_modules/.bin/tsc"
   },
   "dependencies": {
+    "@odata2ts/converter-big-number": "^0.2.8",
+    "@odata2ts/converter-common": "^0.3.7",
+    "@odata2ts/converter-luxon": "^0.2.7",
     "@odata2ts/http-client-fetch": "^0.11.0",
-    "@odata2ts/odata-service": "workspace:^"
+    "@odata2ts/odata-service": "workspace:^",
+    "bignumber.js": "^9.1.2",
+    "luxon": "^3.7.2"
   },
   "devDependencies": {
     "@odata2ts/odata2ts": "workspace:^",
+    "@types/luxon": "^3.7.2",
     "testcontainers": "^12.0.4"
   }
 }

--- a/int-test/cap/test/LibraryConvertedConstants.ts
+++ b/int-test/cap/test/LibraryConvertedConstants.ts
@@ -1,0 +1,9 @@
+import { LibraryConvertedService } from "../src-generated/library-converted/LibraryConvertedService.js";
+import { BASE_URL, ODATA_CLIENT } from "./LibraryTestConstants.js";
+
+/**
+ * The very same service, through the client generated with converters and `v4BigNumberAsString`. Only
+ * `feature/Converters.test.ts` uses it - everywhere else the raw client shows what the server really sends,
+ * and having both side by side is what makes the conversion observable at all.
+ */
+export const CONVERTED = new LibraryConvertedService(ODATA_CLIENT, BASE_URL);

--- a/int-test/cap/test/core/QueryFunctionality.test.ts
+++ b/int-test/cap/test/core/QueryFunctionality.test.ts
@@ -78,12 +78,19 @@ describe("CAP Library: query functionality", () => {
     expect(result.data.Publisher).toBeDefined();
     expect(result.data.Publisher?.Id).toBeDefined();
   });
-  test("$filter with in", async () => {
-    const result = await LIBRARY.Books()
-      .query((builder, qBook) => {
-        builder.filter(qBook.Language.in("de", "en"));
-      })
-      .execute();
+  test("$filter with in, rendered natively", async () => {
+    // This client is generated with `enableNativeInOperator`, while `int-test/asp-net` keeps the emulating
+    // default - the option has two states and this is where the native one meets a server. Both spellings
+    // yield the same rows, so the result alone would not tell them apart: the URL is the assertion that
+    // matters, and executing it is what shows the server accepts that spelling at all.
+    const request = LIBRARY.Books().query((builder, qBook) => {
+      builder.filter(qBook.Language.in("de", "en"));
+    });
+
+    // decoded, since the query string travels percent-encoded
+    expect(decodeURIComponent(request.getUrl())).toContain("$filter=Language in ('de','en')");
+
+    const result = await request.execute();
 
     expect(result.status).toBe(200);
     expect(result.data.value.length).toBeGreaterThan(0);

--- a/int-test/cap/test/feature/Converters.test.ts
+++ b/int-test/cap/test/feature/Converters.test.ts
@@ -1,0 +1,83 @@
+import { BigNumber } from "bignumber.js";
+import { DateTime } from "luxon";
+import { describe, expect, expectTypeOf, test } from "vitest";
+import type { Books, Branches, Members } from "../../src-generated/library-converted/LibraryConvertedModel.js";
+import { CONVERTED } from "../LibraryConvertedConstants.js";
+import { BOOK_DER_PROZESS, LIBRARY } from "../LibraryTestConstants.js";
+
+/**
+ * Value converters against a running **V4** server.
+ *
+ * `int-test/olingo-v2` already drives them against V2, and that is a different problem: there a timestamp
+ * arrives as `/Date(<ticks>)/` and every wide numeric type as a string, so the raw client types all of them
+ * as `string` and the converter has something obvious to parse. V4 sends real ISO values - and types
+ * `Edm.Decimal` and `Edm.Int64` as `number`, which is exactly where precision disappears without anyone
+ * noticing.
+ *
+ * That is why `v4BigNumberAsString` is switched on together with the converters rather than as a variant of
+ * its own: it asks the server for those two types as strings, and only then is there anything left for the
+ * converter to preserve. The two options are meaningless apart.
+ *
+ * `LIBRARY` is the raw client and `CONVERTED` the converted one, driving the same server. Both are needed:
+ * one shows what is actually sent, the other what the converters make of it.
+ */
+describe("CAP Library: value converters", () => {
+  test("an Edm.Date becomes a DateTime rather than a string", async () => {
+    const raw = (await LIBRARY.Books(BOOK_DER_PROZESS).query().execute()).data;
+    const converted = (await CONVERTED.Books(BOOK_DER_PROZESS).query().execute()).data;
+
+    // the same property, the same request, the two clients side by side
+    expect(raw.PublicationDate).toBe("1925-04-26");
+    expect(DateTime.isDateTime(converted.PublicationDate)).toBe(true);
+    expect(converted.PublicationDate!.toISODate()).toBe("1925-04-26");
+
+    expectTypeOf<Books["PublicationDate"]>().toEqualTypeOf<DateTime | null>();
+  });
+
+  test("Edm.Decimal survives as a BigNumber instead of a JS number", async () => {
+    const member = (await CONVERTED.Members(1).query().execute()).data;
+
+    // The point of the pairing: `v4BigNumberAsString` makes the server send this as a string, so the
+    // converter gets the exact value rather than one which has already been through a double.
+    expect(BigNumber.isBigNumber(member.Balance)).toBe(true);
+    expect(member.Balance!.toFixed(2)).toBe("0.00");
+
+    expectTypeOf<Members["Balance"]>().toEqualTypeOf<BigNumber | null>();
+  });
+
+  test("Edm.Int64 becomes a bigint", async () => {
+    const branch = (await CONVERTED.Branches(1).query().execute()).data;
+
+    expect(branch.Population).toBe(BigInt("1841000"));
+    expectTypeOf<Branches["Population"]>().toEqualTypeOf<bigint | null>();
+  });
+
+  test("a converted value goes back out in the format the server expects", async () => {
+    // The direction which a read-only test would never cover: the converter has to serialize as well, and
+    // a server is the only judge of whether the result is acceptable.
+    const created = await CONVERTED.Books()
+      .create({
+        Title: "Converter Round Trip",
+        Language: "de",
+        PublicationDate: DateTime.fromISO("2001-02-03"),
+        PopularityScore: 1,
+        Keywords: [],
+      })
+      .execute();
+
+    expect(created.status).toBe(201);
+    const id = created.data.Id;
+
+    try {
+      // read back through the raw client: proves the value landed on the server as an OData date, not as
+      // whatever a DateTime happens to stringify to
+      const raw = (await LIBRARY.Books(id).query().execute()).data;
+      expect(raw.PublicationDate).toBe("2001-02-03");
+
+      const readBack = (await CONVERTED.Books(id).query().execute()).data;
+      expect(readBack.PublicationDate!.toISODate()).toBe("2001-02-03");
+    } finally {
+      await CONVERTED.Books(id).delete().execute();
+    }
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -658,9 +658,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@odata2ts/int-test-cap@workspace:int-test/cap"
   dependencies:
+    "@odata2ts/converter-big-number": "npm:^0.2.8"
+    "@odata2ts/converter-common": "npm:^0.3.7"
+    "@odata2ts/converter-luxon": "npm:^0.2.7"
     "@odata2ts/http-client-fetch": "npm:^0.11.0"
     "@odata2ts/odata-service": "workspace:^"
     "@odata2ts/odata2ts": "workspace:^"
+    "@types/luxon": "npm:^3.7.2"
+    bignumber.js: "npm:^9.1.2"
+    luxon: "npm:^3.7.2"
     testcontainers: "npm:^12.0.4"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Two axes of the test strategy which had no server coverage, both landing in `int-test/cap`.

- `enableNativeInOperator` is on for the V4 client, while `int-test/asp-net` keeps the emulating default — the option has two states and both are worth having against a real server, so they are split across the two V4 packages instead of duplicating a suite
- both `QueryFunctionality.test.ts` files now assert the URL, because the emulated and the native spelling return the very same rows: without that assertion the distribution would be invisible and the option could stop working unnoticed
- the V2 client keeps the emulation, which is the only thing a V2 service understands
- the V4 model is generated a second time with value converters (luxon, big-number, int64-to-bigint). Converters had only ever met a running server as V2, and V2 is a different problem: there timestamps arrive as `/Date(<ticks>)/` and wide numerics as strings, so the raw client types them as `string`. V4 sends real ISO values — and types `Edm.Decimal` and `Edm.Int64` as `number`, which is where precision disappears unnoticed
- `v4BigNumberAsString` goes with the converters rather than being a variant of its own: it asks the server for those two types as strings, and without it the converter would be handed a number which has already lost its precision. The two only mean anything together
- `test/feature/Converters.test.ts` writes through the converted client and reads back through the raw one, which is what shows the value landed on the server as an OData date rather than as whatever a `DateTime` stringifies to
- verified: 1735 unit tests green, all four int-test packages type-check, cap 135/135 and asp-net 98/98 against their containers
