### PR TITLE
test(cli): cover config discovery, service selection and --source-url

### DIFF
--- a/int-test/README.md
+++ b/int-test/README.md
@@ -2,7 +2,8 @@
 
 This folder contains integration tests in general. Some are static like:
 
-- cli: Testing the CLI
+- cli: Testing the CLI - argument parsing, config discovery and precedence, the service selection,
+  and `--source-url` against a local HTTP server
 - ts-floor-check: Testing that the minimum TS Version promise holds
 - config-variants: Compile gate for the configuration surface - generates the model under a set of
   configurations and type-checks the result

--- a/int-test/cli/README.md
+++ b/int-test/cli/README.md
@@ -1,0 +1,41 @@
+# Integration Tests: CLI
+
+End-to-end tests of the compiled CLI binary. Every case spawns `packages/odata2ts/lib/run-cli.js` as a real
+subprocess - resolved through the actual workspace dependency, so it is the same artefact an npm consumer
+runs - and judges it by its exit code, its output and the files it leaves behind.
+
+```bash
+yarn workspace @odata2ts/cli test
+```
+
+No server and no Docker: what is under test is the generation **run**, not the generated code.
+
+## What belongs here, and what does not
+
+The dividing line is whether a thing is observable without looking at the emitted TypeScript. Argument
+parsing, config-file discovery, precedence between the two, the service selection, exit codes and error
+messages all are. What an option does to the generated code is not - that is the business of the generator
+unit tests in `packages/odata2ts/test/generator` and of the compile gate in `int-test/config-variants`.
+
+The one deliberate exception is `debug`, in `config-file.test.ts`: it decides whether every emitted file
+opens with `@ts-nocheck`, and that is worth pinning here because it is the reason every other generating
+test configuration in this repository switches the option on. A type check over output which has exempted
+itself from type checking proves nothing.
+
+## The files
+
+| File                  | Covers                                                                                |
+| --------------------- | ------------------------------------------------------------------------------------- |
+| `run-cli.test.ts`     | the bare invocation: missing arguments, a missing source file, output folder creation |
+| `config-file.test.ts` | config discovery, the service selection, and what wins when both sides say something  |
+| `source-url.test.ts`  | `--source-url` and `--refresh-file` against a local HTTP server which counts requests |
+
+`config-file.test.ts` runs the binary inside `test/fixture/multi-service` and `test/fixture/single-service`,
+because the CLI searches upwards from the working directory for its config file. Those fixture configs are
+deliberately untyped: they are loaded by the CLI's own TypeScript loader from outside the workspace
+resolution, so they cannot import from `@odata2ts/odata2ts`.
+
+`source-url.test.ts` serves metadata from a throwaway `node:http` server and asserts the _requests_ it
+receives. That is the only way to tell the interesting cases apart: a download which silently re-fetches on
+every run and one which correctly uses the stored file look identical from the outside, and so do a refresh
+which happened and one which did not.

