### PR TITLE
fix(odata-service): declare the OData version on reads as well

### DIFF
--- a/examples/main/test/trippinV401/ODataVersion.test.ts
+++ b/examples/main/test/trippinV401/ODataVersion.test.ts
@@ -51,11 +51,14 @@ describe("Testing OData 4.01 generation of TrippinService", () => {
     expect(ODATA_CLIENT.additionalHeaders?.["OData-Version"]).toBe("4.01");
   });
 
-  test("no version is declared without a request body", async () => {
+  test("a read declares version 4.01 as well", async () => {
+    // The header governs the shape of the *response* as much as it governs how a payload is read: a
+    // service answering a 4.0 request uses the prefixed control information, while this client is typed
+    // for the short form. Declaring the version only on writes left that promise unkept on every GET.
     await TRIPPIN.people().query().execute();
 
     expect(ODATA_CLIENT.lastOperation).toBe("GET");
-    expect(ODATA_CLIENT.additionalHeaders?.["OData-Version"]).toBeUndefined();
+    expect(ODATA_CLIENT.additionalHeaders?.["OData-Version"]).toBe("4.01");
   });
 
   test("the type control info of a payload uses the short form", async () => {

--- a/int-test/asp-net/README.md
+++ b/int-test/asp-net/README.md
@@ -79,6 +79,25 @@ anything if a real server resolves it.
 only being type-checked. Models are therefore imported from their namespace barrel
 (`src-generated/library/library-catalog/index.js`), not from one bundled model file.
 
+### The 4.01 client
+
+`src-generated/library-401` is the model once more with `odataVersionV4: "4.01"`. Unlike
+`enableNativeInOperator`, this axis cannot be split across the two V4 packages - CAP does not speak 4.01, so
+this server is the only place it can be held against anything. It is additive rather than a replacement,
+which is what the difference needs anyway: the point is that the two versions spell the same request
+differently, and that is only visible with both clients present.
+
+Everything the option changes is payload, so a type check sees none of it. `feature/ODataVersion401.test.ts`
+asserts the binding notation on the query object itself (`Location: {"@id": …}` against
+`"Location@odata.bind": …`), because this is the one difference a server would swallow either way: ASP.NET
+accepts both, so a client emitting the 4.0 spelling while announcing 4.01 would pass every behavioural test.
+
+It also pins a limitation. odata2ts announces the version through `OData-Version`, a header on requests
+carrying a body - and a GET carries none. This server therefore answers read requests in 4.0 form, so the
+short-form control information a 4.01 client is _typed_ for (`@count`) arrives undefined while the value
+sits under `@odata.count`. The response typing of `odataVersionV4: "4.01"` is a promise this server does not
+keep on reads.
+
 ### The renamed client
 
 The model is generated a **second** time, into `src-generated/library-renamed`, with `allowRenaming` on.

--- a/int-test/asp-net/odata2ts.config.ts
+++ b/int-test/asp-net/odata2ts.config.ts
@@ -40,6 +40,26 @@ const config: ConfigFileOptions = {
       output: "src-generated/library",
     },
     /**
+     * The same model once more, targeting OData 4.01 instead of the default 4.0.
+     *
+     * Not distributed across the two V4 packages the way `enableNativeInOperator` is, because it cannot be:
+     * CAP does not speak 4.01, so this server is the only place the option can be held against anything.
+     * Hence additive, next to the 4.0 client rather than instead of it - which is what the version
+     * difference needs anyway, since the whole point is that the two spell the same request differently.
+     *
+     * What changes: a binding loses its own property name and shares one with a deep insert
+     * (`{"@id": key}` instead of `Nav@odata.bind`), the control information in a response drops the
+     * `odata.` prefix (`@count` rather than `@odata.count`), and requests carrying a body announce
+     * `OData-Version: 4.01`. All three are payload, so none of them is visible to a type check.
+     * See test/feature/ODataVersion401.test.ts.
+     */
+    library401: {
+      serviceName: "Library401",
+      source: "resource/library.xml",
+      output: "src-generated/library-401",
+      odataVersionV4: "4.01",
+    },
+    /**
      * The same model a second time, with renaming switched on.
      *
      * Generated separately rather than replacing the raw client, because the point is the *mapping* between

--- a/int-test/asp-net/test/Library401Constants.ts
+++ b/int-test/asp-net/test/Library401Constants.ts
@@ -1,0 +1,9 @@
+import { Library401Service } from "../src-generated/library-401/Library401Service.js";
+import { BASE_URL, ODATA_CLIENT } from "./LibraryTestConstants.js";
+
+/**
+ * The very same service, through the client generated with `odataVersionV4: "4.01"`. Only
+ * `feature/ODataVersion401.test.ts` uses it - the difference to the default 4.0 client is entirely in the
+ * payloads, so it is only observable next to that one.
+ */
+export const LIBRARY_401 = new Library401Service(ODATA_CLIENT, BASE_URL);

--- a/int-test/asp-net/test/feature/Binding.test.ts
+++ b/int-test/asp-net/test/feature/Binding.test.ts
@@ -116,7 +116,8 @@ describe("ASP.NET Library: binding existing entities", () => {
   test("the server honours the 4.01 notation as well", async () => {
     // Sent by hand: a client generated for 4.0 emits `Nav@odata.bind`. The point is the server side -
     // both notations have to move the link, otherwise a client generated with `odataVersionV4: "4.01"`
-    // would fail against it, silently.
+    // would fail against it, silently. That client now exists; what it emits, and that this server takes
+    // it, is `feature/ODataVersion401.test.ts`. This case stays because it isolates the server half.
     const response = await fetch(`${BASE_URL}/Copies`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/int-test/asp-net/test/feature/ODataVersion401.test.ts
+++ b/int-test/asp-net/test/feature/ODataVersion401.test.ts
@@ -1,0 +1,94 @@
+import { afterAll, describe, expect, expectTypeOf, test } from "vitest";
+import { qCopy } from "../../src-generated/library-401/library-circulation/copy/QCopy.js";
+import { qCopy as qCopy40 } from "../../src-generated/library/library-circulation/copy/QCopy.js";
+import { LIBRARY_401 } from "../Library401Constants.js";
+import { BOOK_DER_PROZESS, BRANCH_CENTRAL, LIBRARY } from "../LibraryTestConstants.js";
+
+/**
+ * `odataVersionV4: "4.01"` - the same model, targeting the newer minor version.
+ *
+ * Unlike `enableNativeInOperator`, this axis cannot be split across the two V4 packages: CAP does not speak
+ * 4.01, so this server is the only place it can be held against anything at all. It is therefore additive,
+ * a client next to the 4.0 one rather than instead of it - which is what the difference needs anyway, since
+ * the whole point is that the two spell the same thing differently.
+ *
+ * Everything the option changes is payload, so a type check sees none of it:
+ *
+ * - a binding loses its own property name (`Location@odata.bind` becomes `Location: {"@id": …}`)
+ * - control information in a response drops the prefix (`@odata.count` becomes `@count`)
+ *
+ * `Binding.test.ts` already showed that this server *accepts* the 4.01 spelling, by sending one by hand -
+ * a 4.0 client cannot produce it. What was missing is the other half: that odata2ts actually emits it.
+ */
+describe("ASP.NET Library: OData 4.01", () => {
+  const BOUND_BY_401_CLIENT = 4201;
+  const copyKey = (inventoryNumber: number) => ({ MediumId: BOOK_DER_PROZESS, InventoryNumber: inventoryNumber });
+
+  afterAll(async () => {
+    await LIBRARY_401.Copies(copyKey(BOUND_BY_401_CLIENT)).delete().execute();
+  });
+
+  test("the two versions spell a binding differently", () => {
+    // Asserted on the query object rather than through a request, because this is the one difference which
+    // a server would happily swallow either way: ASP.NET accepts both notations, so a client emitting the
+    // 4.0 one while announcing 4.01 would pass every behavioural test.
+    const payload = { Location: { "@id": BRANCH_CENTRAL } };
+
+    const as401 = qCopy.convertToOData(payload);
+    const as40 = qCopy40.convertToOData(payload);
+
+    // 4.01: the navigation property itself carries the reference
+    expect(as401).toStrictEqual({ Location: { "@id": "Branches(1)" } });
+    // 4.0: a property of its own, and the URL rather than an object
+    expect(as40).toStrictEqual({ "Location@odata.bind": "Branches(1)" });
+  });
+
+  test("a binding written by the 4.01 client is honoured by the server", async () => {
+    const created = await LIBRARY_401.Copies()
+      .create({
+        MediumId: BOOK_DER_PROZESS,
+        InventoryNumber: BOUND_BY_401_CLIENT,
+        Condition: 1,
+        IsLoanable: true,
+        WeightKg: 0.4,
+        Location: { "@id": BRANCH_CENTRAL },
+      })
+      .execute();
+
+    expect(created.status).toBe(201);
+
+    // read the link back through the 4.0 client: the same server row, reached the ordinary way
+    const location = await LIBRARY.Copies(copyKey(BOUND_BY_401_CLIENT)).Location().query().execute();
+    expect(location.data.Id).toBe(BRANCH_CENTRAL);
+    expect(location.data.Name).toBe("Central Library");
+  });
+
+  test("the response model uses the short form of the control information", async () => {
+    const result = await LIBRARY_401.Media()
+      .query((builder) => builder.count().top(0))
+      .execute();
+
+    expect(result.status).toBe(200);
+
+    // The typing follows the configured version, so this is what a caller has to reach for ...
+    expectTypeOf(result.data["@count"]).toEqualTypeOf<number | undefined>();
+    // ... and the 4.0 client's spelling is not part of that type at all
+    // @ts-expect-error - "@odata.count" does not exist on a 4.01 response model
+    result.data["@odata.count"];
+  });
+
+  test("what this server actually sends back is the 4.0 spelling", async () => {
+    // The finding, and the reason the test above only pins the *typing*: odata2ts announces the version
+    // through `OData-Version` on requests carrying a body, and a GET carries none. ASP.NET therefore
+    // answers in 4.0 form, so the short-form property a 4.01 client is typed for arrives undefined while
+    // the count sits under the prefixed name. Asserted rather than dropped, because it means the response
+    // typing of `odataVersionV4: "4.01"` is a promise this server does not keep on read requests.
+    const result = await LIBRARY_401.Media()
+      .query((builder) => builder.count().top(0))
+      .execute();
+
+    const asReceived = result.data as unknown as Record<string, unknown>;
+    expect(asReceived["@odata.count"]).toBeDefined();
+    expect(asReceived["@count"]).toBeUndefined();
+  });
+});

--- a/int-test/asp-net/test/feature/ODataVersion401.test.ts
+++ b/int-test/asp-net/test/feature/ODataVersion401.test.ts
@@ -63,32 +63,35 @@ describe("ASP.NET Library: OData 4.01", () => {
     expect(location.data.Name).toBe("Central Library");
   });
 
-  test("the response model uses the short form of the control information", async () => {
+  test("the response carries the short form of the control information, as typed", async () => {
     const result = await LIBRARY_401.Media()
       .query((builder) => builder.count().top(0))
       .execute();
 
     expect(result.status).toBe(200);
 
-    // The typing follows the configured version, so this is what a caller has to reach for ...
+    // The typing follows the configured version ...
     expectTypeOf(result.data["@count"]).toEqualTypeOf<number | undefined>();
     // ... and the 4.0 client's spelling is not part of that type at all
     // @ts-expect-error - "@odata.count" does not exist on a 4.01 response model
     result.data["@odata.count"];
+
+    // ... and so does what actually arrives. Which is the whole reason a GET has to declare the version
+    // too: the header governs the *response* shape as much as it governs how a payload is read, and until
+    // it was sent on reads this server answered in 4.0 form while the client was typed for 4.01.
+    const asReceived = result.data as unknown as Record<string, unknown>;
+    expect(asReceived["@count"]).toBeDefined();
+    expect(asReceived["@odata.count"]).toBeUndefined();
+    expect(result.data["@count"]).toBeGreaterThan(0);
   });
 
-  test("what this server actually sends back is the 4.0 spelling", async () => {
-    // The finding, and the reason the test above only pins the *typing*: odata2ts announces the version
-    // through `OData-Version` on requests carrying a body, and a GET carries none. ASP.NET therefore
-    // answers in 4.0 form, so the short-form property a 4.01 client is typed for arrives undefined while
-    // the count sits under the prefixed name. Asserted rather than dropped, because it means the response
-    // typing of `odataVersionV4: "4.01"` is a promise this server does not keep on read requests.
-    const result = await LIBRARY_401.Media()
+  test("the 4.0 client is unaffected and keeps the prefixed form", async () => {
+    // The counter-sample: the version header is only declared where it was configured, so a client on the
+    // default keeps talking 4.0 and reading the prefixed control information.
+    const result = await LIBRARY.Media()
       .query((builder) => builder.count().top(0))
       .execute();
 
-    const asReceived = result.data as unknown as Record<string, unknown>;
-    expect(asReceived["@odata.count"]).toBeDefined();
-    expect(asReceived["@count"]).toBeUndefined();
+    expect(Number(result.data["@odata.count"])).toBeGreaterThan(0);
   });
 });

--- a/packages/odata-service/src/RequestHeaders.ts
+++ b/packages/odata-service/src/RequestHeaders.ts
@@ -8,10 +8,16 @@ export const BIG_NUMBERS_HEADERS = { Accept: BIG_NUMBER_FORMAT, "Content-Type": 
 export const MERGE_HEADERS = { "X-Http-Method": "MERGE" };
 
 /**
- * The OData version declared for V4 services, which is only done on requests carrying a body: the
- * OData-Version header governs how the service interprets the request payload. It is what makes the
- * notations we generate valid, e.g. `@odata.bind`, which clients must not use when declaring 4.01
- * (see OData JSON Format v4.01, chap. 8.5).
+ * The OData version declared for V4 services.
+ *
+ * On a request carrying a body the header governs how the service interprets that payload. It is what
+ * makes the notations we generate valid, e.g. `@odata.bind`, which clients must not use when declaring
+ * 4.01 (see OData JSON Format v4.01, chap. 8.5).
+ *
+ * It governs the *response* just as much, which is why a configured version is declared on reads as well:
+ * a service answering a 4.0 request uses the prefixed control information (`@odata.count`), and a client
+ * generated for 4.01 is typed for the short form (`@count`). Announcing the version only on writes left
+ * that promise unkept on every GET.
  *
  * Defaults to 4.0, the more widely deployed and the more compatible version. The generator sets 4.01
  * on the main service, if configured accordingly.

--- a/packages/odata-service/src/ServiceStateHelper.ts
+++ b/packages/odata-service/src/ServiceStateHelper.ts
@@ -20,11 +20,21 @@ export class ServiceStateHelper<out ClientType extends ODataHttpClient, V extend
   };
 
   public getDefaultHeaders = () => {
-    return this.options.bigNumbersAsString ? BIG_NUMBERS_HEADERS : DEFAULT_HEADERS;
+    const base = this.options.bigNumbersAsString ? BIG_NUMBERS_HEADERS : DEFAULT_HEADERS;
+    // An explicitly configured version is announced on every request, reads included: it governs how the
+    // service answers just as much as how it reads a payload, and a response in the other version's shape
+    // is precisely what the generated response models cannot describe.
+    //
+    // Only when it was configured, though. This helper is shared with V2, where the option is never set and
+    // an `OData-Version: 4.x` header would be plainly wrong - and it cannot tell that case apart from a V4
+    // service left on the 4.0 default, since the generator writes the option only for 4.01.
+    return this.options.odataVersionV4 ? { ...base, ...getODataVersionHeaders(this.options.odataVersionV4) } : base;
   };
 
   /**
-   * Only to be added to requests carrying a body, see {@link getODataVersionHeaders}.
+   * The version declared on requests which carry a body, where it governs how the service reads the payload
+   * - see {@link getODataVersionHeaders}. Unlike {@link getDefaultHeaders} this falls back to 4.0, so a V4
+   * request with a body always states a version.
    */
   public getVersionHeaders = () => {
     return getODataVersionHeaders(this.options.odataVersionV4);

--- a/packages/odata-service/test/ServiceStateHelper.test.ts
+++ b/packages/odata-service/test/ServiceStateHelper.test.ts
@@ -37,6 +37,39 @@ describe("ServiceStateHelper tests", () => {
     ).toStrictEqual(BIG_NUMBERS_HEADERS);
   });
 
+  test("getDefaultHeaders: a configured version is announced on every request", () => {
+    // Reads included, and that is the point: the version governs the shape of the *response* as well, so a
+    // client generated for 4.01 has to declare it on a GET too - otherwise the service answers in 4.0 form
+    // and the short-form control information the generated response models are typed for never arrives.
+    expect(
+      new ServiceStateHelper(client, "base", "name", { odataVersionV4: "4.01" }).getDefaultHeaders(),
+    ).toStrictEqual({ ...DEFAULT_HEADERS, "OData-Version": "4.01" });
+    expect(
+      new ServiceStateHelper(client, "base", "name", {
+        odataVersionV4: "4.01",
+        bigNumbersAsString: true,
+      }).getDefaultHeaders(),
+    ).toStrictEqual({ ...BIG_NUMBERS_HEADERS, "OData-Version": "4.01" });
+  });
+
+  test("getDefaultHeaders: nothing is announced where no version was configured", () => {
+    // This helper is shared with V2, where an `OData-Version: 4.x` header would be plainly wrong - and it
+    // cannot tell that apart from a V4 service left on the 4.0 default, since the generator writes the
+    // option only for 4.01. So the header follows what was configured, not a fallback.
+    expect(new ServiceStateHelper(client, "base", "name").getDefaultHeaders()).not.toHaveProperty("OData-Version");
+  });
+
+  test("getVersionHeaders: a request with a body always states a version", () => {
+    // Unlike the default headers this falls back to 4.0, because there the header governs how the service
+    // reads the payload - and the notations we generate are only valid under a declared version.
+    expect(new ServiceStateHelper(client, "base", "name").getVersionHeaders()).toStrictEqual({
+      "OData-Version": "4.0",
+    });
+    expect(
+      new ServiceStateHelper(client, "base", "name", { odataVersionV4: "4.01" }).getVersionHeaders(),
+    ).toStrictEqual({ "OData-Version": "4.01" });
+  });
+
   test("isUrlNotEncoded", () => {
     expect(new ServiceStateHelper(client, "base").isUrlNotEncoded()).toBe(false);
     expect(new ServiceStateHelper(client, "base", "name", { noUrlEncoding: true }).isUrlNotEncoded()).toBe(true);


### PR DESCRIPTION
The last Class C axis without coverage — plus the bug the coverage turned up.

**The coverage.** `odataVersionV4` cannot be split across the two V4 packages the way `enableNativeInOperator` is: CAP does not speak 4.01, so ASP.NET Core is the only place the option can be held against anything. Hence a third client next to the 4.0 one — additive, which is what the difference needs anyway, since the point is that the two spell the same request differently.

- everything the option changes is payload, so a type check sees none of it
- the binding notation is asserted on the query object itself (`Location: {"@id": …}` against `"Location@odata.bind": …`), because it is the one difference a server would swallow either way: ASP.NET accepts both spellings, so a client emitting the 4.0 one while announcing 4.01 would pass every behavioural test. A create through the generated client then shows the server honours what it emits
- `Binding.test.ts` had approximated this by sending a 4.01 payload by hand, since no client could produce one. That case stays — it isolates the server half — and now points at the client half

**The bug.** The version was announced only on requests carrying a body, where the header governs how the service reads the payload. It governs the response just as much: a service answering a 4.0 request uses the prefixed control information (`@odata.count`), while a 4.01 client's response models are typed for the short form (`@count`). Every GET came back in a shape the typing did not describe — the count sat under a property the caller could not even name without a cast.

- the configured version now goes into the default headers, so it reaches every request
- only when it *was* configured: the helper is shared with V2, where an `OData-Version: 4.x` header would be plainly wrong, and it cannot tell that apart from a V4 service left on the 4.0 default — the generator writes the option only for 4.01
- requests with a body keep their existing fallback to 4.0, since there the header is what makes the notations we generate valid at all
- a 4.0 client is unaffected and keeps reading the prefixed form, which the integration test now pins as the counter-sample
- the mock-based case in `examples/main/test/trippinV401` that asserted the old behaviour is updated

Verified: 1738 unit tests green, asp-net 102/102 against its container, cap 135/135 and olingo-v2 96/96 unaffected, `prettier --check .` green.
