### PR TITLE
fix: keep package coverage reports out of the aggregate coverage run

### DIFF
--- a/packages/odata2ts/package.json
+++ b/packages/odata2ts/package.json
@@ -32,7 +32,7 @@
     "build": "yarn clean && tsc",
     "check-circular-deps": "madge ./src --extensions ts --circular --exclude \"^\\.\\./\\.\\./\"",
     "check-circular-generated": "madge ./build --extensions ts --circular",
-    "clean": "rimraf lib build",
+    "clean": "rimraf lib build coverage",
     "clean-v2": "rimraf build/v2",
     "clean-v4": "rimraf build/v4",
     "compile": "tsc -p tsconfig.compile.json",

--- a/vitest-coverage.shared.ts
+++ b/vitest-coverage.shared.ts
@@ -1,4 +1,12 @@
+import { coverageConfigDefaults } from "vitest/config";
+
 export const coverageReporterOptions = {
   provider: "istanbul" as const,
   reporter: ["lcov", "html-spa"] as const,
+  // A package-level coverage run writes its HTML report to `packages/<pkg>/coverage`, mirroring the
+  // sources below it - `coverage/src/NamingModel.ts.html`. That path matches the source glob of the
+  // aggregate run, which then tries to parse the report as a source file to count it as uncovered and
+  // dies with a SyntaxError. Vitest's own default only keeps the root's `coverage` out, never the
+  // package ones.
+  exclude: [...coverageConfigDefaults.exclude, "**/coverage/**"],
 };


### PR DESCRIPTION
Running a package-level `coverage` script and then `yarn coverage` from the root made the root run die with `SyntaxError: .../packages/odata2ts/coverage/src/NamingModel.ts.html ... Unexpected token (2:0)`.

- The cause is the **coverage** glob, not the test glob: the HTML report mirrors the sources below `coverage/src`, so `packages/odata2ts/coverage/src/NamingModel.ts.html` matches the aggregate run's `include: ["packages/**/src/**"]`. Vitest loads it to count it as an uncovered file (the request carries `?vitest-uncovered-coverage=true`) and tries to parse the markup as TypeScript. Excluding it from `test.exclude` would therefore not have helped — the report never matched the test include to begin with.
- Fix: add `**/coverage/**` to `coverage.exclude` in `vitest-coverage.shared.ts`, on top of `coverageConfigDefaults.exclude`, so root and package runs alike ignore any report directory. Vitest's default only lists the root's own `coverage`.
- `packages/odata2ts` now cleans its `coverage` directory like the other four packages already do — that omission is why a stale report survived there at all.

The root `clean` script stays as it is: every package's `build` runs its own `clean`, so `yarn build` now clears the report directories anyway, and widening the root script would make it do more than its name says.

Verified: package coverage first (`packages/odata2ts` and `packages/odata-query-builder`), then `yarn coverage` from the root — 136 files / 1594 tests, no error. The resulting `coverage/lcov.info` still lists 164 source files and none from a report directory, so the exclude does not eat real sources; `odata-core` (no tests of its own) is still reported as uncovered. Plus `yarn build`, `yarn test`, `yarn check-format` and `yarn constraints`.