--- a/int-test/cli/test/config-file.test.ts
+++ b/int-test/cli/test/config-file.test.ts
@@ -1,0 +1,126 @@
+import { exec } from "child_process";
+import { readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { rimraf } from "rimraf";
+import { afterEach, describe, expect, test } from "vitest";
+
+// Resolves the actually compiled CLI entrypoint via the real (workspace-linked) dependency, so this test
+// exercises the same artefact a real npm consumer runs.
+const CLI_BIN = createRequire(import.meta.url).resolve("@odata2ts/odata2ts/lib/run-cli.js");
+
+const FIXTURE_DIR = path.join(import.meta.dirname, "fixture");
+const MULTI_SERVICE = path.join(FIXTURE_DIR, "multi-service");
+const SINGLE_SERVICE = path.join(FIXTURE_DIR, "single-service");
+const DUMMY_SOURCE = path.join(FIXTURE_DIR, "dummy.xml");
+
+/**
+ * How the CLI arrives at what it generates: the config file it discovers, the arguments which override it,
+ * and the service selection.
+ *
+ * This is the generation *run*, not the generated code - nothing here asserts anything about the emitted
+ * TypeScript beyond whether a file was produced at all. What the options do to the output belongs to the
+ * generator tests and to `int-test/config-variants`.
+ *
+ * The CLI finds its config file by searching upwards from the working directory, so every case runs the
+ * binary in a fixture directory of its own.
+ */
+describe("Config File Test", () => {
+  afterEach(async () => {
+    await Promise.all([rimraf(path.join(MULTI_SERVICE, "build")), rimraf(path.join(SINGLE_SERVICE, "build"))]);
+  });
+
+  test("without arguments every configured service is generated", async () => {
+    const result = await runCli([], MULTI_SERVICE);
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("Loaded config file:");
+    await expectGenerated(MULTI_SERVICE, "build/alpha/AlphaService.ts");
+    await expectGenerated(MULTI_SERVICE, "build/beta/BetaService.ts");
+  });
+
+  test("naming a service restricts the run to it", async () => {
+    const result = await runCli(["beta"], MULTI_SERVICE);
+
+    expect(result.code).toBe(0);
+    await expectGenerated(MULTI_SERVICE, "build/beta/BetaService.ts");
+    await expectNotGenerated(MULTI_SERVICE, "build/alpha");
+  });
+
+  test("naming several services restricts the run to those", async () => {
+    const result = await runCli(["alpha", "beta"], MULTI_SERVICE);
+
+    expect(result.code).toBe(0);
+    await expectGenerated(MULTI_SERVICE, "build/alpha/AlphaService.ts");
+    await expectGenerated(MULTI_SERVICE, "build/beta/BetaService.ts");
+  });
+
+  test("an unknown service name is refused, and the message names it", async () => {
+    const result = await runCli(["gamma"], MULTI_SERVICE);
+
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain("gamma");
+    expect(result.stderr).toContain("doesn't exist in configuration");
+    await expectNotGenerated(MULTI_SERVICE, "build");
+  });
+
+  test("--source and --output replace the configured services rather than overriding them", async () => {
+    // Not a precedence rule but a consequence of what the two options mean: a source and an output describe
+    // exactly one service, so there is nothing to merge them into. The configured services drop out
+    // entirely and only the file's base settings survive - which is why this asserts that the configured
+    // output stays *absent*, not merely that the one from the command line appears.
+    const result = await runCli(
+      ["-s", DUMMY_SOURCE, "-o", "build/from-cli", "--service-name", "FromCli"],
+      SINGLE_SERVICE,
+    );
+
+    expect(result.code).toBe(0);
+    await expectGenerated(SINGLE_SERVICE, "build/from-cli/FromCliService.ts");
+    await expectNotGenerated(SINGLE_SERVICE, "build/from-config");
+  });
+
+  test("a config file without services demands --source and --output", async () => {
+    // ... and says so, rather than generating nothing and exiting cleanly
+    const result = await runCli([], FIXTURE_DIR);
+
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain("--source");
+    expect(result.stderr).toContain("--output");
+  });
+
+  test("debug decides whether the emitted code exempts itself from type checking", async () => {
+    // The one place `debug: false` is deliberate. Without the option every generated file opens with
+    // `@ts-nocheck`, which makes a type check over that output meaningless - the reason every other
+    // generating test configuration in this repository switches it on.
+    await runCli(["-s", DUMMY_SOURCE, "-o", "build/quiet", "--service-name", "Quiet"], SINGLE_SERVICE);
+    const quiet = await readFile(path.join(SINGLE_SERVICE, "build/quiet/QuietService.ts"), "utf-8");
+    expect(quiet).toContain("@ts-nocheck");
+
+    await runCli(["-s", DUMMY_SOURCE, "-o", "build/loud", "--service-name", "Loud", "-d"], SINGLE_SERVICE);
+    const loud = await readFile(path.join(SINGLE_SERVICE, "build/loud/LoudService.ts"), "utf-8");
+    expect(loud).not.toContain("@ts-nocheck");
+  });
+});
+
+async function expectGenerated(cwd: string, relativePath: string) {
+  const content = await readFile(path.join(cwd, relativePath), "utf-8");
+  expect(content.length).toBeGreaterThan(0);
+}
+
+async function expectNotGenerated(cwd: string, relativePath: string) {
+  await expect(readFile(path.join(cwd, relativePath), "utf-8")).rejects.toThrow();
+}
+
+interface CliResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runCli(args: Array<string>, cwd: string): Promise<CliResult> {
+  return new Promise((resolve) => {
+    exec(`node ${CLI_BIN} ${args.join(" ")}`, { cwd }, (error, stdout, stderr) => {
+      resolve({ code: error && error.code ? error.code : 0, stdout, stderr });
+    });
+  });
+}

--- a/int-test/cli/test/fixture/multi-service/odata2ts.config.ts
+++ b/int-test/cli/test/fixture/multi-service/odata2ts.config.ts
@@ -1,0 +1,12 @@
+/**
+ * Two services, so a run without arguments has to produce both and a run naming one has to produce only
+ * that one. Typed loosely on purpose: this file is loaded by the CLI's own TypeScript loader from a
+ * directory outside the workspace resolution, so it must not import from `@odata2ts/odata2ts`.
+ */
+export default {
+  emitMode: "ts",
+  services: {
+    alpha: { serviceName: "Alpha", source: "../dummy.xml", output: "build/alpha" },
+    beta: { serviceName: "Beta", source: "../dummy.xml", output: "build/beta" },
+  },
+};

--- a/int-test/cli/test/fixture/multi-service/tsconfig.json
+++ b/int-test/cli/test/fixture/multi-service/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES2016",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true
+  }
+}

