### PR TITLE
test(int-test-olingo-v2): cover renaming against a V2 server

### DIFF
--- a/int-test/olingo-v2/README.md
+++ b/int-test/olingo-v2/README.md
@@ -50,14 +50,15 @@ The server holds its data in memory and rebuilds it per process, so a restart is
 nothing to deploy or seed. Test files still share one instance, so `fileParallelism` is off and anything
 written is put back.
 
-## Two generated clients
+## Three generated clients
 
-The package generates the model **twice** from the same snapshot:
+The package generates the model **three times** from the same snapshot:
 
 | Service            | Output                            | Purpose                                             |
 | ------------------ | --------------------------------- | --------------------------------------------------- |
 | `library`          | `src-generated/library`           | no converters - pins what the server actually sends |
 | `libraryConverted` | `src-generated/library-converted` | Luxon, BigNumber, bigint, and `converter-v2-to-v4`  |
+| `libraryRenamed`   | `src-generated/library-renamed`   | `allowRenaming` - the V2 half of the name mapping   |
 
 V2 is where converters earn their keep: the format hands over every timestamp as `/Date(<ticks>)/` and
 every numeric type that does not fit a JS number as a string, so the raw model types all of those as
@@ -66,6 +67,23 @@ covers the wire format, `feature/Converters.test.ts` covers what the converters 
 
 This is the first place converters meet a **running** V2 server at all; `examples/main` covers the
 converted V2 model only against a mock client.
+
+`libraryRenamed` is the V2 half of what `int-test/asp-net` does for V4. Renaming is not version-neutral:
+the mapping between the TypeScript name and the OData one has to survive whatever the client builds, and V2
+builds several of those things differently - a key predicate carries a type prefix (`Books(guid'...')`),
+`$expand` cannot nest query options, a binding goes through `__metadata.uri`, and the payload arrives
+wrapped in `d`. A mapping proven over V4 says nothing about any of that. `feature/Renaming.test.ts` writes
+through the renamed client and reads back through the raw one, which is what shows a value landed under its
+OData name rather than under the TypeScript one.
+
+Two names need help there, the same two as in the V4 metadata since it is the same model: `Location_` (a
+shelf mark) and `Location` (the branch an item sits in) both become `location` under camelCase, so
+`propertiesByName` maps the former to `shelfLocation`; and `Branch` exists in two namespaces, so
+`byTypeAndName` gives the one in `PublisherRegistry` the name `PublisherBranch`.
+
+`enumType` has no counterpart on this side: OData V2 has no enum types at all, and what the V4 model
+declares as the `Amenities` enum is a plain `Edm.Int32` in this metadata. The axis is V4-only, not merely
+untested here.
 
 ## Generation
 

--- a/int-test/olingo-v2/odata2ts.config.ts
+++ b/int-test/olingo-v2/odata2ts.config.ts
@@ -1,4 +1,4 @@
-import { ConfigFileOptions, EmitModes, Modes } from "@odata2ts/odata2ts";
+import { ConfigFileOptions, EmitModes, Modes, TypeModel } from "@odata2ts/odata2ts";
 
 /**
  * Generates the odata2ts client for the "Library" OData V2 test model, as served by the Apache Olingo 2
@@ -28,6 +28,32 @@ const config: ConfigFileOptions = {
       serviceName: "Library",
       source: "resource/library-v2.xml",
       output: "src-generated/library",
+    },
+    /**
+     * The same model a third time, with renaming switched on - the V2 half of what
+     * `int-test/asp-net` does for V4.
+     *
+     * Renaming is not version-neutral, which is why it needs a home on both sides. The mapping between the
+     * TypeScript name and the OData one has to survive whatever the client builds, and V2 builds several of
+     * those things differently: a key predicate carries a type prefix (`Books(guid'…')`), `$expand` cannot
+     * nest query options, and a binding is stated as `__metadata.uri` rather than `@odata.bind`. A mapping
+     * proven over V4 says nothing about any of them.
+     *
+     * Generated separately rather than replacing the raw client, for the same reason as over there: the
+     * point is the mapping, and a mapping is only observable where both name forms are visible at once.
+     * See test/feature/Renaming.test.ts.
+     */
+    libraryRenamed: {
+      serviceName: "LibraryRenamed",
+      source: "resource/library-v2.xml",
+      output: "src-generated/library-renamed",
+      allowRenaming: true,
+      // `Location_` (the shelf mark) and `Location` (the branch an item sits in) both become `location`
+      // under camelCase, and the generator refuses to emit an interface declaring one name twice. The very
+      // same clash as in the V4 metadata, since it is the same model.
+      propertiesByName: [{ name: "Location_", mappedName: "shelfLocation" }],
+      // `Branch` exists in two namespaces here as well
+      byTypeAndName: [{ name: "PublisherRegistry.Branch", type: TypeModel.EntityType, mappedName: "PublisherBranch" }],
     },
     /**
      * The same model a second time, with converters switched on.

--- a/int-test/olingo-v2/test/LibraryRenamedConstants.ts
+++ b/int-test/olingo-v2/test/LibraryRenamedConstants.ts
@@ -1,0 +1,9 @@
+import { LibraryRenamedService } from "../src-generated/library-renamed/LibraryRenamedService.js";
+import { BASE_URL, ODATA_CLIENT } from "./LibraryTestConstants.js";
+
+/**
+ * The very same service, through the client generated with `allowRenaming`. Only `feature/Renaming.test.ts`
+ * uses it - everywhere else the names are the server's own, and having both forms side by side is what makes
+ * the mapping observable at all.
+ */
+export const RENAMED = new LibraryRenamedService(ODATA_CLIENT, BASE_URL);

