### PR TITLE
feat(odata-service)!: services are no longer generic over the HTTP client

### DIFF
--- a/int-test/asp-net/test/feature/RequestConfig.test.ts
+++ b/int-test/asp-net/test/feature/RequestConfig.test.ts
@@ -1,0 +1,56 @@
+import { HttpResponseModel } from "@odata2ts/http-client-api";
+import { FetchRequestConfig } from "@odata2ts/http-client-fetch";
+import { ODataCollectionResponseV4 } from "@odata2ts/odata-core";
+import { describe, expect, expectTypeOf, test } from "vitest";
+import { Medium } from "../../src-generated/library/library-catalog/index.js";
+import { LIBRARY } from "../LibraryTestConstants.js";
+
+/**
+ * The request configuration handed to `execute()`.
+ *
+ * Generated services are not generic over the HTTP client, so `execute` cannot know which client it will
+ * end up talking to. What every client understands - `headers` and `params` - is therefore the default,
+ * and anything a specific client adds on top is opted into by naming that client's config type at the
+ * call site. Both halves are exercised here: the common fields without a type argument, and a
+ * fetch-specific field with one.
+ *
+ * The typing assertions are checked by `test-compile`, not at runtime.
+ */
+describe("ASP.NET Library: request configuration", () => {
+  test("the common config needs no type argument", async () => {
+    const result = await LIBRARY.Media()
+      .query()
+      .execute({ params: { $top: 1 } });
+
+    expectTypeOf(result).toEqualTypeOf<HttpResponseModel<ODataCollectionResponseV4<Medium>>>();
+    expect(result.status).toBe(200);
+    // the extra param reached the URL: without it the seed data holds more than one medium
+    expect(result.data.value).toHaveLength(1);
+  });
+
+  test("headers from the config reach the server", async () => {
+    const created = await LIBRARY.Members()
+      .create({ Name: "RequestConfig Test", Balance: 3, PreviousAddresses: [] })
+      .execute();
+
+    // a patch answers 204 unless the representation is asked for, and here that header travels via the config
+    const patched = await LIBRARY.Members(created.data.Id)
+      .patch<true>({ Balance: 4 })
+      .execute({ headers: { Prefer: "return=representation" } });
+
+    expect(patched.status).toBe(200);
+    expect(patched.data.Balance).toBe(4);
+
+    await LIBRARY.Members(created.data.Id).delete().execute();
+  });
+
+  test("a fetch specific field requires the fetch config type", async () => {
+    const cmd = LIBRARY.Media().query();
+
+    // @ts-expect-error: `signal` belongs to FetchRequestConfig, which the default config does not cover
+    await expect(cmd.execute({ signal: AbortSignal.abort() })).rejects.toThrow();
+
+    // named explicitly it compiles - and the client hands the signal on either way, so both requests abort
+    await expect(cmd.execute<FetchRequestConfig>({ signal: AbortSignal.abort() })).rejects.toThrow();
+  });
+});

--- a/int-test/cap/test/feature/RequestConfig.test.ts
+++ b/int-test/cap/test/feature/RequestConfig.test.ts
@@ -1,0 +1,55 @@
+import { HttpResponseModel } from "@odata2ts/http-client-api";
+import { FetchRequestConfig } from "@odata2ts/http-client-fetch";
+import { ODataCollectionResponseV4 } from "@odata2ts/odata-core";
+import { describe, expect, expectTypeOf, test } from "vitest";
+import { Books, EditableBooks } from "../../src-generated/library/LibraryModel.js";
+import { LIBRARY } from "../LibraryTestConstants.js";
+
+/**
+ * The request configuration handed to `execute()`.
+ *
+ * Generated services are not generic over the HTTP client, so `execute` cannot know which client it will
+ * end up talking to. What every client understands - `headers` and `params` - is therefore the default,
+ * and anything a specific client adds on top is opted into by naming that client's config type at the
+ * call site. Both halves are exercised here: the common fields without a type argument, and a
+ * fetch-specific field with one.
+ *
+ * The typing assertions are checked by `test-compile`, not at runtime.
+ */
+describe("CAP Library: request configuration", () => {
+  test("the common config needs no type argument", async () => {
+    const result = await LIBRARY.Books()
+      .query()
+      .execute({ params: { $top: 1 } });
+
+    expectTypeOf(result).toEqualTypeOf<HttpResponseModel<ODataCollectionResponseV4<Books>>>();
+    expect(result.status).toBe(200);
+    // the extra param reached the URL: without it the seed data holds more than one book
+    expect(result.data.value).toHaveLength(1);
+  });
+
+  test("headers from the config reach the server", async () => {
+    const book: EditableBooks = { Title: "Der Heizer", Language: "de", PageCount: 60 };
+    const created = await LIBRARY.Books().create(book).execute();
+
+    // a patch answers 204 unless the representation is asked for, and here that header travels via the config
+    const patched = await LIBRARY.Books(created.data.Id)
+      .patch<true>({ PageCount: 61 })
+      .execute({ headers: { Prefer: "return=representation" } });
+
+    expect(patched.status).toBe(200);
+    expect(patched.data.PageCount).toBe(61);
+
+    await LIBRARY.Books(created.data.Id).delete().execute();
+  });
+
+  test("a fetch specific field requires the fetch config type", async () => {
+    const cmd = LIBRARY.Books().query();
+
+    // @ts-expect-error: `signal` belongs to FetchRequestConfig, which the default config does not cover
+    await expect(cmd.execute({ signal: AbortSignal.abort() })).rejects.toThrow();
+
+    // named explicitly it compiles - and the client hands the signal on either way, so both requests abort
+    await expect(cmd.execute<FetchRequestConfig>({ signal: AbortSignal.abort() })).rejects.toThrow();
+  });
+});

--- a/packages/odata-service/src/ODataService.ts
+++ b/packages/odata-service/src/ODataService.ts
@@ -6,14 +6,14 @@ import { ServiceStateHelper } from "./ServiceStateHelper.js";
 /**
  * The base class for the main OData service client.
  */