--- a/int-test/cli/test/fixture/single-service/odata2ts.config.ts
+++ b/int-test/cli/test/fixture/single-service/odata2ts.config.ts
@@ -1,0 +1,7 @@
+/** One service, used to show that a CLI argument takes precedence over what this file says. */
+export default {
+  emitMode: "ts",
+  services: {
+    only: { serviceName: "FromConfig", source: "../dummy.xml", output: "build/from-config" },
+  },
+};

--- a/int-test/cli/test/fixture/single-service/tsconfig.json
+++ b/int-test/cli/test/fixture/single-service/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES2016",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true
+  }
+}

--- a/int-test/cli/test/source-url.test.ts
+++ b/int-test/cli/test/source-url.test.ts
@@ -1,0 +1,149 @@
+import { exec } from "child_process";
+import { readFile, writeFile } from "node:fs/promises";
+import { createServer, Server } from "node:http";
+import { createRequire } from "node:module";
+import { AddressInfo } from "node:net";
+import path from "node:path";
+import { mkdirp } from "mkdirp";
+import { rimraf } from "rimraf";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "vitest";
+
+const CLI_BIN = createRequire(import.meta.url).resolve("@odata2ts/odata2ts/lib/run-cli.js");
+const WORK_DIR = path.join(import.meta.dirname, "..", "build", "source-url");
+
+/**
+ * `sourceUrl` and `refreshFile`: fetching the metadata instead of reading it from disk.
+ *
+ * Both belong to the generation *run* rather than to the generated code, and both are easy to get subtly
+ * wrong in ways nothing else would notice - a download which silently re-fetches on every run, or one which
+ * never refreshes although asked to. So this drives the real binary against a real HTTP server, counting
+ * the requests it receives.
+ */
+describe("Source URL Test", () => {
+  /** Served metadata, distinguishable from what a previous run may have stored. */
+  const remoteMetadata = (serviceName: string) => `<?xml version="1.0" encoding="utf-8" ?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="${serviceName}" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="Item">
+        <Key><PropertyRef Name="id" /></Key>
+        <Property Name="id" Type="Edm.Int32" Nullable="false" />
+      </EntityType>
+      <EntityContainer Name="Container">
+        <EntitySet Name="Items" EntityType="${serviceName}.Item" />
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>`;
+
+  let server: Server;
+  let baseUrl: string;
+  let requestedPaths: Array<string>;
+  let servedServiceName: string;
+
+  beforeAll(async () => {
+    requestedPaths = [];
+    servedServiceName = "Remote";
+    server = createServer((req, res) => {
+      requestedPaths.push(req.url ?? "");
+      res.writeHead(200, { "Content-Type": "application/xml" });
+      res.end(remoteMetadata(servedServiceName));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await rimraf(WORK_DIR);
+  });
+
+  afterEach(async () => {
+    requestedPaths = [];
+    servedServiceName = "Remote";
+    await rimraf(WORK_DIR);
+  });
+
+  test("the metadata is downloaded, stored at --source and generated from", async () => {
+    const source = path.join(WORK_DIR, "downloaded.xml");
+    const result = await runCli(["-u", baseUrl, "-s", source, "-o", path.join(WORK_DIR, "gen"), "-e", "ts"]);
+
+    expect(result.code).toBe(0);
+    // `$metadata` is appended by the generator - the option takes the service root
+    expect(requestedPaths).toStrictEqual(["/$metadata"]);
+
+    // stored on disk, which is what makes the next run offline
+    expect(await readFile(source, "utf-8")).toContain('Namespace="Remote"');
+    expect(await readFile(path.join(WORK_DIR, "gen", "RemoteService.ts"), "utf-8")).toContain("class RemoteService");
+  });
+
+  test("an existing file is used as it is, without asking the server again", async () => {
+    const source = path.join(WORK_DIR, "existing.xml");
+    await mkdirp(WORK_DIR);
+    await writeFile(source, remoteMetadata("Local"), "utf-8");
+
+    // the server would answer with something else entirely, so a re-fetch could not go unnoticed
+    servedServiceName = "Remote";
+    const result = await runCli(["-u", baseUrl, "-s", source, "-o", path.join(WORK_DIR, "gen"), "-e", "ts"]);
+
+    expect(result.code).toBe(0);
+    expect(requestedPaths).toStrictEqual([]);
+    expect(await readFile(source, "utf-8")).toContain('Namespace="Local"');
+    expect(await readFile(path.join(WORK_DIR, "gen", "LocalService.ts"), "utf-8")).toContain("class LocalService");
+  });
+
+  test("--refresh-file overwrites the existing file", async () => {
+    const source = path.join(WORK_DIR, "stale.xml");
+    await mkdirp(WORK_DIR);
+    await writeFile(source, remoteMetadata("Local"), "utf-8");
+
+    const result = await runCli([
+      "-u",
+      baseUrl,
+      "-s",
+      source,
+      "-o",
+      path.join(WORK_DIR, "gen"),
+      "-e",
+      "ts",
+      "--refresh-file",
+    ]);
+
+    expect(result.code).toBe(0);
+    expect(requestedPaths).toStrictEqual(["/$metadata"]);
+    // the stale content is gone, and the generation used the fresh one
+    expect(await readFile(source, "utf-8")).toContain('Namespace="Remote"');
+    expect(await readFile(path.join(WORK_DIR, "gen", "RemoteService.ts"), "utf-8")).toContain("class RemoteService");
+  });
+
+  test("a URL already ending in $metadata is not given a second one", async () => {
+    const source = path.join(WORK_DIR, "explicit.xml");
+    const result = await runCli([
+      "-u",
+      `${baseUrl}/$metadata`,
+      "-s",
+      source,
+      "-o",
+      path.join(WORK_DIR, "gen"),
+      "-e",
+      "ts",
+    ]);
+
+    expect(result.code).toBe(0);
+    expect(requestedPaths).toStrictEqual(["/$metadata"]);
+  });
+});
+
+interface CliResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runCli(args: Array<string>): Promise<CliResult> {
+  return new Promise((resolve) => {
+    exec(`node ${CLI_BIN} ${args.join(" ")}`, (error, stdout, stderr) => {
+      resolve({ code: error && error.code ? error.code : 0, stdout, stderr });
+    });
+  });
+}


### PR DESCRIPTION
The CLI package covered the bare invocation — missing arguments, a missing source file, output folder creation — and nothing of how the CLI actually arrives at what it generates. That is a class of its own: all of it is observable without looking at a single line of emitted TypeScript, and none of it was tested anywhere.

- `config-file.test.ts` runs the binary inside fixture directories, since the config file is found by searching upwards from the working directory
- pins that a run without arguments generates every configured service, that naming one restricts the run to it, that naming several works, and that an unknown name is refused with a message saying which
- pins what `--source` plus `--output` do: they **replace** the configured services rather than overriding them. That follows from what the two options mean — a source and an output describe exactly one service, so there is nothing to merge them into — which is why the test asserts the configured output stays *absent*, not merely that the one from the command line appears
- pins `debug`, the one place where `false` is deliberate: without the option every emitted file opens with `@ts-nocheck`, which is precisely why every other generating test configuration in this repository switches it on
- `source-url.test.ts` drives `--source-url` and `--refresh-file` against a throwaway `node:http` server and asserts the **requests** it receives. Nothing else can tell the interesting cases apart: a download which silently re-fetches on every run looks exactly like one which correctly uses the stored file, and a refresh which happened looks exactly like one which did not
- also covers that `$metadata` is appended to a service root but not to a URL which already ends in it
- a README for the package, drawing the line between what belongs here and what belongs to the generator tests or to `int-test/config-variants`

The fixture configs are deliberately untyped: they are loaded by the CLI's own TypeScript loader from outside the workspace resolution, so they cannot import from `@odata2ts/odata2ts`.

Verified: 17 tests in the package (was 6), `test-compile` green, `prettier --check .` green.