--- a/int-test/olingo-v2/test/feature/Renaming.test.ts
+++ b/int-test/olingo-v2/test/feature/Renaming.test.ts
@@ -1,0 +1,115 @@
+import { afterAll, describe, expect, expectTypeOf, test } from "vitest";
+import type { Book, Branch, PublisherBranch } from "../../src-generated/library-renamed/LibraryRenamedModel.js";
+import { RENAMED } from "../LibraryRenamedConstants.js";
+import { BASE_URL, BOOK_DER_PROZESS, COPY_KEY, LIBRARY } from "../LibraryTestConstants.js";
+
+/**
+ * `allowRenaming` against a running **V2** server - the other half of what `int-test/asp-net` covers for V4.
+ *
+ * Renaming is not version-neutral, which is why it needs a home on both sides. The option decouples the
+ * TypeScript names from the OData ones - the model reads `title`, the wire still says `Title` - and V2
+ * builds several of the things carrying those names differently: a key predicate takes a type prefix
+ * (`Books(guid'…')`), `$expand` cannot nest query options, a binding is stated through `__metadata.uri`,
+ * and the payload arrives wrapped in `d`. A mapping proven over V4 says nothing about any of that.
+ *
+ * `RENAMED` is the client generated with the option, `LIBRARY` the one whose names are the server's own.
+ * Both are needed: with only the renamed client, a wrongly built URL and a broken mapping look alike.
+ */
+describe("Olingo Library: renaming", () => {
+  const createdBooks: Array<string> = [];
+
+  afterAll(async () => {
+    for (const id of createdBooks) {
+      await LIBRARY.Books(id).delete().execute();
+    }
+  });
+
+  test("the response is read back into the renamed properties", async () => {
+    const result = await RENAMED.books(BOOK_DER_PROZESS).query().execute();
+
+    expect(result.status).toBe(200);
+    // the server sent `Title` and `ISBN`; the model carries them under their renamed names
+    expect(result.data.d.title).toBe("Der Prozess");
+    expect(result.data.d.isbn).toBe("9783150094440");
+
+    expectTypeOf<Book["title"]>().toEqualTypeOf<string>();
+  });
+
+  test("the key predicate keeps the OData names and V2's type prefix", async () => {
+    // The renaming stops at the TypeScript surface. V2 spells a GUID key with a `guid'…'` prefix, which is
+    // built by the very query objects that also carry the renaming - so this is where the two could collide.
+    expect(RENAMED.books(BOOK_DER_PROZESS).getPath()).toBe(`${BASE_URL}/Books(guid'${BOOK_DER_PROZESS}')`);
+    // ... and it is the same URL the un-renamed client builds
+    expect(RENAMED.books(BOOK_DER_PROZESS).getPath()).toBe(LIBRARY.Books(BOOK_DER_PROZESS).getPath());
+
+    // a composite key, where each part has to find its own OData name again
+    expect(RENAMED.copies({ mediumId: COPY_KEY.MediumId, inventoryNumber: COPY_KEY.InventoryNumber }).getPath()).toBe(
+      LIBRARY.Copies(COPY_KEY).getPath(),
+    );
+  });
+
+  test("$select and $filter send the OData names", async () => {
+    const request = RENAMED.books().query((builder, qBook) => builder.select("title").filter(qBook.language.eq("de")));
+
+    const url = decodeURIComponent(request.getUrl());
+    expect(url).toContain("$select=Title");
+    expect(url).toContain("$filter=Language eq 'de'");
+
+    const result = await request.execute();
+    expect(result.status).toBe(200);
+    expect(result.data.d.results.length).toBeGreaterThan(0);
+    // selected, so present - and under the renamed name
+    expect(result.data.d.results[0].title).toBeDefined();
+  });
+
+  test("$expand sends the OData name and reads back renamed", async () => {
+    // V2 cannot nest query options inside `$expand`, so the whole related entity comes back - which makes
+    // this the case where the renaming has to hold for every property of the expanded model, not just one.
+    const request = RENAMED.books(BOOK_DER_PROZESS).query((builder) => builder.expand("publisher"));
+
+    expect(decodeURIComponent(request.getUrl())).toContain("$expand=Publisher");
+
+    const result = await request.execute();
+    expect(result.data.d.publisher).toBeDefined();
+    expect((result.data.d.publisher as { name: string }).name).toBeDefined();
+  });
+
+  test("a payload is written with the OData names", async () => {
+    const created = await RENAMED.books()
+      .create({ title: "V2 Renaming Round Trip", isbn: "9780000000001", language: "de" })
+      .execute();
+
+    expect(created.status).toBe(201);
+    const id = created.data.d.id;
+    createdBooks.push(id);
+
+    // read back through the raw client: shows the values landed under their OData names on the server, and
+    // are not merely an artefact of the renamed client talking to itself
+    const raw = (await LIBRARY.Books(id).query().execute()).data.d;
+    expect(raw.Title).toBe("V2 Renaming Round Trip");
+    expect(raw.ISBN).toBe("9780000000001");
+  });
+
+  test("two OData names which camelCase would collapse stay apart", async () => {
+    // `Location_` is the shelf mark, `Location` the branch an item sits in - both would be `location`.
+    // `propertiesByName` maps the former to `shelfLocation`, and each still has to reach its own OData name.
+    const key = { mediumId: COPY_KEY.MediumId, inventoryNumber: COPY_KEY.InventoryNumber };
+    const copy = RENAMED.copies(key);
+
+    expect(decodeURIComponent(copy.query((b) => b.select("shelfLocation")).getUrl())).toContain("$select=Location_");
+    expect(decodeURIComponent(copy.query((b) => b.expand("location")).getUrl())).toContain("$expand=Location");
+
+    // the seeded value, read through both clients - the same server field, two different names
+    const renamed = (await copy.query().execute()).data.d;
+    const raw = (await LIBRARY.Copies(COPY_KEY).query().execute()).data.d;
+    expect(renamed.shelfLocation).toBe(raw.Location_);
+    expect(renamed.shelfLocation).toBeDefined();
+  });
+
+  test("a type renamed by hand keeps its own identity", () => {
+    // `Branch` exists in two namespaces; `byTypeAndName` gives the one in PublisherRegistry a name of its
+    // own. Purely a generator concern - nothing about it reaches the wire, so this is a type-level check.
+    expectTypeOf<PublisherBranch>().not.toEqualTypeOf<Branch>();
+    expectTypeOf<PublisherBranch["city"]>().toEqualTypeOf<string | null>();
+  });
+});


