### PR TITLE
fix(odata-query-objects): pass URL conversion options to param converters

### DIFF
--- a/int-test/olingo-v2/test/feature/Converters.test.ts
+++ b/int-test/olingo-v2/test/feature/Converters.test.ts
@@ -1,3 +1,4 @@
+import { HttpResponseModel } from "@odata2ts/http-client-api";
 import { BigNumber } from "bignumber.js";
 import { DateTime } from "luxon";
 import { describe, expect, expectTypeOf, test } from "vitest";
@@ -121,6 +122,23 @@ describe("Olingo Library: value converters", () => {
     expect(raw.data.d.PublicationDate).toBe(`/Date(${publicationDate.toMillis()})/`);
 
     await CONVERTED.Books(id).delete().execute();
+  });
+
+  test("a converted date reaches a function parameter as a V2 literal, not as ticks", async () => {
+    /*
+     * A function parameter goes into the URL just like a filter value does, so the converter has to be
+     * told that it is converting for a URL. Without that it produces V2's *body* format and the literal
+     * becomes `datetime'/Date(1766534400000)/'` - which no V2 server accepts. The filter side above was
+     * already covered; this is the same conversion reached through a QParam instead of a QPath.
+     */
+    const cmd = CONVERTED.ClosureDay({ Day: DateTime.fromISO("2026-12-24T00:00:00", { zone: "utc" }) });
+
+    expect(decodeURIComponent(cmd.getUrl())).toContain("datetime'2026-12-24T00:00:00'");
+
+    const result = await cmd.execute();
+    expect(result.status).toBe(204);
+    expect(result.data).toBeUndefined();
+    expectTypeOf(result).toEqualTypeOf<HttpResponseModel<undefined>>();
   });
 
   test("a converted primitive property service converts too", async () => {

--- a/packages/odata-query-objects/src/param/QParam.ts
+++ b/packages/odata-query-objects/src/param/QParam.ts
@@ -1,7 +1,8 @@
-import { ParamValueModel, ValueConverter } from "@odata2ts/converter-api";
+import { ConverterOptions, ParamValueModel, ValueConverter } from "@odata2ts/converter-api";
 import { getIdentityConverter } from "../IdentityConverter";
 import { FlexibleConversionModel } from "../QueryObjectModel";
 import { QParamModel } from "./QParamModel";
+import { URL_CONVERSION_OPTIONS } from "./UrlParamHelper";
 import { UrlParamValueFormatter, UrlParamValueParser } from "./UrlParamModel";
 
 export type PrimitiveParamType = string | number | boolean;
@@ -38,16 +39,28 @@ export abstract class QParam<Type extends PrimitiveParamType, ConvertedType> imp
   protected abstract getUrlConformValue: UrlParamValueFormatter<Type>;
   protected abstract parseValueFromUrl: UrlParamValueParser<Type>;
 
-  public convertFrom(value: FlexibleConversionModel<Type>): FlexibleConversionModel<ConvertedType> {
-    return Array.isArray(value) ? value.map((v) => this.converter.convertFrom(v)) : this.converter.convertFrom(value);
+  public convertFrom(
+    value: FlexibleConversionModel<Type>,
+    options?: ConverterOptions,
+  ): FlexibleConversionModel<ConvertedType> {
+    return Array.isArray(value)
+      ? value.map((v) => this.converter.convertFrom(v, options))
+      : this.converter.convertFrom(value, options);
   }
 
-  public convertTo(value: FlexibleConversionModel<ConvertedType>): FlexibleConversionModel<Type> {
-    return Array.isArray(value) ? value.map((v) => this.converter.convertTo(v)) : this.converter.convertTo(value);
+  public convertTo(
+    value: FlexibleConversionModel<ConvertedType>,
+    options?: ConverterOptions,
+  ): FlexibleConversionModel<Type> {
+    return Array.isArray(value)
+      ? value.map((v) => this.converter.convertTo(v, options))
+      : this.converter.convertTo(value, options);
   }
 
   public formatUrlValue(value: FlexibleConversionModel<ConvertedType>): string | undefined {
-    const converted = this.convertTo(value);
+    // a param value ends up in the URL just like a path value does - entity keys and function
+    // parameters both go there, so the converter has to be told, same as in QBasePath
+    const converted = this.convertTo(value, URL_CONVERSION_OPTIONS);
     return Array.isArray(value)
       ? JSON.stringify(converted)
       : this.getUrlConformValue(converted as ParamValueModel<Type>);
@@ -59,10 +72,10 @@ export abstract class QParam<Type extends PrimitiveParamType, ConvertedType> imp
       try {
         const jsonParsed = JSON.parse(value);
         if (Array.isArray(jsonParsed)) {
-          return this.convertFrom(jsonParsed);
+          return this.convertFrom(jsonParsed, URL_CONVERSION_OPTIONS);
         }
       } catch (e) {}
     }
-    return this.convertFrom(parsed);
+    return this.convertFrom(parsed, URL_CONVERSION_OPTIONS);
   }
 }

--- a/packages/odata-query-objects/src/param/UrlParamHelper.ts
+++ b/packages/odata-query-objects/src/param/UrlParamHelper.ts
@@ -1,4 +1,4 @@
-import { ParamValueModel } from "@odata2ts/converter-api";
+import { ConverterOptions, ParamValueModel } from "@odata2ts/converter-api";
 import {
   CollectionFilterFunctions,
   DateTimeFilterFunctions,
@@ -10,6 +10,17 @@ import {
 import { QPathModel } from "../path/QPathModel";
 import { QFilterExpression } from "../QFilterExpression";
 import { UrlExpressionValueModel, UrlValueModel } from "./UrlParamModel";
+
+/**
+ * Handed to a converter whenever the value it converts belongs into a URL rather than into a
+ * request or response body. Some conversions differ between the two - `Edm.DateTime` for example
+ * is written as `/Date(<ticks>)/` in a V2 body, but never in a URL.
+ *
+ * Every place building a URL value has to pass this along: paths (`$filter`, `$orderby`) as well
+ * as params (entity keys, function parameters). Action parameters are exempt on purpose, they
+ * travel in the body.
+ */
+export const URL_CONVERSION_OPTIONS: ConverterOptions = { urlConversion: true };
 
 function parseNullValue(value: string | undefined): string | null | undefined {
   return value === "null" ? null : value;

--- a/packages/odata-query-objects/src/path/base/QBasePath.ts
+++ b/packages/odata-query-objects/src/path/base/QBasePath.ts
@@ -1,6 +1,6 @@
-import { ConverterOptions, ValueConverter } from "@odata2ts/converter-api";
+import { ValueConverter } from "@odata2ts/converter-api";
 import { getIdentityConverter } from "../../IdentityConverter";
-import { isPathValue } from "../../param/UrlParamHelper";
+import { isPathValue, URL_CONVERSION_OPTIONS } from "../../param/UrlParamHelper";
 import { UrlExpressionValueModel } from "../../param/UrlParamModel";
 import { QValuePathModel } from "../QPathModel";
 import {
@@ -20,8 +20,6 @@ import {
 
 export type ExtractConverted<T> = T extends ValueConverter<any, infer Converted> ? Converted : never;
 export type InputModel<T> = QValuePathModel | ExtractConverted<T>;
-
-const CONVERSION_OPTIONS: ConverterOptions = { urlConversion: true };
 
 export abstract class QBasePath<ValueType extends UrlExpressionValueModel, ConvertedType> implements QValuePathModel {
   protected abstract formatValue(value: ValueType): string;
@@ -44,7 +42,7 @@ export abstract class QBasePath<ValueType extends UrlExpressionValueModel, Conve
       return value.getPath();
     }
 
-    const converted = this.converter.convertTo(value, CONVERSION_OPTIONS);
+    const converted = this.converter.convertTo(value, URL_CONVERSION_OPTIONS);
     if (converted === null || converted === undefined) {
       throw new Error(`Value "${value}" converted to ${converted}!`);
     }

--- a/packages/odata-query-objects/test/param/QParam.test.ts
+++ b/packages/odata-query-objects/test/param/QParam.test.ts
@@ -1,0 +1,60 @@
+import { ParamValueModel, ValueConverter } from "@odata2ts/converter-api";
+import { describe, expect, test } from "vitest";
+import { QStringParam } from "../../src";
+
+/**
+ * Makes the difference between a URL conversion and a body conversion observable.
+ *
+ * A converter may legitimately produce different output for the two - `Edm.DateTime` is written as
+ * `/Date(<ticks>)/` in a V2 body but never in a URL - so every place building a URL value has to hand
+ * the option down.
+ */
+const urlAwareConverter: ValueConverter<string, string> = {
+  id: "urlAwareConverter",
+  from: "Edm.String",
+  to: "string",
+
+  convertFrom: function (value: ParamValueModel<string>, options?): ParamValueModel<string> {
+    return typeof value !== "string" ? value : `${value}|from:${options?.urlConversion ? "url" : "body"}`;
+  },
+
+  convertTo: function (value: ParamValueModel<string>, options?): ParamValueModel<string> {
+    return typeof value !== "string" ? value : `${value}|to:${options?.urlConversion ? "url" : "body"}`;
+  },
+};
+
+describe("QParam Tests", () => {
+  const toTest = new QStringParam("Test", undefined, urlAwareConverter);
+
+  test("formatUrlValue tells the converter it is converting for a URL", () => {
+    // entity keys and function parameters end up in the URL, exactly like a path value does
+    expect(toTest.formatUrlValue("x")).toBe("'x|to:url'");
+  });
+
+  test("parseUrlValue tells the converter the value came from a URL", () => {
+    expect(toTest.parseUrlValue("'x'")).toBe("x|from:url");
+  });
+
+  test("the body conversion is left alone", () => {
+    // action parameters and response data travel in the body and must not get the URL treatment
+    expect(toTest.convertTo("x")).toBe("x|to:body");
+    expect(toTest.convertFrom("x")).toBe("x|from:body");
+  });
+
+  test("explicitly passed options win over the default", () => {
+    expect(toTest.convertTo("x", { urlConversion: true })).toBe("x|to:url");
+    expect(toTest.convertFrom("x", { urlConversion: true })).toBe("x|from:url");
+  });
+
+  test("collections hand the options down for every entry", () => {
+    expect(toTest.formatUrlValue(["x", "y"])).toBe(JSON.stringify(["x|to:url", "y|to:url"]));
+    expect(toTest.convertTo(["x", "y"])).toStrictEqual(["x|to:body", "y|to:body"]);
+  });
+
+  test("null and undefined stay untouched on either route", () => {
+    expect(toTest.formatUrlValue(null)).toBe("null");
+    expect(toTest.formatUrlValue(undefined)).toBeUndefined();
+    expect(toTest.convertTo(null)).toBeNull();
+    expect(toTest.convertFrom(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
- `QBasePath` told its converter it was converting for a URL, `QParam` did not — although a param value ends up in the URL just as a path value does: entity keys and function parameters both go there.
- For `dateTimeToDateTimeOffsetConverter`, the one converter acting on the option, a converted `Edm.DateTime` was therefore rendered in V2's *body* format and then wrapped as a URL literal: `ClosureDay?Day=datetime'/Date(1798070400000)/'`. No V2 server accepts that, so calling a function with a converted date was impossible — while the same value worked inside a `$filter`, which goes through a path.
- `formatUrlValue` and `parseUrlValue` now pass the option, producing the literal the path side already produced: `ClosureDay?Day=datetime'2026-12-24T00:00:00'`.
- `convertFrom`/`convertTo` take the options as an optional argument and default to unset, so the body route — action parameters, request and response data — keeps converting as before.
- The constant lived privately in `QBasePath` and now sits in `UrlParamHelper` as `URL_CONVERSION_OPTIONS`, shared by both sides.
- New `test/param/QParam.test.ts` pins the plumbing with an options-aware converter; `int-test/olingo-v2` covers it end to end against a native V2 server. Both were verified to fail without the fix.