-export class ODataService<in out ClientType extends ODataHttpClient, V extends ODataVersionV4 = "4.0"> {
-  protected readonly __base: ServiceStateHelper<any, V>;
+export class ODataService<V extends ODataVersionV4 = "4.0"> {
+  protected readonly __base: ServiceStateHelper<V>;
 
   /**
    * Takes the internal options, so that generated main services can pass on what the generator decided,
    * e.g. the OData version. Users only get to see the public options via the generated service.
    */
-  constructor(client: ClientType, basePath: string, options?: ODataServiceOptionsInternal<ODataVersionV4>) {
+  constructor(client: ODataHttpClient, basePath: string, options?: ODataServiceOptionsInternal<ODataVersionV4>) {
     if (!client) {
       throw new Error("[client] must be supplied to ODataService!");
     }

--- a/packages/odata-service/src/ServiceStateHelper.ts
+++ b/packages/odata-service/src/ServiceStateHelper.ts
@@ -3,11 +3,11 @@ import { ODataVersionV4 } from "@odata2ts/odata-core";
 import { ODataServiceOptionsInternal } from "./ODataServiceOptions";
 import { BIG_NUMBERS_HEADERS, DEFAULT_HEADERS, getODataVersionHeaders } from "./RequestHeaders.js";
 
-export class ServiceStateHelper<out ClientType extends ODataHttpClient, V extends ODataVersionV4 = "4.0"> {
+export class ServiceStateHelper<V extends ODataVersionV4 = "4.0"> {
   public readonly path: string;
 
   public constructor(
-    public readonly client: ClientType,
+    public readonly client: ODataHttpClient,
     public basePath: string,
     public name?: string,
     public options: ODataServiceOptionsInternal<V> = {},

--- a/packages/odata-service/src/StreamServiceBase.ts
+++ b/packages/odata-service/src/StreamServiceBase.ts
@@ -20,10 +20,15 @@ const DEFAULT_MIME_TYPE = "application/octet-stream";
  * declare JSON. What the URL looks like is the versions' business, not this class's: V4 knows a stream
  * property as well as a media entity's `$value`, V2 only the latter.
  */
-export abstract class StreamServiceBase<out ClientType extends ODataHttpClient, V extends ODataVersionV4 = "4.0"> {
-  protected readonly __base: ServiceStateHelper<ClientType, V>;
+export abstract class StreamServiceBase<V extends ODataVersionV4 = "4.0"> {
+  protected readonly __base: ServiceStateHelper<V>;
 
-  public constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+  public constructor(
+    client: ODataHttpClient,
+    basePath: string,
+    name: string,
+    options?: ODataServiceOptionsInternal<V>,
+  ) {
     this.__base = new ServiceStateHelper(client, basePath, name, options);
   }
 
@@ -40,7 +45,7 @@ export abstract class StreamServiceBase<out ClientType extends ODataHttpClient, 
   public getBlob() {
     const { client, path } = this.__base;
 
-    return new BlobGetRequestCmd<ClientType>(client, path);
+    return new BlobGetRequestCmd(client, path);
   }
 
   /**
@@ -56,7 +61,7 @@ export abstract class StreamServiceBase<out ClientType extends ODataHttpClient, 
   public updateBlob(data: Blob, mimeType?: string) {
     const { client, path } = this.__base;
 
-    return new BlobUpdateRequestCmd<ClientType>(client, path, data, mimeType || data.type || DEFAULT_MIME_TYPE);
+    return new BlobUpdateRequestCmd(client, path, data, mimeType || data.type || DEFAULT_MIME_TYPE);
   }
 
   /**
@@ -70,7 +75,7 @@ export abstract class StreamServiceBase<out ClientType extends ODataHttpClient, 
   public getStream() {
     const { client, path } = this.__base;
 
-    return new StreamGetRequestCmd<ClientType>(client, path);
+    return new StreamGetRequestCmd(client, path);
   }
 
   /**
@@ -88,7 +93,7 @@ export abstract class StreamServiceBase<out ClientType extends ODataHttpClient, 
   public updateStream(data: ReadableStream, mimeType?: string) {
     const { client, path } = this.__base;
 
-    return new StreamUpdateRequestCmd<ClientType>(client, path, data, mimeType || DEFAULT_MIME_TYPE);
+    return new StreamUpdateRequestCmd(client, path, data, mimeType || DEFAULT_MIME_TYPE);
   }
 
   /**
@@ -100,6 +105,6 @@ export abstract class StreamServiceBase<out ClientType extends ODataHttpClient, 
   public deleteBlob() {
     const { client, path } = this.__base;
 
-    return new UrlRequestCmd<ClientType, undefined>(client, ODataHttpMethods.Delete, path);
+    return new UrlRequestCmd<undefined>(client, ODataHttpMethods.Delete, path);
   }
 }

--- a/packages/odata-service/src/request/BlobGetRequestCmd.ts
+++ b/packages/odata-service/src/request/BlobGetRequestCmd.ts
@@ -1,4 +1,4 @@
-import { ODataHttpClient, ODataHttpClientConfig, ODataHttpMethods } from "@odata2ts/http-client-api";
+import { ODataHttpClient, ODataHttpMethods, ODataRequestConfig } from "@odata2ts/http-client-api";
 import { RequestCmd, RequestCmdOptions } from "./RequestCmd";
 import { RequestInfo } from "./RequestInfo";
 
@@ -11,9 +11,9 @@ import { RequestInfo } from "./RequestInfo";
  * A stream that exists but carries no content answers 204 - hence `Blob | undefined`. Response
  * converters are not involved: binary data is handed over as it came.
  */
-export class BlobGetRequestCmd<ClientType extends ODataHttpClient> extends RequestCmd<ClientType, Blob | undefined> {
+export class BlobGetRequestCmd extends RequestCmd<Blob | undefined> {
   constructor(
-    client: ClientType,
+    client: ODataHttpClient,
     protected url: string,
     options: RequestCmdOptions<Blob | undefined, undefined> = {},
   ) {
@@ -24,7 +24,7 @@ export class BlobGetRequestCmd<ClientType extends ODataHttpClient> extends Reque
     return this.url;
   }
 
-  protected sendRequest(request: RequestInfo<any>, requestConfig?: ODataHttpClientConfig<ClientType>) {
+  protected sendRequest(request: RequestInfo<any>, requestConfig?: ODataRequestConfig) {
     return this.client.getBlob(request.url, requestConfig, request.headers);
   }
 }

--- a/packages/odata-service/src/request/BlobUpdateRequestCmd.ts
+++ b/packages/odata-service/src/request/BlobUpdateRequestCmd.ts
@@ -1,4 +1,4 @@
-import { ODataHttpClient, ODataHttpClientConfig, ODataHttpMethods } from "@odata2ts/http-client-api";
+import { ODataHttpClient, ODataHttpMethods, ODataRequestConfig } from "@odata2ts/http-client-api";
 import { RequestCmd, RequestCmdOptions } from "./RequestCmd";
 import { RequestInfo } from "./RequestInfo";
 
@@ -12,13 +12,9 @@ import { RequestInfo } from "./RequestInfo";
  * The response is either empty (204) or the stored content, depending on the server, hence
  * `Blob | undefined`.
  */
-export class BlobUpdateRequestCmd<ClientType extends ODataHttpClient> extends RequestCmd<
-  ClientType,
-  Blob | undefined,
-  Blob
-> {
+export class BlobUpdateRequestCmd extends RequestCmd<Blob | undefined, Blob> {
   constructor(
-    client: ClientType,
+    client: ODataHttpClient,
     protected url: string,
     data: Blob,
     protected mimeType: string,
@@ -31,7 +27,7 @@ export class BlobUpdateRequestCmd<ClientType extends ODataHttpClient> extends Re
     return this.url;
   }
 
-  protected sendRequest(request: RequestInfo<any>, requestConfig?: ODataHttpClientConfig<ClientType>) {
+  protected sendRequest(request: RequestInfo<any>, requestConfig?: ODataRequestConfig) {
     return this.client.updateBlob(request.url, request.data, this.mimeType, requestConfig, request.headers);
   }
 }

--- a/packages/odata-service/src/request/ComposableUrlRequestCmd.ts
+++ b/packages/odata-service/src/request/ComposableUrlRequestCmd.ts
@@ -5,13 +5,12 @@ import { RequestCmd, RequestCmdOptions } from "./RequestCmd";
 export type CreateServiceFunction<ComposableService> = (path: string) => ComposableService;
 
 export class ComposableUrlRequestCmd<
-  ClientType extends ODataHttpClient,
   ComposableService,
   ResponseStructure,
   DataStructure = undefined,
-> extends RequestCmd<ClientType, ResponseStructure, DataStructure> {
+> extends RequestCmd<ResponseStructure, DataStructure> {
   constructor(
-    client: ClientType,
+    client: ODataHttpClient,
     protected basePath: string,
     protected createService: CreateServiceFunction<ComposableService>,
     protected options: RequestCmdOptions<ResponseStructure, DataStructure> = {},
@@ -33,7 +32,7 @@ export class ComposableUrlRequestCmd<
       throw new Error("withUrl requires a new URL!");
     }
 
-    return new ComposableUrlRequestCmd<ClientType, ComposableService, ResponseStructure, DataStructure>(
+    return new ComposableUrlRequestCmd<ComposableService, ResponseStructure, DataStructure>(
       this.client,
       url,
       this.createService,

--- a/packages/odata-service/src/request/NoInferConfig.ts
+++ b/packages/odata-service/src/request/NoInferConfig.ts
@@ -1,0 +1,15 @@
+/**
+ * Blocks inference of <code>T</code> from the argument it annotates, so that a type parameter which has a
+ * default is only ever what the caller wrote or what the default says - never what the passed object happens
+ * to look like.
+ *
+ * This matters for the request config: {@link ODataRequestConfig} declares nothing but optional properties,
+ * so every object structurally satisfies it. Were the type parameter inferable, <code>execute({ whatever: 1 })</code>
+ * would infer <code>{ whatever: number }</code>, pass the constraint and silently accept a config the chosen HTTP
+ * client knows nothing about.
+ *
+ * TypeScript ships this as <code>NoInfer</code> since 5.4, but the peer range of the generator declares 4.7 as
+ * the lower bound, so it is spelled out here. The indexed access into a one-element tuple defers resolution,
+ * which is what keeps the inference engine out of it.
+ */
+export type NoInferConfig<T> = [T][T extends any ? 0 : never];

--- a/packages/odata-service/src/request/RequestCmd.ts
+++ b/packages/odata-service/src/request/RequestCmd.ts
@@ -1,9 +1,10 @@
-import { HttpResponseModel, ODataHttpClient, ODataHttpClientConfig, ODataHttpMethods } from "@odata2ts/http-client-api";
+import { HttpResponseModel, ODataHttpClient, ODataHttpMethods, ODataRequestConfig } from "@odata2ts/http-client-api";
 import { MainResponseConverter } from "@odata2ts/odata-query-objects";
 import { MainRequestConverter, RequestConverter } from "./converter/RequestConverter";
 import { RequestConverterChain } from "./converter/RequestConverterChain";
 import { ResponseConverter } from "./converter/ResponseConverter";
 import { ResponseConverterChain } from "./converter/ResponseConverterChain";
+import { NoInferConfig } from "./NoInferConfig";
 import { RequestInfo } from "./RequestInfo";
 
 export interface RequestCmdOptions<ResponseStructure, DataStructure> {
@@ -27,7 +28,6 @@ export interface RequestCmdOptions<ResponseStructure, DataStructure> {
  * Encapsulates an HTTP request to the OData server. Follows the Command Pattern.
  */
 export abstract class RequestCmd<
-  ClientType extends ODataHttpClient,
   ResponseStructure,
   DataStructure = undefined,
   FinalResponseStructure = ResponseStructure,
@@ -36,7 +36,7 @@ export abstract class RequestCmd<
   private readonly responseConverter: ResponseConverterChain<ResponseStructure, FinalResponseStructure>;
 
   public constructor(
-    protected client: ClientType,
+    protected client: ODataHttpClient,
     protected method: ODataHttpMethods,
     protected data?: DataStructure,
     protected options: RequestCmdOptions<ResponseStructure, DataStructure> = {},
@@ -139,15 +139,21 @@ export abstract class RequestCmd<
   ) {
     this.responseConverter.appendConverter<NewRespStructure>(converter);
 
-    return this as unknown as RequestCmd<ClientType, ResponseStructure, DataStructure, NewRespStructure>;
+    return this as unknown as RequestCmd<ResponseStructure, DataStructure, NewRespStructure>;
   }
 
   /**
    * Main method of this command object: Executes the request.
    *
+   * The config type defaults to what every HTTP client understands - headers and URL params. Anything a
+   * specific client adds on top of that is opted into by naming its config type, e.g.
+   * <code>execute&lt;FetchRequestConfig&gt;({ credentials: "include" })</code>.
+   *
    * @param requestConfig optional configuration
    */
-  public async execute(requestConfig?: ODataHttpClientConfig<ClientType>) {
+  public async execute<RequestConfig extends ODataRequestConfig = ODataRequestConfig>(
+    requestConfig?: NoInferConfig<RequestConfig>,
+  ) {
     // apply request converters
     const request = this.getInfoConverted();
 
@@ -170,7 +176,7 @@ export abstract class RequestCmd<
    */
   protected sendRequest(
     request: RequestInfo<any>,
-    requestConfig?: ODataHttpClientConfig<ClientType>,
+    requestConfig?: ODataRequestConfig,
   ): Promise<HttpResponseModel<any>> {
     return this.client.request<ResponseStructure>(
       request.url,

--- a/packages/odata-service/src/request/StreamGetRequestCmd.ts
+++ b/packages/odata-service/src/request/StreamGetRequestCmd.ts
@@ -1,4 +1,4 @@
-import { ODataHttpClient, ODataHttpClientConfig, ODataHttpMethods } from "@odata2ts/http-client-api";
+import { ODataHttpClient, ODataHttpMethods, ODataRequestConfig } from "@odata2ts/http-client-api";
 import { RequestCmd, RequestCmdOptions } from "./RequestCmd";
 import { RequestInfo } from "./RequestInfo";
 
@@ -12,12 +12,9 @@ import { RequestInfo } from "./RequestInfo";
  * A stream that exists but carries no content answers 204 - hence `ReadableStream | undefined`.
  * Response converters are not involved: binary data is handed over as it came.
  */
-export class StreamGetRequestCmd<ClientType extends ODataHttpClient> extends RequestCmd<
-  ClientType,
-  ReadableStream | undefined
-> {
+export class StreamGetRequestCmd extends RequestCmd<ReadableStream | undefined> {
   constructor(
-    client: ClientType,
+    client: ODataHttpClient,
     protected url: string,
     options: RequestCmdOptions<ReadableStream | undefined, undefined> = {},
   ) {
@@ -28,7 +25,7 @@ export class StreamGetRequestCmd<ClientType extends ODataHttpClient> extends Req
     return this.url;
   }
 
-  protected sendRequest(request: RequestInfo<any>, requestConfig?: ODataHttpClientConfig<ClientType>) {
+  protected sendRequest(request: RequestInfo<any>, requestConfig?: ODataRequestConfig) {
     return this.client.getStream(request.url, requestConfig, request.headers);
   }
 }

--- a/packages/odata-service/src/request/StreamUpdateRequestCmd.ts
+++ b/packages/odata-service/src/request/StreamUpdateRequestCmd.ts
@@ -1,4 +1,4 @@
-import { ODataHttpClient, ODataHttpClientConfig, ODataHttpMethods } from "@odata2ts/http-client-api";
+import { ODataHttpClient, ODataHttpMethods, ODataRequestConfig } from "@odata2ts/http-client-api";
 import { RequestCmd, RequestCmdOptions } from "./RequestCmd";
 import { RequestInfo } from "./RequestInfo";
 
@@ -12,13 +12,9 @@ import { RequestInfo } from "./RequestInfo";
  * The response is either empty (204) or the stored content, depending on the server, hence
  * `ReadableStream | undefined`.
  */
-export class StreamUpdateRequestCmd<ClientType extends ODataHttpClient> extends RequestCmd<
-  ClientType,
-  ReadableStream | undefined,
-  ReadableStream
-> {
+export class StreamUpdateRequestCmd extends RequestCmd<ReadableStream | undefined, ReadableStream> {
   constructor(
-    client: ClientType,
+    client: ODataHttpClient,
     protected url: string,
     data: ReadableStream,
     protected mimeType: string,
@@ -31,7 +27,7 @@ export class StreamUpdateRequestCmd<ClientType extends ODataHttpClient> extends 
     return this.url;
   }
 
-  protected sendRequest(request: RequestInfo<any>, requestConfig?: ODataHttpClientConfig<ClientType>) {
+  protected sendRequest(request: RequestInfo<any>, requestConfig?: ODataRequestConfig) {
     return this.client.updateStream(request.url, request.data, this.mimeType, requestConfig, request.headers);
   }
 }

--- a/packages/odata-service/src/request/UrlBuilderRequestCmdV2.ts
+++ b/packages/odata-service/src/request/UrlBuilderRequestCmdV2.ts
@@ -4,14 +4,13 @@ import { QueryObjectModel } from "@odata2ts/odata-query-objects";
 import { RequestCmd, RequestCmdOptions } from "./RequestCmd";
 
 export class UrlBuilderRequestCmdV2<
-  ClientType extends ODataHttpClient,
   ResponseStructure,
   Q extends QueryObjectModel,
   Builder extends ModelQueryBuilderV2<Q> = CollectionQueryBuilderV2<Q>,
   DataStructure = undefined,
-> extends RequestCmd<ClientType, ResponseStructure, DataStructure> {
+> extends RequestCmd<ResponseStructure, DataStructure> {
   constructor(
-    protected client: ClientType,
+    protected client: ODataHttpClient,
     method: ODataHttpMethods,
     protected urlBuilder: Builder,
     protected q: Q,
@@ -36,7 +35,7 @@ export class UrlBuilderRequestCmdV2<
     }
     const builder = modFunction(this.urlBuilder.clone() as Builder, this.q);
 
-    return new UrlBuilderRequestCmdV2<ClientType, ResponseStructure, Q, Builder, DataStructure>(
+    return new UrlBuilderRequestCmdV2<ResponseStructure, Q, Builder, DataStructure>(
       this.client,
       this.method,
       builder,

--- a/packages/odata-service/src/request/UrlBuilderRequestCmdV4.ts
+++ b/packages/odata-service/src/request/UrlBuilderRequestCmdV4.ts
@@ -5,14 +5,13 @@ import { RequestCmd, RequestCmdOptions } from "./RequestCmd";
 import { GetToPostConverter } from "./RequestHelper";
 
 export class UrlBuilderRequestCmdV4<
-  ClientType extends ODataHttpClient,
   ResponseStructure,
   Q extends QueryObjectModel,
   Builder extends ModelQueryBuilderV4<Q> = CollectionQueryBuilderV4<Q>,
   DataStructure = undefined,
-> extends RequestCmd<ClientType, ResponseStructure, DataStructure> {
+> extends RequestCmd<ResponseStructure, DataStructure> {
   constructor(
-    protected client: ClientType,
+    protected client: ODataHttpClient,
     method: ODataHttpMethods,
     protected urlBuilder: Builder,
     protected q: Q,
@@ -38,7 +37,7 @@ export class UrlBuilderRequestCmdV4<
     }
     const builder = modFunction(this.urlBuilder.clone() as Builder, this.q);
 
-    return new UrlBuilderRequestCmdV4<ClientType, ResponseStructure, Q, Builder, DataStructure>(
+    return new UrlBuilderRequestCmdV4<ResponseStructure, Q, Builder, DataStructure>(
       this.client,
       this.method,
       builder,

--- a/packages/odata-service/src/request/UrlGetRequestCmd.ts
+++ b/packages/odata-service/src/request/UrlGetRequestCmd.ts
@@ -3,12 +3,9 @@ import { RequestCmdOptions } from "./RequestCmd";
 import { GetToPostConverter } from "./RequestHelper";
 import { UrlRequestCmd } from "./UrlRequestCmd";
 
-export class UrlGetRequestCmd<ClientType extends ODataHttpClient, ResponseStructure> extends UrlRequestCmd<
-  ClientType,
-  ResponseStructure
-> {
+export class UrlGetRequestCmd<ResponseStructure> extends UrlRequestCmd<ResponseStructure> {
   constructor(
-    protected client: ClientType,
+    protected client: ODataHttpClient,
     protected url: string,
     protected options: RequestCmdOptions<ResponseStructure, undefined> = {},
   ) {

--- a/packages/odata-service/src/request/UrlRequestCmd.ts
+++ b/packages/odata-service/src/request/UrlRequestCmd.ts
@@ -1,13 +1,12 @@
 import { ODataHttpClient, ODataHttpMethods } from "@odata2ts/http-client-api";
 import { RequestCmd, RequestCmdOptions } from "./RequestCmd";
 
-export class UrlRequestCmd<
-  ClientType extends ODataHttpClient,
+export class UrlRequestCmd<ResponseStructure, DataStructure = undefined> extends RequestCmd<
   ResponseStructure,
-  DataStructure = undefined,
-> extends RequestCmd<ClientType, ResponseStructure, DataStructure> {
+  DataStructure
+> {
   constructor(
-    client: ClientType,
+    client: ODataHttpClient,
     method: ODataHttpMethods,
     protected url: string,
     data?: DataStructure,
@@ -30,12 +29,6 @@ export class UrlRequestCmd<
       throw new Error("withUrl requires a new URL!");
     }
 
-    return new UrlRequestCmd<ClientType, ResponseStructure, DataStructure>(
-      this.client,
-      this.method,
-      url,
-      this.data,
-      this.options,
-    );
+    return new UrlRequestCmd<ResponseStructure, DataStructure>(this.client, this.method, url, this.data, this.options);
   }
 }

--- a/packages/odata-service/src/v2/CollectionServiceV2.ts
+++ b/packages/odata-service/src/v2/CollectionServiceV2.ts
@@ -14,15 +14,16 @@ import { ServiceStateHelperV2 } from "./ServiceStateHelperV2.js";
 
 type PrimitiveExtractor<T> = T extends PrimitiveCollectionType<infer E> ? E : T;
 
-export class CollectionServiceV2<
-  in out ClientType extends ODataHttpClient,
-  T,
-  Q extends QueryObjectModel,
-  PrimitiveT = PrimitiveExtractor<T>,
-> {
-  protected readonly __base: ServiceStateHelperV2<ClientType, Q>;
+export class CollectionServiceV2<T, Q extends QueryObjectModel, PrimitiveT = PrimitiveExtractor<T>> {
+  protected readonly __base: ServiceStateHelperV2<Q>;
 
-  public constructor(client: ClientType, basePath: string, name: string, qModel: Q, options?: ODataServiceOptions) {
+  public constructor(
+    client: ODataHttpClient,
+    basePath: string,
+    name: string,
+    qModel: Q,
+    options?: ODataServiceOptions,
+  ) {
     this.__base = new ServiceStateHelperV2(client, basePath, name, qModel, options);
   }
 
@@ -51,7 +52,6 @@ export class CollectionServiceV2<
     const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
 
     return new UrlBuilderRequestCmdV2<
-      ClientType,
       CollectionModificationResponseV2<Response, PrimitiveT>,
       Q,
       ModelQueryBuilderV2<Q>,
@@ -87,7 +87,6 @@ export class CollectionServiceV2<
     const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
 
     return new UrlBuilderRequestCmdV2<
-      ClientType,
       CollectionModificationResponseV2<Response, PrimitiveT>,
       Q,
       ModelQueryBuilderV2<Q>,
@@ -108,7 +107,7 @@ export class CollectionServiceV2<
   public delete() {
     const { client, path } = this.__base;
 
-    return new UrlRequestCmd<ClientType, undefined>(client, ODataHttpMethods.Delete, path, undefined);
+    return new UrlRequestCmd<undefined>(client, ODataHttpMethods.Delete, path, undefined);
   }
 
   /**
@@ -117,7 +116,7 @@ export class CollectionServiceV2<
   public query<ReturnType = T>(queryFn?: (builder: CollectionQueryBuilderV2<Q>, qObject: Q) => void) {
     const { client, qModel, getDefaultHeaders, createQueryBuilder } = this.__base;
 
-    return new UrlBuilderRequestCmdV2<ClientType, ODataCollectionResponseV2<ReturnType>, Q>(
+    return new UrlBuilderRequestCmdV2<ODataCollectionResponseV2<ReturnType>, Q>(
       client,
       ODataHttpMethods.Get,
       createQueryBuilder(queryFn),

--- a/packages/odata-service/src/v2/ComplexTypeServiceV2.ts
+++ b/packages/odata-service/src/v2/ComplexTypeServiceV2.ts
@@ -7,10 +7,16 @@ import { UrlBuilderRequestCmdV2, UrlRequestCmd } from "../request";
 import { MERGE_HEADERS } from "../RequestHeaders.js";
 import { ServiceStateHelperV2 } from "./ServiceStateHelperV2.js";
 
-export class ComplexTypeServiceV2<in out ClientType extends ODataHttpClient, T, EditableT, Q extends QueryObjectModel> {
-  protected readonly __base: ServiceStateHelperV2<ClientType, Q>;
+export class ComplexTypeServiceV2<T, EditableT, Q extends QueryObjectModel> {
+  protected readonly __base: ServiceStateHelperV2<Q>;
 
-  protected constructor(client: ClientType, basePath: string, name: string, qModel: Q, options?: ODataServiceOptions) {
+  protected constructor(
+    client: ODataHttpClient,
+    basePath: string,
+    name: string,
+    qModel: Q,
+    options?: ODataServiceOptions,
+  ) {
     this.__base = new ServiceStateHelperV2(client, basePath, name, qModel, options);
   }
 
@@ -22,7 +28,7 @@ export class ComplexTypeServiceV2<in out ClientType extends ODataHttpClient, T, 
     const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
     const headers = { ...getDefaultHeaders(), ...MERGE_HEADERS };
 
-    return new UrlBuilderRequestCmdV2<ClientType, undefined, Q, ModelQueryBuilderV2<Q>, Partial<EditableT>>(
+    return new UrlBuilderRequestCmdV2<undefined, Q, ModelQueryBuilderV2<Q>, Partial<EditableT>>(
       client,
       ODataHttpMethods.Post,
       createModelQueryBuilder(queryFn),
@@ -38,7 +44,7 @@ export class ComplexTypeServiceV2<in out ClientType extends ODataHttpClient, T, 
   public update(model: EditableT, queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void) {
     const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
 
-    return new UrlBuilderRequestCmdV2<ClientType, undefined, Q, ModelQueryBuilderV2<Q>, EditableT>(
+    return new UrlBuilderRequestCmdV2<undefined, Q, ModelQueryBuilderV2<Q>, EditableT>(
       client,
       ODataHttpMethods.Put,
       createModelQueryBuilder(queryFn),
@@ -54,13 +60,13 @@ export class ComplexTypeServiceV2<in out ClientType extends ODataHttpClient, T, 
   public delete() {
     const { client, path } = this.__base;
 
-    return new UrlRequestCmd<ClientType, undefined>(client, ODataHttpMethods.Delete, path, undefined);
+    return new UrlRequestCmd<undefined>(client, ODataHttpMethods.Delete, path, undefined);
   }
 
   public query<ReturnType extends Partial<T> = T>(queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void) {
     const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
 
-    return new UrlBuilderRequestCmdV2<ClientType, ODataComplexModelResponseV2<ReturnType>, Q, ModelQueryBuilderV2<Q>>(
+    return new UrlBuilderRequestCmdV2<ODataComplexModelResponseV2<ReturnType>, Q, ModelQueryBuilderV2<Q>>(
       client,
       ODataHttpMethods.Get,
       createModelQueryBuilder(queryFn),

--- a/packages/odata-service/src/v2/EntitySetServiceV2.ts
+++ b/packages/odata-service/src/v2/EntitySetServiceV2.ts
@@ -11,18 +11,12 @@ import { ODataServiceOptions } from "../ODataServiceOptions";
 import { UrlBuilderRequestCmdV2 } from "../request";
 import { ServiceStateHelperV2 } from "./ServiceStateHelperV2.js";
 
-export abstract class EntitySetServiceV2<
-  in out ClientType extends ODataHttpClient,
-  T,
-  EditableT,
-  Q extends QueryObjectModel,
-  EIdType,
-> {
-  protected readonly __base: ServiceStateHelperV2<ClientType, Q>;
+export abstract class EntitySetServiceV2<T, EditableT, Q extends QueryObjectModel, EIdType> {
+  protected readonly __base: ServiceStateHelperV2<Q>;
   protected readonly __idFunction: QId<EIdType>;
 
   protected constructor(
-    client: ClientType,
+    client: ODataHttpClient,
     basePath: string,
     name: string,
     qModel: Q,
@@ -84,7 +78,7 @@ export abstract class EntitySetServiceV2<
   public create(model: EditableT, queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void) {
     const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
 
-    return new UrlBuilderRequestCmdV2<ClientType, ODataEntityModelResponseV2<T>, Q, ModelQueryBuilderV2<Q>, EditableT>(
+    return new UrlBuilderRequestCmdV2<ODataEntityModelResponseV2<T>, Q, ModelQueryBuilderV2<Q>, EditableT>(
       client,
       ODataHttpMethods.Post,
       createModelQueryBuilder(queryFn),
@@ -108,7 +102,7 @@ export abstract class EntitySetServiceV2<
   ) {
     const { client, qModel, getDefaultHeaders, createQueryBuilder } = this.__base;
 
-    return new UrlBuilderRequestCmdV2<ClientType, ODataCollectionResponseV2<ReturnType>, Q>(
+    return new UrlBuilderRequestCmdV2<ODataCollectionResponseV2<ReturnType>, Q>(
       client,
       ODataHttpMethods.Get,
       createQueryBuilder(queryFn),

--- a/packages/odata-service/src/v2/EntityTypeServiceV2.ts
+++ b/packages/odata-service/src/v2/EntityTypeServiceV2.ts
@@ -7,10 +7,16 @@ import { UrlBuilderRequestCmdV2, UrlRequestCmd } from "../request";
 import { MERGE_HEADERS } from "../RequestHeaders.js";
 import { ServiceStateHelperV2 } from "./ServiceStateHelperV2.js";
 
-export class EntityTypeServiceV2<in out ClientType extends ODataHttpClient, T, EditableT, Q extends QueryObjectModel> {
-  protected readonly __base: ServiceStateHelperV2<ClientType, Q>;
+export class EntityTypeServiceV2<T, EditableT, Q extends QueryObjectModel> {
+  protected readonly __base: ServiceStateHelperV2<Q>;
 
-  protected constructor(client: ClientType, basePath: string, name: string, qModel: Q, options?: ODataServiceOptions) {
+  protected constructor(
+    client: ODataHttpClient,
+    basePath: string,
+    name: string,
+    qModel: Q,
+    options?: ODataServiceOptions,
+  ) {
     this.__base = new ServiceStateHelperV2(client, basePath, name, qModel, options);
   }
 
@@ -31,7 +37,7 @@ export class EntityTypeServiceV2<in out ClientType extends ODataHttpClient, T, E
     const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
     const headers = { ...getDefaultHeaders(), ...MERGE_HEADERS };
 
-    return new UrlBuilderRequestCmdV2<ClientType, undefined, Q, ModelQueryBuilderV2<Q>, Partial<EditableT>>(
+    return new UrlBuilderRequestCmdV2<undefined, Q, ModelQueryBuilderV2<Q>, Partial<EditableT>>(
       client,
       ODataHttpMethods.Post,
       createModelQueryBuilder(queryFn),
@@ -55,7 +61,7 @@ export class EntityTypeServiceV2<in out ClientType extends ODataHttpClient, T, E
   public update(model: EditableT, queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void) {
     const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
 
-    return new UrlBuilderRequestCmdV2<ClientType, undefined, Q, ModelQueryBuilderV2<Q>, EditableT>(
+    return new UrlBuilderRequestCmdV2<undefined, Q, ModelQueryBuilderV2<Q>, EditableT>(
       client,
       ODataHttpMethods.Put,
       createModelQueryBuilder(queryFn),
@@ -76,13 +82,13 @@ export class EntityTypeServiceV2<in out ClientType extends ODataHttpClient, T, E
    */
   public delete() {
     const { client, path } = this.__base;
-    return new UrlRequestCmd<ClientType, undefined>(client, ODataHttpMethods.Delete, path, undefined);
+    return new UrlRequestCmd<undefined>(client, ODataHttpMethods.Delete, path, undefined);
   }
 
   public query<ReturnType extends Partial<T> = T>(queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void) {
     const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
 
-    return new UrlBuilderRequestCmdV2<ClientType, ODataEntityModelResponseV2<ReturnType>, Q, ModelQueryBuilderV2<Q>>(
+    return new UrlBuilderRequestCmdV2<ODataEntityModelResponseV2<ReturnType>, Q, ModelQueryBuilderV2<Q>>(
       client,
       ODataHttpMethods.Get,
       createModelQueryBuilder(queryFn),

--- a/packages/odata-service/src/v2/MediaEntityServiceV2.ts
+++ b/packages/odata-service/src/v2/MediaEntityServiceV2.ts
@@ -1,4 +1,3 @@
-import { ODataHttpClient } from "@odata2ts/http-client-api";
 import { QueryObjectModel } from "@odata2ts/odata-query-objects";
 import { EntityTypeServiceV2 } from "./EntityTypeServiceV2";
 import { StreamServiceV2 } from "./StreamServiceV2";
@@ -19,21 +18,20 @@ const VALUE_SEGMENT = "$value";
  * Everything an ordinary entity service does stays available - the media link entry still has regular
  * properties, which are read and written as JSON; only its content is separate.
  */
-export class MediaEntityServiceV2<
-  in out ClientType extends ODataHttpClient,
+export class MediaEntityServiceV2<T, EditableT, Q extends QueryObjectModel> extends EntityTypeServiceV2<
   T,
   EditableT,
-  Q extends QueryObjectModel,
-> extends EntityTypeServiceV2<ClientType, T, EditableT, Q> {
-  private _content?: StreamServiceV2<ClientType>;
+  Q
+> {
+  private _content?: StreamServiceV2;
 
   /**
    * The entity's content as its own service, bound to the `$value` URL.
    */
-  public content(): StreamServiceV2<ClientType> {
+  public content(): StreamServiceV2 {
     if (!this._content) {
       const { client, path, options } = this.__base;
-      this._content = new StreamServiceV2<ClientType>(client, path, VALUE_SEGMENT, options);
+      this._content = new StreamServiceV2(client, path, VALUE_SEGMENT, options);
     }
 
     return this._content;

--- a/packages/odata-service/src/v2/PrimitiveTypeServiceV2.ts
+++ b/packages/odata-service/src/v2/PrimitiveTypeServiceV2.ts
@@ -27,12 +27,12 @@ class ValueRequestConverter<T> {
   }
 }
 
-export class PrimitiveTypeServiceV2<in out ClientType extends ODataHttpClient, T> {
-  protected readonly __base: ServiceStateHelper<ClientType>;
+export class PrimitiveTypeServiceV2<T> {
+  protected readonly __base: ServiceStateHelper;
   protected readonly __converter: RequestResponseConverter<T>;
 
   public constructor(
-    client: ClientType,
+    client: ODataHttpClient,
     basePath: string,
     name: string,
     converter: ValueConverter<any, T> = getIdentityConverter(),
@@ -73,15 +73,11 @@ export class PrimitiveTypeServiceV2<in out ClientType extends ODataHttpClient, T
     const { client, path, getDefaultHeaders } = this.__base;
     const converter = this.__converter;
 
-    return new UrlRequestCmd<ClientType, ODataValueResponseV2<T>>(client, ODataHttpMethods.Get, path, undefined, {
+    return new UrlRequestCmd<ODataValueResponseV2<T>>(client, ODataHttpMethods.Get, path, undefined, {
       headers: getDefaultHeaders(),
       mainResponseConverter: new ValueResponseConverterV2(converter),
     });
   }
-
-  /*public getRawValue(requestConfig?: ODataHttpClientConfig<ClientType>): ODataResponse<any> {
-    return this.client.get(this.getPath() + RAW_VALUE_SUFFIX, requestConfig, { headers: OPEN_ACCEPT_HEADER });
-  }*/
 
   /**
    * Update the value.
@@ -95,7 +91,7 @@ export class PrimitiveTypeServiceV2<in out ClientType extends ODataHttpClient, T
     const { client, path, getDefaultHeaders, name } = this.__base;
     const converter = this.__converter;
 
-    return new UrlRequestCmd<ClientType, undefined, T>(client, ODataHttpMethods.Put, path, value, {
+    return new UrlRequestCmd<undefined, T>(client, ODataHttpMethods.Put, path, value, {
       headers: getDefaultHeaders(),
       mainRequestConverter: new ValueRequestConverter(converter, name!),
     });
@@ -109,6 +105,6 @@ export class PrimitiveTypeServiceV2<in out ClientType extends ODataHttpClient, T
   public deleteValue() {
     const { client, path } = this.__base;
 
-    return new UrlRequestCmd<ClientType, undefined>(client, ODataHttpMethods.Delete, path, undefined);
+    return new UrlRequestCmd<undefined>(client, ODataHttpMethods.Delete, path, undefined);
   }
 }

--- a/packages/odata-service/src/v2/ServiceStateHelperV2.ts
+++ b/packages/odata-service/src/v2/ServiceStateHelperV2.ts
@@ -4,12 +4,9 @@ import { QueryObjectModel } from "@odata2ts/odata-query-objects";
 import { ODataServiceOptions } from "../ODataServiceOptions";
 import { ServiceStateHelper } from "../ServiceStateHelper";
 
-export class ServiceStateHelperV2<
-  in out ClientType extends ODataHttpClient,
-  Q extends QueryObjectModel,
-> extends ServiceStateHelper<ClientType> {
+export class ServiceStateHelperV2<Q extends QueryObjectModel> extends ServiceStateHelper {
   public constructor(
-    client: ClientType,
+    client: ODataHttpClient,
     basePath: string,
     name: string,
     public qModel: Q,

--- a/packages/odata-service/src/v2/StreamServiceV2.ts
+++ b/packages/odata-service/src/v2/StreamServiceV2.ts
@@ -11,8 +11,8 @@ import { StreamServiceBase } from "../StreamServiceBase.js";
  * service is ever bound to is the entity's `$value`, and an entity can carry exactly one such payload.
  * That is also why it is not generated for any property - a V2 model has no way of declaring one.
  */
-export class StreamServiceV2<out ClientType extends ODataHttpClient> extends StreamServiceBase<ClientType> {
-  public constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+export class StreamServiceV2 extends StreamServiceBase {
+  public constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, options);
   }
 }

--- a/packages/odata-service/src/v4/CollectionServiceV4.ts
+++ b/packages/odata-service/src/v4/CollectionServiceV4.ts
@@ -31,16 +31,15 @@ class CollectionRequestConverter<T> {
 }
 
 export class CollectionServiceV4<
-  in out ClientType extends ODataHttpClient,
   T,
   Q extends QueryObjectModel,
   PrimitiveT = PrimitiveExtractor<T>,
   V extends ODataVersionV4 = "4.0",
 > {
-  protected readonly __base: ServiceStateHelperV4<ClientType, Q, V>;
+  protected readonly __base: ServiceStateHelperV4<Q, V>;
 
   public constructor(
-    client: ClientType,
+    client: ODataHttpClient,
     basePath: string,
     name: string,
     qModel: Q,
@@ -75,7 +74,6 @@ export class CollectionServiceV4<
     const { client, getDefaultHeaders, getVersionHeaders, qModel, createModelQueryBuilder } = this.__base;
 
     return new UrlBuilderRequestCmdV4<
-      ClientType,
       CollectionModificationResponseV4<Response, PrimitiveT, V>,
       Q,
       ModelQueryBuilderV4<Q>,
@@ -112,7 +110,6 @@ export class CollectionServiceV4<
     const { client, getDefaultHeaders, getVersionHeaders, qModel, createModelQueryBuilder } = this.__base;
 
     return new UrlBuilderRequestCmdV4<
-      ClientType,
       CollectionModificationResponseV4<Response, PrimitiveT, V>,
       Q,
       ModelQueryBuilderV4<Q>,
@@ -136,7 +133,7 @@ export class CollectionServiceV4<
   public delete() {
     const { client, path } = this.__base;
 
-    return new UrlRequestCmd<ClientType, undefined>(client, ODataHttpMethods.Delete, path, undefined);
+    return new UrlRequestCmd<undefined>(client, ODataHttpMethods.Delete, path, undefined);
   }
 
   /**
@@ -148,7 +145,7 @@ export class CollectionServiceV4<
   public query<ReturnType = T>(queryFn?: (builder: CollectionQueryBuilderV4<Q>, qObject: Q) => void) {
     const { client, qModel, getDefaultHeaders, createQueryBuilder } = this.__base;
 
-    return new UrlBuilderRequestCmdV4<ClientType, ODataCollectionResponseFor<V, ReturnType>, Q>(
+    return new UrlBuilderRequestCmdV4<ODataCollectionResponseFor<V, ReturnType>, Q>(
       client,
       ODataHttpMethods.Get,
       createQueryBuilder(queryFn),

--- a/packages/odata-service/src/v4/EntitySetServiceV4.ts
+++ b/packages/odata-service/src/v4/EntitySetServiceV4.ts
@@ -13,14 +13,13 @@ import { EntityModificationResponseV4 } from "./ResponseTypeChoicesV4";
 import { ServiceStateHelperV4, SubtypeOptions } from "./ServiceStateHelperV4.js";
 
 export abstract class EntitySetServiceV4<
-  in out ClientType extends ODataHttpClient,
   T,
   EditableT,
   Q extends QueryObjectModel,
   EIdType,
   V extends ODataVersionV4 = "4.0",
 > {
-  protected readonly __base: ServiceStateHelperV4<ClientType, Q, V>;
+  protected readonly __base: ServiceStateHelperV4<Q, V>;
   protected readonly __idFunction: QId<EIdType>;
 
   /**
@@ -36,7 +35,7 @@ export abstract class EntitySetServiceV4<
    * @protected
    */
   protected constructor(
-    client: ClientType,
+    client: ODataHttpClient,
     basePath: string,
     name: string,
     qModel: Q,
@@ -119,7 +118,6 @@ export abstract class EntitySetServiceV4<
     const actualPath = dontUseCastPathSegment ? basePath : path;
 
     return new UrlBuilderRequestCmdV4<
-      ClientType,
       EntityModificationResponseV4<Response, T, V>,
       Q,
       ModelQueryBuilderV4<Q>,
@@ -142,7 +140,7 @@ export abstract class EntitySetServiceV4<
   ) {
     const { client, qModel, createQueryBuilder, getDefaultHeaders } = this.__base;
 
-    return new UrlBuilderRequestCmdV4<ClientType, ODataCollectionResponseFor<V, ReturnType>, Q>(
+    return new UrlBuilderRequestCmdV4<ODataCollectionResponseFor<V, ReturnType>, Q>(
       client,
       ODataHttpMethods.Get,
       createQueryBuilder(queryFn),

--- a/packages/odata-service/src/v4/EntityTypeServiceV4.ts
+++ b/packages/odata-service/src/v4/EntityTypeServiceV4.ts
@@ -7,17 +7,11 @@ import { UrlBuilderRequestCmdV4, UrlRequestCmd } from "../request";
 import { EntityModificationResponseV4 } from "./ResponseTypeChoicesV4";
 import { ServiceStateHelperV4, SubtypeOptions } from "./ServiceStateHelperV4.js";
 
-export class EntityTypeServiceV4<
-  in out ClientType extends ODataHttpClient,
-  T,
-  EditableT,
-  Q extends QueryObjectModel,
-  V extends ODataVersionV4 = "4.0",
-> {
-  protected readonly __base: ServiceStateHelperV4<ClientType, Q, V>;
+export class EntityTypeServiceV4<T, EditableT, Q extends QueryObjectModel, V extends ODataVersionV4 = "4.0"> {
+  protected readonly __base: ServiceStateHelperV4<Q, V>;
 
   public constructor(
-    client: ClientType,
+    client: ODataHttpClient,
     basePath: string,
     name: string,
     qModel: Q,
@@ -60,7 +54,6 @@ export class EntityTypeServiceV4<
     const actualPath = dontUseCastPathSegment ? basePath : path;
 
     return new UrlBuilderRequestCmdV4<
-      ClientType,
       EntityModificationResponseV4<Response, T, V>,
       Q,
       ModelQueryBuilderV4<Q>,
@@ -102,7 +95,6 @@ export class EntityTypeServiceV4<
     const actualPath = dontUseCastPathSegment ? basePath : path;
 
     return new UrlBuilderRequestCmdV4<
-      ClientType,
       EntityModificationResponseV4<Response, T, V>,
       Q,
       ModelQueryBuilderV4<Q>,
@@ -123,7 +115,7 @@ export class EntityTypeServiceV4<
    */
   public delete() {
     const { client, path } = this.__base;
-    return new UrlRequestCmd<ClientType, undefined>(client, ODataHttpMethods.Delete, path);
+    return new UrlRequestCmd<undefined>(client, ODataHttpMethods.Delete, path);
   }
 
   /**
@@ -136,7 +128,7 @@ export class EntityTypeServiceV4<
   public query<ReturnType extends Partial<T> = T>(queryFn?: (builder: ModelQueryBuilderV4<Q>, qObject: Q) => void) {
     const { client, qModel, createModelQueryBuilder, getDefaultHeaders } = this.__base;
 
-    return new UrlBuilderRequestCmdV4<ClientType, ODataModelResponseFor<V, ReturnType>, Q, ModelQueryBuilderV4<Q>>(
+    return new UrlBuilderRequestCmdV4<ODataModelResponseFor<V, ReturnType>, Q, ModelQueryBuilderV4<Q>>(
       client,
       ODataHttpMethods.Get,
       createModelQueryBuilder(queryFn),

--- a/packages/odata-service/src/v4/MediaEntityServiceV4.ts
+++ b/packages/odata-service/src/v4/MediaEntityServiceV4.ts
@@ -1,4 +1,3 @@
-import { ODataHttpClient } from "@odata2ts/http-client-api";
 import { ODataVersionV4 } from "@odata2ts/odata-core";
 import { QueryObjectModel } from "@odata2ts/odata-query-objects";
 import { EntityTypeServiceV4 } from "./EntityTypeServiceV4";
@@ -16,13 +15,12 @@ const VALUE_SEGMENT = "$value";
  * properties, which are read and written as JSON; only its content is separate.
  */
 export class MediaEntityServiceV4<
-  in out ClientType extends ODataHttpClient,
   T,
   EditableT,
   Q extends QueryObjectModel,
   V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, T, EditableT, Q, V> {
-  private _content?: StreamServiceV4<ClientType, V>;
+> extends EntityTypeServiceV4<T, EditableT, Q, V> {
+  private _content?: StreamServiceV4<V>;
 
   /**
    * The entity's content as its own service, bound to the `$value` URL.
@@ -35,17 +33,17 @@ export class MediaEntityServiceV4<
    *
    * @param subtypeOptions opt the cast path segment back in
    */
-  public content(subtypeOptions?: SubtypeOptions): StreamServiceV4<ClientType, V> {
+  public content(subtypeOptions?: SubtypeOptions): StreamServiceV4<V> {
     const { client, basePath, path, options } = this.__base;
     const { dontUseCastPathSegment } = this.__base.evaluateSubtypeOptions(subtypeOptions);
     const actualPath = dontUseCastPathSegment ? basePath : path;
 
     // only the default is worth caching; anything else is a one-off request shape
     if (subtypeOptions) {
-      return new StreamServiceV4<ClientType, V>(client, actualPath, VALUE_SEGMENT, options);
+      return new StreamServiceV4<V>(client, actualPath, VALUE_SEGMENT, options);
     }
     if (!this._content) {
-      this._content = new StreamServiceV4<ClientType, V>(client, actualPath, VALUE_SEGMENT, options);
+      this._content = new StreamServiceV4<V>(client, actualPath, VALUE_SEGMENT, options);
     }
 
     return this._content;

--- a/packages/odata-service/src/v4/PrimitiveTypeServiceV4.ts
+++ b/packages/odata-service/src/v4/PrimitiveTypeServiceV4.ts
@@ -22,12 +22,12 @@ class ValueRequestConverter<T> {
   }
 }
 
-export class PrimitiveTypeServiceV4<out ClientType extends ODataHttpClient, T, V extends ODataVersionV4 = "4.0"> {
-  protected readonly __base: ServiceStateHelper<ClientType, V>;
+export class PrimitiveTypeServiceV4<T, V extends ODataVersionV4 = "4.0"> {
+  protected readonly __base: ServiceStateHelper<V>;
   protected readonly __converter: ValueConverter<any, T>;
 
   public constructor(
-    client: ClientType,
+    client: ODataHttpClient,
     basePath: string,
     name: string,
     converter: ValueConverter<any, any> = getIdentityConverter(),
@@ -51,16 +51,10 @@ export class PrimitiveTypeServiceV4<out ClientType extends ODataHttpClient, T, V
     const { client, path, getDefaultHeaders } = this.__base;
     const converter = this.__converter;
 
-    return new UrlRequestCmd<ClientType, ODataValueResponseFor<V, T> | undefined>(
-      client,
-      ODataHttpMethods.Get,
-      path,
-      undefined,
-      {
-        headers: getDefaultHeaders(),
-        mainResponseConverter: new ValueResponseConverterV4(converter),
-      },
-    );
+    return new UrlRequestCmd<ODataValueResponseFor<V, T> | undefined>(client, ODataHttpMethods.Get, path, undefined, {
+      headers: getDefaultHeaders(),
+      mainResponseConverter: new ValueResponseConverterV4(converter),
+    });
   }
 
   /**
@@ -81,7 +75,7 @@ export class PrimitiveTypeServiceV4<out ClientType extends ODataHttpClient, T, V
     const { client, path, getDefaultHeaders, getVersionHeaders } = this.__base;
     const converter = this.__converter;
 
-    return new UrlRequestCmd<ClientType, ValueModificationResponseV4<Response, T, V>, T>(
+    return new UrlRequestCmd<ValueModificationResponseV4<Response, T, V>, T>(
       client,
       ODataHttpMethods.Put,
       path,
@@ -105,6 +99,6 @@ export class PrimitiveTypeServiceV4<out ClientType extends ODataHttpClient, T, V
    */
   public deleteValue() {
     const { client, path } = this.__base;
-    return new UrlRequestCmd<ClientType, undefined>(client, ODataHttpMethods.Delete, path);
+    return new UrlRequestCmd<undefined>(client, ODataHttpMethods.Delete, path);
   }
 }

--- a/packages/odata-service/src/v4/ServiceStateHelperV4.ts
+++ b/packages/odata-service/src/v4/ServiceStateHelperV4.ts
@@ -11,12 +11,11 @@ export interface SubtypeOptions {
 }
 
 export class ServiceStateHelperV4<
-  in out ClientType extends ODataHttpClient,
   Q extends QueryObjectModel,
   V extends ODataVersionV4 = "4.0",
-> extends ServiceStateHelper<ClientType, V> {
+> extends ServiceStateHelper<V> {
   public constructor(
-    client: ClientType,
+    client: ODataHttpClient,
     basePath: string,
     name: string,
     public qModel: Q,

--- a/packages/odata-service/src/v4/StreamServiceV4.ts
+++ b/packages/odata-service/src/v4/StreamServiceV4.ts
@@ -1,4 +1,3 @@
-import { ODataHttpClient } from "@odata2ts/http-client-api";
 import { ODataVersionV4 } from "@odata2ts/odata-core";
 import { StreamServiceBase } from "../StreamServiceBase.js";
 
@@ -8,7 +7,4 @@ import { StreamServiceBase } from "../StreamServiceBase.js";
  *
  * The bound URL is the property name for a stream property and `$value` for a media entity's content.
  */
-export class StreamServiceV4<
-  out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends StreamServiceBase<ClientType, V> {}
+export class StreamServiceV4<V extends ODataVersionV4 = "4.0"> extends StreamServiceBase<V> {}

--- a/packages/odata-service/test/EntitySetServiceTests.ts
+++ b/packages/odata-service/test/EntitySetServiceTests.ts
@@ -13,16 +13,16 @@ export function commonEntitySetTests(
     name: string,
     options?: ODataServiceOptions,
   ) =>
-    | EntitySetServiceV4<MockClient, PersonModel, EditablePersonModel, QPersonV4, PersonId>
-    | EntitySetServiceV2<MockClient, PersonModel, EditablePersonModel, QPersonV2, PersonId>,
+    | EntitySetServiceV4<PersonModel, EditablePersonModel, QPersonV4, PersonId>
+    | EntitySetServiceV2<PersonModel, EditablePersonModel, QPersonV2, PersonId>,
 ) {
   const BASE_URL = "/base";
   const NAME = "EntityXY";
   const EXPECTED_PATH = `${BASE_URL}/${NAME}`;
 
   let testService:
-    | EntitySetServiceV4<MockClient, PersonModel, EditablePersonModel, QPersonV4, PersonId>
-    | EntitySetServiceV2<MockClient, PersonModel, EditablePersonModel, QPersonV2, PersonId>;
+    | EntitySetServiceV4<PersonModel, EditablePersonModel, QPersonV4, PersonId>
+    | EntitySetServiceV2<PersonModel, EditablePersonModel, QPersonV2, PersonId>;
 
   beforeEach(() => {
     testService = new serviceConstructor(odataClient, BASE_URL, NAME);

--- a/packages/odata-service/test/ODataService.test.ts
+++ b/packages/odata-service/test/ODataService.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 import { ODataService } from "../src";
 import { MockClient } from "./mock/MockClient";
 
-class TestODataService extends ODataService<MockClient> {
+class TestODataService extends ODataService {
   public exposeAddFullPath(path?: string) {
     return this.__base.addFullPath(path);
   }

--- a/packages/odata-service/test/fixture/PersonModel.ts
+++ b/packages/odata-service/test/fixture/PersonModel.ts
@@ -46,8 +46,8 @@ export interface GetSomethingFunctionParams {
   testTime: string;
 }
 
-export type PersonModelServiceVersion = PMServiceV2<MockClient> | PMServiceV4<MockClient>;
-export type PersonCollectionServiceVersion = PMCServiceV2<MockClient> | PMCServiceV4<MockClient>;
+export type PersonModelServiceVersion = PMServiceV2 | PMServiceV4;
+export type PersonCollectionServiceVersion = PMCServiceV2 | PMCServiceV4;
 
 export type StringCollectionServiceConstructor = (
   basePath: string,
@@ -55,10 +55,9 @@ export type StringCollectionServiceConstructor = (
   options?: ODataServiceOptions,
 ) => StringCollectionService;
 export type StringCollectionService =
-  | CollectionServiceV4<MockClient, StringCollection, QStringCollection>
-  | CollectionServiceV2<MockClient, StringCollection, QStringV2Collection>;
+  CollectionServiceV4<StringCollection, QStringCollection> | CollectionServiceV2<StringCollection, QStringV2Collection>;
 
 export type EnumCollectionServiceConstructor = (basePath: string, name: string) => EnumCollectionService;
 export type EnumCollectionService =
-  | CollectionServiceV4<MockClient, EnumCollection<StringTestEnum>, QEnumCollection<any>>
-  | CollectionServiceV2<MockClient, NumericEnumCollection<NumericTestEnum>, QNumericEnumCollection<any>>;
+  | CollectionServiceV4<EnumCollection<StringTestEnum>, QEnumCollection<any>>
+  | CollectionServiceV2<NumericEnumCollection<NumericTestEnum>, QNumericEnumCollection<any>>;

--- a/packages/odata-service/test/fixture/v2/FakedComplexServiceV2.ts
+++ b/packages/odata-service/test/fixture/v2/FakedComplexServiceV2.ts
@@ -3,13 +3,8 @@ import { ComplexTypeServiceV2, ODataServiceOptions } from "../../../src";
 import { EditablePersonModel, PersonModel } from "../PersonModel";
 import { qPersonV2, QPersonV2 } from "./QPersonV2";
 
-export class FakedComplexServiceV2<ClientType extends ODataHttpClient> extends ComplexTypeServiceV2<
-  ClientType,
-  PersonModel,
-  EditablePersonModel,
-  QPersonV2
-> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+export class FakedComplexServiceV2 extends ComplexTypeServiceV2<PersonModel, EditablePersonModel, QPersonV2> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qPersonV2, options);
   }
 }

--- a/packages/odata-service/test/fixture/v2/PersonModelV2Service.ts
+++ b/packages/odata-service/test/fixture/v2/PersonModelV2Service.ts
@@ -14,12 +14,7 @@ import { EditablePersonModel, Feature, GetSomethingFunctionParams, PersonId, Per
 import { QPersonIdFunction } from "../QPerson";
 import { QGetSomethingFunction, QPersonV2, qPersonV2 } from "./QPersonV2";
 
-export class PersonModelV2Service<ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
-  ClientType,
-  PersonModel,
-  EditablePersonModel,
-  QPersonV2
-> {
+export class PersonModelV2Service extends EntityTypeServiceV2<PersonModel, EditablePersonModel, QPersonV2> {
   private _qGetSomething = new QGetSomethingFunction();
 
   public get features() {
@@ -30,14 +25,7 @@ export class PersonModelV2Service<ClientType extends ODataHttpClient> extends En
   public userName() {
     const { client, path, qModel, options } = this.__base;
 
-    return new PrimitiveTypeServiceV2<ClientType, string>(
-      client,
-      path,
-      "UserName",
-      qModel.userName.converter,
-      "userName",
-      options,
-    );
+    return new PrimitiveTypeServiceV2<string>(client, path, "UserName", qModel.userName.converter, "userName", options);
   }
 
   public get bestFriend() {
@@ -50,45 +38,33 @@ export class PersonModelV2Service<ClientType extends ODataHttpClient> extends En
     return new PersonModelV2CollectionService(client, path, "Friends", options);
   }
 
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, new QPersonV2(), options);
   }
 
   public getSomething(params: GetSomethingFunctionParams) {
     const { client, addFullPath, isUrlNotEncoded } = this.__base;
     const url = addFullPath(this._qGetSomething.buildUrl(params, isUrlNotEncoded()));
-    return new UrlRequestCmd<ClientType, ODataEntityModelResponseV2<PersonModel>>(
-      client,
-      ODataHttpMethods.Get,
-      url,
-      undefined,
-      {
-        mainResponseConverter: new EntityResponseConverterV2(qPersonV2),
-      },
-    );
+    return new UrlRequestCmd<ODataEntityModelResponseV2<PersonModel>>(client, ODataHttpMethods.Get, url, undefined, {
+      mainResponseConverter: new EntityResponseConverterV2(qPersonV2),
+    });
   }
 }
 
 /** Same entity, only declared `m:HasStream="true"` - which is all the generator does differently. */
-export class PersonModelV2MediaService<ClientType extends ODataHttpClient> extends MediaEntityServiceV2<
-  ClientType,
-  PersonModel,
-  EditablePersonModel,
-  QPersonV2
-> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+export class PersonModelV2MediaService extends MediaEntityServiceV2<PersonModel, EditablePersonModel, QPersonV2> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, new QPersonV2(), options);
   }
 }
 
-export class PersonModelV2CollectionService<ClientType extends ODataHttpClient> extends EntitySetServiceV2<
-  ClientType,
+export class PersonModelV2CollectionService extends EntitySetServiceV2<
   PersonModel,
   EditablePersonModel,
   QPersonV2,
   PersonId
 > {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qPersonV2, new QPersonIdFunction(name), options);
   }
 }

--- a/packages/odata-service/test/fixture/v4/BaseTypeModel.ts
+++ b/packages/odata-service/test/fixture/v4/BaseTypeModel.ts
@@ -79,11 +79,13 @@ export class QFlight extends QPlanItemBaseType<FlightModel> {
   public readonly flightNumber = new QStringPath(this.withPrefix("FlightNumber"));
 }
 
-export class PlanItemService<
-  ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, PlanItemModel, EditablePlanItemModel, QPlanItem, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class PlanItemService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<
+  PlanItemModel,
+  EditablePlanItemModel,
+  QPlanItem,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, new QPlanItem(), options);
   }
 
@@ -100,11 +102,14 @@ export class PlanItemService<
   }
 }
 
-export class PlanItemCollectionService<
-  ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntitySetServiceV4<ClientType, PlanItemModel, EditablePlanItemModel, QPlanItem, PlanItemIdModel, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class PlanItemCollectionService<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
+  PlanItemModel,
+  EditablePlanItemModel,
+  QPlanItem,
+  PlanItemIdModel,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, new QPlanItem(), new QPlanItemId(name), options);
   }
 
@@ -121,38 +126,48 @@ export class PlanItemCollectionService<
   }
 }
 
-export class FlightService<
-  ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, FlightModel, EditableFlightModel, QFlight, V> {
-  constructor(client: ClientType, basePath: string, name: string, options: ODataServiceOptionsInternal<V>) {
+export class FlightService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<
+  FlightModel,
+  EditableFlightModel,
+  QFlight,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, new QFlight(), options);
   }
 }
 
-export class FlightCollectionService<
-  ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntitySetServiceV4<ClientType, FlightModel, EditableFlightModel, QFlight, PlanItemIdModel, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class FlightCollectionService<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
+  FlightModel,
+  EditableFlightModel,
+  QFlight,
+  PlanItemIdModel,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, new QFlight(), new QPlanItemId(name), options);
   }
 }
 
-export class EventService<
-  ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, EventModel, EditableEventModel, QEvent, V> {
-  constructor(client: ClientType, basePath: string, name: string, options: ODataServiceOptionsInternal<V>) {
+export class EventService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<
+  EventModel,
+  EditableEventModel,
+  QEvent,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, new QEvent(), options);
   }
 }
 
-export class EventCollectionService<
-  ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntitySetServiceV4<ClientType, EventModel, EditableEventModel, QEvent, PlanItemIdModel, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class EventCollectionService<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
+  EventModel,
+  EditableEventModel,
+  QEvent,
+  PlanItemIdModel,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, new QEvent(), new QPlanItemId(name), options);
   }
 }

--- a/packages/odata-service/test/fixture/v4/PersonModelService.ts
+++ b/packages/odata-service/test/fixture/v4/PersonModelService.ts
@@ -15,34 +15,30 @@ import { EditablePersonModel, Feature, GetSomethingFunctionParams, PersonId, Per
 import { QPersonIdFunction } from "../QPerson";
 import { QGetScoreFunction, QGetSomethingComposable, QGetSomethingFunction, QPersonV4, qPersonV4 } from "./QPersonV4";
 
-export class PersonModelService<
-  ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, PersonModel, EditablePersonModel, QPersonV4, V> {
+export class PersonModelService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<
+  PersonModel,
+  EditablePersonModel,
+  QPersonV4,
+  V
+> {
   private _qGetSomething = new QGetSomethingFunction();
 
   private _qGetComposable = new QGetSomethingComposable();
 
   private _qGetScore = new QGetScoreFunction();
 
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, new QPersonV4(), options);
   }
 
   public userName() {
     const { client, path, qModel, options } = this.__base;
-    return new PrimitiveTypeServiceV4<ClientType, string, V>(
-      client,
-      path,
-      "UserName",
-      qModel.userName.converter,
-      options,
-    );
+    return new PrimitiveTypeServiceV4<string, V>(client, path, "UserName", qModel.userName.converter, options);
   }
 
   public age() {
     const { client, path, qModel, options } = this.__base;
-    return new PrimitiveTypeServiceV4<ClientType, string, V>(client, path, "Age", qModel.age.converter, options);
+    return new PrimitiveTypeServiceV4<string, V>(client, path, "Age", qModel.age.converter, options);
   }
 
   public get features() {
@@ -64,22 +60,16 @@ export class PersonModelService<
     const { addFullPath, client, isUrlNotEncoded } = this.__base;
     const url = addFullPath(this._qGetSomething.buildUrl(params, isUrlNotEncoded()));
 
-    return new UrlRequestCmd<ClientType, ODataModelResponseV4<PersonModel>>(
-      client,
-      ODataHttpMethods.Get,
-      url,
-      undefined,
-      {
-        mainResponseConverter: new ModelResponseConverterV4(qPersonV4),
-      },
-    );
+    return new UrlRequestCmd<ODataModelResponseV4<PersonModel>>(client, ODataHttpMethods.Get, url, undefined, {
+      mainResponseConverter: new ModelResponseConverterV4(qPersonV4),
+    });
   }
 
   public getSomething2() {
     const { addFullPath, client, isUrlNotEncoded } = this.__base;
     const url = addFullPath(this._qGetSomething.buildUrl(undefined, isUrlNotEncoded()));
 
-    return new UrlGetRequestCmd<ClientType, ODataModelResponseV4<PersonModel>>(client, url, {
+    return new UrlGetRequestCmd<ODataModelResponseV4<PersonModel>>(client, url, {
       mainResponseConverter: new ModelResponseConverterV4(qPersonV4),
     });
   }
@@ -88,13 +78,14 @@ export class PersonModelService<
     const { addFullPath, client, isUrlNotEncoded, options } = this.__base;
     const url = addFullPath(this._qGetComposable.buildUrl(params, isUrlNotEncoded()));
 
-    return new ComposableUrlRequestCmd<
-      ClientType,
-      PersonModelService<ClientType, V>,
-      ODataModelResponseV4<PersonModel>
-    >(client, url, (finalUrl: string) => new PersonModelService<ClientType, V>(client, finalUrl, "", options), {
-      mainResponseConverter: new ModelResponseConverterV4(qPersonV4),
-    });
+    return new ComposableUrlRequestCmd<PersonModelService<V>, ODataModelResponseV4<PersonModel>>(
+      client,
+      url,
+      (finalUrl: string) => new PersonModelService<V>(client, finalUrl, "", options),
+      {
+        mainResponseConverter: new ModelResponseConverterV4(qPersonV4),
+      },
+    );
   }
 
   /**
@@ -105,19 +96,22 @@ export class PersonModelService<
     const { addFullPath, client, isUrlNotEncoded } = this.__base;
     const url = addFullPath(this._qGetScore.buildUrl(undefined, isUrlNotEncoded()));
 
-    return new UrlGetRequestCmd<ClientType, ODataValueResponseV4<string>>(client, url, {
+    return new UrlGetRequestCmd<ODataValueResponseV4<string>>(client, url, {
       mainResponseConverter: this._qGetScore.getResponseConverter(),
     });
   }
 }
 
-export class PersonModelCollectionService<
-  ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntitySetServiceV4<ClientType, PersonModel, EditablePersonModel, QPersonV4, PersonId, V> {
+export class PersonModelCollectionService<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
+  PersonModel,
+  EditablePersonModel,
+  QPersonV4,
+  PersonId,
+  V
+> {
   private _qGetSomething = new QGetSomethingFunction();
 
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qPersonV4, new QPersonIdFunction(name), options);
   }
 
@@ -130,14 +124,8 @@ export class PersonModelCollectionService<
     const { addFullPath, client, isUrlNotEncoded } = this.__base;
     const url = addFullPath(this._qGetSomething.buildUrl(params, isUrlNotEncoded()));
 
-    return new UrlRequestCmd<ClientType, ODataModelResponseV4<PersonModel>>(
-      client,
-      ODataHttpMethods.Get,
-      url,
-      undefined,
-      {
-        mainResponseConverter: new ModelResponseConverterV4(qPersonV4),
-      },
-    );
+    return new UrlRequestCmd<ODataModelResponseV4<PersonModel>>(client, ODataHttpMethods.Get, url, undefined, {
+      mainResponseConverter: new ModelResponseConverterV4(qPersonV4),
+    });
   }
 }

--- a/packages/odata-service/test/fixture/v4/TypingModelService.ts
+++ b/packages/odata-service/test/fixture/v4/TypingModelService.ts
@@ -48,20 +48,25 @@ export class QTestIdFunction extends QId<TestModelId> {
   }
 }
 
-export class TestService<
-  ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, TestModel, EditableTestModel, QTest, V> {
-  constructor(client: ClientType, basePath: string, name: string, options: ODataServiceOptionsInternal<V>) {
+export class TestService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<
+  TestModel,
+  EditableTestModel,
+  QTest,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qTest, options);
   }
 }
 
-export class TestCollectionService<
-  ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntitySetServiceV4<ClientType, TestModel, EditableTestModel, QTest, TestModelId, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class TestCollectionService<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
+  TestModel,
+  EditableTestModel,
+  QTest,
+  TestModelId,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qTest, new QTestIdFunction(name), options);
   }
 }

--- a/packages/odata-service/test/request/ComposableUrlRequestCmd.test.ts
+++ b/packages/odata-service/test/request/ComposableUrlRequestCmd.test.ts
@@ -14,18 +14,19 @@ describe("ComposableUrlRequestCmd tests", () => {
   const DEFAULT_HEADERS = { x: "y" };
 
   let client: MockClient;
-  let candidate: ComposableUrlRequestCmd<MockClient, PersonModelService<MockClient>, ODataModelResponseV4<PersonModel>>;
+  let candidate: ComposableUrlRequestCmd<PersonModelService, ODataModelResponseV4<PersonModel>>;
 
   beforeEach(() => {
     client = new MockClient(false);
-    candidate = new ComposableUrlRequestCmd<
-      MockClient,
-      PersonModelService<MockClient>,
-      ODataModelResponseV4<PersonModel>
-    >(client, DEFAULT_URL, (url: string) => new PersonModelService(client, url, "", { noUrlEncoding: true }), {
-      headers: DEFAULT_HEADERS,
-      mainResponseConverter: new ModelResponseConverterV4(new QPersonV4()),
-    });
+    candidate = new ComposableUrlRequestCmd<PersonModelService, ODataModelResponseV4<PersonModel>>(
+      client,
+      DEFAULT_URL,
+      (url: string) => new PersonModelService(client, url, "", { noUrlEncoding: true }),
+      {
+        headers: DEFAULT_HEADERS,
+        mainResponseConverter: new ModelResponseConverterV4(new QPersonV4()),
+      },
+    );
   });
 
   test("base props", () => {
@@ -39,7 +40,7 @@ describe("ComposableUrlRequestCmd tests", () => {
   });
 
   test("without options argument", () => {
-    const noOptionsCandidate = new ComposableUrlRequestCmd<MockClient, PersonModelService<MockClient>, undefined>(
+    const noOptionsCandidate = new ComposableUrlRequestCmd<PersonModelService, undefined>(
       client,
       DEFAULT_URL,
       (url: string) => new PersonModelService(client, url, "", { noUrlEncoding: true }),
@@ -94,7 +95,6 @@ describe("ComposableUrlRequestCmd tests", () => {
     // Model cardinality, because `candidate` is composed directly (bound to a single resource), not via a
     // collection-valued navigation property.
     const typeCheck: UrlBuilderRequestCmdV4<
-      MockClient,
       ODataModelResponseV4<PersonModel>,
       QPersonV4,
       ModelQueryBuilderV4<QPersonV4>
@@ -109,7 +109,6 @@ describe("ComposableUrlRequestCmd tests", () => {
 
     // see comment in "compose: direct select query" above
     const typeCheck: UrlBuilderRequestCmdV4<
-      MockClient,
       ODataCollectionResponseV4<PersonModel>,
       QPersonV4,
       CollectionQueryBuilderV4<QPersonV4>

--- a/packages/odata-service/test/request/RequestCmd.test.ts
+++ b/packages/odata-service/test/request/RequestCmd.test.ts
@@ -1,9 +1,9 @@
 import { ODataHttpMethods } from "@odata2ts/http-client-api";
 import { describe, expect, test } from "vitest";
 import { RequestCmd } from "../../src/request/RequestCmd";
-import { MockClient } from "../mock/MockClient";
+import { MockClient, MockRequestConfig } from "../mock/MockClient";
 
-class TestRequestCmd extends RequestCmd<MockClient, void> {
+class TestRequestCmd extends RequestCmd<void> {
   public getUrl(): string {
     return "test/ing";
   }
@@ -26,5 +26,43 @@ describe("RequestCmd tests", () => {
       data: undefined,
     });
     expect(candidate.getInfoConverted()).toStrictEqual(candidate.getInfo());
+  });
+
+  /**
+   * The command is not generic over the HTTP client, so `execute` knows nothing about the config type of
+   * the client it was handed. What every client understands - headers and URL params - is the default;
+   * anything a specific client adds on top is opted into by naming its config type at the call site.
+   *
+   * These assertions are about typing, hence checked by `test-compile` rather than at runtime.
+   */
+  describe("request config typing", () => {
+    test("no config at all", async () => {
+      const client = new MockClient(false);
+      await new TestRequestCmd(client, ODataHttpMethods.Get).execute();
+
+      expect(client.lastRequestConfig).toBeUndefined();
+    });
+
+    test("the common config needs no type argument", async () => {
+      const client = new MockClient(false);
+      await new TestRequestCmd(client, ODataHttpMethods.Get).execute({
+        headers: { add: "plus" },
+        params: { $count: true },
+      });
+
+      expect(client.lastRequestConfig).toStrictEqual({ headers: { add: "plus" }, params: { $count: true } });
+    });
+
+    test("a client specific field requires its config type", async () => {
+      const client = new MockClient(false);
+      const candidate = new TestRequestCmd(client, ODataHttpMethods.Get);
+
+      // @ts-expect-error: `test` belongs to MockRequestConfig, which the default does not cover
+      await candidate.execute({ test: "ing" });
+
+      await candidate.execute<MockRequestConfig>({ headers: { add: "plus" }, test: "ing" });
+
+      expect(client.lastRequestConfig).toStrictEqual({ headers: { add: "plus" }, test: "ing" });
+    });
   });
 });

--- a/packages/odata-service/test/request/UrlBuilderRequestCmdV2.test.ts
+++ b/packages/odata-service/test/request/UrlBuilderRequestCmdV2.test.ts
@@ -35,7 +35,6 @@ describe("UrlBuilderRequestCmd tests", () => {
 
   test("carries an explicit method and data payload, e.g. for a write operation", () => {
     const candidate = new UrlBuilderRequestCmdV2<
-      MockClient,
       undefined,
       QPersonV2,
       CollectionQueryBuilderV2<QPersonV2>,
@@ -48,7 +47,6 @@ describe("UrlBuilderRequestCmd tests", () => {
 
   test("addToQuery on a write Cmd keeps method and data intact", () => {
     const candidate = new UrlBuilderRequestCmdV2<
-      MockClient,
       undefined,
       QPersonV2,
       CollectionQueryBuilderV2<QPersonV2>,
@@ -87,7 +85,7 @@ describe("UrlBuilderRequestCmd tests", () => {
   });
 
   test("execute", async () => {
-    const candidate = new UrlBuilderRequestCmdV2<MockClient, ODataEntityModelResponseV2<PersonModel>, QPersonV2>(
+    const candidate = new UrlBuilderRequestCmdV2<ODataEntityModelResponseV2<PersonModel>, QPersonV2>(
       client,
       ODataHttpMethods.Get,
       queryBuilder,

--- a/packages/odata-service/test/request/UrlBuilderRequestCmdV4.test.ts
+++ b/packages/odata-service/test/request/UrlBuilderRequestCmdV4.test.ts
@@ -35,7 +35,6 @@ describe("UrlBuilderRequestCmdV4 tests", () => {
 
   test("carries an explicit method and data payload, e.g. for a write operation", () => {
     const candidate = new UrlBuilderRequestCmdV4<
-      MockClient,
       undefined,
       QPersonV4,
       CollectionQueryBuilderV4<QPersonV4>,
@@ -48,7 +47,6 @@ describe("UrlBuilderRequestCmdV4 tests", () => {
 
   test("addToQuery on a write Cmd keeps method and data intact", () => {
     const candidate = new UrlBuilderRequestCmdV4<
-      MockClient,
       undefined,
       QPersonV4,
       CollectionQueryBuilderV4<QPersonV4>,
@@ -87,7 +85,7 @@ describe("UrlBuilderRequestCmdV4 tests", () => {
   });
 
   test("execute", async () => {
-    const candidate = new UrlBuilderRequestCmdV4<MockClient, ODataModelResponseV4<PersonModel>, QPersonV4>(
+    const candidate = new UrlBuilderRequestCmdV4<ODataModelResponseV4<PersonModel>, QPersonV4>(
       client,
       ODataHttpMethods.Get,
       queryBuilder,
@@ -128,7 +126,7 @@ describe("UrlBuilderRequestCmdV4 tests", () => {
   });
 
   test("as POST request", () => {
-    const candidate = new UrlBuilderRequestCmdV4<MockClient, ODataModelResponseV4<PersonModel>, QPersonV4>(
+    const candidate = new UrlBuilderRequestCmdV4<ODataModelResponseV4<PersonModel>, QPersonV4>(
       client,
       ODataHttpMethods.Get,
       queryBuilder,

--- a/packages/odata-service/test/request/UrlGetRequestCmd.test.ts
+++ b/packages/odata-service/test/request/UrlGetRequestCmd.test.ts
@@ -7,7 +7,7 @@ describe("UrlRequestCmd tests", () => {
   const DEFAULT_HEADERS = { "Content-Type": "application/json" };
   const CLIENT = new MockClient(false);
 
-  let candidate: UrlGetRequestCmd<MockClient, string>;
+  let candidate: UrlGetRequestCmd<string>;
 
   beforeEach(() => {
     candidate = new UrlGetRequestCmd(CLIENT, DEFAULT_URL, { headers: DEFAULT_HEADERS });

--- a/packages/odata-service/test/request/UrlRequestCmd.test.ts
+++ b/packages/odata-service/test/request/UrlRequestCmd.test.ts
@@ -31,7 +31,7 @@ describe("UrlRequestCmd tests", () => {
   });
 
   test("base props", () => {
-    const candidate = new UrlRequestCmd<MockClient, void>(client, ODataHttpMethods.Get, DEFAULT_URL);
+    const candidate = new UrlRequestCmd<void>(client, ODataHttpMethods.Get, DEFAULT_URL);
 
     expect(candidate.getUrl()).toBe(DEFAULT_URL);
     expect(candidate.getInfo()).toMatchObject({
@@ -45,7 +45,7 @@ describe("UrlRequestCmd tests", () => {
   });
 
   test("max props", () => {
-    const candidate = new UrlRequestCmd<MockClient, ODataModelResponseV4<PersonModel>, EditablePersonModel>(
+    const candidate = new UrlRequestCmd<ODataModelResponseV4<PersonModel>, EditablePersonModel>(
       client,
       ODataHttpMethods.Get,
       DEFAULT_URL,
@@ -68,7 +68,7 @@ describe("UrlRequestCmd tests", () => {
 
   test("with new url", () => {
     const newUrl = "/foo/bar/baz";
-    const candidate = new UrlRequestCmd<MockClient, ODataModelResponseV4<PersonModel>, EditablePersonModel>(
+    const candidate = new UrlRequestCmd<ODataModelResponseV4<PersonModel>, EditablePersonModel>(
       client,
       ODataHttpMethods.Get,
       DEFAULT_URL,
@@ -88,14 +88,14 @@ describe("UrlRequestCmd tests", () => {
   });
 
   test("with new url: guard against empty url", () => {
-    const candidate = new UrlRequestCmd<MockClient, void>(client, ODataHttpMethods.Get, DEFAULT_URL);
+    const candidate = new UrlRequestCmd<void>(client, ODataHttpMethods.Get, DEFAULT_URL);
 
     expect(() => candidate.withUrl("")).toThrow("withUrl requires a new URL!");
     expect(() => candidate.withUrl("   ")).toThrow("withUrl requires a new URL!");
   });
 
   test("execute", async () => {
-    const candidate = new UrlRequestCmd<MockClient, void>(client, ODataHttpMethods.Get, DEFAULT_URL);
+    const candidate = new UrlRequestCmd<void>(client, ODataHttpMethods.Get, DEFAULT_URL);
 
     const result = await candidate.execute();
 
@@ -109,7 +109,7 @@ describe("UrlRequestCmd tests", () => {
   });
 
   test("execute: with headers & request config", async () => {
-    const candidate = new UrlRequestCmd<MockClient, void>(client, ODataHttpMethods.Put, DEFAULT_URL, undefined, {
+    const candidate = new UrlRequestCmd<void>(client, ODataHttpMethods.Put, DEFAULT_URL, undefined, {
       headers: DEFAULT_HEADERS,
     });
 
@@ -123,7 +123,7 @@ describe("UrlRequestCmd tests", () => {
   });
 
   test("execute: with data", async () => {
-    const candidate = new UrlRequestCmd<MockClient, void, EditablePersonModel>(
+    const candidate = new UrlRequestCmd<void, EditablePersonModel>(
       client,
       ODataHttpMethods.Post,
       DEFAULT_URL,
@@ -139,7 +139,7 @@ describe("UrlRequestCmd tests", () => {
   });
 
   test("execute: with data & main converter", async () => {
-    const candidate = new UrlRequestCmd<MockClient, void, EditablePersonModel>(
+    const candidate = new UrlRequestCmd<void, EditablePersonModel>(
       client,
       ODataHttpMethods.Delete,
       DEFAULT_URL,
@@ -160,7 +160,7 @@ describe("UrlRequestCmd tests", () => {
   });
 
   test("execute: with data & prepended converter", async () => {
-    const candidate = new UrlRequestCmd<MockClient, void, EditablePersonModel>(
+    const candidate = new UrlRequestCmd<void, EditablePersonModel>(
       client,
       ODataHttpMethods.Post,
       DEFAULT_URL,
@@ -181,7 +181,7 @@ describe("UrlRequestCmd tests", () => {
   });
 
   test("execute: with data & appended converter", async () => {
-    const candidate = new UrlRequestCmd<MockClient, void, EditablePersonModel>(
+    const candidate = new UrlRequestCmd<void, EditablePersonModel>(
       client,
       ODataHttpMethods.Get,
       DEFAULT_URL,
@@ -196,11 +196,7 @@ describe("UrlRequestCmd tests", () => {
   });
 
   test("execute: with response", async () => {
-    const candidate = new UrlRequestCmd<MockClient, ODataModelResponseV4<PersonModel>>(
-      client,
-      ODataHttpMethods.Patch,
-      DEFAULT_URL,
-    );
+    const candidate = new UrlRequestCmd<ODataModelResponseV4<PersonModel>>(client, ODataHttpMethods.Patch, DEFAULT_URL);
 
     // we respond with the converted model
     client.responseData = DEFAULT_USER_DATA;
@@ -213,7 +209,7 @@ describe("UrlRequestCmd tests", () => {
   });
 
   test("execute: with response & converter", async () => {
-    const candidate = new UrlRequestCmd<MockClient, ODataModelResponseV4<PersonModel>>(
+    const candidate = new UrlRequestCmd<ODataModelResponseV4<PersonModel>>(
       client,
       ODataHttpMethods.Post,
       DEFAULT_URL,
@@ -235,7 +231,7 @@ describe("UrlRequestCmd tests", () => {
   });
 
   test("execute: with response & prepended converter", async () => {
-    const candidate = new UrlRequestCmd<MockClient, ODataModelResponseV4<PersonModel>>(
+    const candidate = new UrlRequestCmd<ODataModelResponseV4<PersonModel>>(
       client,
       ODataHttpMethods.Post,
       DEFAULT_URL,
@@ -257,7 +253,7 @@ describe("UrlRequestCmd tests", () => {
   });
 
   test("execute: with response & appended converter", async () => {
-    const candidate = new UrlRequestCmd<MockClient, ODataModelResponseV4<PersonModel>>(
+    const candidate = new UrlRequestCmd<ODataModelResponseV4<PersonModel>>(
       client,
       ODataHttpMethods.Post,
       DEFAULT_URL,
@@ -274,7 +270,7 @@ describe("UrlRequestCmd tests", () => {
   });
 
   test("execute: combined features", async () => {
-    const candidate = new UrlRequestCmd<MockClient, ODataCollectionResponseV4<PersonModel>, EditablePersonModel>(
+    const candidate = new UrlRequestCmd<ODataCollectionResponseV4<PersonModel>, EditablePersonModel>(
       client,
       ODataHttpMethods.Post,
       DEFAULT_URL,
@@ -295,7 +291,6 @@ describe("UrlRequestCmd tests", () => {
 
     expectTypeOf(candidate).toEqualTypeOf<
       RequestCmd<
-        MockClient,
         ODataCollectionResponseV4<PersonModel>,
         EditablePersonModel,
         { x: ODataCollectionResponseV4<PersonModel> }

--- a/packages/odata-service/test/v2/CollectionServiceV2.test.ts
+++ b/packages/odata-service/test/v2/CollectionServiceV2.test.ts
@@ -31,17 +31,13 @@ describe("CollectionService V2 Tests", () => {
     basePath: string,
     name: string,
     options?: ODataServiceOptions,
-  ): CollectionServiceV2<MockClient, StringCollection, QStringV2Collection> => {
+  ): CollectionServiceV2<StringCollection, QStringV2Collection> => {
     return new CollectionServiceV2(odataClient, basePath, name, new QStringV2Collection(), options);
   };
   const enumConstructor = (
     basePath: string,
     name: string,
-  ): CollectionServiceV2<
-    MockClient,
-    EnumCollection<NumericTestEnum>,
-    QNumericEnumCollection<typeof NumericTestEnum>
-  > => {
+  ): CollectionServiceV2<EnumCollection<NumericTestEnum>, QNumericEnumCollection<typeof NumericTestEnum>> => {
     return new CollectionServiceV2(odataClient, basePath, name, new QNumericEnumCollection(NumericTestEnum));
   };
 

--- a/packages/odata-service/test/v2/ComplexTypeServiceV2.test.ts
+++ b/packages/odata-service/test/v2/ComplexTypeServiceV2.test.ts
@@ -12,7 +12,7 @@ describe("ComplexTypeService V2 Test", () => {
   const NAME = "test('tester')";
   const EXPECTED_PATH = `${BASE_URL}/${NAME}`;
 
-  let testService: FakedComplexServiceV2<MockClient>;
+  let testService: FakedComplexServiceV2;
 
   beforeEach(() => {
     testService = new FakedComplexServiceV2(odataClient, BASE_URL, NAME);

--- a/packages/odata-service/test/v2/EntitySetServiceV2.test.ts
+++ b/packages/odata-service/test/v2/EntitySetServiceV2.test.ts
@@ -13,7 +13,7 @@ describe("V2 EntitySetService Test", () => {
   const NAME = "test";
   const EXPECTED_PATH = `${BASE_URL}/${NAME}`;
 
-  let testService: PersonModelV2CollectionService<MockClient>;
+  let testService: PersonModelV2CollectionService;
 
   commonEntitySetTests(odataClient, PersonModelV2CollectionService);
 

--- a/packages/odata-service/test/v2/EntityTypeServiceV2.test.ts
+++ b/packages/odata-service/test/v2/EntityTypeServiceV2.test.ts
@@ -12,7 +12,7 @@ describe("EntityTypeService V2 Test", () => {
   const NAME = "test('tester')";
   const EXPECTED_PATH = `${BASE_URL}/${NAME}`;
 
-  let testService: PersonModelV2Service<MockClient>;
+  let testService: PersonModelV2Service;
 
   commonEntityTypeServiceTests(odataClient, PersonModelV2Service);
 

--- a/packages/odata-service/test/v2/MediaEntityServiceV2.test.ts
+++ b/packages/odata-service/test/v2/MediaEntityServiceV2.test.ts
@@ -10,7 +10,7 @@ describe("MediaEntityService V2 Test", () => {
   const ENTITY_PATH = `${BASE_URL}/${NAME}`;
   const CONTENT_PATH = `${ENTITY_PATH}/$value`;
 
-  let service: PersonModelV2MediaService<MockClient>;
+  let service: PersonModelV2MediaService;
 
   beforeEach(() => {
     service = new PersonModelV2MediaService(odataClient, BASE_URL, NAME);

--- a/packages/odata-service/test/v2/PrimitiveTypeServiceV2.test.ts
+++ b/packages/odata-service/test/v2/PrimitiveTypeServiceV2.test.ts
@@ -12,7 +12,7 @@ describe("PrimitiveTypeService V2 Test", () => {
   const PROPERTY_NAME = "UserName";
   const EXPECTED_PATH = `${BASE_URL}/${NAME}/${PROPERTY_NAME}`;
 
-  let testService: PrimitiveTypeServiceV2<MockClient, string>;
+  let testService: PrimitiveTypeServiceV2<string>;
 
   beforeEach(() => {
     testService = new PersonModelV2Service(odataClient, BASE_URL, NAME).userName();
@@ -30,20 +30,14 @@ describe("PrimitiveTypeService V2 Test", () => {
   });
 
   test("primitiveType V2: internal converter without mapped name falls back to name", () => {
-    const noMappedNameService = new PrimitiveTypeServiceV2<MockClient, string>(odataClient, BASE_URL, NAME);
+    const noMappedNameService = new PrimitiveTypeServiceV2<string>(odataClient, BASE_URL, NAME);
     const converter = (noMappedNameService as any).__converter;
 
     expect(converter.getMappedName()).toBe(NAME);
   });
 
   test("primitiveType V2: internal converter with explicit mapped name", () => {
-    const mappedService = new PrimitiveTypeServiceV2<MockClient, string>(
-      odataClient,
-      BASE_URL,
-      NAME,
-      undefined,
-      "mappedUserName",
-    );
+    const mappedService = new PrimitiveTypeServiceV2<string>(odataClient, BASE_URL, NAME, undefined, "mappedUserName");
     const converter = (mappedService as any).__converter;
 
     expect(converter.getName()).toBe(NAME);
@@ -70,13 +64,7 @@ describe("PrimitiveTypeService V2 Test", () => {
       }
     })();
 
-    const service = new PrimitiveTypeServiceV2<MockClient, string>(
-      odataClient,
-      BASE_URL,
-      NAME,
-      stateful as any,
-      PROPERTY_NAME,
-    );
+    const service = new PrimitiveTypeServiceV2<string>(odataClient, BASE_URL, NAME, stateful as any, PROPERTY_NAME);
     const converter = (service as any).__converter;
 
     expect(converter.convertFrom("value")).toBe("from!value");

--- a/packages/odata-service/test/v2/StreamServiceV2.test.ts
+++ b/packages/odata-service/test/v2/StreamServiceV2.test.ts
@@ -10,10 +10,10 @@ describe("StreamService V2 Test", () => {
   const EXPECTED_PATH = `${BASE_URL}/${NAME}`;
   const MIME_TYPE = "application/epub+zip";
 
-  let service: StreamServiceV2<MockClient>;
+  let service: StreamServiceV2;
 
   beforeEach(() => {
-    service = new StreamServiceV2<MockClient>(odataClient, BASE_URL, NAME);
+    service = new StreamServiceV2(odataClient, BASE_URL, NAME);
   });
 
   test("stream V2: base tests", () => {

--- a/packages/odata-service/test/v4/CollectionServiceV4.test.ts
+++ b/packages/odata-service/test/v4/CollectionServiceV4.test.ts
@@ -35,7 +35,7 @@ describe("CollectionService V4 Tests", () => {
   const NAME_STRING = "testString";
   const NAME_ENUM = "testEnum";
 
-  const serviceConv = new CollectionServiceV4<MockClient, BooleanCollection, QBooleanCollection<number>, number>(
+  const serviceConv = new CollectionServiceV4<BooleanCollection, QBooleanCollection<number>, number>(
     odataClient,
     BASE_PATH,
     NAME_STRING,
@@ -46,13 +46,13 @@ describe("CollectionService V4 Tests", () => {
     basePath: string,
     name: string,
     options?: ODataServiceOptions,
-  ): CollectionServiceV4<MockClient, StringCollection, QStringCollection> => {
+  ): CollectionServiceV4<StringCollection, QStringCollection> => {
     return new CollectionServiceV4(odataClient, basePath, name, new QStringCollection(), options);
   };
   const enumConstructor = (
     basePath: string,
     name: string,
-  ): CollectionServiceV4<MockClient, EnumCollection<StringTestEnum>, QEnumCollection<typeof StringTestEnum>> => {
+  ): CollectionServiceV4<EnumCollection<StringTestEnum>, QEnumCollection<typeof StringTestEnum>> => {
     return new CollectionServiceV4(odataClient, basePath, name, new QEnumCollection(StringTestEnum));
   };
 
@@ -159,7 +159,7 @@ describe("CollectionService V4 Tests", () => {
   });
 
   test("collection: big number", async () => {
-    const testService = new CollectionServiceV4<MockClient, StringCollection, QStringCollection>(
+    const testService = new CollectionServiceV4<StringCollection, QStringCollection>(
       odataClient,
       BASE_PATH,
       NAME_STRING,

--- a/packages/odata-service/test/v4/EntitySetServiceV4.test.ts
+++ b/packages/odata-service/test/v4/EntitySetServiceV4.test.ts
@@ -20,7 +20,7 @@ describe("V4 EntitySetService Test", () => {
   const NAME = "test";
   const EXPECTED_PATH = `${BASE_URL}/${NAME}`;
 
-  let testService: PersonModelCollectionService<MockClient>;
+  let testService: PersonModelCollectionService;
 
   commonEntitySetTests(odataClient, PersonModelCollectionService);
 

--- a/packages/odata-service/test/v4/EntityTypeServiceV4.test.ts
+++ b/packages/odata-service/test/v4/EntityTypeServiceV4.test.ts
@@ -14,7 +14,7 @@ describe("EntityTypeService V4 Tests", () => {
   const NAME = "test('tester')";
   const EXPECTED_PATH = `${BASE_URL}/${NAME}`;
 
-  let testService: PersonModelService<MockClient>;
+  let testService: PersonModelService;
 
   commonEntityTypeServiceTests(odataClient, PersonModelService);
 

--- a/packages/odata-service/test/v4/MediaEntityServiceV4.test.ts
+++ b/packages/odata-service/test/v4/MediaEntityServiceV4.test.ts
@@ -12,10 +12,10 @@ describe("MediaEntityService V4 Test", () => {
   const ENTITY_PATH = `${BASE_URL}/${NAME}`;
   const CONTENT_PATH = `${ENTITY_PATH}/$value`;
 
-  let service: MediaEntityServiceV4<MockClient, PersonModel, EditablePersonModel, QPersonV4>;
+  let service: MediaEntityServiceV4<PersonModel, EditablePersonModel, QPersonV4>;
 
   beforeEach(() => {
-    service = new MediaEntityServiceV4<MockClient, PersonModel, EditablePersonModel, QPersonV4>(
+    service = new MediaEntityServiceV4<PersonModel, EditablePersonModel, QPersonV4>(
       odataClient,
       BASE_URL,
       NAME,
@@ -85,7 +85,7 @@ describe("MediaEntityService V4 Test", () => {
     // `$value` addresses the entity, which its key already identifies - servers answer 404 for the
     // combination. A stream *property* declared on the derived type is the opposite case: it exists only
     // behind the cast, which is why the generated property getter keeps the segment.
-    const subtypeService = new MediaEntityServiceV4<MockClient, PersonModel, EditablePersonModel, QPersonV4>(
+    const subtypeService = new MediaEntityServiceV4<PersonModel, EditablePersonModel, QPersonV4>(
       odataClient,
       ENTITY_PATH,
       "Library.Catalog.EBook",

--- a/packages/odata-service/test/v4/PrimitiveTypeServiceV4.test.ts
+++ b/packages/odata-service/test/v4/PrimitiveTypeServiceV4.test.ts
@@ -11,9 +11,9 @@ describe("PrimitiveTypeService V4 Test", () => {
   const NAME = "test('tester')";
   const EXPECTED_PATH = `${BASE_URL}/${NAME}/UserName`;
 
-  let service: PrimitiveTypeServiceV4<MockClient, string>;
+  let service: PrimitiveTypeServiceV4<string>;
   // with number to string converter
-  let serviceConv: PrimitiveTypeServiceV4<MockClient, string>;
+  let serviceConv: PrimitiveTypeServiceV4<string>;
 
   beforeEach(() => {
     const personService = new PersonModelService(odataClient, BASE_URL, NAME);
@@ -26,7 +26,7 @@ describe("PrimitiveTypeService V4 Test", () => {
   });
 
   test("primitiveType V4: defaults to identity converter when none is given", async () => {
-    const defaultService = new PrimitiveTypeServiceV4<MockClient, string>(odataClient, BASE_URL, NAME);
+    const defaultService = new PrimitiveTypeServiceV4<string>(odataClient, BASE_URL, NAME);
 
     odataClient.setValueResponse("tester");
     const response = await defaultService.getValue().execute();

--- a/packages/odata-service/test/v4/StreamServiceV4.test.ts
+++ b/packages/odata-service/test/v4/StreamServiceV4.test.ts
@@ -10,10 +10,10 @@ describe("StreamService V4 Test", () => {
   const EXPECTED_PATH = `${BASE_URL}/${NAME}`;
   const MIME_TYPE = "audio/mpeg";
 
-  let service: StreamServiceV4<MockClient>;
+  let service: StreamServiceV4;
 
   beforeEach(() => {
-    service = new StreamServiceV4<MockClient>(odataClient, BASE_URL, NAME);
+    service = new StreamServiceV4(odataClient, BASE_URL, NAME);
   });
 
   test("stream V4: base tests", () => {

--- a/packages/odata2ts/src/generator/ServiceGenerator.ts
+++ b/packages/odata2ts/src/generator/ServiceGenerator.ts
@@ -66,30 +66,41 @@ class ServiceGenerator {
   }
 
   /**
-   * The version type argument as seen from the main service, which pins it: the main service does not
+   * The version type argument list as seen from the main service, which pins it: the main service does not
    * declare V itself, everything it hands out infers the version from the options.
+   *
+   * Empty unless the version is actually pinned, since V defaults to 4.0.
    */
   private getMainVersionArg() {
-    return this.isV401() ? `, "4.01"` : "";
+    return this.isV401() ? `<"4.01">` : "";
   }
 
   /**
-   * The version type argument as seen from a generated service class, which declares V itself and passes
-   * it on, so that nested services keep the version of the client they belong to.
+   * The version type argument list as seen from a generated service class, which declares V itself and
+   * passes it on, so that nested services keep the version of the client they belong to.
+   *
+   * Empty for V2, which knows no such type parameter.
    */
   private getServiceVersionArg() {
+    return this.version === ODataVersions.V4 ? "<V>" : "";
+  }
+
+  /**
+   * {@link getServiceVersionArg} for a type argument list which already carries entries, so that the
+   * version reads as the last argument instead of the only one.
+   */
+  private getServiceVersionArgSuffix() {
     return this.version === ODataVersions.V4 ? ", V" : "";
   }
 
   /**
-   * Type parameters of a generated service class. V4 services are generic over the OData version.
+   * Type parameters of a generated service class. V4 services are generic over the OData version; V2
+   * services have no type parameter at all.
    */
-  private getServiceTypeParams(imports: ImportContainer, httpClient: string) {
-    const params = [`in out ClientType extends ${httpClient}`];
-    if (this.version === ODataVersions.V4) {
-      params.push(`V extends ${imports.addCoreLib(ODataVersions.V4, CoreImports.ODataVersionV4)} = "4.0"`);
-    }
-    return params;
+  private getServiceTypeParams(imports: ImportContainer) {
+    return this.version === ODataVersions.V4
+      ? [`V extends ${imports.addCoreLib(ODataVersions.V4, CoreImports.ODataVersionV4)} = "4.0"`]
+      : [];
   }
 
   /**
@@ -126,7 +137,6 @@ class ServiceGenerator {
     const container = this.dataModel.getEntityContainer();
     const unboundOperations = [...Object.values(container.functions), ...Object.values(container.actions)];
 
-    const httpClient = importContainer.addClientApi(ClientApiImports.ODataHttpClient);
     const rootService = importContainer.addServiceObject(this.version, ServiceImports.ODataService);
 
     const { properties, methods }: PropsAndOps = deepmerge(
@@ -135,17 +145,19 @@ class ServiceGenerator {
     );
 
     const runtimeOptions = this.getRuntimeOptions();
+    // the main service names the client type only where it declares a constructor of its own; without one
+    // it inherits the base signature, and the import would sit there unused
+    const httpClient = runtimeOptions.length ? importContainer.addClientApi(ClientApiImports.ODataHttpClient) : "";
 
     mainServiceFile.getFile().addClass({
       isExported: true,
       name: mainServiceName,
-      typeParameters: [`in out ClientType extends ${httpClient}`],
-      extends: `${rootService}<ClientType${this.getMainVersionArg()}>`,
+      extends: `${rootService}${this.getMainVersionArg()}`,
       ctors: runtimeOptions.length
         ? [
             {
               parameters: [
-                { name: "client", type: "ClientType" },
+                { name: "client", type: httpClient },
                 { name: "basePath", type: "string" },
                 {
                   name: "options",
@@ -226,7 +238,7 @@ class ServiceGenerator {
       overloads: [
         {
           parameters: [],
-          returnType: `${collectionName}<ClientType${versionArg}>`,
+          returnType: `${collectionName}${versionArg}`,
         },
         {
           parameters: [
@@ -235,7 +247,7 @@ class ServiceGenerator {
               type: idName,
             },
           ],
-          returnType: `${serviceName}<ClientType${versionArg}>`,
+          returnType: `${serviceName}${versionArg}`,
         },
       ],
       statements: [
@@ -258,7 +270,7 @@ class ServiceGenerator {
     return {
       scope: Scope.Private,
       name: this.namingHelper.getPrivatePropName(name),
-      type: `${type}<ClientType${this.getMainVersionArg()}>`,
+      type: `${type}${this.getMainVersionArg()}`,
       hasQuestionToken: true,
     };
   }
@@ -336,18 +348,17 @@ class ServiceGenerator {
     file.getFile().addClass({
       isExported: true,
       name: model.serviceName,
-      typeParameters: this.getServiceTypeParams(importContainer, httpClient),
-      extends:
-        entityServiceType + `<ClientType, ${modelName}, ${editableModelName}, ${qName}${this.getServiceVersionArg()}>`,
+      typeParameters: this.getServiceTypeParams(importContainer),
+      extends: entityServiceType + `<${modelName}, ${editableModelName}, ${qName}${this.getServiceVersionArgSuffix()}>`,
       ctors: [
         {
           parameters: [
-            { name: "client", type: "ClientType" },
+            { name: "client", type: httpClient },
             { name: "basePath", type: "string" },
             { name: "name", type: "string" },
             {
               name: "options",
-              type: `${serviceOptions}${this.getServiceVersionArg() ? "<V>" : ""}`,
+              type: `${serviceOptions}${this.getServiceVersionArg()}`,
               hasQuestionToken: true,
             },
           ],
@@ -442,10 +453,10 @@ class ServiceGenerator {
       const qModelName = imports.addGeneratedQObject(propModel.fqName, propModel.qName, true);
       const collectionServiceType = imports.addServiceObject(this.version, ServiceImports.CollectionService);
 
-      propModelType = `${collectionServiceType}<ClientType, ${modelName}, ${qModelName}, ${editableModelName}${this.getServiceVersionArg()}>`;
+      propModelType = `${collectionServiceType}<${modelName}, ${qModelName}, ${editableModelName}${this.getServiceVersionArgSuffix()}>`;
     } else {
       const serviceName = imports.addGeneratedService(propModel.fqName, propModel.serviceName);
-      propModelType = `${serviceName}<ClientType${this.getServiceVersionArg()}>`;
+      propModelType = `${serviceName}${this.getServiceVersionArg()}`;
     }
 
     return {
@@ -484,7 +495,7 @@ class ServiceGenerator {
     const versionArgs = this.getServiceVersionArg()
       ? `, ${imports.addServiceObject(this.version, ServiceImports.PrimitiveExtractor)}<${type}>, V`
       : "";
-    const collectionType = `${collectionServiceType}<ClientType, ${type}, ${qType}${versionArgs}>`;
+    const collectionType = `${collectionServiceType}<${type}, ${qType}${versionArgs}>`;
 
     return {
       scope: Scope.Private,
@@ -504,7 +515,7 @@ class ServiceGenerator {
     return {
       scope: Scope.Private,
       name: this.namingHelper.getPrivatePropName(prop.name),
-      type: `${serviceType}<ClientType, ${type}${this.getServiceVersionArg()}>`,
+      type: `${serviceType}<${type}${this.getServiceVersionArgSuffix()}>`,
       hasQuestionToken: true,
     };
   }
@@ -518,7 +529,7 @@ class ServiceGenerator {
     return {
       scope: Scope.Private,
       name: this.namingHelper.getPrivatePropName(prop.name),
-      type: `${serviceType}<ClientType${this.getServiceVersionArg()}>`,
+      type: `${serviceType}${this.getServiceVersionArg()}`,
       hasQuestionToken: true,
     };
   }
@@ -556,12 +567,12 @@ class ServiceGenerator {
         ? model.serviceCollectionName
         : model.serviceName;
     const typeWithGenerics = isComplexCollection
-      ? `${type}<ClientType, ${imports.addGeneratedModel(model.fqName, model.modelName)}, ${imports.addGeneratedQObject(
+      ? `${type}<${imports.addGeneratedModel(model.fqName, model.modelName)}, ${imports.addGeneratedQObject(
           model.fqName,
           model.qName,
           true,
-        )}, ${imports.addGeneratedModel(model.fqName, model.editableName)}${this.getServiceVersionArg()}>`
-      : `${type}<ClientType${this.getServiceVersionArg()}>`;
+        )}, ${imports.addGeneratedModel(model.fqName, model.editableName)}${this.getServiceVersionArgSuffix()}>`
+      : `${type}${this.getServiceVersionArg()}`;
 
     const privateSrvProp = "this." + this.namingHelper.getPrivatePropName(prop.name);
 
@@ -652,19 +663,19 @@ class ServiceGenerator {
     file.getFile().addClass({
       isExported: true,
       name: model.serviceCollectionName,
-      typeParameters: this.getServiceTypeParams(importContainer, "ODataHttpClient"),
+      typeParameters: this.getServiceTypeParams(importContainer),
       extends:
         entitySetServiceType +
-        `<ClientType, ${model.modelName}, ${editableModelName}, ${model.qName}, ${paramsModelName}${this.getServiceVersionArg()}>`,
+        `<${model.modelName}, ${editableModelName}, ${model.qName}, ${paramsModelName}${this.getServiceVersionArgSuffix()}>`,
       ctors: [
         {
           parameters: [
-            { name: "client", type: "ClientType" },
+            { name: "client", type: importContainer.addClientApi(ClientApiImports.ODataHttpClient) },
             { name: "basePath", type: "string" },
             { name: "name", type: "string" },
             {
               name: "options",
-              type: `${serviceOptions}${this.getServiceVersionArg() ? "<V>" : ""}`,
+              type: `${serviceOptions}${this.getServiceVersionArg()}`,
               hasQuestionToken: true,
             },
           ],
@@ -765,13 +776,13 @@ class ServiceGenerator {
       (returnType ? `, mainResponseConverter: ${qOpProp}.getResponseConverter()` : "") +
       `}`;
     const requestCmdStmt = isComposable
-      ? `return new ${requestCmd}<ClientType, ${responseService}<ClientType${versionArg}>, ${responseStructure}<${rtType}>>(` +
+      ? `return new ${requestCmd}<${responseService}${versionArg}, ${responseStructure}<${rtType}>>(` +
         `client,` +
         `url,` +
-        `(finalUrl: string) => new ${responseService}<ClientType${versionArg}>(client, finalUrl, "", options),` +
+        `(finalUrl: string) => new ${responseService}${versionArg}(client, finalUrl, "", options),` +
         optionStmt +
         `);`
-      : `return new ${requestCmd}<ClientType, ${responseStructure ? `${responseStructure}<${rtType}>` : "undefined"}${!isFunc && hasParams ? ", " + paramsModelName : ""}>(` +
+      : `return new ${requestCmd}<${responseStructure ? `${responseStructure}<${rtType}>` : "undefined"}${!isFunc && hasParams ? ", " + paramsModelName : ""}>(` +
         `client,` +
         `${useUrlGetCmd ? "" : `${importContainer.addClientApi(ClientApiImports.ODataHttpMethods)}.${!isFunc || operation.usePost ? "Post" : "Get"},`}` +
         `url, ` +

--- a/packages/odata2ts/src/generator/import/ImportObjects.ts
+++ b/packages/odata2ts/src/generator/import/ImportObjects.ts
@@ -57,7 +57,6 @@ export enum QueryObjectImports {
  */
 export enum ClientApiImports {
   ODataHttpClient,
-  ODataHttpClientConfig,
   HttpResponseModel,
   ODataHttpMethods,
 }

--- a/packages/odata2ts/test/fixture/generator/service/v2/abstract-and-open-types.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/abstract-and-open-types.ts
@@ -25,9 +25,9 @@ import type {
   // @ts-ignore
 } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
-  public fromAbstract(): ExtendedFromAbstractCollectionService<ClientType>;
-  public fromAbstract(id: ExtendedFromAbstractId): ExtendedFromAbstractService<ClientType>;
+export class TesterService extends ODataService {
+  public fromAbstract(): ExtendedFromAbstractCollectionService;
+  public fromAbstract(id: ExtendedFromAbstractId): ExtendedFromAbstractService;
   public fromAbstract(id?: ExtendedFromAbstractId | undefined) {
     const fieldName = "FromAbstract";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -41,8 +41,8 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
         );
   }
 
-  public fromOpen(): ExtendedFromOpenCollectionService<ClientType>;
-  public fromOpen(id: ExtendedFromOpenId): ExtendedFromOpenService<ClientType>;
+  public fromOpen(): ExtendedFromOpenCollectionService;
+  public fromOpen(id: ExtendedFromOpenId): ExtendedFromOpenService;
   public fromOpen(id?: ExtendedFromOpenId | undefined) {
     const fieldName = "FromOpen";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -57,72 +57,60 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
   }
 }
 
-export class AbstractEntityService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
-  ClientType,
+export class AbstractEntityService extends EntityTypeServiceV2<
   AbstractEntity,
   EditableAbstractEntity,
   QAbstractEntity
 > {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qAbstractEntity, options);
   }
 }
 
-export class OpenEntityService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
-  ClientType,
-  OpenEntity,
-  EditableOpenEntity,
-  QOpenEntity
-> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+export class OpenEntityService extends EntityTypeServiceV2<OpenEntity, EditableOpenEntity, QOpenEntity> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qOpenEntity, options);
   }
 }
 
-export class ExtendedFromAbstractService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
-  ClientType,
+export class ExtendedFromAbstractService extends EntityTypeServiceV2<
   ExtendedFromAbstract,
   EditableExtendedFromAbstract,
   QExtendedFromAbstract
 > {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qExtendedFromAbstract, options);
   }
 }
 
-export class ExtendedFromAbstractCollectionService<
-  in out ClientType extends ODataHttpClient,
-> extends EntitySetServiceV2<
-  ClientType,
+export class ExtendedFromAbstractCollectionService extends EntitySetServiceV2<
   ExtendedFromAbstract,
   EditableExtendedFromAbstract,
   QExtendedFromAbstract,
   ExtendedFromAbstractId
 > {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qExtendedFromAbstract, new QExtendedFromAbstractId(name), options);
   }
 }
 
-export class ExtendedFromOpenService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
-  ClientType,
+export class ExtendedFromOpenService extends EntityTypeServiceV2<
   ExtendedFromOpen,
   EditableExtendedFromOpen,
   QExtendedFromOpen
 > {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qExtendedFromOpen, options);
   }
 }
 
-export class ExtendedFromOpenCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV2<
-  ClientType,
+export class ExtendedFromOpenCollectionService extends EntitySetServiceV2<
   ExtendedFromOpen,
   EditableExtendedFromOpen,
   QExtendedFromOpen,
   ExtendedFromOpenId
 > {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qExtendedFromOpen, new QExtendedFromOpenId(name), options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v2/complex-type.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/complex-type.ts
@@ -14,9 +14,9 @@ import { qBook, QBookId, qReviewer } from "./QTester.js";
 // @ts-ignore
 import type { Book, BookId, EditableBook, EditableReviewer, Reviewer } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
-  public books(): BookCollectionService<ClientType>;
-  public books(id: BookId): BookService<ClientType>;
+export class TesterService extends ODataService {
+  public books(): BookCollectionService;
+  public books(id: BookId): BookService;
   public books(id?: BookId | undefined) {
     const fieldName = "Books";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -26,20 +26,15 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
   }
 }
 
-export class BookService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
-  ClientType,
-  Book,
-  EditableBook,
-  QBook
-> {
-  private _lector?: ReviewerService<ClientType>;
-  private _reviewers?: CollectionServiceV2<ClientType, Reviewer, QReviewer, EditableReviewer>;
+export class BookService extends EntityTypeServiceV2<Book, EditableBook, QBook> {
+  private _lector?: ReviewerService;
+  private _reviewers?: CollectionServiceV2<Reviewer, QReviewer, EditableReviewer>;
 
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qBook, options);
   }
 
-  public lector(): ReviewerService<ClientType> {
+  public lector(): ReviewerService {
     if (!this._lector) {
       const { client, path, options } = this.__base;
       this._lector = new ReviewerService(client, path, "lector", options);
@@ -48,7 +43,7 @@ export class BookService<in out ClientType extends ODataHttpClient> extends Enti
     return this._lector;
   }
 
-  public reviewers(): CollectionServiceV2<ClientType, Reviewer, QReviewer, EditableReviewer> {
+  public reviewers(): CollectionServiceV2<Reviewer, QReviewer, EditableReviewer> {
     if (!this._reviewers) {
       const { client, path, options } = this.__base;
       this._reviewers = new CollectionServiceV2(client, path, "reviewers", qReviewer, options);
@@ -58,25 +53,14 @@ export class BookService<in out ClientType extends ODataHttpClient> extends Enti
   }
 }
 
-export class BookCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV2<
-  ClientType,
-  Book,
-  EditableBook,
-  QBook,
-  BookId
-> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+export class BookCollectionService extends EntitySetServiceV2<Book, EditableBook, QBook, BookId> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qBook, new QBookId(name), options);
   }
 }
 
-export class ReviewerService<in out ClientType extends ODataHttpClient> extends ComplexTypeServiceV2<
-  ClientType,
-  Reviewer,
-  EditableReviewer,
-  QReviewer
-> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+export class ReviewerService extends ComplexTypeServiceV2<Reviewer, EditableReviewer, QReviewer> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qReviewer, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v2/entity-hierarchy.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/entity-hierarchy.ts
@@ -16,9 +16,9 @@ import type {
   // @ts-ignore
 } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
-  public tests(): ChildCollectionService<ClientType>;
-  public tests(id: ChildId): ChildService<ClientType>;
+export class TesterService extends ODataService {
+  public tests(): ChildCollectionService;
+  public tests(id: ChildId): ChildService;
   public tests(id?: ChildId | undefined) {
     const fieldName = "tests";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -28,71 +28,43 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
   }
 }
 
-export class GrandParentService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
-  ClientType,
-  GrandParent,
-  EditableGrandParent,
-  QGrandParent
-> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+export class GrandParentService extends EntityTypeServiceV2<GrandParent, EditableGrandParent, QGrandParent> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qGrandParent, options);
   }
 }
 
-export class GrandParentCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV2<
-  ClientType,
+export class GrandParentCollectionService extends EntitySetServiceV2<
   GrandParent,
   EditableGrandParent,
   QGrandParent,
   GrandParentId
 > {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qGrandParent, new QGrandParentId(name), options);
   }
 }
 
-export class ParentService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
-  ClientType,
-  Parent,
-  EditableParent,
-  QParent
-> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+export class ParentService extends EntityTypeServiceV2<Parent, EditableParent, QParent> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qParent, options);
   }
 }
 
-export class ParentCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV2<
-  ClientType,
-  Parent,
-  EditableParent,
-  QParent,
-  GrandParentId
-> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+export class ParentCollectionService extends EntitySetServiceV2<Parent, EditableParent, QParent, GrandParentId> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qParent, new QGrandParentId(name), options);
   }
 }
 
-export class ChildService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
-  ClientType,
-  Child,
-  EditableChild,
-  QChild
-> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+export class ChildService extends EntityTypeServiceV2<Child, EditableChild, QChild> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qChild, options);
   }
 }
 
-export class ChildCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV2<
-  ClientType,
-  Child,
-  EditableChild,
-  QChild,
-  ChildId
-> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+export class ChildCollectionService extends EntitySetServiceV2<Child, EditableChild, QChild, ChildId> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qChild, new QChildId(name), options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v2/entity-relationships.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/entity-relationships.ts
@@ -13,9 +13,9 @@ import { qAuthor, QAuthorId, qBook, QBookId } from "./QTester.js";
 // @ts-ignore
 import type { Author, AuthorId, Book, BookId, EditableAuthor, EditableBook } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
-  public books(): BookCollectionService<ClientType>;
-  public books(id: BookId): BookService<ClientType>;
+export class TesterService extends ODataService {
+  public books(): BookCollectionService;
+  public books(id: BookId): BookService;
   public books(id?: BookId | undefined) {
     const fieldName = "books";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -25,16 +25,11 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
   }
 }
 
-export class AuthorService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
-  ClientType,
-  Author,
-  EditableAuthor,
-  QAuthor
-> {
-  private _id?: PrimitiveTypeServiceV2<ClientType, string>;
-  private _name?: PrimitiveTypeServiceV2<ClientType, string>;
+export class AuthorService extends EntityTypeServiceV2<Author, EditableAuthor, QAuthor> {
+  private _id?: PrimitiveTypeServiceV2<string>;
+  private _name?: PrimitiveTypeServiceV2<string>;
 
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qAuthor, options);
   }
 
@@ -57,28 +52,17 @@ export class AuthorService<in out ClientType extends ODataHttpClient> extends En
   }
 }
 
-export class AuthorCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV2<
-  ClientType,
-  Author,
-  EditableAuthor,
-  QAuthor,
-  AuthorId
-> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+export class AuthorCollectionService extends EntitySetServiceV2<Author, EditableAuthor, QAuthor, AuthorId> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qAuthor, new QAuthorId(name), options);
   }
 }
 
-export class BookService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
-  ClientType,
-  Book,
-  EditableBook,
-  QBook
-> {
-  private _id?: PrimitiveTypeServiceV2<ClientType, string>;
-  private _author?: AuthorService<ClientType>;
+export class BookService extends EntityTypeServiceV2<Book, EditableBook, QBook> {
+  private _id?: PrimitiveTypeServiceV2<string>;
+  private _author?: AuthorService;
 
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qBook, options);
   }
 
@@ -91,7 +75,7 @@ export class BookService<in out ClientType extends ODataHttpClient> extends Enti
     return this._id;
   }
 
-  public author(): AuthorService<ClientType> {
+  public author(): AuthorService {
     if (!this._author) {
       const { client, path, options } = this.__base;
       this._author = new AuthorService(client, path, "author", options);
@@ -100,8 +84,8 @@ export class BookService<in out ClientType extends ODataHttpClient> extends Enti
     return this._author;
   }
 
-  public relatedAuthors(): AuthorCollectionService<ClientType>;
-  public relatedAuthors(id: AuthorId): AuthorService<ClientType>;
+  public relatedAuthors(): AuthorCollectionService;
+  public relatedAuthors(id: AuthorId): AuthorService;
   public relatedAuthors(id?: AuthorId | undefined) {
     const fieldName = "relatedAuthors";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -111,14 +95,8 @@ export class BookService<in out ClientType extends ODataHttpClient> extends Enti
   }
 }
 
-export class BookCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV2<
-  ClientType,
-  Book,
-  EditableBook,
-  QBook,
-  BookId
-> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+export class BookCollectionService extends EntitySetServiceV2<Book, EditableBook, QBook, BookId> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qBook, new QBookId(name), options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v2/enum-numeric-type.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/enum-numeric-type.ts
@@ -17,9 +17,9 @@ import type { Book, BookId, EditableBook } from "./TesterModel.js";
 // @ts-ignore
 import { Choice } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
-  public books(): BookCollectionService<ClientType>;
-  public books(id: BookId): BookService<ClientType>;
+export class TesterService extends ODataService {
+  public books(): BookCollectionService;
+  public books(id: BookId): BookService;
   public books(id?: BookId | undefined) {
     const fieldName = "books";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -29,19 +29,10 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
   }
 }
 
-export class BookService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
-  ClientType,
-  Book,
-  EditableBook,
-  QBook
-> {
-  private _altChoices?: CollectionServiceV2<
-    ClientType,
-    EnumCollection<typeof Choice>,
-    QNumericEnumCollection<typeof Choice>
-  >;
+export class BookService extends EntityTypeServiceV2<Book, EditableBook, QBook> {
+  private _altChoices?: CollectionServiceV2<EnumCollection<typeof Choice>, QNumericEnumCollection<typeof Choice>>;
 
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qBook, options);
   }
 
@@ -61,14 +52,8 @@ export class BookService<in out ClientType extends ODataHttpClient> extends Enti
   }
 }
 
-export class BookCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV2<
-  ClientType,
-  Book,
-  EditableBook,
-  QBook,
-  BookId
-> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+export class BookCollectionService extends EntitySetServiceV2<Book, EditableBook, QBook, BookId> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qBook, new QBookId(name), options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v2/enum-type.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/enum-type.ts
@@ -17,9 +17,9 @@ import type { Book, BookId, EditableBook } from "./TesterModel.js";
 // @ts-ignore
 import { Choice } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
-  public books(): BookCollectionService<ClientType>;
-  public books(id: BookId): BookService<ClientType>;
+export class TesterService extends ODataService {
+  public books(): BookCollectionService;
+  public books(id: BookId): BookService;
   public books(id?: BookId | undefined) {
     const fieldName = "books";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -29,15 +29,10 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
   }
 }
 
-export class BookService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
-  ClientType,
-  Book,
-  EditableBook,
-  QBook
-> {
-  private _altChoices?: CollectionServiceV2<ClientType, EnumCollection<typeof Choice>, QEnumCollection<typeof Choice>>;
+export class BookService extends EntityTypeServiceV2<Book, EditableBook, QBook> {
+  private _altChoices?: CollectionServiceV2<EnumCollection<typeof Choice>, QEnumCollection<typeof Choice>>;
 
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qBook, options);
   }
 
@@ -51,14 +46,8 @@ export class BookService<in out ClientType extends ODataHttpClient> extends Enti
   }
 }
 
-export class BookCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV2<
-  ClientType,
-  Book,
-  EditableBook,
-  QBook,
-  BookId
-> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+export class BookCollectionService extends EntitySetServiceV2<Book, EditableBook, QBook, BookId> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qBook, new QBookId(name), options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v2/function-import-special-params.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/function-import-special-params.ts
@@ -15,11 +15,11 @@ import { QBestBook, qTestEntity, QTestEntityId } from "./QTester.js";
 // @ts-ignore
 import type { BestBookParams, EditableTestEntity, TestEntity, TestEntityId } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
+export class TesterService extends ODataService {
   private _qBestBook?: QBestBook;
 
-  public tests(): TestEntityCollectionService<ClientType>;
-  public tests(id: TestEntityId): TestEntityService<ClientType>;
+  public tests(): TestEntityCollectionService;
+  public tests(id: TestEntityId): TestEntityService;
   public tests(id?: TestEntityId | undefined) {
     const fieldName = "tests";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -36,35 +36,26 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
     const { addFullPath, client, getDefaultHeaders, isUrlNotEncoded } = this.__base;
     const url = addFullPath(this._qBestBook.buildUrl(params, isUrlNotEncoded()));
 
-    return new UrlRequestCmd<ClientType, ODataCollectionResponseV2<TestEntity>>(
-      client,
-      ODataHttpMethods.Get,
-      url,
-      undefined,
-      { headers: getDefaultHeaders(), mainResponseConverter: this._qBestBook.getResponseConverter() },
-    );
+    return new UrlRequestCmd<ODataCollectionResponseV2<TestEntity>>(client, ODataHttpMethods.Get, url, undefined, {
+      headers: getDefaultHeaders(),
+      mainResponseConverter: this._qBestBook.getResponseConverter(),
+    });
   }
 }
 
-export class TestEntityService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
-  ClientType,
-  TestEntity,
-  EditableTestEntity,
-  QTestEntity
-> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+export class TestEntityService extends EntityTypeServiceV2<TestEntity, EditableTestEntity, QTestEntity> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qTestEntity, options);
   }
 }
 
-export class TestEntityCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV2<
-  ClientType,
+export class TestEntityCollectionService extends EntitySetServiceV2<
   TestEntity,
   EditableTestEntity,
   QTestEntity,
   TestEntityId
 > {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qTestEntity, new QTestEntityId(name), options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v2/function-import.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/function-import.ts
@@ -21,13 +21,13 @@ import type {
   // @ts-ignore
 } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
+export class TesterService extends ODataService {
   private _qMostPop?: QMostPop;
   private _qBestBook?: QBestBook;
   private _qPostBestBook?: QPostBestBook;
 
-  public tests(): TestEntityCollectionService<ClientType>;
-  public tests(id: TestEntityId): TestEntityService<ClientType>;
+  public tests(): TestEntityCollectionService;
+  public tests(id: TestEntityId): TestEntityService;
   public tests(id?: TestEntityId | undefined) {
     const fieldName = "tests";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -44,13 +44,10 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
     const { addFullPath, client, getDefaultHeaders, isUrlNotEncoded } = this.__base;
     const url = addFullPath(this._qMostPop.buildUrl(isUrlNotEncoded()));
 
-    return new UrlRequestCmd<ClientType, ODataCollectionResponseV2<TestEntity>>(
-      client,
-      ODataHttpMethods.Get,
-      url,
-      undefined,
-      { headers: getDefaultHeaders(), mainResponseConverter: this._qMostPop.getResponseConverter() },
-    );
+    return new UrlRequestCmd<ODataCollectionResponseV2<TestEntity>>(client, ODataHttpMethods.Get, url, undefined, {
+      headers: getDefaultHeaders(),
+      mainResponseConverter: this._qMostPop.getResponseConverter(),
+    });
   }
 
   public bestBook(params: BestBookParams) {
@@ -61,13 +58,10 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
     const { addFullPath, client, getDefaultHeaders, isUrlNotEncoded } = this.__base;
     const url = addFullPath(this._qBestBook.buildUrl(params, isUrlNotEncoded()));
 
-    return new UrlRequestCmd<ClientType, ODataEntityModelResponseV2<TestEntity>>(
-      client,
-      ODataHttpMethods.Get,
-      url,
-      undefined,
-      { headers: getDefaultHeaders(), mainResponseConverter: this._qBestBook.getResponseConverter() },
-    );
+    return new UrlRequestCmd<ODataEntityModelResponseV2<TestEntity>>(client, ODataHttpMethods.Get, url, undefined, {
+      headers: getDefaultHeaders(),
+      mainResponseConverter: this._qBestBook.getResponseConverter(),
+    });
   }
 
   public postBestBook(params: PostBestBookParams) {
@@ -78,35 +72,26 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
     const { addFullPath, client, getDefaultHeaders, isUrlNotEncoded } = this.__base;
     const url = addFullPath(this._qPostBestBook.buildUrl(params, isUrlNotEncoded()));
 
-    return new UrlRequestCmd<ClientType, ODataEntityModelResponseV2<TestEntity>>(
-      client,
-      ODataHttpMethods.Post,
-      url,
-      undefined,
-      { headers: getDefaultHeaders(), mainResponseConverter: this._qPostBestBook.getResponseConverter() },
-    );
+    return new UrlRequestCmd<ODataEntityModelResponseV2<TestEntity>>(client, ODataHttpMethods.Post, url, undefined, {
+      headers: getDefaultHeaders(),
+      mainResponseConverter: this._qPostBestBook.getResponseConverter(),
+    });
   }
 }
 
-export class TestEntityService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
-  ClientType,
-  TestEntity,
-  EditableTestEntity,
-  QTestEntity
-> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+export class TestEntityService extends EntityTypeServiceV2<TestEntity, EditableTestEntity, QTestEntity> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qTestEntity, options);
   }
 }
 
-export class TestEntityCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV2<
-  ClientType,
+export class TestEntityCollectionService extends EntitySetServiceV2<
   TestEntity,
   EditableTestEntity,
   QTestEntity,
   TestEntityId
 > {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qTestEntity, new QTestEntityId(name), options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v2/media-entity.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/media-entity.ts
@@ -7,9 +7,9 @@ import { qEBook, QEBookId } from "./QTester.js";
 // @ts-ignore
 import type { EBook, EBookId, EditableEBook } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
-  public eBooks(): EBookCollectionService<ClientType>;
-  public eBooks(id: EBookId): EBookService<ClientType>;
+export class TesterService extends ODataService {
+  public eBooks(): EBookCollectionService;
+  public eBooks(id: EBookId): EBookService;
   public eBooks(id?: EBookId | undefined) {
     const fieldName = "EBooks";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -19,25 +19,14 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
   }
 }
 
-export class EBookService<in out ClientType extends ODataHttpClient> extends MediaEntityServiceV2<
-  ClientType,
-  EBook,
-  EditableEBook,
-  QEBook
-> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+export class EBookService extends MediaEntityServiceV2<EBook, EditableEBook, QEBook> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qEBook, options);
   }
 }
 
-export class EBookCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV2<
-  ClientType,
-  EBook,
-  EditableEBook,
-  QEBook,
-  EBookId
-> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+export class EBookCollectionService extends EntitySetServiceV2<EBook, EditableEBook, QEBook, EBookId> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qEBook, new QEBookId(name), options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v2/min.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/min.ts
@@ -1,4 +1,3 @@
-import type { ODataHttpClient } from "@odata2ts/http-client-api";
 import { ODataService } from "@odata2ts/odata-service";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {}
+export class TesterService extends ODataService {}

--- a/packages/odata2ts/test/fixture/generator/service/v2/one-entityset.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/one-entityset.ts
@@ -13,9 +13,9 @@ import { qTestEntity, QTestEntityId } from "./QTester.js";
 // @ts-ignore
 import type { EditableTestEntity, TestEntity, TestEntityId } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
-  public ents(): TestEntityCollectionService<ClientType>;
-  public ents(id: TestEntityId): TestEntityService<ClientType>;
+export class TesterService extends ODataService {
+  public ents(): TestEntityCollectionService;
+  public ents(id: TestEntityId): TestEntityService;
   public ents(id?: TestEntityId | undefined) {
     const fieldName = "Ents";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -25,22 +25,17 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
   }
 }
 
-export class TestEntityService<in out ClientType extends ODataHttpClient> extends EntityTypeServiceV2<
-  ClientType,
-  TestEntity,
-  EditableTestEntity,
-  QTestEntity
-> {
-  private _id?: PrimitiveTypeServiceV2<ClientType, string>;
-  private _age?: PrimitiveTypeServiceV2<ClientType, number>;
-  private _deceased?: PrimitiveTypeServiceV2<ClientType, boolean>;
-  private _desc?: PrimitiveTypeServiceV2<ClientType, string>;
-  private _dateAndTime?: PrimitiveTypeServiceV2<ClientType, string>;
-  private _dateAndTimeAndOffset?: PrimitiveTypeServiceV2<ClientType, string>;
-  private _time?: PrimitiveTypeServiceV2<ClientType, string>;
-  private _test?: PrimitiveTypeServiceV2<ClientType, string>;
+export class TestEntityService extends EntityTypeServiceV2<TestEntity, EditableTestEntity, QTestEntity> {
+  private _id?: PrimitiveTypeServiceV2<string>;
+  private _age?: PrimitiveTypeServiceV2<number>;
+  private _deceased?: PrimitiveTypeServiceV2<boolean>;
+  private _desc?: PrimitiveTypeServiceV2<string>;
+  private _dateAndTime?: PrimitiveTypeServiceV2<string>;
+  private _dateAndTimeAndOffset?: PrimitiveTypeServiceV2<string>;
+  private _time?: PrimitiveTypeServiceV2<string>;
+  private _test?: PrimitiveTypeServiceV2<string>;
 
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qTestEntity, options);
   }
 
@@ -138,14 +133,13 @@ export class TestEntityService<in out ClientType extends ODataHttpClient> extend
   }
 }
 
-export class TestEntityCollectionService<in out ClientType extends ODataHttpClient> extends EntitySetServiceV2<
-  ClientType,
+export class TestEntityCollectionService extends EntitySetServiceV2<
   TestEntity,
   EditableTestEntity,
   QTestEntity,
   TestEntityId
 > {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptions) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qTestEntity, new QTestEntityId(name), options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/abstract-and-open-types.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/abstract-and-open-types.ts
@@ -31,9 +31,9 @@ import type {
   // @ts-ignore
 } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
-  public fromAbstract(): ExtendedFromAbstractCollectionService<ClientType>;
-  public fromAbstract(id: ExtendedFromAbstractId): ExtendedFromAbstractService<ClientType>;
+export class TesterService extends ODataService {
+  public fromAbstract(): ExtendedFromAbstractCollectionService;
+  public fromAbstract(id: ExtendedFromAbstractId): ExtendedFromAbstractService;
   public fromAbstract(id?: ExtendedFromAbstractId | undefined) {
     const fieldName = "FromAbstract";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -47,8 +47,8 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
         );
   }
 
-  public fromOpen(): ExtendedFromOpenCollectionService<ClientType>;
-  public fromOpen(id: ExtendedFromOpenId): ExtendedFromOpenService<ClientType>;
+  public fromOpen(): ExtendedFromOpenCollectionService;
+  public fromOpen(id: ExtendedFromOpenId): ExtendedFromOpenService;
   public fromOpen(id?: ExtendedFromOpenId | undefined) {
     const fieldName = "FromOpen";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -63,11 +63,13 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
   }
 }
 
-export class AbstractEntityService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, AbstractEntity, EditableAbstractEntity, QAbstractEntity, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class AbstractEntityService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<
+  AbstractEntity,
+  EditableAbstractEntity,
+  QAbstractEntity,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qAbstractEntity, options);
   }
 
@@ -87,11 +89,13 @@ export class AbstractEntityService<
   }
 }
 
-export class OpenEntityService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, OpenEntity, EditableOpenEntity, QOpenEntity, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class OpenEntityService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<
+  OpenEntity,
+  EditableOpenEntity,
+  QOpenEntity,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qOpenEntity, options);
   }
 
@@ -101,58 +105,48 @@ export class OpenEntityService<
   }
 }
 
-export class ExtendedFromAbstractService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<
-  ClientType,
+export class ExtendedFromAbstractService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<
   ExtendedFromAbstract,
   EditableExtendedFromAbstract,
   QExtendedFromAbstract,
   V
 > {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qExtendedFromAbstract, options);
   }
 }
 
-export class ExtendedFromAbstractCollectionService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntitySetServiceV4<
-  ClientType,
+export class ExtendedFromAbstractCollectionService<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
   ExtendedFromAbstract,
   EditableExtendedFromAbstract,
   QExtendedFromAbstract,
   ExtendedFromAbstractId,
   V
 > {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qExtendedFromAbstract, new QExtendedFromAbstractId(name), options);
   }
 }
 
-export class ExtendedFromOpenService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, ExtendedFromOpen, EditableExtendedFromOpen, QExtendedFromOpen, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class ExtendedFromOpenService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<
+  ExtendedFromOpen,
+  EditableExtendedFromOpen,
+  QExtendedFromOpen,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qExtendedFromOpen, options);
   }
 }
 
-export class ExtendedFromOpenCollectionService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntitySetServiceV4<
-  ClientType,
+export class ExtendedFromOpenCollectionService<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
   ExtendedFromOpen,
   EditableExtendedFromOpen,
   QExtendedFromOpen,
   ExtendedFromOpenId,
   V
 > {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qExtendedFromOpen, new QExtendedFromOpenId(name), options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/abstract-with-inheritance.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/abstract-with-inheritance.ts
@@ -19,9 +19,9 @@ import type {
   // @ts-ignore
 } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
-  public testing(): TestEntityCollectionService<ClientType>;
-  public testing(id: AbstractEntityId): TestEntityService<ClientType>;
+export class TesterService extends ODataService {
+  public testing(): TestEntityCollectionService;
+  public testing(id: AbstractEntityId): TestEntityService;
   public testing(id?: AbstractEntityId | undefined) {
     const fieldName = "Testing";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -31,11 +31,13 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
   }
 }
 
-export class AbstractEntityService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, AbstractEntity, EditableAbstractEntity, QAbstractEntity, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class AbstractEntityService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<
+  AbstractEntity,
+  EditableAbstractEntity,
+  QAbstractEntity,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qAbstractEntity, options);
   }
 
@@ -45,11 +47,14 @@ export class AbstractEntityService<
   }
 }
 
-export class AbstractEntityCollectionService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntitySetServiceV4<ClientType, AbstractEntity, EditableAbstractEntity, QAbstractEntity, AbstractEntityId, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class AbstractEntityCollectionService<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
+  AbstractEntity,
+  EditableAbstractEntity,
+  QAbstractEntity,
+  AbstractEntityId,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qAbstractEntity, new QAbstractEntityId(name), options);
   }
 
@@ -59,20 +64,25 @@ export class AbstractEntityCollectionService<
   }
 }
 
-export class TestEntityService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, TestEntity, EditableTestEntity, QTestEntity, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class TestEntityService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<
+  TestEntity,
+  EditableTestEntity,
+  QTestEntity,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qTestEntity, options);
   }
 }
 
-export class TestEntityCollectionService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntitySetServiceV4<ClientType, TestEntity, EditableTestEntity, QTestEntity, AbstractEntityId, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class TestEntityCollectionService<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
+  TestEntity,
+  EditableTestEntity,
+  QTestEntity,
+  AbstractEntityId,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qTestEntity, new QAbstractEntityId(name), options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/action-bound-unbound.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/action-bound-unbound.ts
@@ -15,12 +15,12 @@ import { QPing, qTestEntity, QTestEntityId, QVote } from "./QTester.js";
 // @ts-ignore
 import type { EditableTestEntity, TestEntity, TestEntityId, VoteParams } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
+export class TesterService extends ODataService {
   private _qPing?: QPing;
   private _qVote?: QVote;
 
-  public tests(): TestEntityCollectionService<ClientType>;
-  public tests(id: TestEntityId): TestEntityService<ClientType>;
+  public tests(): TestEntityCollectionService;
+  public tests(id: TestEntityId): TestEntityService;
   public tests(id?: TestEntityId | undefined) {
     const fieldName = "tests";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -37,7 +37,7 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
     const { addFullPath, client, getDefaultHeaders } = this.__base;
     const url = addFullPath(this._qPing.buildUrl());
 
-    return new UrlRequestCmd<ClientType, undefined>(client, ODataHttpMethods.Post, url, undefined, {
+    return new UrlRequestCmd<undefined>(client, ODataHttpMethods.Post, url, undefined, {
       headers: getDefaultHeaders(),
     });
   }
@@ -50,34 +50,33 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
     const { addFullPath, client, getDefaultHeaders } = this.__base;
     const url = addFullPath(this._qVote.buildUrl());
 
-    return new UrlRequestCmd<ClientType, ODataModelResponseV4<TestEntity>, VoteParams>(
-      client,
-      ODataHttpMethods.Post,
-      url,
-      params,
-      {
-        headers: getDefaultHeaders(),
-        mainRequestConverter: this._qVote.getRequestConverter(),
-        mainResponseConverter: this._qVote.getResponseConverter(),
-      },
-    );
+    return new UrlRequestCmd<ODataModelResponseV4<TestEntity>, VoteParams>(client, ODataHttpMethods.Post, url, params, {
+      headers: getDefaultHeaders(),
+      mainRequestConverter: this._qVote.getRequestConverter(),
+      mainResponseConverter: this._qVote.getResponseConverter(),
+    });
   }
 }
 
-export class TestEntityService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, TestEntity, EditableTestEntity, QTestEntity, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class TestEntityService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<
+  TestEntity,
+  EditableTestEntity,
+  QTestEntity,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qTestEntity, options);
   }
 }
 
-export class TestEntityCollectionService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntitySetServiceV4<ClientType, TestEntity, EditableTestEntity, QTestEntity, TestEntityId, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class TestEntityCollectionService<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
+  TestEntity,
+  EditableTestEntity,
+  QTestEntity,
+  TestEntityId,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qTestEntity, new QTestEntityId(name), options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/action-rt-enum.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/action-rt-enum.ts
@@ -22,9 +22,9 @@ import type {
   // @ts-ignore
 } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
-  public books(): BookCollectionService<ClientType>;
-  public books(id: BookId): BookService<ClientType>;
+export class TesterService extends ODataService {
+  public books(): BookCollectionService;
+  public books(id: BookId): BookService;
   public books(id?: BookId | undefined) {
     const fieldName = "books";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -34,14 +34,11 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
   }
 }
 
-export class BookService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, Book, EditableBook, QBook, V> {
+export class BookService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<Book, EditableBook, QBook, V> {
   private _bookQLike?: Book_QLike;
   private _bookQRate?: Book_QRate;
 
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qBook, options);
   }
 
@@ -53,7 +50,7 @@ export class BookService<
     const { addFullPath, client, getDefaultHeaders } = this.__base;
     const url = addFullPath(this._bookQLike.buildUrl());
 
-    return new UrlRequestCmd<ClientType, undefined>(client, ODataHttpMethods.Post, url, undefined, {
+    return new UrlRequestCmd<undefined>(client, ODataHttpMethods.Post, url, undefined, {
       headers: getDefaultHeaders(),
     });
   }
@@ -66,7 +63,7 @@ export class BookService<
     const { addFullPath, client, getDefaultHeaders } = this.__base;
     const url = addFullPath(this._bookQRate.buildUrl());
 
-    return new UrlRequestCmd<ClientType, ODataModelResponseV4<Rating>, Book_RateParams>(
+    return new UrlRequestCmd<ODataModelResponseV4<Rating>, Book_RateParams>(
       client,
       ODataHttpMethods.Post,
       url,
@@ -80,13 +77,16 @@ export class BookService<
   }
 }
 
-export class BookCollectionService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntitySetServiceV4<ClientType, Book, EditableBook, QBook, BookId, V> {
+export class BookCollectionService<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
+  Book,
+  EditableBook,
+  QBook,
+  BookId,
+  V
+> {
   private _bookCollectionQRatings?: BookCollection_QRatings;
 
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qBook, new QBookId(name), options);
   }
 
@@ -98,7 +98,7 @@ export class BookCollectionService<
     const { addFullPath, client, getDefaultHeaders } = this.__base;
     const url = addFullPath(this._bookCollectionQRatings.buildUrl());
 
-    return new UrlRequestCmd<ClientType, ODataCollectionResponseV4<Rating>, BookCollection_RatingsParams>(
+    return new UrlRequestCmd<ODataCollectionResponseV4<Rating>, BookCollection_RatingsParams>(
       client,
       ODataHttpMethods.Post,
       url,

--- a/packages/odata2ts/test/fixture/generator/service/v4/action-rt-primitive.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/action-rt-primitive.ts
@@ -15,13 +15,13 @@ import { QPingCollection, QPingNumber, QPingString, qTestEntity, QTestEntityId }
 // @ts-ignore
 import type { EditableTestEntity, TestEntity, TestEntityId } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
+export class TesterService extends ODataService {
   private _qPingString?: QPingString;
   private _qPingNumber?: QPingNumber;
   private _qPingCollection?: QPingCollection;
 
-  public tests(): TestEntityCollectionService<ClientType>;
-  public tests(id: TestEntityId): TestEntityService<ClientType>;
+  public tests(): TestEntityCollectionService;
+  public tests(id: TestEntityId): TestEntityService;
   public tests(id?: TestEntityId | undefined) {
     const fieldName = "tests";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -38,7 +38,7 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
     const { addFullPath, client, getDefaultHeaders } = this.__base;
     const url = addFullPath(this._qPingString.buildUrl());
 
-    return new UrlRequestCmd<ClientType, ODataValueResponseV4<string>>(client, ODataHttpMethods.Post, url, undefined, {
+    return new UrlRequestCmd<ODataValueResponseV4<string>>(client, ODataHttpMethods.Post, url, undefined, {
       headers: getDefaultHeaders(),
       mainResponseConverter: this._qPingString.getResponseConverter(),
     });
@@ -52,7 +52,7 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
     const { addFullPath, client, getDefaultHeaders } = this.__base;
     const url = addFullPath(this._qPingNumber.buildUrl());
 
-    return new UrlRequestCmd<ClientType, ODataValueResponseV4<number>>(client, ODataHttpMethods.Post, url, undefined, {
+    return new UrlRequestCmd<ODataValueResponseV4<number>>(client, ODataHttpMethods.Post, url, undefined, {
       headers: getDefaultHeaders(),
       mainResponseConverter: this._qPingNumber.getResponseConverter(),
     });
@@ -66,30 +66,32 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
     const { addFullPath, client, getDefaultHeaders } = this.__base;
     const url = addFullPath(this._qPingCollection.buildUrl());
 
-    return new UrlRequestCmd<ClientType, ODataCollectionResponseV4<string>>(
-      client,
-      ODataHttpMethods.Post,
-      url,
-      undefined,
-      { headers: getDefaultHeaders(), mainResponseConverter: this._qPingCollection.getResponseConverter() },
-    );
+    return new UrlRequestCmd<ODataCollectionResponseV4<string>>(client, ODataHttpMethods.Post, url, undefined, {
+      headers: getDefaultHeaders(),
+      mainResponseConverter: this._qPingCollection.getResponseConverter(),
+    });
   }
 }
 
-export class TestEntityService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, TestEntity, EditableTestEntity, QTestEntity, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class TestEntityService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<
+  TestEntity,
+  EditableTestEntity,
+  QTestEntity,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qTestEntity, options);
   }
 }
 
-export class TestEntityCollectionService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntitySetServiceV4<ClientType, TestEntity, EditableTestEntity, QTestEntity, TestEntityId, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class TestEntityCollectionService<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
+  TestEntity,
+  EditableTestEntity,
+  QTestEntity,
+  TestEntityId,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qTestEntity, new QTestEntityId(name), options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/big-number-return-types.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/big-number-return-types.ts
@@ -16,17 +16,17 @@ import { QPingBigNumber, QPingDecimal, QPingDecimalCollection, qTestEntity, QTes
 // @ts-ignore
 import type { EditableTestEntity, TestEntity, TestEntityId } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
+export class TesterService extends ODataService {
   private _qPingBigNumber?: QPingBigNumber;
   private _qPingDecimal?: QPingDecimal;
   private _qPingDecimalCollection?: QPingDecimalCollection;
 
-  constructor(client: ClientType, basePath: string, options?: ODataServiceOptions) {
+  constructor(client: ODataHttpClient, basePath: string, options?: ODataServiceOptions) {
     super(client, basePath, { ...options, bigNumbersAsString: true });
   }
 
-  public tests(): TestEntityCollectionService<ClientType>;
-  public tests(id: TestEntityId): TestEntityService<ClientType>;
+  public tests(): TestEntityCollectionService;
+  public tests(id: TestEntityId): TestEntityService;
   public tests(id?: TestEntityId | undefined) {
     const fieldName = "tests";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -43,7 +43,7 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
     const { addFullPath, client, getDefaultHeaders } = this.__base;
     const url = addFullPath(this._qPingBigNumber.buildUrl());
 
-    return new UrlRequestCmd<ClientType, ODataValueResponseV4<string>>(client, ODataHttpMethods.Post, url, undefined, {
+    return new UrlRequestCmd<ODataValueResponseV4<string>>(client, ODataHttpMethods.Post, url, undefined, {
       headers: getDefaultHeaders(),
       mainResponseConverter: this._qPingBigNumber.getResponseConverter(),
     });
@@ -57,7 +57,7 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
     const { addFullPath, client, getDefaultHeaders } = this.__base;
     const url = addFullPath(this._qPingDecimal.buildUrl());
 
-    return new UrlRequestCmd<ClientType, ODataValueResponseV4<string>>(client, ODataHttpMethods.Post, url, undefined, {
+    return new UrlRequestCmd<ODataValueResponseV4<string>>(client, ODataHttpMethods.Post, url, undefined, {
       headers: getDefaultHeaders(),
       mainResponseConverter: this._qPingDecimal.getResponseConverter(),
     });
@@ -71,30 +71,32 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
     const { addFullPath, client, getDefaultHeaders } = this.__base;
     const url = addFullPath(this._qPingDecimalCollection.buildUrl());
 
-    return new UrlRequestCmd<ClientType, ODataCollectionResponseV4<string>>(
-      client,
-      ODataHttpMethods.Post,
-      url,
-      undefined,
-      { headers: getDefaultHeaders(), mainResponseConverter: this._qPingDecimalCollection.getResponseConverter() },
-    );
+    return new UrlRequestCmd<ODataCollectionResponseV4<string>>(client, ODataHttpMethods.Post, url, undefined, {
+      headers: getDefaultHeaders(),
+      mainResponseConverter: this._qPingDecimalCollection.getResponseConverter(),
+    });
   }
 }
 
-export class TestEntityService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, TestEntity, EditableTestEntity, QTestEntity, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class TestEntityService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<
+  TestEntity,
+  EditableTestEntity,
+  QTestEntity,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qTestEntity, options);
   }
 }
 
-export class TestEntityCollectionService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntitySetServiceV4<ClientType, TestEntity, EditableTestEntity, QTestEntity, TestEntityId, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class TestEntityCollectionService<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
+  TestEntity,
+  EditableTestEntity,
+  QTestEntity,
+  TestEntityId,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qTestEntity, new QTestEntityId(name), options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/big-numbers.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/big-numbers.ts
@@ -18,13 +18,13 @@ import { qTestEntity, QTestEntityId } from "./QTester.js";
 // @ts-ignore
 import type { EditableTestEntity, TestEntity, TestEntityId } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
-  constructor(client: ClientType, basePath: string, options?: ODataServiceOptions) {
+export class TesterService extends ODataService {
+  constructor(client: ODataHttpClient, basePath: string, options?: ODataServiceOptions) {
     super(client, basePath, { ...options, bigNumbersAsString: true });
   }
 
-  public ents(): TestEntityCollectionService<ClientType>;
-  public ents(id: TestEntityId): TestEntityService<ClientType>;
+  public ents(): TestEntityCollectionService;
+  public ents(id: TestEntityId): TestEntityService;
   public ents(id?: TestEntityId | undefined) {
     const fieldName = "Ents";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -34,19 +34,20 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
   }
 }
 
-export class TestEntityService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, TestEntity, EditableTestEntity, QTestEntity, V> {
+export class TestEntityService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<
+  TestEntity,
+  EditableTestEntity,
+  QTestEntity,
+  V
+> {
   private _bigNumberCollection?: CollectionServiceV4<
-    ClientType,
     StringCollection,
     QBigNumberCollection,
     PrimitiveExtractor<StringCollection>,
     V
   >;
 
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qTestEntity, options);
   }
 
@@ -66,11 +67,14 @@ export class TestEntityService<
   }
 }
 
-export class TestEntityCollectionService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntitySetServiceV4<ClientType, TestEntity, EditableTestEntity, QTestEntity, TestEntityId, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class TestEntityCollectionService<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
+  TestEntity,
+  EditableTestEntity,
+  QTestEntity,
+  TestEntityId,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qTestEntity, new QTestEntityId(name), options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/complex-type.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/complex-type.ts
@@ -14,9 +14,9 @@ import { qBook, QBookId, qReviewer } from "./QTester.js";
 // @ts-ignore
 import type { Book, BookId, EditableBook, EditableReviewer, Reviewer } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
-  public books(): BookCollectionService<ClientType>;
-  public books(id: BookId): BookService<ClientType>;
+export class TesterService extends ODataService {
+  public books(): BookCollectionService;
+  public books(id: BookId): BookService;
   public books(id?: BookId | undefined) {
     const fieldName = "Books";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -26,18 +26,15 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
   }
 }
 
-export class BookService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, Book, EditableBook, QBook, V> {
-  private _lector?: ReviewerService<ClientType, V>;
-  private _reviewers?: CollectionServiceV4<ClientType, Reviewer, QReviewer, EditableReviewer, V>;
+export class BookService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<Book, EditableBook, QBook, V> {
+  private _lector?: ReviewerService<V>;
+  private _reviewers?: CollectionServiceV4<Reviewer, QReviewer, EditableReviewer, V>;
 
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qBook, options);
   }
 
-  public lector(): ReviewerService<ClientType, V> {
+  public lector(): ReviewerService<V> {
     if (!this._lector) {
       const { client, path, options } = this.__base;
       this._lector = new ReviewerService(client, path, "lector", options);
@@ -46,7 +43,7 @@ export class BookService<
     return this._lector;
   }
 
-  public reviewers(): CollectionServiceV4<ClientType, Reviewer, QReviewer, EditableReviewer, V> {
+  public reviewers(): CollectionServiceV4<Reviewer, QReviewer, EditableReviewer, V> {
     if (!this._reviewers) {
       const { client, path, options } = this.__base;
       this._reviewers = new CollectionServiceV4(client, path, "reviewers", qReviewer, options);
@@ -56,20 +53,25 @@ export class BookService<
   }
 }
 
-export class BookCollectionService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntitySetServiceV4<ClientType, Book, EditableBook, QBook, BookId, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class BookCollectionService<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
+  Book,
+  EditableBook,
+  QBook,
+  BookId,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qBook, new QBookId(name), options);
   }
 }
 
-export class ReviewerService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, Reviewer, EditableReviewer, QReviewer, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class ReviewerService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<
+  Reviewer,
+  EditableReviewer,
+  QReviewer,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qReviewer, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/entity-relationships.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/entity-relationships.ts
@@ -14,9 +14,9 @@ import { qAuthor, QAuthorId, qBook, QBookId } from "./QTester.js";
 // @ts-ignore
 import type { Author, AuthorId, Book, BookId, EditableAuthor, EditableBook } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
-  public books(): BookCollectionService<ClientType>;
-  public books(id: BookId): BookService<ClientType>;
+export class TesterService extends ODataService {
+  public books(): BookCollectionService;
+  public books(id: BookId): BookService;
   public books(id?: BookId | undefined) {
     const fieldName = "books";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -26,14 +26,16 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
   }
 }
 
-export class AuthorService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, Author, EditableAuthor, QAuthor, V> {
-  private _id?: PrimitiveTypeServiceV4<ClientType, string, V>;
-  private _name?: PrimitiveTypeServiceV4<ClientType, string, V>;
+export class AuthorService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<
+  Author,
+  EditableAuthor,
+  QAuthor,
+  V
+> {
+  private _id?: PrimitiveTypeServiceV4<string, V>;
+  private _name?: PrimitiveTypeServiceV4<string, V>;
 
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qAuthor, options);
   }
 
@@ -56,23 +58,23 @@ export class AuthorService<
   }
 }
 
-export class AuthorCollectionService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntitySetServiceV4<ClientType, Author, EditableAuthor, QAuthor, AuthorId, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class AuthorCollectionService<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
+  Author,
+  EditableAuthor,
+  QAuthor,
+  AuthorId,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qAuthor, new QAuthorId(name), options);
   }
 }
 
-export class BookService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, Book, EditableBook, QBook, V> {
-  private _id?: PrimitiveTypeServiceV4<ClientType, string, V>;
-  private _author?: AuthorService<ClientType, V>;
+export class BookService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<Book, EditableBook, QBook, V> {
+  private _id?: PrimitiveTypeServiceV4<string, V>;
+  private _author?: AuthorService<V>;
 
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qBook, options);
   }
 
@@ -85,7 +87,7 @@ export class BookService<
     return this._id;
   }
 
-  public author(): AuthorService<ClientType, V> {
+  public author(): AuthorService<V> {
     if (!this._author) {
       const { client, path, options } = this.__base;
       this._author = new AuthorService(client, path, "AUTHOR", options);
@@ -94,8 +96,8 @@ export class BookService<
     return this._author;
   }
 
-  public relatedAuthors(): AuthorCollectionService<ClientType, V>;
-  public relatedAuthors(id: AuthorId): AuthorService<ClientType, V>;
+  public relatedAuthors(): AuthorCollectionService<V>;
+  public relatedAuthors(id: AuthorId): AuthorService<V>;
   public relatedAuthors(id?: AuthorId | undefined) {
     const fieldName = "RelatedAuthors";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -105,11 +107,14 @@ export class BookService<
   }
 }
 
-export class BookCollectionService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntitySetServiceV4<ClientType, Book, EditableBook, QBook, BookId, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class BookCollectionService<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
+  Book,
+  EditableBook,
+  QBook,
+  BookId,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qBook, new QBookId(name), options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/enum-numeric-type.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/enum-numeric-type.ts
@@ -19,9 +19,9 @@ import type { Book, BookId, EditableBook } from "./TesterModel.js";
 // @ts-ignore
 import { Choice } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
-  public books(): BookCollectionService<ClientType>;
-  public books(id: BookId): BookService<ClientType>;
+export class TesterService extends ODataService {
+  public books(): BookCollectionService;
+  public books(id: BookId): BookService;
   public books(id?: BookId | undefined) {
     const fieldName = "books";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -31,19 +31,15 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
   }
 }
 
-export class BookService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, Book, EditableBook, QBook, V> {
+export class BookService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<Book, EditableBook, QBook, V> {
   private _altChoices?: CollectionServiceV4<
-    ClientType,
     EnumCollection<typeof Choice>,
     QNumericEnumCollection<typeof Choice>,
     PrimitiveExtractor<EnumCollection<typeof Choice>>,
     V
   >;
 
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qBook, options);
   }
 
@@ -63,11 +59,14 @@ export class BookService<
   }
 }
 
-export class BookCollectionService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntitySetServiceV4<ClientType, Book, EditableBook, QBook, BookId, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class BookCollectionService<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
+  Book,
+  EditableBook,
+  QBook,
+  BookId,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qBook, new QBookId(name), options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/enum-type.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/enum-type.ts
@@ -19,9 +19,9 @@ import type { Book, BookId, EditableBook } from "./TesterModel.js";
 // @ts-ignore
 import { Choice } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
-  public books(): BookCollectionService<ClientType>;
-  public books(id: BookId): BookService<ClientType>;
+export class TesterService extends ODataService {
+  public books(): BookCollectionService;
+  public books(id: BookId): BookService;
   public books(id?: BookId | undefined) {
     const fieldName = "books";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -31,19 +31,15 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
   }
 }
 
-export class BookService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, Book, EditableBook, QBook, V> {
+export class BookService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<Book, EditableBook, QBook, V> {
   private _altChoices?: CollectionServiceV4<
-    ClientType,
     EnumCollection<typeof Choice>,
     QEnumCollection<typeof Choice>,
     PrimitiveExtractor<EnumCollection<typeof Choice>>,
     V
   >;
 
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qBook, options);
   }
 
@@ -57,11 +53,14 @@ export class BookService<
   }
 }
 
-export class BookCollectionService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntitySetServiceV4<ClientType, Book, EditableBook, QBook, BookId, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class BookCollectionService<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
+  Book,
+  EditableBook,
+  QBook,
+  BookId,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qBook, new QBookId(name), options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/function-bound-unbound.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/function-bound-unbound.ts
@@ -14,12 +14,12 @@ import { QFirstBook, QGetBestsellers, qTestEntity, QTestEntityId } from "./QTest
 // @ts-ignore
 import type { EditableTestEntity, FirstBookParams, TestEntity, TestEntityId } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
+export class TesterService extends ODataService {
   private _qGetBestsellers?: QGetBestsellers;
   private _qFirstBook?: QFirstBook;
 
-  public tests(): TestEntityCollectionService<ClientType>;
-  public tests(id: TestEntityId): TestEntityService<ClientType>;
+  public tests(): TestEntityCollectionService;
+  public tests(id: TestEntityId): TestEntityService;
   public tests(id?: TestEntityId | undefined) {
     const fieldName = "tests";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -36,7 +36,7 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
     const { addFullPath, client, getDefaultHeaders, isUrlNotEncoded } = this.__base;
     const url = addFullPath(this._qGetBestsellers.buildUrl(isUrlNotEncoded()));
 
-    return new UrlGetRequestCmd<ClientType, ODataCollectionResponseV4<TestEntity>>(client, url, {
+    return new UrlGetRequestCmd<ODataCollectionResponseV4<TestEntity>>(client, url, {
       headers: getDefaultHeaders(),
       mainResponseConverter: this._qGetBestsellers.getResponseConverter(),
     });
@@ -50,27 +50,32 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
     const { addFullPath, client, getDefaultHeaders, isUrlNotEncoded } = this.__base;
     const url = addFullPath(this._qFirstBook.buildUrl(params, isUrlNotEncoded()));
 
-    return new UrlGetRequestCmd<ClientType, ODataModelResponseV4<TestEntity>>(client, url, {
+    return new UrlGetRequestCmd<ODataModelResponseV4<TestEntity>>(client, url, {
       headers: getDefaultHeaders(),
       mainResponseConverter: this._qFirstBook.getResponseConverter(),
     });
   }
 }
 
-export class TestEntityService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, TestEntity, EditableTestEntity, QTestEntity, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class TestEntityService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<
+  TestEntity,
+  EditableTestEntity,
+  QTestEntity,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qTestEntity, options);
   }
 }
 
-export class TestEntityCollectionService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntitySetServiceV4<ClientType, TestEntity, EditableTestEntity, QTestEntity, TestEntityId, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class TestEntityCollectionService<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
+  TestEntity,
+  EditableTestEntity,
+  QTestEntity,
+  TestEntityId,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qTestEntity, new QTestEntityId(name), options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/function-composable.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/function-composable.ts
@@ -14,13 +14,13 @@ import { qBook, QBookId, QGetBest, QGetBestReview, QGetTop10, qReview } from "./
 // @ts-ignore
 import type { Book, BookId, EditableBook, EditableReview, Review } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
+export class TesterService extends ODataService {
   private _qGetBest?: QGetBest;
   private _qGetTop10?: QGetTop10;
   private _qGetBestReview?: QGetBestReview;
 
-  public books(): BookCollectionService<ClientType>;
-  public books(id: BookId): BookService<ClientType>;
+  public books(): BookCollectionService;
+  public books(id: BookId): BookService;
   public books(id?: BookId | undefined) {
     const fieldName = "Books";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -37,10 +37,10 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
     const { addFullPath, client, getDefaultHeaders, isUrlNotEncoded, options } = this.__base;
     const url = addFullPath(this._qGetBest.buildUrl(isUrlNotEncoded()));
 
-    return new ComposableUrlRequestCmd<ClientType, BookService<ClientType>, ODataModelResponseV4<Book>>(
+    return new ComposableUrlRequestCmd<BookService, ODataModelResponseV4<Book>>(
       client,
       url,
-      (finalUrl: string) => new BookService<ClientType>(client, finalUrl, "", options),
+      (finalUrl: string) => new BookService(client, finalUrl, "", options),
       { headers: getDefaultHeaders(), mainResponseConverter: this._qGetBest.getResponseConverter() },
     );
   }
@@ -53,10 +53,10 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
     const { addFullPath, client, getDefaultHeaders, isUrlNotEncoded, options } = this.__base;
     const url = addFullPath(this._qGetTop10.buildUrl(isUrlNotEncoded()));
 
-    return new ComposableUrlRequestCmd<ClientType, BookCollectionService<ClientType>, ODataCollectionResponseV4<Book>>(
+    return new ComposableUrlRequestCmd<BookCollectionService, ODataCollectionResponseV4<Book>>(
       client,
       url,
-      (finalUrl: string) => new BookCollectionService<ClientType>(client, finalUrl, "", options),
+      (finalUrl: string) => new BookCollectionService(client, finalUrl, "", options),
       { headers: getDefaultHeaders(), mainResponseConverter: this._qGetTop10.getResponseConverter() },
     );
   }
@@ -69,26 +69,23 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
     const { addFullPath, client, getDefaultHeaders, isUrlNotEncoded, options } = this.__base;
     const url = addFullPath(this._qGetBestReview.buildUrl(isUrlNotEncoded()));
 
-    return new ComposableUrlRequestCmd<ClientType, ReviewService<ClientType>, ODataModelResponseV4<Review>>(
+    return new ComposableUrlRequestCmd<ReviewService, ODataModelResponseV4<Review>>(
       client,
       url,
-      (finalUrl: string) => new ReviewService<ClientType>(client, finalUrl, "", options),
+      (finalUrl: string) => new ReviewService(client, finalUrl, "", options),
       { headers: getDefaultHeaders(), mainResponseConverter: this._qGetBestReview.getResponseConverter() },
     );
   }
 }
 
-export class BookService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, Book, EditableBook, QBook, V> {
-  private _review?: ReviewService<ClientType, V>;
+export class BookService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<Book, EditableBook, QBook, V> {
+  private _review?: ReviewService<V>;
 
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qBook, options);
   }
 
-  public review(): ReviewService<ClientType, V> {
+  public review(): ReviewService<V> {
     if (!this._review) {
       const { client, path, options } = this.__base;
       this._review = new ReviewService(client, path, "review", options);
@@ -98,20 +95,25 @@ export class BookService<
   }
 }
 
-export class BookCollectionService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntitySetServiceV4<ClientType, Book, EditableBook, QBook, BookId, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class BookCollectionService<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
+  Book,
+  EditableBook,
+  QBook,
+  BookId,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qBook, new QBookId(name), options);
   }
 }
 
-export class ReviewService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, Review, EditableReview, QReview, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class ReviewService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<
+  Review,
+  EditableReview,
+  QReview,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qReview, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/function-overload-optional.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/function-overload-optional.ts
@@ -1,4 +1,3 @@
-import type { ODataHttpClient } from "@odata2ts/http-client-api";
 import type { ODataValueResponseV4 } from "@odata2ts/odata-core";
 import { ODataService, UrlGetRequestCmd } from "@odata2ts/odata-service";
 // @ts-ignore
@@ -6,7 +5,7 @@ import { QBestReview } from "./QTester.js";
 // @ts-ignore
 import type { BestReviewParams } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
+export class TesterService extends ODataService {
   private _qBestReview?: QBestReview;
 
   public bestReview(params?: BestReviewParams) {
@@ -17,7 +16,7 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
     const { addFullPath, client, getDefaultHeaders, isUrlNotEncoded } = this.__base;
     const url = addFullPath(this._qBestReview.buildUrl(params, isUrlNotEncoded()));
 
-    return new UrlGetRequestCmd<ClientType, ODataValueResponseV4<string>>(client, url, {
+    return new UrlGetRequestCmd<ODataValueResponseV4<string>>(client, url, {
       headers: getDefaultHeaders(),
       mainResponseConverter: this._qBestReview.getResponseConverter(),
     });

--- a/packages/odata2ts/test/fixture/generator/service/v4/function-overload.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/function-overload.ts
@@ -1,4 +1,3 @@
-import type { ODataHttpClient } from "@odata2ts/http-client-api";
 import type { ODataValueResponseV4 } from "@odata2ts/odata-core";
 import { ODataService, UrlGetRequestCmd } from "@odata2ts/odata-service";
 // @ts-ignore
@@ -6,7 +5,7 @@ import { QBestReview } from "./QTester.js";
 // @ts-ignore
 import type { BestReviewParams } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
+export class TesterService extends ODataService {
   private _qBestReview?: QBestReview;
 
   public bestReview(params: BestReviewParams) {
@@ -17,7 +16,7 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
     const { addFullPath, client, getDefaultHeaders, isUrlNotEncoded } = this.__base;
     const url = addFullPath(this._qBestReview.buildUrl(params, isUrlNotEncoded()));
 
-    return new UrlGetRequestCmd<ClientType, ODataValueResponseV4<string>>(client, url, {
+    return new UrlGetRequestCmd<ODataValueResponseV4<string>>(client, url, {
       headers: getDefaultHeaders(),
       mainResponseConverter: this._qBestReview.getResponseConverter(),
     });

--- a/packages/odata2ts/test/fixture/generator/service/v4/function-rt-complex.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/function-rt-complex.ts
@@ -14,9 +14,9 @@ import { Book_QBestReview, BookCollection_QFilterReviews, qBook, QBookId } from 
 // @ts-ignore
 import type { Book, BookCollection_FilterReviewsParams, BookId, EditableBook, Review } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
-  public books(): BookCollectionService<ClientType>;
-  public books(id: BookId): BookService<ClientType>;
+export class TesterService extends ODataService {
+  public books(): BookCollectionService;
+  public books(id: BookId): BookService;
   public books(id?: BookId | undefined) {
     const fieldName = "books";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -26,13 +26,10 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
   }
 }
 
-export class BookService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, Book, EditableBook, QBook, V> {
+export class BookService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<Book, EditableBook, QBook, V> {
   private _bookQBestReview?: Book_QBestReview;
 
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qBook, options);
   }
 
@@ -44,20 +41,23 @@ export class BookService<
     const { addFullPath, client, getDefaultHeaders, isUrlNotEncoded } = this.__base;
     const url = addFullPath(this._bookQBestReview.buildUrl(isUrlNotEncoded()));
 
-    return new UrlGetRequestCmd<ClientType, ODataModelResponseV4<Review>>(client, url, {
+    return new UrlGetRequestCmd<ODataModelResponseV4<Review>>(client, url, {
       headers: getDefaultHeaders(),
       mainResponseConverter: this._bookQBestReview.getResponseConverter(),
     });
   }
 }
 
-export class BookCollectionService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntitySetServiceV4<ClientType, Book, EditableBook, QBook, BookId, V> {
+export class BookCollectionService<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
+  Book,
+  EditableBook,
+  QBook,
+  BookId,
+  V
+> {
   private _bookCollectionQFilterReviews?: BookCollection_QFilterReviews;
 
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qBook, new QBookId(name), options);
   }
 
@@ -69,7 +69,7 @@ export class BookCollectionService<
     const { addFullPath, client, getDefaultHeaders, isUrlNotEncoded } = this.__base;
     const url = addFullPath(this._bookCollectionQFilterReviews.buildUrl(params, isUrlNotEncoded()));
 
-    return new UrlGetRequestCmd<ClientType, ODataCollectionResponseV4<Review>>(client, url, {
+    return new UrlGetRequestCmd<ODataCollectionResponseV4<Review>>(client, url, {
       headers: getDefaultHeaders(),
       mainResponseConverter: this._bookCollectionQFilterReviews.getResponseConverter(),
     });

--- a/packages/odata2ts/test/fixture/generator/service/v4/media-entity.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/media-entity.ts
@@ -13,9 +13,9 @@ import { qEBook, QEBookId } from "./QTester.js";
 // @ts-ignore
 import type { EBook, EBookId, EditableEBook } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
-  public eBooks(): EBookCollectionService<ClientType>;
-  public eBooks(id: EBookId): EBookService<ClientType>;
+export class TesterService extends ODataService {
+  public eBooks(): EBookCollectionService;
+  public eBooks(id: EBookId): EBookService;
   public eBooks(id?: EBookId | undefined) {
     const fieldName = "EBooks";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -25,20 +25,25 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
   }
 }
 
-export class EBookService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends MediaEntityServiceV4<ClientType, EBook, EditableEBook, QEBook, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class EBookService<V extends ODataVersionV4 = "4.0"> extends MediaEntityServiceV4<
+  EBook,
+  EditableEBook,
+  QEBook,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qEBook, options);
   }
 }
 
-export class EBookCollectionService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntitySetServiceV4<ClientType, EBook, EditableEBook, QEBook, EBookId, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class EBookCollectionService<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
+  EBook,
+  EditableEBook,
+  QEBook,
+  EBookId,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qEBook, new QEBookId(name), options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/min-big-numbers.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/min-big-numbers.ts
@@ -1,8 +1,8 @@
 import type { ODataHttpClient } from "@odata2ts/http-client-api";
 import { ODataService, ODataServiceOptions } from "@odata2ts/odata-service";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
-  constructor(client: ClientType, basePath: string, options?: ODataServiceOptions) {
+export class TesterService extends ODataService {
+  constructor(client: ODataHttpClient, basePath: string, options?: ODataServiceOptions) {
     super(client, basePath, { ...options, bigNumbersAsString: true });
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/min-v401.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/min-v401.ts
@@ -1,8 +1,8 @@
 import type { ODataHttpClient } from "@odata2ts/http-client-api";
 import { ODataService, ODataServiceOptions } from "@odata2ts/odata-service";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType, "4.01"> {
-  constructor(client: ClientType, basePath: string, options?: ODataServiceOptions) {
+export class TesterService extends ODataService<"4.01"> {
+  constructor(client: ODataHttpClient, basePath: string, options?: ODataServiceOptions) {
     super(client, basePath, { ...options, odataVersionV4: "4.01" });
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/min.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/min.ts
@@ -1,4 +1,3 @@
-import type { ODataHttpClient } from "@odata2ts/http-client-api";
 import { ODataService } from "@odata2ts/odata-service";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {}
+export class TesterService extends ODataService {}

--- a/packages/odata2ts/test/fixture/generator/service/v4/naming.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/naming.ts
@@ -13,9 +13,9 @@ import { q_TEST_ENTITY, Q_TEST_ENTITY_ID } from "./QTester.js";
 // @ts-ignore
 import type { EDITABLE_TEST_ENTITY, TEST_ENTITY, TEST_ENTITY_ID } from "./TesterModel.js";
 
-export class tester<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
-  public NAVIGATE_TO_LIST(): TEST_ENTITY_COLLECTION_SRV<ClientType>;
-  public NAVIGATE_TO_LIST(id: TEST_ENTITY_ID): TEST_ENTITY_SRV<ClientType>;
+export class tester extends ODataService {
+  public NAVIGATE_TO_LIST(): TEST_ENTITY_COLLECTION_SRV;
+  public NAVIGATE_TO_LIST(id: TEST_ENTITY_ID): TEST_ENTITY_SRV;
   public NAVIGATE_TO_LIST(id?: TEST_ENTITY_ID | undefined) {
     const fieldName = "list";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -25,20 +25,25 @@ export class tester<in out ClientType extends ODataHttpClient> extends ODataServ
   }
 }
 
-export class TEST_ENTITY_SRV<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, TEST_ENTITY, EDITABLE_TEST_ENTITY, Q_TEST_ENTITY, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class TEST_ENTITY_SRV<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<
+  TEST_ENTITY,
+  EDITABLE_TEST_ENTITY,
+  Q_TEST_ENTITY,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, q_TEST_ENTITY, options);
   }
 }
 
-export class TEST_ENTITY_COLLECTION_SRV<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntitySetServiceV4<ClientType, TEST_ENTITY, EDITABLE_TEST_ENTITY, Q_TEST_ENTITY, TEST_ENTITY_ID, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class TEST_ENTITY_COLLECTION_SRV<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
+  TEST_ENTITY,
+  EDITABLE_TEST_ENTITY,
+  Q_TEST_ENTITY,
+  TEST_ENTITY_ID,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, q_TEST_ENTITY, new Q_TEST_ENTITY_ID(name), options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/one-entityset.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/one-entityset.ts
@@ -14,9 +14,9 @@ import { qTestEntity, QTestEntityId } from "./QTester.js";
 // @ts-ignore
 import type { EditableTestEntity, TestEntity, TestEntityId } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
-  public ents(): TestEntityCollectionService<ClientType>;
-  public ents(id: TestEntityId): TestEntityService<ClientType>;
+export class TesterService extends ODataService {
+  public ents(): TestEntityCollectionService;
+  public ents(id: TestEntityId): TestEntityService;
   public ents(id?: TestEntityId | undefined) {
     const fieldName = "Ents";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -26,16 +26,18 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
   }
 }
 
-export class TestEntityService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, TestEntity, EditableTestEntity, QTestEntity, V> {
-  private _id?: PrimitiveTypeServiceV4<ClientType, string, V>;
-  private _age?: PrimitiveTypeServiceV4<ClientType, number, V>;
-  private _deceased?: PrimitiveTypeServiceV4<ClientType, boolean, V>;
-  private _desc?: PrimitiveTypeServiceV4<ClientType, string, V>;
+export class TestEntityService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<
+  TestEntity,
+  EditableTestEntity,
+  QTestEntity,
+  V
+> {
+  private _id?: PrimitiveTypeServiceV4<string, V>;
+  private _age?: PrimitiveTypeServiceV4<number, V>;
+  private _deceased?: PrimitiveTypeServiceV4<boolean, V>;
+  private _desc?: PrimitiveTypeServiceV4<string, V>;
 
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qTestEntity, options);
   }
 
@@ -76,11 +78,14 @@ export class TestEntityService<
   }
 }
 
-export class TestEntityCollectionService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntitySetServiceV4<ClientType, TestEntity, EditableTestEntity, QTestEntity, TestEntityId, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class TestEntityCollectionService<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
+  TestEntity,
+  EditableTestEntity,
+  QTestEntity,
+  TestEntityId,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qTestEntity, new QTestEntityId(name), options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/singleton.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/singleton.ts
@@ -13,8 +13,8 @@ import { qTestEntity, QTestEntityId } from "./QTester.js";
 // @ts-ignore
 import type { EditableTestEntity, TestEntity, TestEntityId } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
-  private _currentUser?: TestEntityService<ClientType>;
+export class TesterService extends ODataService {
+  private _currentUser?: TestEntityService;
 
   public currentUser() {
     if (!this._currentUser) {
@@ -26,20 +26,25 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
   }
 }
 
-export class TestEntityService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, TestEntity, EditableTestEntity, QTestEntity, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class TestEntityService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<
+  TestEntity,
+  EditableTestEntity,
+  QTestEntity,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qTestEntity, options);
   }
 }
 
-export class TestEntityCollectionService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntitySetServiceV4<ClientType, TestEntity, EditableTestEntity, QTestEntity, TestEntityId, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class TestEntityCollectionService<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
+  TestEntity,
+  EditableTestEntity,
+  QTestEntity,
+  TestEntityId,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qTestEntity, new QTestEntityId(name), options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/stream-property.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/stream-property.ts
@@ -14,9 +14,9 @@ import { qAudiobook, QAudiobookId } from "./QTester.js";
 // @ts-ignore
 import type { Audiobook, AudiobookId, EditableAudiobook } from "./TesterModel.js";
 
-export class TesterService<in out ClientType extends ODataHttpClient> extends ODataService<ClientType> {
-  public audiobooks(): AudiobookCollectionService<ClientType>;
-  public audiobooks(id: AudiobookId): AudiobookService<ClientType>;
+export class TesterService extends ODataService {
+  public audiobooks(): AudiobookCollectionService;
+  public audiobooks(id: AudiobookId): AudiobookService;
   public audiobooks(id?: AudiobookId | undefined) {
     const fieldName = "Audiobooks";
     const { client, path, options, isUrlNotEncoded } = this.__base;
@@ -26,13 +26,15 @@ export class TesterService<in out ClientType extends ODataHttpClient> extends OD
   }
 }
 
-export class AudiobookService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntityTypeServiceV4<ClientType, Audiobook, EditableAudiobook, QAudiobook, V> {
-  private _sample?: StreamServiceV4<ClientType, V>;
+export class AudiobookService<V extends ODataVersionV4 = "4.0"> extends EntityTypeServiceV4<
+  Audiobook,
+  EditableAudiobook,
+  QAudiobook,
+  V
+> {
+  private _sample?: StreamServiceV4<V>;
 
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qAudiobook, options);
   }
 
@@ -46,11 +48,14 @@ export class AudiobookService<
   }
 }
 
-export class AudiobookCollectionService<
-  in out ClientType extends ODataHttpClient,
-  V extends ODataVersionV4 = "4.0",
-> extends EntitySetServiceV4<ClientType, Audiobook, EditableAudiobook, QAudiobook, AudiobookId, V> {
-  constructor(client: ClientType, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+export class AudiobookCollectionService<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
+  Audiobook,
+  EditableAudiobook,
+  QAudiobook,
+  AudiobookId,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qAudiobook, new QAudiobookId(name), options);
   }
 }


### PR DESCRIPTION
- removed the `ClientType` type parameter from `ODataService`, all `EntityTypeService*`, `EntitySetService*`, `CollectionService*`, `ComplexTypeServiceV2`, `PrimitiveTypeService*`, `MediaEntityService*`, `StreamService*` and every `RequestCmd`; `client` is plainly `ODataHttpClient` now
- `ServiceGenerator` stops emitting it, so a generated main service reads `export class TrippinService extends ODataService` and a V4 entity service keeps only `V`; V2 services carry no type parameter at all
- `execute()` takes the config every HTTP client understands (`headers`, `params`) by default and accepts a client specific one by naming its type: `execute<FetchRequestConfig>({ credentials: "include" })`
- added `NoInferConfig`, since the built-in `NoInfer` arrived in TS 5.4 and the declared peer floor is 4.7 — without it the type parameter would be inferred from the argument, and the all-optional base config would accept anything
- closed the `any` in `ODataService.__base`, which had made the type parameter an assertion rather than a check at exactly the class users name
- split the version type argument helper into a standalone and a suffix form, since `V` is now sometimes the only type argument and sometimes the last
- the entity collection service passed the literal `"ODataHttpClient"` instead of the `addClientApi()` result, which would have emitted a dangling identifier had the import ever been renamed on a name clash
- dropped the dead `ODataHttpClientConfig` member from `ClientApiImports` and the commented-out `getRawValue` in `PrimitiveTypeServiceV2`
- new `RequestConfig.test.ts` in `int-test/asp-net` and `int-test/cap`: the common config without a type argument, headers travelling to the server, and a fetch specific `signal` that needs `FetchRequestConfig` named
- verified the new signature under the pinned TypeScript 4.7 against a real generated client, including that the client specific field is rejected without the type argument