### PR DESCRIPTION
The V2 half of the name mapping, which `int-test/asp-net` covers for V4.

- renaming is not version-neutral, so it needs a home on both sides: V2 spells a key predicate with a type prefix (`Books(guid'…')`), cannot nest query options inside `$expand`, states a binding through `__metadata.uri` and wraps the payload in `d` — a mapping proven over V4 says nothing about any of that
- the model is generated a third time with `allowRenaming`, alongside the raw and the converted client; `test/feature/Renaming.test.ts` is the only file using it
- it writes through the renamed client and reads back through the raw one, which is what shows a value landed under its OData name rather than under the TypeScript one
- both rename options are in use against the very same clashes the V4 metadata has, since it is the same model: `Location_` → `shelfLocation`, `PublisherRegistry.Branch` → `PublisherBranch`
- `enumType` gets no counterpart here, and not for lack of trying: OData V2 has no enum types at all, and what the V4 model declares as the `Amenities` enum is a plain `Edm.Int32` in this metadata. The axis is V4-only rather than untested on this side — recorded in the README so it does not get re-opened
- verified: olingo-v2 96/96 against its container, `test-compile` green, `prettier --check .` green

One thing the tests avoid on purpose: writing to `Copies`. That entity carries a concurrency token here and a write is refused — a property of this server, not of the renaming — so the write assertions go through `Books`, and the `Location_`/`Location` split is pinned by reading the seeded copy through both clients plus the URLs the query objects build.
