### PR TITLE
chore: declare tooling devDependencies per workspace and enforce versions via constraints

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,6 +22,8 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Install packages
         run: yarn --immutable
+      - name: Check dependency consistency
+        run: yarn constraints
       - name: Build packages
         run: yarn build
       - name: Type Test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,27 @@ yarn install
 yarn build
 ```
 
+### Dependencies
+
+Every workspace must declare the tools its own scripts call — `typescript`, `vitest`, `rimraf`, `madge` and the like.
+Yarn only exposes the binaries of the dependencies a workspace declares itself; there is no fallback to the root's
+`node_modules/.bin`. A script invoking an undeclared binary fails with `command not found`.
+
+To keep those repeated declarations from drifting apart, the root `package.json` is the single source of truth:
+`yarn.config.cjs` holds a [Yarn constraint](https://yarnpkg.com/features/constraints) that pins the
+`dependencies` and `devDependencies` of every workspace to the range declared in the root.
+
+So whenever you add a dependency or change its version:
+
+1. Set the version in the root `package.json`.
+2. Add the dependency to each workspace that needs it — the range doesn't matter yet.
+3. Run `yarn constraints --fix` to align all workspaces with the root, then `yarn install`.
+
+`yarn constraints` (check only, no changes) runs in CI and fails the build on any mismatch.
+
+`peerDependencies` are exempt on purpose: they state what a consumer has to bring along, not what this repo
+installs — e.g. the `typescript: ">= 4.7"` floor of `packages/odata2ts`, which `int-test/ts-floor-check` verifies.
+
 ### Running Unit Tests
 
 To run the **unit tests** of all modules:

--- a/examples/main/package.json
+++ b/examples/main/package.json
@@ -11,7 +11,7 @@
     "build": "yarn clean && yarn generate",
     "clean": "rimraf build src-generated",
     "generate": "odata2ts",
-    "test": "node ../../node_modules/.bin/vitest run --testTimeout=30000",
+    "test": "vitest run --testTimeout=30000",
     "test-compile": "tsc"
   },
   "dependencies": {
@@ -28,7 +28,10 @@
   },
   "devDependencies": {
     "@odata2ts/odata2ts": "workspace:^",
-    "@types/luxon": "^3.7.2"
+    "@types/luxon": "^3.7.2",
+    "rimraf": "^6.1.3",
+    "typescript": "6.0.3",
+    "vitest": "^4.1.10"
   },
   "publishConfig": {
     "access": "public"

--- a/examples/test-converters/package.json
+++ b/examples/test-converters/package.json
@@ -22,5 +22,9 @@
   "dependencies": {
     "@odata2ts/converter-api": "^0.2.6",
     "@odata2ts/odata-core": "^0.6.0"
+  },
+  "devDependencies": {
+    "rimraf": "^6.1.3",
+    "typescript": "6.0.3"
   }
 }

--- a/int-test/asp-net/package.json
+++ b/int-test/asp-net/package.json
@@ -10,8 +10,8 @@
     "build": "yarn clean && yarn generate",
     "clean": "rimraf build src-generated",
     "generate": "odata2ts",
-    "test": "node ../../node_modules/.bin/vitest run",
-    "test-compile": "node ../../node_modules/.bin/tsc"
+    "test": "vitest run",
+    "test-compile": "tsc"
   },
   "dependencies": {
     "@odata2ts/http-client-fetch": "^0.11.0",
@@ -19,6 +19,9 @@
   },
   "devDependencies": {
     "@odata2ts/odata2ts": "workspace:^",
-    "testcontainers": "^12.0.4"
+    "rimraf": "^6.1.3",
+    "testcontainers": "^12.0.4",
+    "typescript": "6.0.3",
+    "vitest": "^4.1.10"
   }
 }

--- a/int-test/cap/package.json
+++ b/int-test/cap/package.json
@@ -10,8 +10,8 @@
     "build": "yarn clean && yarn generate",
     "clean": "rimraf build src-generated",
     "generate": "odata2ts",
-    "test": "node ../../node_modules/.bin/vitest run",
-    "test-compile": "node ../../node_modules/.bin/tsc"
+    "test": "vitest run",
+    "test-compile": "tsc"
   },
   "dependencies": {
     "@odata2ts/converter-big-number": "^0.2.8",
@@ -25,6 +25,9 @@
   "devDependencies": {
     "@odata2ts/odata2ts": "workspace:^",
     "@types/luxon": "^3.7.2",
-    "testcontainers": "^12.0.4"
+    "rimraf": "^6.1.3",
+    "testcontainers": "^12.0.4",
+    "typescript": "6.0.3",
+    "vitest": "^4.1.10"
   }
 }

--- a/int-test/cli/package.json
+++ b/int-test/cli/package.json
@@ -9,9 +9,11 @@
   "type": "module",
   "scripts": {
     "clean": "rimraf build",
-    "test": "node ../../node_modules/.bin/vitest run run"
+    "test": "vitest run run"
   },
   "devDependencies": {
-    "@odata2ts/odata2ts": "workspace:^"
+    "@odata2ts/odata2ts": "workspace:^",
+    "rimraf": "^6.1.3",
+    "vitest": "^4.1.10"
   }
 }

--- a/int-test/config-variants/package.json
+++ b/int-test/config-variants/package.json
@@ -11,12 +11,14 @@
     "build": "yarn clean && yarn generate",
     "clean": "rimraf src-generated",
     "generate": "odata2ts",
-    "test-compile": "node ../../node_modules/.bin/tsc"
+    "test-compile": "tsc"
   },
   "dependencies": {
     "@odata2ts/odata-service": "workspace:^"
   },
   "devDependencies": {
-    "@odata2ts/odata2ts": "workspace:^"
+    "@odata2ts/odata2ts": "workspace:^",
+    "rimraf": "^6.1.3",
+    "typescript": "6.0.3"
   }
 }

--- a/int-test/olingo-v2/package.json
+++ b/int-test/olingo-v2/package.json
@@ -10,8 +10,8 @@
     "build": "yarn clean && yarn generate",
     "clean": "rimraf build src-generated",
     "generate": "odata2ts",
-    "test": "node ../../node_modules/.bin/vitest run",
-    "test-compile": "node ../../node_modules/.bin/tsc"
+    "test": "vitest run",
+    "test-compile": "tsc"
   },
   "dependencies": {
     "@odata2ts/converter-big-number": "^0.2.8",
@@ -26,6 +26,9 @@
   "devDependencies": {
     "@odata2ts/odata2ts": "workspace:^",
     "@types/luxon": "^3.7.2",
-    "testcontainers": "^12.0.4"
+    "rimraf": "^6.1.3",
+    "testcontainers": "^12.0.4",
+    "typescript": "6.0.3",
+    "vitest": "^4.1.10"
   }
 }

--- a/int-test/ts-floor-check/package.json
+++ b/int-test/ts-floor-check/package.json
@@ -10,12 +10,14 @@
   "scripts": {
     "build": "npm run clean && npm --prefix floor-ts install",
     "clean": "rimraf floor-ts/node_modules",
-    "test": "node ../../node_modules/.bin/vitest run"
+    "test": "vitest run"
   },
   "dependencies": {
     "@odata2ts/odata-service": "workspace:^"
   },
   "devDependencies": {
-    "@odata2ts/odata2ts": "workspace:^"
+    "@odata2ts/odata2ts": "workspace:^",
+    "rimraf": "^6.1.3",
+    "vitest": "^4.1.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@prettier/plugin-xml": "^3.4.2",
     "@types/node": "^24",
     "@vitest/coverage-istanbul": "^4.1.10",
+    "@yarnpkg/types": "^4.0.1",
     "env-cmd": "^11.0.0",
     "madge": "^8.0.0",
     "prettier": "^3.9.6",

--- a/packages/odata-core/package.json
+++ b/packages/odata-core/package.json
@@ -33,6 +33,11 @@
   "dependencies": {
     "tslib": "^2.8.1"
   },
+  "devDependencies": {
+    "madge": "^8.0.0",
+    "rimraf": "^6.1.3",
+    "typescript": "6.0.3"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/odata-query-builder/package.json
+++ b/packages/odata-query-builder/package.json
@@ -36,6 +36,13 @@
     "@odata2ts/odata-query-objects": "^0.29.0",
     "tslib": "^2.8.1"
   },
+  "devDependencies": {
+    "@vitest/coverage-istanbul": "^4.1.10",
+    "madge": "^8.0.0",
+    "rimraf": "^6.1.3",
+    "typescript": "6.0.3",
+    "vitest": "^4.1.10"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/odata-query-objects/package.json
+++ b/packages/odata-query-objects/package.json
@@ -38,7 +38,12 @@
     "tslib": "^2.8.1"
   },
   "devDependencies": {
-    "type-fest": "^5.8.0"
+    "@vitest/coverage-istanbul": "^4.1.10",
+    "madge": "^8.0.0",
+    "rimraf": "^6.1.3",
+    "type-fest": "^5.8.0",
+    "typescript": "6.0.3",
+    "vitest": "^4.1.10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/odata-service/package.json
+++ b/packages/odata-service/package.json
@@ -41,7 +41,12 @@
     "tslib": "^2.8.1"
   },
   "devDependencies": {
-    "ts-expect": "^1.3.0"
+    "@vitest/coverage-istanbul": "^4.1.10",
+    "madge": "^8.0.0",
+    "rimraf": "^6.1.3",
+    "ts-expect": "^1.3.0",
+    "typescript": "6.0.3",
+    "vitest": "^4.1.10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/odata2ts/package.json
+++ b/packages/odata2ts/package.json
@@ -71,7 +71,12 @@
     "@odata2ts/odata-query-objects": "^0.29.0",
     "@odata2ts/odata-service": "^0.24.0",
     "@odata2ts/test-converters": "^0.5.0",
-    "@types/node": "^24"
+    "@types/node": "^24",
+    "@vitest/coverage-istanbul": "^4.1.10",
+    "madge": "^8.0.0",
+    "rimraf": "^6.1.3",
+    "typescript": "6.0.3",
+    "vitest": "^4.1.10"
   },
   "peerDependencies": {
     "@odata2ts/odata-query-objects": "^0.29.0",

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -1,0 +1,34 @@
+/**
+ * Yarn constraints: the root package.json is the single source of truth for dependency versions.
+ *
+ * Every workspace has to declare the tools its own scripts invoke — Yarn only exposes the binaries of
+ * dependencies a workspace declares itself (it does not fall back to the root's node_modules/.bin).
+ * That would invite version drift across a dozen package.json files, so this constraint pins every
+ * duplicated range back to whatever the root declares.
+ *
+ * Check: `yarn constraints` (also runs in CI) — fix: `yarn constraints --fix`.
+ */
+
+/** @type {import('@yarnpkg/types').Yarn.Config} */
+module.exports = {
+  constraints({ Yarn }) {
+    const root = Yarn.workspace({ cwd: "." });
+
+    // peerDependencies are excluded on purpose: they express what a consumer has to bring along
+    // (e.g. odata2ts's `typescript: ">= 4.7"` floor, verified by int-test/ts-floor-check), not what
+    // this repo installs.
+    for (const dependency of [
+      ...Yarn.dependencies({ type: "dependencies" }),
+      ...Yarn.dependencies({ type: "devDependencies" }),
+    ]) {
+      if (dependency.workspace.cwd === root.cwd) continue;
+      // workspace:^ links resolve locally and have no root counterpart
+      if (dependency.range.startsWith("workspace:")) continue;
+
+      const rootDependency = Yarn.dependency({ workspace: root, ident: dependency.ident });
+      if (rootDependency) {
+        dependency.update(rootDependency.range);
+      }
+    }
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -374,6 +374,8 @@ __metadata:
   resolution: "@odata2ts/cli@workspace:int-test/cli"
   dependencies:
     "@odata2ts/odata2ts": "workspace:^"
+    rimraf: "npm:^6.1.3"
+    vitest: "npm:^4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -448,6 +450,9 @@ __metadata:
     axios: "npm:^1.18.1"
     bignumber.js: "npm:^9.1.2"
     luxon: "npm:^3.7.2"
+    rimraf: "npm:^6.1.3"
+    typescript: "npm:6.0.3"
+    vitest: "npm:^4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -457,6 +462,8 @@ __metadata:
   dependencies:
     "@odata2ts/odata-service": "workspace:^"
     "@odata2ts/odata2ts": "workspace:^"
+    rimraf: "npm:^6.1.3"
+    vitest: "npm:^4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -508,7 +515,10 @@ __metadata:
     "@odata2ts/http-client-fetch": "npm:^0.11.0"
     "@odata2ts/odata-service": "workspace:^"
     "@odata2ts/odata2ts": "workspace:^"
+    rimraf: "npm:^6.1.3"
     testcontainers: "npm:^12.0.4"
+    typescript: "npm:6.0.3"
+    vitest: "npm:^4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -525,7 +535,10 @@ __metadata:
     "@types/luxon": "npm:^3.7.2"
     bignumber.js: "npm:^9.1.2"
     luxon: "npm:^3.7.2"
+    rimraf: "npm:^6.1.3"
     testcontainers: "npm:^12.0.4"
+    typescript: "npm:6.0.3"
+    vitest: "npm:^4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -535,6 +548,8 @@ __metadata:
   dependencies:
     "@odata2ts/odata-service": "workspace:^"
     "@odata2ts/odata2ts": "workspace:^"
+    rimraf: "npm:^6.1.3"
+    typescript: "npm:6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -552,7 +567,10 @@ __metadata:
     "@types/luxon": "npm:^3.7.2"
     bignumber.js: "npm:^9.1.2"
     luxon: "npm:^3.7.2"
+    rimraf: "npm:^6.1.3"
     testcontainers: "npm:^12.0.4"
+    typescript: "npm:6.0.3"
+    vitest: "npm:^4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -560,7 +578,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@odata2ts/odata-core@workspace:packages/odata-core"
   dependencies:
+    madge: "npm:^8.0.0"
+    rimraf: "npm:^6.1.3"
     tslib: "npm:^2.8.1"
+    typescript: "npm:6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -569,7 +590,12 @@ __metadata:
   resolution: "@odata2ts/odata-query-builder@workspace:packages/odata-query-builder"
   dependencies:
     "@odata2ts/odata-query-objects": "npm:^0.29.0"
+    "@vitest/coverage-istanbul": "npm:^4.1.10"
+    madge: "npm:^8.0.0"
+    rimraf: "npm:^6.1.3"
     tslib: "npm:^2.8.1"
+    typescript: "npm:6.0.3"
+    vitest: "npm:^4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -580,8 +606,13 @@ __metadata:
     "@odata2ts/converter-api": "npm:^0.2.6"
     "@odata2ts/http-client-api": "npm:^0.6.7"
     "@odata2ts/odata-core": "npm:^0.6.1"
+    "@vitest/coverage-istanbul": "npm:^4.1.10"
+    madge: "npm:^8.0.0"
+    rimraf: "npm:^6.1.3"
     tslib: "npm:^2.8.1"
     type-fest: "npm:^5.8.0"
+    typescript: "npm:6.0.3"
+    vitest: "npm:^4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -592,8 +623,13 @@ __metadata:
     "@odata2ts/http-client-api": "npm:^0.6.7"
     "@odata2ts/odata-query-builder": "npm:^0.19.0"
     "@odata2ts/odata-query-objects": "npm:^0.29.0"
+    "@vitest/coverage-istanbul": "npm:^4.1.10"
+    madge: "npm:^8.0.0"
+    rimraf: "npm:^6.1.3"
     ts-expect: "npm:^1.3.0"
     tslib: "npm:^2.8.1"
+    typescript: "npm:6.0.3"
+    vitest: "npm:^4.1.10"
   languageName: unknown
   linkType: soft
 
@@ -612,19 +648,23 @@ __metadata:
     "@prettier/plugin-xml": "npm:^3.4.2"
     "@types/node": "npm:^24"
     "@types/xml2js": "npm:^0.4.14"
+    "@vitest/coverage-istanbul": "npm:^4.1.10"
     axios: "npm:^1.18.1"
     change-case: "npm:^5.4.4"
     commander: "npm:^15.0.0"
     cosmiconfig: "npm:^10.0.0"
     cosmiconfig-typescript-loader: "npm:^6.3.0"
     deepmerge: "npm:^4.3.1"
+    madge: "npm:^8.0.0"
     mkdirp: "npm:^3.0.1"
     prettier: "npm:^3.9.6"
     rimraf: "npm:^6.1.3"
     ts-morph: "npm:^28.0.0"
     tsconfig-loader: "npm:^1.1.0"
     type-fest: "npm:^5.8.0"
+    typescript: "npm:6.0.3"
     upper-case-first: "npm:^3.0.0"
+    vitest: "npm:^4.1.10"
     xml2js: "npm:^0.6.2"
   peerDependencies:
     "@odata2ts/odata-query-objects": ^0.29.0
@@ -641,6 +681,8 @@ __metadata:
   dependencies:
     "@odata2ts/converter-api": "npm:^0.2.6"
     "@odata2ts/odata-core": "npm:^0.6.0"
+    rimraf: "npm:^6.1.3"
+    typescript: "npm:6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -652,6 +694,7 @@ __metadata:
     "@prettier/plugin-xml": "npm:^3.4.2"
     "@types/node": "npm:^24"
     "@vitest/coverage-istanbul": "npm:^4.1.10"
+    "@yarnpkg/types": "npm:^4.0.1"
     env-cmd: "npm:^11.0.0"
     madge: "npm:^8.0.0"
     prettier: "npm:^3.9.6"
@@ -1249,6 +1292,15 @@ __metadata:
   dependencies:
     chevrotain: "npm:7.1.1"
   checksum: 10/df1aa7ac0ec81ec6363b515f4bb80043c8c29c2e2c87ba668f142d20090f8a67ae1bde3665ee63ebbca12dd9d77991795d97f02fa0e2e64c20ba7a0636209463
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/types@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@yarnpkg/types@npm:4.0.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10/f391763cd955356e9aad551b29e8de7bbf68a6c8992af7cdc950ccf53f8aff6695ad81aa4c8a8e7c582786a840a4f30617732e2cb49f4109b971a9242c31c9fc
   languageName: node
   linkType: hard
 
@@ -4327,7 +4379,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.8.1":
+"tslib@npm:^2.4.0, tslib@npm:^2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10/3e2e043d5c2316461cb54e5c7fe02c30ef6dccb3384717ca22ae5c6b5bc95232a6241df19c622d9c73b809bea33b187f6dbc73030963e29950c2141bc32a79f7


### PR DESCRIPTION
- Declare `typescript`, `vitest`, `@vitest/coverage-istanbul`, `rimraf` and `madge` in every workspace whose scripts invoke them — Yarn only exposes the binaries of dependencies a workspace declares itself, with no fallback to the root's `node_modules/.bin`, so `yarn test-compile` & friends failed with `command not found: tsc` inside a package. Root scripts kept working only because `yarn build` passes its own shim folder down to the nested `foreach` processes via PATH, which is why CI never surfaced it.
- Replace the `node ../../node_modules/.bin/{vitest,tsc}` workarounds in `int-test/*` and `examples/main` with plain `vitest` / `tsc` calls.
- Add `yarn.config.cjs`: the root `package.json` is the single source of truth for dependency ranges, and the constraint pins every workspace's `dependencies` and `devDependencies` to it. Change a version in the root, then `yarn constraints --fix`.
- Exclude `peerDependencies` from that constraint on purpose, so the `typescript: ">= 4.7"` floor of `packages/odata2ts` — guarded by `int-test/ts-floor-check` — stays untouched.
- Run `yarn constraints` as a CI step right after the install.
- Add `@yarnpkg/types` for typing the constraint config.

Verified locally: package scripts now run standalone from their own directory, root `build` / `test` / `test-compile` / `check-circular-deps` / `check-format` are green, as are `int-test/cli`, `ts-floor-check` and the `test-compile` of asp-net, cap, olingo-v2, config-variants and examples/main. Container suites were not started.