### PR TITLE
feat(odata2ts): reconstruct complex types which a service states flat

### DIFF
--- a/int-test/cap/odata2ts.config.ts
+++ b/int-test/cap/odata2ts.config.ts
@@ -41,6 +41,33 @@ const config: ConfigFileOptions = {
       enableNativeInOperator: true,
     },
     /**
+     * The V4 model with `unflattenComplexTypes`, which is what this whole server is the case for:
+     * CAP states `Member.Address` as four flat properties and never as the `<ComplexType>` it declares
+     * elsewhere, so only a real CAP server settles whether odata2ts puts it back together correctly.
+     *
+     * Generated next to the raw client rather than replacing it, because both halves are the point: the raw
+     * one proves what the server actually sends and keeps the flat form covered, this one proves the
+     * reshaping. See test/feature/UnflattenComplexTypes.test.ts.
+     */
+    libraryShaped: {
+      serviceName: "LibraryShaped",
+      source: "resource/library.xml",
+      output: "src-generated/library-shaped",
+      unflattenComplexTypes: true,
+    },
+    /**
+     * The same option against the V2 rendition, since the adapter flattens exactly as the V4 endpoint does
+     * but the client builds different URLs and payloads for it. See test/v2/feature/UnflattenComplexTypes.test.ts.
+     */
+    libraryShapedV2: {
+      serviceName: "LibraryShapedV2",
+      source: "resource/library-v2.xml",
+      output: "src-generated/library-shaped-v2",
+      unflattenComplexTypes: true,
+      v2ResponseResultsWrapping: true,
+      v2PayloadResultsWrapping: false,
+    },
+    /**
      * The V4 model a second time, with converters switched on.
      *
      * Converters had only ever met a real server as V2, through `int-test/olingo-v2`, and V2 is a

--- a/int-test/cap/test/feature/UnflattenComplexTypes.test.ts
+++ b/int-test/cap/test/feature/UnflattenComplexTypes.test.ts
@@ -1,0 +1,184 @@
+import { HttpResponseModel } from "@odata2ts/http-client-api";
+import { ODataModelResponseV4 } from "@odata2ts/odata-core";
+import { afterAll, describe, expect, expectTypeOf, test } from "vitest";
+import { Library_Catalog_PostalAddress, Members } from "../../src-generated/library-shaped/LibraryShapedModel.js";
+import { LibraryShapedService } from "../../src-generated/library-shaped/LibraryShapedService.js";
+import { BASE_URL, LIBRARY, ODATA_CLIENT } from "../LibraryTestConstants.js";
+
+/**
+ * `unflattenComplexTypes` against the server it exists for.
+ *
+ * CAP states `Member.Address` as four flat properties - `Address_Street`, `Address_City`,
+ * `Address_PostalCode`, `Address_Country` - and never as the `<ComplexType>` it declares elsewhere for
+ * `PreviousAddresses`. The option puts them back together, so only a real CAP server settles whether the
+ * client still speaks the flat form on the wire while the models read as one object.
+ *
+ * `LIBRARY` (the raw client generated from the very same metadata) is used for contrast throughout: both
+ * halves are the point, since the reshaping is only correct if the flat form is what actually travels.
+ */
+const SHAPED = new LibraryShapedService(ODATA_CLIENT, BASE_URL);
+
+const ANNA = 1;
+const ANNA_ADDRESS = { Street: "Lindenweg 4", City: "Hamburg", PostalCode: "22765", Country: "DE" };
+
+describe("CAP Library: unflattenComplexTypes", () => {
+  // the seed data is the contract other files assert against, so anything written here is put back
+  afterAll(async () => {
+    await LIBRARY.Members(ANNA)
+      .patch({
+        Address_Street: ANNA_ADDRESS.Street,
+        Address_City: ANNA_ADDRESS.City,
+        Address_PostalCode: ANNA_ADDRESS.PostalCode,
+        Address_Country: ANNA_ADDRESS.Country,
+      })
+      .execute();
+  });
+
+  describe("response body", () => {
+    test("the four flat properties arrive as one object", async () => {
+      const result = await SHAPED.Members(ANNA).query().execute();
+
+      expect(result.status).toBe(200);
+      expect(result.data.Address).toStrictEqual(ANNA_ADDRESS);
+      // the model states the reshaped property as the complex type, not as four strings
+      expectTypeOf(result).toEqualTypeOf<HttpResponseModel<ODataModelResponseV4<Members>>>();
+      expectTypeOf(result.data.Address).toEqualTypeOf<Library_Catalog_PostalAddress | null>();
+    });
+
+    test("the very same response is flat without the option", async () => {
+      const raw = await LIBRARY.Members(ANNA).query().execute();
+
+      expect(raw.data.Address_Street).toBe(ANNA_ADDRESS.Street);
+      expect(raw.data.Address_City).toBe(ANNA_ADDRESS.City);
+      // @ts-expect-error - the raw client knows no such property, which is the whole point of the option
+      expect(raw.data.Address).toBeUndefined();
+    });
+
+    test("a complex type the service really declares is untouched", async () => {
+      const result = await SHAPED.Members(ANNA).query().execute();
+
+      // `PreviousAddresses` is a genuine Collection(PostalAddress) in the metadata and stays one
+      expect(result.data.PreviousAddresses).toStrictEqual([
+        { Street: "Alte Gasse 9", City: "Bremen", PostalCode: "28195", Country: "DE" },
+      ]);
+      expectTypeOf(result.data.PreviousAddresses).toEqualTypeOf<Array<Library_Catalog_PostalAddress>>();
+    });
+
+    test("a foreign key which looks flattened stays a property of its own", async () => {
+      const result = await SHAPED.Members(ANNA).query().execute();
+
+      // `IdDocument_Id` belongs to the navigation property `IdDocument`, not to a structured element
+      expect(result.data.IdDocument_Id).toBe("aaaaaaaa-0000-0000-0000-000000000001");
+    });
+
+    test("collections of entities carry it too", async () => {
+      const result = await SHAPED.Members().query().execute();
+
+      expect(result.status).toBe(200);
+      // asserted on a seeded row rather than on all of them: other suites leave members behind
+      expect(result.data.value.find((member) => member.Id === ANNA)?.Address).toStrictEqual(ANNA_ADDRESS);
+    });
+  });
+
+  describe("queries", () => {
+    test("filters on a leaf by the name the service knows", async () => {
+      const request = SHAPED.Members().query((builder, qMember) =>
+        builder.filter(qMember.Address.props.City.eq("Hamburg")),
+      );
+
+      expect(decodeURIComponent(request.getUrl())).toContain("$filter=Address_City eq 'Hamburg'");
+
+      const result = await request.execute();
+      expect(result.status).toBe(200);
+      expect(result.data.value.length).toBeGreaterThanOrEqual(3);
+      expect(result.data.value.every((member) => member.Address?.City === "Hamburg")).toBe(true);
+    });
+
+    test("orders by a leaf", async () => {
+      // restricted to the seeded rows, since other suites leave members without an address behind
+      const request = SHAPED.Members().query((builder, qMember) =>
+        builder.filter(qMember.Id.le(3)).orderBy(qMember.Address.props.Street.asc()),
+      );
+
+      expect(decodeURIComponent(request.getUrl())).toContain("$orderby=Address_Street asc");
+
+      const result = await request.execute();
+      expect(result.status).toBe(200);
+      expect(result.data.value.map((m) => m.Address?.Street)).toStrictEqual([
+        "Lindenweg 4",
+        "Marktplatz 7",
+        "Parkallee 88",
+      ]);
+    });
+
+    test("expanding selects the leaves instead of nesting a clause", async () => {
+      const request = SHAPED.Members(ANNA).query((builder) =>
+        builder.expanding("Address", (address) => address.select("Street", "City")),
+      );
+
+      // a nested `$select=Address($select=City)` would be 400 here - the server knows no such property
+      expect(decodeURIComponent(request.getUrl())).toContain("$select=Address_Street,Address_City");
+
+      const result = await request.execute();
+      expect(result.status).toBe(200);
+      expect(result.data.Address).toStrictEqual({ Street: ANNA_ADDRESS.Street, City: ANNA_ADDRESS.City });
+    });
+
+    test("selecting the property as a whole selects every leaf", async () => {
+      const request = SHAPED.Members(ANNA).query((builder) => builder.select("Address"));
+
+      expect(decodeURIComponent(request.getUrl())).toContain(
+        "$select=Address_Street,Address_City,Address_PostalCode,Address_Country",
+      );
+
+      const result = await request.execute();
+      expect(result.status).toBe(200);
+      expect(result.data.Address).toStrictEqual(ANNA_ADDRESS);
+    });
+
+    test("combines with an ordinary select", async () => {
+      const request = SHAPED.Members(ANNA).query((builder) =>
+        builder.select("Name").expanding("Address", (address) => address.select("City")),
+      );
+
+      expect(decodeURIComponent(request.getUrl())).toContain("$select=Name,Address_City");
+
+      const result = await request.execute();
+      expect(result.data.Name).toBe("Anna Berger");
+      expect(result.data.Address).toStrictEqual({ City: "Hamburg" });
+    });
+  });
+
+  describe("request body", () => {
+    test("an update sends the leaves flat and takes effect", async () => {
+      const updated = await SHAPED.Members(ANNA)
+        .patch({ Address: { Street: "Neuer Weg 2", City: "Bremen" } })
+        .execute();
+
+      expect(updated.status).toBe(200);
+
+      const reread = await SHAPED.Members(ANNA).query().execute();
+      expect(reread.data.Address).toStrictEqual({
+        Street: "Neuer Weg 2",
+        City: "Bremen",
+        PostalCode: ANNA_ADDRESS.PostalCode,
+        Country: ANNA_ADDRESS.Country,
+      });
+
+      // the raw client sees exactly the flat properties that were written
+      const raw = await LIBRARY.Members(ANNA).query().execute();
+      expect(raw.data.Address_Street).toBe("Neuer Weg 2");
+      expect(raw.data.Address_City).toBe("Bremen");
+    });
+
+    test("clearing the property nulls every leaf it owns", async () => {
+      await SHAPED.Members(ANNA).patch({ Address: null }).execute();
+
+      const raw = await LIBRARY.Members(ANNA).query().execute();
+      expect(raw.data.Address_Street).toBeNull();
+      expect(raw.data.Address_City).toBeNull();
+      expect(raw.data.Address_PostalCode).toBeNull();
+      expect(raw.data.Address_Country).toBeNull();
+    });
+  });
+});

--- a/int-test/cap/test/v2/feature/UnflattenComplexTypes.test.ts
+++ b/int-test/cap/test/v2/feature/UnflattenComplexTypes.test.ts
@@ -1,0 +1,110 @@
+import { afterAll, describe, expect, test } from "vitest";
+import { LibraryShapedV2Service } from "../../../src-generated/library-shaped-v2/LibraryShapedV2Service.js";
+import { BASE_URL, LIBRARY_V2, ODATA_CLIENT } from "../LibraryV2TestConstants.js";
+
+/**
+ * `unflattenComplexTypes` through the V2 adapter.
+ *
+ * The adapter flattens exactly as the V4 endpoint does - one database, one model - but the client builds
+ * different URLs and payloads for it, and `expanding()` means something else in V2: it normally adds an
+ * `$expand` next to the `$select`. A flattened complex property must produce neither, only flat selects,
+ * which is what makes this worth running next to the V4 suite rather than trusting it.
+ */
+const SHAPED_V2 = new LibraryShapedV2Service(ODATA_CLIENT, BASE_URL);
+
+const ANNA = 1;
+const ANNA_ADDRESS = { Street: "Lindenweg 4", City: "Hamburg", PostalCode: "22765", Country: "DE" };
+
+describe("CAP Library V2: unflattenComplexTypes", () => {
+  // the seed data is the contract other files assert against, so anything written here is put back
+  afterAll(async () => {
+    await LIBRARY_V2.Members(ANNA)
+      .patch({
+        Address_Street: ANNA_ADDRESS.Street,
+        Address_City: ANNA_ADDRESS.City,
+        Address_PostalCode: ANNA_ADDRESS.PostalCode,
+        Address_Country: ANNA_ADDRESS.Country,
+      })
+      .execute();
+  });
+
+  describe("response body", () => {
+    test("the four flat properties arrive as one object", async () => {
+      const result = await SHAPED_V2.Members(ANNA).query().execute();
+
+      expect(result.status).toBe(200);
+      expect(result.data.d.Address).toStrictEqual(ANNA_ADDRESS);
+    });
+
+    test("the very same response is flat without the option", async () => {
+      const raw = await LIBRARY_V2.Members(ANNA).query().execute();
+
+      expect(raw.data.d.Address_Street).toBe(ANNA_ADDRESS.Street);
+      // @ts-expect-error - the raw client knows no such property, which is the whole point of the option
+      expect(raw.data.d.Address).toBeUndefined();
+    });
+
+    test("a foreign key which looks flattened stays a property of its own", async () => {
+      const result = await SHAPED_V2.Members(ANNA).query().execute();
+
+      expect(result.data.d.IdDocument_Id).toBe("aaaaaaaa-0000-0000-0000-000000000001");
+    });
+  });
+
+  describe("queries", () => {
+    test("filters on a leaf by the name the service knows", async () => {
+      const request = SHAPED_V2.Members().query((builder, qMember) =>
+        builder.filter(qMember.Address.props.City.eq("Hamburg")),
+      );
+
+      expect(decodeURIComponent(request.getUrl())).toContain("$filter=Address_City eq 'Hamburg'");
+
+      const result = await request.execute();
+      expect(result.status).toBe(200);
+      expect(result.data.d.results.length).toBe(3);
+      expect(result.data.d.results.every((member) => member.Address?.City === "Hamburg")).toBe(true);
+    });
+
+    test("expanding selects the leaves and expands nothing", async () => {
+      const request = SHAPED_V2.Members(ANNA).query((builder) =>
+        builder.expanding("Address", (address) => address.select("Street", "City")),
+      );
+
+      const url = decodeURIComponent(request.getUrl());
+      expect(url).toContain("$select=Address_Street,Address_City");
+      // there is no navigation property to expand - the leaves are properties of the member itself
+      expect(url).not.toContain("$expand");
+
+      const result = await request.execute();
+      expect(result.status).toBe(200);
+      expect(result.data.d.Address).toStrictEqual({ Street: ANNA_ADDRESS.Street, City: ANNA_ADDRESS.City });
+    });
+
+    test("selecting the property as a whole selects every leaf", async () => {
+      const request = SHAPED_V2.Members(ANNA).query((builder) => builder.select("Address"));
+
+      expect(decodeURIComponent(request.getUrl())).toContain(
+        "$select=Address_Street,Address_City,Address_PostalCode,Address_Country",
+      );
+
+      const result = await request.execute();
+      expect(result.status).toBe(200);
+      expect(result.data.d.Address).toStrictEqual(ANNA_ADDRESS);
+    });
+  });
+
+  describe("request body", () => {
+    test("an update sends the leaves flat and takes effect", async () => {
+      const updated = await SHAPED_V2.Members(ANNA)
+        .patch({ Address: { Street: "Neuer Weg 2", City: "Bremen" } })
+        .execute();
+
+      // the adapter answers a MERGE with 200 and the updated entity, where a native V2 server sends 204
+      expect(updated.status).toBe(200);
+
+      const raw = await LIBRARY_V2.Members(ANNA).query().execute();
+      expect(raw.data.d.Address_Street).toBe("Neuer Weg 2");
+      expect(raw.data.d.Address_City).toBe("Bremen");
+    });
+  });
+});

--- a/packages/odata-query-builder/src/ODataQueryBuilder.ts
+++ b/packages/odata-query-builder/src/ODataQueryBuilder.ts
@@ -3,6 +3,7 @@ import {
   QComplexPath,
   QEntityPathModel,
   QFilterExpression,
+  QFlatComplexPath,
   QOrderByExpression,
   QPathModel,
   QSearchTerm,
@@ -135,7 +136,7 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
   public filterSelectAndMapPath(props: NullableParamList<SelectType<Q>>): Array<string> {
     return props
       .filter((p): p is SelectType<Q> => !!p)
-      .map((p): string => {
+      .flatMap((p): string | Array<string> => {
         if (p instanceof QSelectExpression) {
           return p.getPath();
         }
@@ -144,7 +145,9 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
         if (p === "*") {
           return "*";
         }
-        return this.getEntityProp(p as keyof Q).getPath();
+        const entityProp = this.getEntityProp(p as keyof Q);
+        // a flattened complex property is not a property the service knows, so it is selected by its leaves
+        return entityProp instanceof QFlatComplexPath ? entityProp.getLeafPaths() : entityProp.getPath();
       });
   }
 
@@ -201,7 +204,11 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
   ) {
     const entityProp = this.getEntityProp<QEntityPathModel<Q>>(prop);
     const path = entityProp.getPath();
-    const entity = entityProp.getEntity();
+    const isFlat = entityProp instanceof QFlatComplexPath;
+    // a flattened complex property is not nested on the wire at all - its leaves are ordinary properties of
+    // this very entity - so the nested builder works on already prefixed paths and everything it collected
+    // is merged in here instead of being embedded
+    const entity = entityProp.getEntity(isFlat);
     const isComplex = entityProp instanceof QComplexPath || entityProp instanceof QComplexCollectionPath;
 
     const facade = creator(path, entity);
@@ -209,6 +216,12 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
     builderFn(facade, entity);
 
     const nestedEngine = facade.getEngine() as ODataQueryBuilder<any>;
+
+    if (isFlat) {
+      this.absorbFlat(nestedEngine);
+      return;
+    }
+
     const { content, hoistedExpands } = nestedEngine.buildNested(isComplex);
 
     if (isComplex) {
@@ -218,6 +231,25 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
     }
     if (hoistedExpands.length) {
       this.getHoistedExpandsBucket().push(...hoistedExpands.map((fragment) => `${path}/${fragment}`));
+    }
+  }
+
+  /**
+   * Takes over what a nested builder collected for a flattened complex property. Since that property has no
+   * representation of its own, there is no clause to embed the content in - its selects are paths of this
+   * very entity and simply become this builder's own.
+   *
+   * The nested builder was handed a query object which already carries the prefix, so everything it
+   * produced is fully qualified and none of it is prefixed again here. That also holds for a navigation
+   * property reached through it, which still cannot be embedded and is relayed on like any other expand
+   * reached through a complex hop.
+   */
+  private absorbFlat(nested: ODataQueryBuilder<any>) {
+    this.addSelects(...(nested.selects ?? []));
+
+    const expands = [...(nested.expands ?? []), ...(nested.hoistedExpandsBucket ?? [])];
+    if (expands.length) {
+      this.getHoistedExpandsBucket().push(...expands);
     }
   }
 

--- a/packages/odata-query-builder/src/ODataQueryBuilderModel.ts
+++ b/packages/odata-query-builder/src/ODataQueryBuilderModel.ts
@@ -4,6 +4,7 @@ import {
   QEntityCollectionPath,
   QEntityPath,
   QFilterExpression,
+  QFlatComplexPath,
   QOrderByExpression,
   QSearchTerm,
   QSelectExpression,
@@ -11,7 +12,8 @@ import {
 } from "@odata2ts/odata-query-objects";
 
 /**
- * Extracts the wrapped entity from QEntityPath, QEntityCollectionPath, QComplexPath or QComplexCollectionPath
+ * Extracts the wrapped entity from QEntityPath, QEntityCollectionPath, QComplexPath, QComplexCollectionPath
+ * or QFlatComplexPath
  */
 export type EntityExtractor<QProp> =
   QProp extends QEntityPath<infer ET>
@@ -22,7 +24,9 @@ export type EntityExtractor<QProp> =
         ? ET
         : QProp extends QComplexCollectionPath<infer ET>
           ? ET
-          : never;
+          : QProp extends QFlatComplexPath<infer ET>
+            ? ET
+            : never;
 
 /**
  * Extracts all keys from a property (Q*Path), but only for the given types
@@ -51,7 +55,11 @@ export type ExpandType<Q extends QueryObjectModel> = ExtractPropertyNamesOfType<
  */
 export type NestingType<Q extends QueryObjectModel> = ExtractPropertyNamesOfType<
   Q,
-  QEntityPath<any> | QEntityCollectionPath<any> | QComplexPath<any> | QComplexCollectionPath<any>
+  | QEntityPath<any>
+  | QEntityCollectionPath<any>
+  | QComplexPath<any>
+  | QComplexCollectionPath<any>
+  | QFlatComplexPath<any>
 >;
 
 /**

--- a/packages/odata-query-builder/src/v2/ExpandingODataQueryBuilderV2.ts
+++ b/packages/odata-query-builder/src/v2/ExpandingODataQueryBuilderV2.ts
@@ -1,4 +1,4 @@
-import { QEntityPathModel, QSelectExpression, QueryObjectModel } from "@odata2ts/odata-query-objects";
+import { QEntityPathModel, QFlatComplexPath, QSelectExpression, QueryObjectModel } from "@odata2ts/odata-query-objects";
 import { ODataQueryBuilder } from "../ODataQueryBuilder";
 import {
   EntityExtractor,
@@ -12,9 +12,10 @@ import {
 export function createExpandingQueryBuilderV2<Q extends QueryObjectModel>(
   property: string,
   qEntity: Q,
+  flat: boolean = false,
 ): ExpandingODataQueryBuilderV2Model<Q> {
   // must never be encoded, since it is part of $expand
-  return new ExpandingODataQueryBuilderV2<Q>(property, qEntity);
+  return new ExpandingODataQueryBuilderV2<Q>(property, qEntity, flat);
 }
 
 /**
@@ -26,12 +27,23 @@ class ExpandingODataQueryBuilderV2<Q extends QueryObjectModel> implements Expand
 
   private builder: ODataQueryBuilder<Q>;
 
-  constructor(property: string, qEntity: Q) {
+  /**
+   * @param flat whether `property` is a complex property the service states flat. There is then nothing to
+   *   expand - the service knows no property of that name, only its leaves - and the query object handed in
+   *   already carries the prefix, so its paths need none of their own.
+   */
+  constructor(
+    property: string,
+    qEntity: Q,
+    private flat: boolean = false,
+  ) {
     this.builder = new ODataQueryBuilder(property, qEntity, { expandingBuilder: true });
-    this.expands.add(property);
+    if (!flat) {
+      this.expands.add(property);
+    }
   }
 
-  private getPrefixedPath = (path: string) => `${this.builder.getPath()}/${path}`;
+  private getPrefixedPath = (path: string) => (this.flat ? path : `${this.builder.getPath()}/${path}`);
 
   public select(...props: NullableParamList<SelectType<Q>>) {
     const filtered = this.builder.filterSelectAndMapPath(props);
@@ -61,8 +73,9 @@ class ExpandingODataQueryBuilderV2<Q extends QueryObjectModel> implements Expand
     }
 
     const entityProp = this.builder.getEntityProp<QEntityPathModel<any>>(prop);
-    const entity = entityProp.getEntity();
-    const expander = new ExpandingODataQueryBuilderV2<EntityExtractor<Q[Prop]>>(entityProp.getPath(), entity);
+    const isFlat = entityProp instanceof QFlatComplexPath;
+    const entity = entityProp.getEntity(isFlat);
+    const expander = new ExpandingODataQueryBuilderV2<EntityExtractor<Q[Prop]>>(entityProp.getPath(), entity, isFlat);
 
     builderFn(expander, entity);
 

--- a/packages/odata-query-builder/src/v2/ODataQueryBuilderV2.ts
+++ b/packages/odata-query-builder/src/v2/ODataQueryBuilderV2.ts
@@ -1,6 +1,7 @@
 import {
   QEntityPathModel,
   QFilterExpression,
+  QFlatComplexPath,
   QOrderByExpression,
   QSelectExpression,
   QueryObjectModel,
@@ -85,9 +86,12 @@ class ODataQueryBuilderV2<Q extends QueryObjectModel> implements ODataQueryBuild
     }
 
     const entityProp = this.builder.getEntityProp<QEntityPathModel<any>>(prop);
-    const entity = entityProp.getEntity();
+    // a complex property the service states flat is nothing to expand: its leaves are ordinary properties
+    // of this entity, so the nested builder works on prefixed paths and only contributes selects
+    const isFlat = entityProp instanceof QFlatComplexPath;
+    const entity = entityProp.getEntity(isFlat);
 
-    const expander = createExpandingQueryBuilderV2(entityProp.getPath(), entity);
+    const expander = createExpandingQueryBuilderV2(entityProp.getPath(), entity, isFlat);
 
     builderFn(expander, entity);
 

--- a/packages/odata-query-builder/test/FlatComplexQuery.test.ts
+++ b/packages/odata-query-builder/test/FlatComplexQuery.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { CollectionQueryBuilderV2, CollectionQueryBuilderV4, createQueryBuilderV2, createQueryBuilderV4 } from "../src";
+import { QPerson, qPerson } from "./fixture/types/QSimplePersonModel";
+
+/**
+ * A complex property which the service states flat (`unflattenComplexTypes`) is not a property the
+ * service knows - only its leaves are. So it can never appear in a query as itself: neither as a nested
+ * `$select=Prop(...)` clause in V4 nor as an `$expand` in V2, but always as the flat paths of its leaves.
+ */
+describe("Flat complex properties in queries", () => {
+  describe("V4", () => {
+    let toTest: CollectionQueryBuilderV4<QPerson>;
+
+    beforeEach(() => {
+      toTest = createQueryBuilderV4("/Persons", qPerson, { unencoded: true });
+    });
+
+    const addBase = (urlPart: string) => `/Persons${urlPart ? `?${urlPart}` : ""}`;
+
+    test("expanding selects the leaves, without nesting them into a clause", () => {
+      const result = toTest.expanding("flatAddress", (builder) => builder.select("street", "city")).build();
+
+      expect(result).toBe(addBase("$select=FlatAddress_street,FlatAddress_city"));
+    });
+
+    test("the query object handed to the callback carries the prefix", () => {
+      let seen = "";
+      toTest.expanding("flatAddress", (builder, qAddress) => {
+        seen = qAddress.city.getPath();
+        builder.select("city");
+      });
+
+      expect(seen).toBe("FlatAddress_city");
+    });
+
+    test("filters on a leaf, which is a property of the entity itself", () => {
+      const result = toTest.filter(qPerson.flatAddress.props.city.eq("Berlin")).build();
+
+      expect(result).toBe(addBase("$filter=FlatAddress_city eq 'Berlin'"));
+    });
+
+    test("filters on a leaf of a nested group", () => {
+      const result = toTest.filter(qPerson.flatAddress.props.geo.props.lat.gt(50)).build();
+
+      expect(result).toBe(addBase("$filter=FlatAddress_geo_lat gt 50"));
+    });
+
+    test("carries through nested flat groups", () => {
+      const result = toTest
+        .expanding("flatAddress", (builder) => builder.expanding("geo", (geo) => geo.select("lat", "lng")))
+        .build();
+
+      expect(result).toBe(addBase("$select=FlatAddress_geo_lat,FlatAddress_geo_lng"));
+    });
+
+    test("selecting the property as a whole selects every leaf it owns", () => {
+      const result = toTest.select("flatAddress").build();
+
+      expect(result).toBe(
+        addBase("$select=FlatAddress_street,FlatAddress_city,FlatAddress_geo_lat,FlatAddress_geo_lng"),
+      );
+    });
+
+    test("combines with ordinary selects", () => {
+      const result = toTest
+        .select("name")
+        .expanding("flatAddress", (b) => b.select("city"))
+        .build();
+
+      expect(result).toBe(addBase("$select=name,FlatAddress_city"));
+    });
+
+    test("orders by a leaf", () => {
+      const result = toTest.orderBy(qPerson.flatAddress.props.city.asc()).build();
+
+      expect(result).toBe(addBase("$orderby=FlatAddress_city asc"));
+    });
+
+    test("relays a navigation property reached through it up to the expand, already flat", () => {
+      const result = toTest
+        .expanding("flatAddress", (builder) => builder.expanding("responsible", (r) => r.select("name")))
+        .build();
+
+      // there is no `FlatAddress` path to hop through - a service which flattened the property knows the
+      // navigation property under the flat name too
+      expect(result).toBe(addBase("$expand=FlatAddress_responsible($select=name)"));
+    });
+
+    test("leaves a genuinely complex property nested, as before", () => {
+      const result = toTest.expanding("address", (builder) => builder.select("street")).build();
+
+      expect(result).toBe(addBase("$select=Address($select=street)"));
+    });
+  });
+
+  describe("V2", () => {
+    let toTest: CollectionQueryBuilderV2<QPerson>;
+
+    beforeEach(() => {
+      toTest = createQueryBuilderV2("/Persons", qPerson, { unencoded: true });
+    });
+
+    const addBase = (urlPart: string) => `/Persons${urlPart ? `?${urlPart}` : ""}`;
+
+    test("expanding selects the leaves and expands nothing", () => {
+      const result = toTest.expanding("flatAddress", (builder) => builder.select("street", "city")).build();
+
+      expect(result).toBe(addBase("$select=FlatAddress_street,FlatAddress_city"));
+    });
+
+    test("carries through nested flat groups", () => {
+      const result = toTest
+        .expanding("flatAddress", (builder) => builder.expanding("geo", (geo) => geo.select("lat")))
+        .build();
+
+      expect(result).toBe(addBase("$select=FlatAddress_geo_lat"));
+    });
+
+    test("selecting the property as a whole selects every leaf it owns", () => {
+      const result = toTest.select("flatAddress").build();
+
+      expect(result).toBe(
+        addBase("$select=FlatAddress_street,FlatAddress_city,FlatAddress_geo_lat,FlatAddress_geo_lng"),
+      );
+    });
+
+    test("leaves a genuinely complex property expanded, as before", () => {
+      const result = toTest.expanding("address", (builder) => builder.select("street")).build();
+
+      expect(result).toBe(addBase("$select=Address/street&$expand=Address"));
+    });
+  });
+});

--- a/packages/odata-query-builder/test/fixture/types/QSimplePersonModel.ts
+++ b/packages/odata-query-builder/test/fixture/types/QSimplePersonModel.ts
@@ -5,6 +5,7 @@ import {
   QDateTimeOffsetPath,
   QEntityCollectionPath,
   QEntityPath,
+  QFlatComplexPath,
   QNumberPath,
   QNumericEnumCollectionPath,
   QNumericEnumPath,
@@ -24,9 +25,11 @@ export class QPerson extends QueryObject {
   public readonly likedFeatures = new QNumericEnumCollectionPath(this.withPrefix("likedFeatures"), Features);
   public readonly bestFriend = new QEntityPath(this.withPrefix("bestFriend"), () => QPerson);
   public readonly friends = new QEntityCollectionPath(this.withPrefix("friends"), () => QPerson);
+  /** the same complex type, but stated flat by the service - see `unflattenComplexTypes` */
+  public readonly flatAddress = new QFlatComplexPath<QFlatAddress>(this.withPrefix("FlatAddress"), () => QFlatAddress);
 
-  constructor(path?: string) {
-    super(path);
+  constructor(path?: string, separator?: string) {
+    super(path, separator);
   }
 }
 
@@ -37,8 +40,8 @@ export class QAddress extends QueryObject {
   public readonly responsible = new QEntityPath<QPerson>(this.withPrefix("responsible"), () => QPerson);
   public readonly geo = new QComplexPath<QGeoPosition>(this.withPrefix("geo"), () => QGeoPosition);
 
-  constructor(path?: string) {
-    super(path);
+  constructor(path?: string, separator?: string) {
+    super(path, separator);
   }
 }
 
@@ -48,9 +51,27 @@ export class QGeoPosition extends QueryObject {
   public readonly lat = new QNumberPath(this.withPrefix("lat"));
   public readonly lng = new QNumberPath(this.withPrefix("lng"));
 
-  constructor(path?: string) {
-    super(path);
+  constructor(path?: string, separator?: string) {
+    super(path, separator);
   }
 }
 
 export const qGeoPosition = new QGeoPosition();
+
+/**
+ * The flat counterpart of QAddress: no constructor of its own, exactly as generated query objects are
+ * emitted, so the separator handed down by QFlatComplexPath survives.
+ */
+export class QFlatAddress extends QueryObject {
+  public readonly street = new QStringPath(this.withPrefix("street"));
+  public readonly city = new QStringPath(this.withPrefix("city"));
+  public readonly geo = new QFlatComplexPath<QFlatGeoPosition>(this.withPrefix("geo"), () => QFlatGeoPosition);
+  public readonly responsible = new QEntityPath<QPerson>(this.withPrefix("responsible"), () => QPerson);
+}
+
+export const qFlatAddress = new QFlatAddress();
+
+export class QFlatGeoPosition extends QueryObject {
+  public readonly lat = new QNumberPath(this.withPrefix("lat"));
+  public readonly lng = new QNumberPath(this.withPrefix("lng"));
+}

--- a/packages/odata-query-objects/src/QueryObject.ts
+++ b/packages/odata-query-objects/src/QueryObject.ts
@@ -96,13 +96,64 @@ function convertNavProp(
   }
 }
 
+/**
+ * What joins a flattened complex property to its leaves. SAP CAP uses the underscore and that is the only
+ * spelling in the field, hence it is fixed rather than configurable.
+ *
+ * Lives here rather than with {@link QFlatComplexPath} so that the dependency between the two runs one way
+ * only: the path knows the query object, not the other way round.
+ */
+export const FLAT_SEPARATOR = "_";
+
+/**
+ * A complex property which the service states flat, i.e. as one property per leaf joined by
+ * {@link FLAT_SEPARATOR}. Such a property owns several keys of the payload instead of one.
+ */
+function isFlatComplex(prop: any): prop is QEntityPathModel<QueryObject> {
+  return prop?.discriminator === "FlatComplexType";
+}
+
+/**
+ * Every path a flattened complex property occupies, which is what addressing the property as a whole comes
+ * down to: it has no representation of its own, neither in a payload nor in a query, so selecting it means
+ * selecting its leaves and clearing it means nulling them.
+ */
+export function flatLeafPaths(entity: QueryObject): Array<string> {
+  const result: Array<string> = [];
+  for (const key in entity) {
+    // @ts-ignore - getters live on the prototype, hence the for-in loop
+    const prop = entity[key];
+    if (typeof prop?.getPath !== "function") {
+      continue;
+    }
+    if (isFlatComplex(prop)) {
+      result.push(...flatLeafPaths(prop.getEntity(true)));
+    } else if (typeof prop.getEntity !== "function") {
+      result.push(prop.getPath());
+    }
+    // anything else reached from here - a navigation property, a collection - is not a leaf of this
+    // property: it is addressed in its own right and needs an $expand rather than a path
+  }
+  return result;
+}
+
 export const ENUMERABLE_PROP_DEFINITION = { enumerable: true };
 
 export class QueryObject<T extends object = any> implements QueryObjectModel<T> {
   private __propMapping?: Map<string, string>;
   protected readonly __subtypeMapping?: Record<string, string>;
 
-  constructor(private __prefix?: string) {}
+  /**
+   * @param __prefix the path this query object is reached by, if it is a nested one
+   * @param __separator what joins that prefix to the paths of the own properties. The slash of OData by
+   *   default; an underscore where the service flattened this complex type into the entity carrying it,
+   *   so `Address/City` is stated as the `Address_City` such a service actually knows. Set by
+   *   {@link QFlatComplexPath}, never by generated code.
+   */
+  constructor(
+    private __prefix?: string,
+    private __separator: string = "/",
+  ) {}
 
   private __getPropMapping(): Map<string, string> {
     if (!this.__propMapping) {
@@ -112,14 +163,14 @@ export class QueryObject<T extends object = any> implements QueryObjectModel<T> 
   }
 
   /**
-   * Adds the prefix of this QueryObject including a separating slash in front of the given path.
+   * Adds the prefix of this QueryObject including its separator in front of the given path.
    * Only applies, if this QueryObject has a prefix.
    *
    * @param path the path to be prefixed
    * @protected
    */
   protected withPrefix(path: string) {
-    return this.__prefix ? `${this.__prefix}/${path}` : path;
+    return this.__prefix ? `${this.__prefix}${this.__separator}${path}` : path;
   }
 
   /**
@@ -155,7 +206,11 @@ export class QueryObject<T extends object = any> implements QueryObjectModel<T> 
 
     const result = models.map((model) => {
       const typeByCi = getTypeControlInfo(model);
-      return Object.entries(model).reduce((collector, [key, value]) => {
+      // a flattened complex property owns several keys of the payload, so its value is assembled from all
+      // of them and can only be converted once the whole model has been walked
+      const flatBuckets = new Map<string, Record<string, any>>();
+
+      const converted = Object.entries(model).reduce((collector, [key, value]) => {
         let propKey = this.__getPropMapping().get(key);
         let finalKey: string = propKey as string;
 
@@ -193,14 +248,50 @@ export class QueryObject<T extends object = any> implements QueryObjectModel<T> 
         }
         // be permissive here to allow passing unknown values as they are
         else {
-          collector[key] = value;
+          const flat = this.__findFlatComplexProp(key);
+          if (flat) {
+            const bucket = flatBuckets.get(flat.propKey) ?? {};
+            bucket[key.substring(flat.path.length + FLAT_SEPARATOR.length)] = value;
+            flatBuckets.set(flat.propKey, bucket);
+          } else {
+            collector[key] = value;
+          }
         }
 
         return collector;
       }, {} as any) as T;
+
+      for (const [propKey, bucket] of flatBuckets) {
+        const prop = this[propKey as keyof this] as unknown as QEntityPathModel<any>;
+        // the entity is built without a prefix, so it reads the leaves by their bare names - and takes any
+        // nesting of its own apart in turn
+        (converted as any)[propKey] = prop.getEntity().convertFromOData(bucket);
+      }
+
+      return converted;
     });
 
     return isList ? result : result[0];
+  }
+
+  /**
+   * The flattened complex property a payload key belongs to, if any: `Address_City` belongs to `Address`.
+   * The longest match wins, so a nested group is preferred over the one enclosing it.
+   */
+  private __findFlatComplexProp(key: string): { propKey: string; path: string } | undefined {
+    let match: { propKey: string; path: string } | undefined;
+
+    for (const [path, propKey] of this.__getPropMapping()) {
+      if (
+        key.startsWith(`${path}${FLAT_SEPARATOR}`) &&
+        isFlatComplex(this[propKey as keyof this]) &&
+        (!match || path.length > match.path.length)
+      ) {
+        match = { propKey, path };
+      }
+    }
+
+    return match;
   }
 
   /**
@@ -253,7 +344,17 @@ export class QueryObject<T extends object = any> implements QueryObjectModel<T> 
         if (typeof asEntity?.getEntity === "function") {
           const entity = asEntity.getEntity();
           const binding = asEntity.getBinding?.();
-          if (binding) {
+          if (isFlatComplex(asEntity)) {
+            // the service knows no property of this name, only its leaves - so the converted object is
+            // spread into the payload instead of nested into it
+            if (value === null || value === undefined) {
+              flatLeafPaths(asEntity.getEntity(true)).forEach((leaf) => (collector[leaf] = value));
+            } else {
+              Object.entries(entity.convertToOData(value, failForUnknownProps)).forEach(
+                ([leafKey, leafValue]) => (collector[`${finalKey}${FLAT_SEPARATOR}${leafKey}`] = leafValue),
+              );
+            }
+          } else if (binding) {
             convertNavProp(collector, finalKey!, value, entity, binding);
           } else {
             collector[finalKey!] = entity.convertToOData(value);

--- a/packages/odata-query-objects/src/index.ts
+++ b/packages/odata-query-objects/src/index.ts
@@ -51,6 +51,7 @@ export { QBooleanPath } from "./path/QBooleanPath";
 export { QBinaryPath } from "./path/QBinaryPath";
 export { QCollectionPath } from "./path/QCollectionPath";
 export { QComplexPath } from "./path/QComplexPath";
+export { QFlatComplexPath } from "./path/QFlatComplexPath";
 export { QComplexCollectionPath } from "./path/QComplexCollectionPath";
 export { QEntityPath } from "./path/QEntityPath";
 export { QEntityCollectionPath } from "./path/QEntityCollectionPath";

--- a/packages/odata-query-objects/src/path/QFlatComplexPath.ts
+++ b/packages/odata-query-objects/src/path/QFlatComplexPath.ts
@@ -1,0 +1,27 @@
+import { FLAT_SEPARATOR, flatLeafPaths, QueryObject } from "../QueryObject";
+import { QModelBasePath } from "./QModelBasePath";
+
+/**
+ * A complex property of a service which does not know it as one: the service unfolded it into a property
+ * per leaf, joined by an underscore, so what the models state as `address.city` travels and is queried as
+ * `Address_City`. Generated in place of {@link QComplexPath} for the `unflattenComplexTypes`
+ * option - see there for why a service would do that.
+ *
+ * Everything else follows from the separator: the query builder phrases `$select`, `$filter` and
+ * `$orderby` from these paths, and {@link QueryObject} reads the same separator to take such a property
+ * apart and put it back together when converting payloads.
+ */
+export class QFlatComplexPath<Q extends QueryObject> extends QModelBasePath<Q> {
+  public readonly discriminator = "FlatComplexType";
+
+  protected override readonly separator = FLAT_SEPARATOR;
+
+  /**
+   * The paths of every leaf this property is made of, which is what addressing it as a whole comes down to:
+   * a service which knows no property of this name cannot select it either, so `$select=Address` has to be
+   * stated as `$select=Address_Street,Address_City`.
+   */
+  public getLeafPaths(): Array<string> {
+    return flatLeafPaths(this.getEntity(true));
+  }
+}

--- a/packages/odata-query-objects/src/path/QModelBasePath.ts
+++ b/packages/odata-query-objects/src/path/QModelBasePath.ts
@@ -3,9 +3,15 @@ import { QBinding } from "./QBinding";
 import { QEntityPathModel } from "./QPathModel";
 
 export class QModelBasePath<Q extends QueryObject> implements QEntityPathModel<Q> {
+  /**
+   * What joins this path to the paths of the nested properties. The slash of OData, unless a subclass
+   * states otherwise - see {@link QFlatComplexPath}.
+   */
+  protected readonly separator: string = "/";
+
   constructor(
     protected path: string,
-    protected qEntityFn: () => new (prefix?: string) => Q,
+    protected qEntityFn: () => new (prefix?: string, separator?: string) => Q,
     protected binding?: QBinding<any>,
   ) {
     if (!path || !path.trim()) {
@@ -25,7 +31,7 @@ export class QModelBasePath<Q extends QueryObject> implements QEntityPathModel<Q
   }
 
   public getEntity(withPrefix: boolean = false): Q {
-    return new (this.qEntityFn())(withPrefix ? this.path : undefined);
+    return new (this.qEntityFn())(withPrefix ? this.path : undefined, this.separator);
   }
 
   public isCollectionType() {
@@ -33,6 +39,6 @@ export class QModelBasePath<Q extends QueryObject> implements QEntityPathModel<Q
   }
 
   public get props(): Q {
-    return new (this.qEntityFn())(this.path);
+    return new (this.qEntityFn())(this.path, this.separator);
   }
 }

--- a/packages/odata-query-objects/test/fixture/FlatComplexModel.ts
+++ b/packages/odata-query-objects/test/fixture/FlatComplexModel.ts
@@ -1,0 +1,42 @@
+import { QFlatComplexPath, QNumberPath, QStringPath, QueryObject } from "../../src";
+
+/**
+ * The CAP case: `Member.Address` is a structured element which the service unfolded into `Address_Street`
+ * and `Address_City`, so no complex property of that name exists on the wire. `Home` adds the nesting on
+ * top of it, which CAP flattens just as recursively (`Home_Address_Street`).
+ */
+export interface PostalAddress {
+  street: string | null;
+  city: string | null;
+}
+
+export interface Residence {
+  label: string | null;
+  address: PostalAddress;
+}
+
+export interface Member {
+  id: number;
+  name: string;
+  address: PostalAddress;
+  home: Residence;
+}
+
+export class QPostalAddress extends QueryObject<PostalAddress> {
+  public readonly street = new QStringPath(this.withPrefix("Street"));
+  public readonly city = new QStringPath(this.withPrefix("City"));
+}
+
+export class QResidence extends QueryObject<Residence> {
+  public readonly label = new QStringPath(this.withPrefix("Label"));
+  public readonly address = new QFlatComplexPath(this.withPrefix("Address"), () => QPostalAddress);
+}
+
+export class QMember extends QueryObject<Member> {
+  public readonly id = new QNumberPath(this.withPrefix("Id"));
+  public readonly name = new QStringPath(this.withPrefix("Name"));
+  public readonly address = new QFlatComplexPath(this.withPrefix("Address"), () => QPostalAddress);
+  public readonly home = new QFlatComplexPath(this.withPrefix("Home"), () => QResidence);
+}
+
+export const qMember = new QMember();

--- a/packages/odata-query-objects/test/path/QFlatComplexPath.test.ts
+++ b/packages/odata-query-objects/test/path/QFlatComplexPath.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "vitest";
+import { qMember } from "../fixture/FlatComplexModel";
+
+describe("QFlatComplexPath", () => {
+  describe("query paths", () => {
+    test("joins a leaf with an underscore instead of a slash", () => {
+      expect(qMember.address.props.city.getPath()).toBe("Address_City");
+      expect(qMember.address.props.street.getPath()).toBe("Address_Street");
+    });
+
+    test("keeps the property itself addressable by its own name", () => {
+      expect(qMember.address.getPath()).toBe("Address");
+    });
+
+    test("carries the separator through nested groups", () => {
+      expect(qMember.home.props.label.getPath()).toBe("Home_Label");
+      expect(qMember.home.props.address.props.street.getPath()).toBe("Home_Address_Street");
+    });
+
+    test("builds filters the service can read", () => {
+      expect(qMember.address.props.city.eq("Berlin").toString()).toBe("Address_City eq 'Berlin'");
+      expect(qMember.home.props.address.props.city.eq("Berlin").toString()).toBe("Home_Address_City eq 'Berlin'");
+    });
+
+    test("leaves the surrounding entity's own paths alone", () => {
+      expect(qMember.name.getPath()).toBe("Name");
+    });
+  });
+
+  describe("convertFromOData", () => {
+    test("assembles a flat response into the nested model", () => {
+      expect(
+        qMember.convertFromOData({ Id: 1, Name: "Bob", Address_Street: "Main St", Address_City: "Berlin" }),
+      ).toStrictEqual({
+        id: 1,
+        name: "Bob",
+        address: { street: "Main St", city: "Berlin" },
+      });
+    });
+
+    test("assembles nested groups", () => {
+      expect(qMember.convertFromOData({ Home_Label: "at home", Home_Address_City: "Berlin" })).toStrictEqual({
+        home: { label: "at home", address: { city: "Berlin" } },
+      });
+    });
+
+    test("states only the leaves the service actually sent", () => {
+      expect(qMember.convertFromOData({ Address_City: "Berlin" })).toStrictEqual({ address: { city: "Berlin" } });
+    });
+
+    test("passes unknown keys through, as it does for any other property", () => {
+      expect(qMember.convertFromOData({ Address_Unknown: "?", Whatever: 1 })).toStrictEqual({
+        address: { Unknown: "?" },
+        Whatever: 1,
+      });
+    });
+
+    test("handles a collection of models", () => {
+      expect(qMember.convertFromOData([{ Address_City: "Berlin" }, { Address_City: "Rome" }])).toStrictEqual([
+        { address: { city: "Berlin" } },
+        { address: { city: "Rome" } },
+      ]);
+    });
+  });
+
+  describe("convertToOData", () => {
+    test("spreads the nested model back into flat properties", () => {
+      expect(qMember.convertToOData({ id: 1, address: { street: "Main St", city: "Berlin" } } as any)).toStrictEqual({
+        Id: 1,
+        Address_Street: "Main St",
+        Address_City: "Berlin",
+      });
+    });
+
+    test("sends only the leaves the user set", () => {
+      expect(qMember.convertToOData({ address: { city: "Berlin" } } as any)).toStrictEqual({ Address_City: "Berlin" });
+    });
+
+    test("spreads nested groups", () => {
+      expect(qMember.convertToOData({ home: { address: { city: "Berlin" } } } as any)).toStrictEqual({
+        Home_Address_City: "Berlin",
+      });
+    });
+
+    test("clears the property by nulling every leaf it owns", () => {
+      // the property has no representation of its own on the wire, so there is nothing else to null
+      expect(qMember.convertToOData({ address: null } as any)).toStrictEqual({
+        Address_Street: null,
+        Address_City: null,
+      });
+    });
+
+    test("nulls the leaves of a nested group as well", () => {
+      expect(qMember.convertToOData({ home: null } as any)).toStrictEqual({
+        Home_Label: null,
+        Home_Address_Street: null,
+        Home_Address_City: null,
+      });
+    });
+  });
+
+  test("round trips a model through both directions", () => {
+    const userModel = { id: 1, name: "Bob", address: { street: "Main St", city: "Berlin" } };
+    const payload = qMember.convertToOData(userModel as any);
+
+    expect(payload).toStrictEqual({ Id: 1, Name: "Bob", Address_Street: "Main St", Address_City: "Berlin" });
+    expect(qMember.convertFromOData(payload)).toStrictEqual(userModel);
+  });
+});

--- a/packages/odata2ts/src/FactoryFunctionModel.ts
+++ b/packages/odata2ts/src/FactoryFunctionModel.ts
@@ -18,6 +18,7 @@ export type DigestionOptions = Pick<
   | "skipIdModels"
   | "disableAutomaticNameClashResolution"
   | "bundledFileGeneration"
+  | "unflattenComplexTypes"
   | "enumType"
   | "enableNativeInOperator"
 >;

--- a/packages/odata2ts/src/OptionModel.ts
+++ b/packages/odata2ts/src/OptionModel.ts
@@ -286,6 +286,34 @@ export interface ConfigFileOptions extends Omit<CliOptions, "sourceUrl" | "sourc
    */
   enumType?: "string" | "numeric" | "string-union";
   /**
+   * More or less a CAP feature. In newer versions SAP CAP unfolds `<ComplexType>` into one
+   * property per leaf, joined by an underscore: So instead of an `Address` object you get
+   * `Address_Street`, `Address_City`, `Address_PostalCode` and `Address_Country`.
+   * That is the shape CAP recommends, and its structured mode (`cds.odata.structs`) is deprecated.
+   *
+   * Switching this on groups such flat properties back into one complex property, so the models read
+   * `address: { street, city, ... }`. Off by default, which leaves the structure exactly as the metadata
+   * states it.
+   *
+   * The reshaping affects the whole surface, since the service still knows nothing but the flat
+   * properties: request and response payloads are converted in both directions, and query paths are
+   * rewritten, so `$select`, `$filter` and `$orderby` reach the service in the shape it understands -
+   * `address.city` is phrased as `Address_City`.
+   *
+   * Which flat properties form a group is decided from the metadata alone.
+   * The following are excluded:
+   * - a group named like a navigation property
+   * - a group consisting of nothing but an `Id`, which makes it a foreign key: CAP writes `Publisher_Id`
+   *   next to the navigation property `Publisher`. The price is that a complex type made up of a single
+   *   property named `Id` goes unrecognised. `Publisher_Id` next to `Publisher_Name` is a group again.
+   * - a key property, which every URL of the entity addresses by name
+   * - an empty segment, i.e. a name ending with the underscore: CAP's `Location_` sits right next to
+   *   `Location_Id` and neither is a structured element
+   * Where a `<ComplexType>` exists whose properties match the group exactly, it
+   * is used with its own name; otherwise one is synthesized.
+   */
+  unflattenComplexTypes?: boolean;
+  /**
    * By default, odata2ts emulates the in operator by rolling it out as a series of equals-or-expressions.
    * This allows for maximum compatibility with all V4 services, as well as V2 services.
    *

--- a/packages/odata2ts/src/data-model/ComplexTypeUnflattener.ts
+++ b/packages/odata2ts/src/data-model/ComplexTypeUnflattener.ts
@@ -1,0 +1,338 @@
+import { withNamespace } from "./DataModel.js";
+import { ComplexType, EntityType, Property, Schema } from "./edmx/ODataEdmxModelBase.js";
+
+/**
+ * The character by which a service joins the path of a flattened structured element. SAP CAP uses the
+ * underscore and that is the only spelling in the field, hence it is fixed rather than configurable.
+ */
+const SEPARATOR = "_";
+
+/**
+ * The leaf name which marks a group as a foreign key rather than a structured element, as long as it is the
+ * only one under that prefix.
+ */
+const FOREIGN_KEY_LEAF = "Id";
+
+/**
+ * One structured element that a service has unfolded into a property per leaf, reconstructed as a tree:
+ * a node is either a leaf, carrying the flat EDMX property it stands for, or a nested group.
+ */
+interface GroupNode {
+  leaf?: Property;
+  children?: Map<string, GroupNode>;
+}
+
+function isLeaf(node: GroupNode): node is Required<Pick<GroupNode, "leaf">> {
+  return !!node.leaf;
+}
+
+/**
+ * Reshapes structured elements which a service states flat - one property per leaf, joined by an
+ * underscore - back into complex properties, by rewriting the EDMX before it is digested.
+ *
+ * Rewriting the source rather than the digested data model is what keeps this feature contained: from the
+ * digester's point of view the service simply declared a complex property in the first place, so naming,
+ * per-property configuration, converters and every generator downstream need to know nothing about it.
+ *
+ * See the `unflattenComplexTypes` option for what is grouped and what deliberately is not.
+ */
+export class ComplexTypeUnflattener<ET extends EntityType, CT extends ComplexType> {
+  /**
+   * All complex types of all schemas by their fully qualified name - the pool that a group of flat
+   * properties is matched against, so an existing type is reused instead of a synthesized one.
+   */
+  private readonly complexTypes = new Map<string, CT>();
+
+  constructor(
+    private readonly schemas: Array<Schema<ET, CT>>,
+    /**
+     * The names of the navigation properties of a model. A group named like one of them is a foreign key,
+     * not a structured element.
+     */
+    private readonly getNavPropNames: (model: ET | CT) => Array<string>,
+  ) {
+    for (const schema of schemas) {
+      for (const ct of schema.ComplexType ?? []) {
+        this.complexTypes.set(withNamespace(schema.$.Namespace, ct.$.Name), ct);
+      }
+    }
+  }
+
+  /**
+   * Every property this shaper formed, as `<fully qualified model name>/<property name>`. The generator
+   * needs to tell them from complex properties the service declared itself: only these travel and are
+   * queried flat, so only these get a {@link QFlatComplexPath}.
+   */
+  private readonly reshaped = new Set<string>();
+
+  /**
+   * Groups the flat properties of every entity and complex type back into complex properties, mutating the
+   * schemas in place. Complex types synthesized on the way are appended to the schema of the model that
+   * needed them.
+   *
+   * @returns the reshaped properties, see {@link reshaped}
+   */
+  public unflatten(): Set<string> {
+    for (const schema of this.schemas) {
+      const synthesized: Array<CT> = [];
+
+      for (const model of [...(schema.EntityType ?? []), ...(schema.ComplexType ?? [])]) {
+        this.reshapeModel(schema, model, synthesized);
+      }
+
+      if (synthesized.length) {
+        schema.ComplexType = [...(schema.ComplexType ?? []), ...synthesized];
+      }
+    }
+
+    return this.reshaped;
+  }
+
+  private reshapeModel(schema: Schema<ET, CT>, model: ET | CT, synthesized: Array<CT>): void {
+    const props = model.Property ?? [];
+    if (!props.length) {
+      return;
+    }
+
+    const blocked = new Set([
+      ...this.getNavPropNames(model),
+      // a key is addressed by name in every URL of the entity; burying it inside a complex property would
+      // take that away, so it stays where the service put it
+      ...((model as EntityType).Key?.[0]?.PropertyRef ?? []).map((ref) => ref.$.Name),
+    ]);
+
+    const groups = this.buildGroups(props, blocked);
+    if (!groups.size) {
+      return;
+    }
+
+    const replacements = new Map<string, Property>();
+    for (const [name, node] of groups) {
+      const fqType = this.resolveType(schema, model, name, node, synthesized);
+      if (fqType) {
+        this.reshaped.add(`${withNamespace(schema.$.Namespace, model.$.Name)}/${name}`);
+        replacements.set(name, {
+          $: {
+            Name: name,
+            Type: fqType,
+            // a flattened structured element carries no nullability of its own; it is only non-nullable
+            // where every one of its leaves is
+            Nullable: collectLeaves(node).every((leaf) => leaf.$.Nullable === "false") ? "false" : "true",
+          },
+        });
+      }
+    }
+
+    if (!replacements.size) {
+      return;
+    }
+
+    // keep the declaration order of the service: the group takes the place of its first member
+    const consumed = new Set<string>();
+    for (const [name, node] of groups) {
+      if (replacements.has(name)) {
+        collectLeaves(node).forEach((leaf) => consumed.add(leaf.$.Name));
+      }
+    }
+
+    const result: Array<Property> = [];
+    for (const prop of props) {
+      if (!consumed.has(prop.$.Name)) {
+        result.push(prop);
+        continue;
+      }
+      const groupName = prop.$.Name.split(SEPARATOR)[0];
+      const replacement = replacements.get(groupName);
+      if (replacement) {
+        result.push(replacement);
+        replacements.delete(groupName);
+      }
+    }
+    model.Property = result;
+  }
+
+  /**
+   * Builds the group tree of those properties whose name carries a separator, and drops every group that
+   * cannot be told apart from an ordinary property with an underscore in its name.
+   *
+   * A group is discarded when it is blocked (a navigation property or a key), when it collides with a
+   * property the service declares under the group name itself, when any of its segments is empty - CAP's
+   * `Location_` sits right next to `Location_Id` and neither is a structured element - or when it consists
+   * of nothing but an `Id`, which makes it a foreign key.
+   */
+  private buildGroups(props: Array<Property>, blocked: Set<string>): Map<string, GroupNode> {
+    const declaredNames = new Set(props.map((p) => p.$.Name));
+    const groups = new Map<string, GroupNode>();
+    const discarded = new Set<string>();
+
+    for (const prop of props) {
+      const segments = prop.$.Name.split(SEPARATOR);
+      if (segments.length < 2) {
+        continue;
+      }
+      const groupName = segments[0];
+      if (discarded.has(groupName)) {
+        continue;
+      }
+      if (
+        segments.some((segment) => !segment) ||
+        blocked.has(prop.$.Name) ||
+        blocked.has(groupName) ||
+        declaredNames.has(groupName)
+      ) {
+        discarded.add(groupName);
+        groups.delete(groupName);
+        continue;
+      }
+
+      if (!this.addToTree(groups, segments, prop)) {
+        discarded.add(groupName);
+        groups.delete(groupName);
+      }
+    }
+
+    // A lone `Publisher_Id` is a foreign key. OData does not require a service to state one as a property
+    // at all - the navigation property alone traverses the relation - but where one does, as SAP CAP does,
+    // it spells it exactly like a flattened structured element. Reading it as a foreign key costs only the
+    // ability to recognise a complex type which consists of nothing but a property named `Id`, whereas
+    // `Publisher_Id` next to `Publisher_Name` is a structured element again.
+    for (const [groupName, node] of groups) {
+      const onlyChild = node.children?.size === 1 ? node.children.get(FOREIGN_KEY_LEAF) : undefined;
+      if (onlyChild && isLeaf(onlyChild)) {
+        groups.delete(groupName);
+      }
+    }
+
+    return groups;
+  }
+
+  /**
+   * Files one flat property into the group tree. Fails where a name is used as both a leaf and a group
+   * (`A_B` next to `A_B_C`), which no structured element can produce and which therefore means the
+   * underscore is part of the name rather than a separator.
+   */
+  private addToTree(root: Map<string, GroupNode>, segments: Array<string>, prop: Property): boolean {
+    let level = root;
+
+    for (let i = 0; i < segments.length - 1; i++) {
+      const existing = level.get(segments[i]);
+      if (existing && isLeaf(existing)) {
+        return false;
+      }
+      const node: GroupNode = existing ?? { children: new Map() };
+      level.set(segments[i], node);
+      level = node.children!;
+    }
+
+    const lastSegment = segments[segments.length - 1];
+    if (level.has(lastSegment)) {
+      return false;
+    }
+    level.set(lastSegment, { leaf: prop });
+    return true;
+  }
+
+  /**
+   * The type a group is stated as: an existing complex type wherever one matches the group exactly, so the
+   * generated client speaks the vocabulary of the service instead of an invented one. Only where the
+   * service never declares the type - which happens when it uses the structured element in no other place -
+   * is one synthesized.
+   */
+  private resolveType(
+    schema: Schema<ET, CT>,
+    model: ET | CT,
+    groupName: string,
+    node: GroupNode,
+    synthesized: Array<CT>,
+  ): string | undefined {
+    const children = node.children;
+    if (!children?.size) {
+      return undefined;
+    }
+
+    const matches = [...this.complexTypes].filter(([, candidate]) => this.matches(candidate, children));
+    if (matches.length) {
+      // several complex types can be structurally identical - `DateRange` and a hypothetical `Period` both
+      // being {From, To} - in which case the one named after the group is the one the service means
+      const byName = matches.find(([fqName]) => fqName.split(".").pop()!.endsWith(groupName));
+      return (byName ?? matches[0])[0];
+    }
+
+    return this.synthesize(schema, model, groupName, children, synthesized);
+  }
+
+  /**
+   * Whether a complex type states exactly the group: the same property names, the same types, and nothing
+   * on either side that the other does not have. Anything less than exact would silently type a property
+   * as something the service does not send.
+   */
+  private matches(candidate: CT, children: Map<string, GroupNode>): boolean {
+    const candidateProps = candidate.Property ?? [];
+    if (candidateProps.length !== children.size) {
+      return false;
+    }
+
+    return candidateProps.every((candidateProp) => {
+      const child = children.get(candidateProp.$.Name);
+      if (!child) {
+        return false;
+      }
+      if (isLeaf(child)) {
+        return child.leaf.$.Type === candidateProp.$.Type;
+      }
+      // a nested group only matches a nested complex type, which has to match in turn
+      const nested = this.complexTypes.get(candidateProp.$.Type);
+      return !!nested && !!child.children && this.matches(nested, child.children);
+    });
+  }
+
+  /**
+   * Declares a complex type for a group the service states nowhere else, named after the model it was found
+   * in and the group itself (`Members` + `Address` -> `Members_Address`), which keeps it recognisable and
+   * unique without inventing domain vocabulary.
+   */
+  private synthesize(
+    schema: Schema<ET, CT>,
+    model: ET | CT,
+    groupName: string,
+    children: Map<string, GroupNode>,
+    synthesized: Array<CT>,
+  ): string | undefined {
+    const name = `${model.$.Name}${SEPARATOR}${groupName}`;
+    const fqName = withNamespace(schema.$.Namespace, name);
+    if (this.complexTypes.has(fqName)) {
+      return undefined;
+    }
+
+    const props: Array<Property> = [];
+    for (const [childName, child] of children) {
+      if (isLeaf(child)) {
+        props.push({ ...child.leaf, $: { ...child.leaf.$, Name: childName } });
+        continue;
+      }
+      const nestedType = this.synthesize(
+        schema,
+        model,
+        `${groupName}${SEPARATOR}${childName}`,
+        child.children!,
+        synthesized,
+      );
+      if (!nestedType) {
+        return undefined;
+      }
+      props.push({ $: { Name: childName, Type: nestedType, Nullable: "true" } });
+    }
+
+    const complexType = { $: { Name: name }, Property: props } as unknown as CT;
+    this.complexTypes.set(fqName, complexType);
+    synthesized.push(complexType);
+    return fqName;
+  }
+}
+
+function collectLeaves(node: GroupNode): Array<Property> {
+  if (isLeaf(node)) {
+    return [node.leaf];
+  }
+  return [...(node.children?.values() ?? [])].flatMap(collectLeaves);
+}

--- a/packages/odata2ts/src/data-model/DataModelDigestion.ts
+++ b/packages/odata2ts/src/data-model/DataModelDigestion.ts
@@ -7,6 +7,7 @@ import {
   Modes,
   PropertyGenerationOptions,
 } from "../OptionModel.js";
+import { ComplexTypeUnflattener } from "./ComplexTypeUnflattener.js";
 import { DataModel, NamespaceWithAlias, withNamespace } from "./DataModel.js";
 import {
   ComplexType as ComplexModelType,
@@ -57,6 +58,13 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
    * Reverse mapping from fqName to data type: EntityType, ComplexType, EnumType, or Primitive Type.
    */
   private model2Type = new Map<string, DataTypes>();
+
+  /**
+   * The complex properties which `unflattenComplexTypes` formed from flat ones, as
+   * `<fully qualified model name>/<property name>`. They are the ones which still travel and are queried
+   * flat, hence they get a `QFlatComplexPath` instead of a `QComplexPath`.
+   */
+  private flattenedProps = new Set<string>();
 
   protected constructor(
     protected version: ODataVersion,
@@ -129,6 +137,14 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
   }
 
   private digestEntityTypesAndOperations() {
+    // reshaping happens on the EDMX itself, before anything is digested: from here on the model looks like
+    // one the service stated in that shape to begin with
+    if (this.options.unflattenComplexTypes) {
+      this.flattenedProps = new ComplexTypeUnflattener<ET, CT>(this.schemas, (model) =>
+        this.getNavigationProps(model).map((np) => np.$.Name),
+      ).unflatten();
+    }
+
     this.schemas.forEach((schema) => {
       const ns: NamespaceWithAlias = [schema.$.Namespace, schema.$.Alias];
 
@@ -193,7 +209,7 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
     // map properties respecting the config
     const props = [...(model.Property ?? []), ...this.getNavigationProps(model)].map((p) => {
       const epConfig = entityConfig?.properties?.find((ep) => ep.name === p.$.Name);
-      return this.mapProp(p, epConfig);
+      return this.mapProp(p, epConfig, fqName);
     });
     this.assertNoPropNameClash(props, fqName);
 
@@ -492,7 +508,18 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
     );
   }
 
-  protected mapProp = (p: Property, entityPropConfig?: PropertyGenerationOptions | undefined): PropertyModel => {
+  /**
+   * @param p the property to map
+   * @param entityPropConfig the configuration for the prop
+   * @param fqOwnerName the fully qualified name of the model this property belongs to, where there is one -
+   *   operation parameters and return types have no owner. Only needed to recognise a property which
+   *   `unflattenComplexTypes` reshaped.
+   */
+  protected mapProp = (
+    p: Property,
+    entityPropConfig?: PropertyGenerationOptions | undefined,
+    fqOwnerName?: string,
+  ): PropertyModel => {
     if (!p.$.Type) {
       throw new Error(`No type information given for property [${p.$.Name}]!`);
     }
@@ -564,7 +591,9 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
               ? QueryObjectTypes.QComplexCollectionPath
               : QueryObjectTypes.QEntityCollectionPath
             : isComplexType
-              ? QueryObjectTypes.QComplexPath
+              ? this.flattenedProps.has(`${fqOwnerName}/${p.$.Name}`)
+                ? QueryObjectTypes.QFlatComplexPath
+                : QueryObjectTypes.QComplexPath
               : QueryObjectTypes.QEntityPath,
           qObject: this.namingHelper.getQName(typeName),
           qParam: "QComplexParam",

--- a/packages/odata2ts/src/data-model/QueryObjectTypes.ts
+++ b/packages/odata2ts/src/data-model/QueryObjectTypes.ts
@@ -7,6 +7,7 @@ export enum QueryObjectTypes {
   QNumericEnumCollectionPath = "QNumericEnumCollectionPath",
   QCollectionPath = "QCollectionPath",
   QComplexPath = "QComplexPath",
+  QFlatComplexPath = "QFlatComplexPath",
   QEntityPath = "QEntityPath",
   QComplexCollectionPath = "QComplexCollectionPath",
   QEntityCollectionPath = "QEntityCollectionPath",

--- a/packages/odata2ts/src/defaultConfig.ts
+++ b/packages/odata2ts/src/defaultConfig.ts
@@ -26,6 +26,7 @@ const defaultConfig: DefaultConfiguration = {
   v4BigNumberAsString: false,
   disableAutomaticNameClashResolution: false,
   bundledFileGeneration: false,
+  unflattenComplexTypes: false,
   enumType: "string",
   naming: {
     models: {

--- a/packages/odata2ts/test/data-model/ComplexTypeUnflattener.test.ts
+++ b/packages/odata2ts/test/data-model/ComplexTypeUnflattener.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, test } from "vitest";
+import { ComplexTypeUnflattener } from "../../src/data-model/ComplexTypeUnflattener.js";
+import { ComplexType, EntityType, Property, Schema } from "../../src/data-model/edmx/ODataEdmxModelBase.js";
+
+const NS = "Test";
+
+function prop(name: string, type = "Edm.String", nullable?: "true" | "false"): Property {
+  return { $: { Name: name, Type: type, ...(nullable ? { Nullable: nullable } : {}) } };
+}
+
+function entity(name: string, props: Array<Property>, keys: Array<string> = []): EntityType {
+  return { $: { Name: name }, Key: [{ PropertyRef: keys.map((k) => ({ $: { Name: k } })) }], Property: props };
+}
+
+function complex(name: string, props: Array<Property>): ComplexType {
+  return { $: { Name: name }, Property: props };
+}
+
+interface ShapeSetup {
+  entityTypes?: Array<EntityType>;
+  complexTypes?: Array<ComplexType>;
+  /** navigation property names per entity type name */
+  navProps?: Record<string, Array<string>>;
+}
+
+/**
+ * Runs the shaper over one schema and hands back that schema, mutated in place - which is how the digester
+ * uses it.
+ */
+function shape({ entityTypes = [], complexTypes = [], navProps = {} }: ShapeSetup) {
+  const schema: Schema<EntityType, ComplexType> = {
+    $: { Namespace: NS, xmlns: "" },
+    EntityType: entityTypes,
+    ComplexType: complexTypes,
+  };
+
+  new ComplexTypeUnflattener([schema], (model) => navProps[model.$.Name] ?? []).unflatten();
+
+  return schema;
+}
+
+function propsOf(schema: Schema<EntityType, ComplexType>, entityName: string) {
+  return schema.EntityType!.find((et) => et.$.Name === entityName)!.Property.map((p) => `${p.$.Name}:${p.$.Type}`);
+}
+
+const ADDRESS_PROPS = [prop("Street"), prop("City"), prop("PostalCode")];
+const FLAT_ADDRESS = [prop("Address_Street"), prop("Address_City"), prop("Address_PostalCode")];
+
+describe("ComplexTypeUnflattener", () => {
+  test("groups flat props into the complex type the service already declares", () => {
+    const schema = shape({
+      entityTypes: [entity("Member", [prop("Id", "Edm.Int32"), ...FLAT_ADDRESS])],
+      complexTypes: [complex("PostalAddress", ADDRESS_PROPS)],
+    });
+
+    expect(propsOf(schema, "Member")).toStrictEqual(["Id:Edm.Int32", `Address:${NS}.PostalAddress`]);
+    // no type is invented where one already fits
+    expect(schema.ComplexType).toHaveLength(1);
+  });
+
+  test("puts the group where its first member was, keeping the declaration order", () => {
+    const schema = shape({
+      entityTypes: [entity("Member", [prop("Id", "Edm.Int32"), ...FLAT_ADDRESS, prop("Balance", "Edm.Decimal")])],
+      complexTypes: [complex("PostalAddress", ADDRESS_PROPS)],
+    });
+
+    expect(propsOf(schema, "Member")).toStrictEqual([
+      "Id:Edm.Int32",
+      `Address:${NS}.PostalAddress`,
+      "Balance:Edm.Decimal",
+    ]);
+  });
+
+  test("is only non-nullable where every leaf is", () => {
+    const schema = shape({
+      entityTypes: [
+        entity("A", [prop("X_One", "Edm.String", "false"), prop("X_Two", "Edm.String", "false")]),
+        entity("B", [prop("X_One", "Edm.String", "false"), prop("X_Two", "Edm.String", "true")]),
+      ],
+    });
+
+    const nullableOf = (name: string) => schema.EntityType!.find((et) => et.$.Name === name)!.Property[0].$.Nullable;
+    expect(nullableOf("A")).toBe("false");
+    expect(nullableOf("B")).toBe("true");
+  });
+
+  test("synthesizes a complex type where the service declares none that matches", () => {
+    const schema = shape({
+      entityTypes: [entity("Member", [prop("Id", "Edm.Int32"), ...FLAT_ADDRESS])],
+      // same names, but one type differs - anything less than an exact match would mistype the property
+      complexTypes: [complex("PostalAddress", [prop("Street"), prop("City"), prop("PostalCode", "Edm.Int32")])],
+    });
+
+    expect(propsOf(schema, "Member")).toStrictEqual(["Id:Edm.Int32", `Address:${NS}.Member_Address`]);
+    const synthesized = schema.ComplexType!.find((ct) => ct.$.Name === "Member_Address");
+    expect(synthesized?.Property.map((p) => p.$.Name)).toStrictEqual(["Street", "City", "PostalCode"]);
+  });
+
+  test("does not match a complex type which has props the group has not", () => {
+    const schema = shape({
+      entityTypes: [entity("Member", FLAT_ADDRESS)],
+      complexTypes: [complex("PostalAddress", [...ADDRESS_PROPS, prop("Country")])],
+    });
+
+    expect(propsOf(schema, "Member")).toStrictEqual([`Address:${NS}.Member_Address`]);
+  });
+
+  test("prefers the structurally identical complex type which is named after the group", () => {
+    const schema = shape({
+      entityTypes: [entity("Loan", [prop("Period_From", "Edm.Date"), prop("Period_To", "Edm.Date")])],
+      complexTypes: [
+        complex("Timespan", [prop("From", "Edm.Date"), prop("To", "Edm.Date")]),
+        complex("DatePeriod", [prop("From", "Edm.Date"), prop("To", "Edm.Date")]),
+      ],
+    });
+
+    expect(propsOf(schema, "Loan")).toStrictEqual([`Period:${NS}.DatePeriod`]);
+  });
+
+  describe("leaves alone what only looks like a flattened complex type", () => {
+    test("a lone Id, which is a foreign key - even where no navigation property gives it away", () => {
+      const schema = shape({
+        entityTypes: [entity("Book", [prop("Id", "Edm.Int32"), prop("Publisher_Id", "Edm.Int32")])],
+      });
+
+      expect(propsOf(schema, "Book")).toStrictEqual(["Id:Edm.Int32", "Publisher_Id:Edm.Int32"]);
+    });
+
+    test("a composite foreign key, which looks like a struct of two fields", () => {
+      const schema = shape({
+        entityTypes: [entity("Loan", [prop("Copy_MediumId", "Edm.Guid"), prop("Copy_InventoryNumber", "Edm.Int32")])],
+        // neither leaf is a lone `Id`, so only the navigation property tells this one apart
+        navProps: { Loan: ["Copy"] },
+      });
+
+      expect(propsOf(schema, "Loan")).toStrictEqual(["Copy_MediumId:Edm.Guid", "Copy_InventoryNumber:Edm.Int32"]);
+    });
+
+    test("a group named like a navigation property, even without a constraint", () => {
+      const schema = shape({
+        entityTypes: [entity("Book", [prop("Publisher_Id", "Edm.Int32")])],
+        navProps: { Book: ["Publisher"] },
+      });
+
+      expect(propsOf(schema, "Book")).toStrictEqual(["Publisher_Id:Edm.Int32"]);
+    });
+
+    test("a foreign key whose group name is not the navigation property name (CAP's up__Id)", () => {
+      const schema = shape({
+        entityTypes: [entity("Chapter", [prop("up__Id", "Edm.Guid")])],
+        // the nav prop is `up_`, so splitting at the separator yields `up` and the name rule misses it -
+        // what settles this one is the empty segment between the two underscores
+        navProps: { Chapter: ["up_"] },
+      });
+
+      expect(propsOf(schema, "Chapter")).toStrictEqual(["up__Id:Edm.Guid"]);
+    });
+
+    test("a trailing separator, which yields an empty segment", () => {
+      const schema = shape({
+        entityTypes: [entity("Copy", [prop("Location_"), prop("Location_Id", "Edm.Int32")])],
+      });
+
+      expect(propsOf(schema, "Copy")).toStrictEqual(["Location_:Edm.String", "Location_Id:Edm.Int32"]);
+    });
+
+    test("a key property, which every URL of the entity addresses by name", () => {
+      const schema = shape({
+        entityTypes: [
+          entity("Chapter", [prop("Parent_Id", "Edm.Guid"), prop("Parent_Pos", "Edm.Int32")], ["Parent_Id"]),
+        ],
+      });
+
+      expect(propsOf(schema, "Chapter")).toStrictEqual(["Parent_Id:Edm.Guid", "Parent_Pos:Edm.Int32"]);
+    });
+
+    test("a group colliding with a property the service declares under that very name", () => {
+      const schema = shape({
+        entityTypes: [entity("Member", [prop("Address"), prop("Address_City")])],
+      });
+
+      expect(propsOf(schema, "Member")).toStrictEqual(["Address:Edm.String", "Address_City:Edm.String"]);
+    });
+
+    test("a name used as both leaf and group, which no structured element produces", () => {
+      const schema = shape({
+        entityTypes: [entity("Member", [prop("A_B"), prop("A_B_C")])],
+      });
+
+      expect(propsOf(schema, "Member")).toStrictEqual(["A_B:Edm.String", "A_B_C:Edm.String"]);
+    });
+
+    test("but not an Id which has company: that is a structured element again", () => {
+      const schema = shape({
+        entityTypes: [entity("Book", [prop("Publisher_Id", "Edm.Int32"), prop("Publisher_Name")])],
+      });
+
+      expect(propsOf(schema, "Book")).toStrictEqual([`Publisher:${NS}.Book_Publisher`]);
+      const synthesized = schema.ComplexType!.find((ct) => ct.$.Name === "Book_Publisher");
+      expect(synthesized?.Property.map((p) => p.$.Name)).toStrictEqual(["Id", "Name"]);
+    });
+
+    test("a property without any separator", () => {
+      const schema = shape({ entityTypes: [entity("Member", [prop("Name")])] });
+
+      expect(propsOf(schema, "Member")).toStrictEqual(["Name:Edm.String"]);
+    });
+  });
+
+  describe("nested structured elements", () => {
+    test("match a complex type which nests another one", () => {
+      const schema = shape({
+        entityTypes: [entity("Member", [prop("Home_Label"), prop("Home_Address_Street"), prop("Home_Address_City")])],
+        complexTypes: [
+          complex("PostalAddress", [prop("Street"), prop("City")]),
+          complex("Residence", [prop("Label"), prop("Address", `${NS}.PostalAddress`)]),
+        ],
+      });
+
+      expect(propsOf(schema, "Member")).toStrictEqual([`Home:${NS}.Residence`]);
+    });
+
+    test("are synthesized level by level where nothing matches", () => {
+      const schema = shape({
+        entityTypes: [entity("Member", [prop("Home_Label"), prop("Home_Address_Street")])],
+      });
+
+      expect(propsOf(schema, "Member")).toStrictEqual([`Home:${NS}.Member_Home`]);
+      const home = schema.ComplexType!.find((ct) => ct.$.Name === "Member_Home");
+      expect(home?.Property.map((p) => `${p.$.Name}:${p.$.Type}`)).toStrictEqual([
+        "Label:Edm.String",
+        `Address:${NS}.Member_Home_Address`,
+      ]);
+      const address = schema.ComplexType!.find((ct) => ct.$.Name === "Member_Home_Address");
+      expect(address?.Property.map((p) => p.$.Name)).toStrictEqual(["Street"]);
+    });
+  });
+
+  test("reshapes complex types just as it does entity types", () => {
+    const schema = shape({
+      complexTypes: [complex("Branch", [prop("Name"), ...FLAT_ADDRESS]), complex("PostalAddress", ADDRESS_PROPS)],
+    });
+
+    const branch = schema.ComplexType!.find((ct) => ct.$.Name === "Branch");
+    expect(branch?.Property.map((p) => `${p.$.Name}:${p.$.Type}`)).toStrictEqual([
+      "Name:Edm.String",
+      `Address:${NS}.PostalAddress`,
+    ]);
+  });
+});

--- a/packages/odata2ts/test/data-model/ServiceConfigHelper.test.ts
+++ b/packages/odata2ts/test/data-model/ServiceConfigHelper.test.ts
@@ -23,6 +23,7 @@ describe("ServiceConfigHelper Tests", function () {
       bundledFileGeneration: false,
       enumType: "string",
       enableNativeInOperator: false,
+      unflattenComplexTypes: false,
     });
   }
 
@@ -41,6 +42,7 @@ describe("ServiceConfigHelper Tests", function () {
       bundledFileGeneration: false,
       enumType: "string",
       enableNativeInOperator: false,
+      unflattenComplexTypes: false,
     });
   }
 


### PR DESCRIPTION
New option `unflattenComplexTypes` (off by default), for services which unfold a structured element into one property per leaf joined by an underscore - SAP CAP being the case it exists for.

- `ComplexTypeUnflattener` rewrites the EDMX before it is digested, so naming, per-property configuration, converters and every generator downstream see a service which declared a complex property in the first place
- a group is not formed where its name is that of a navigation property, where it would swallow a key, where a segment is empty (`Location_` next to `Location_Id`), or where it consists of nothing but an `Id` - each of which is a foreign key CAP spells like a flattened complex type
- a declared `<ComplexType>` matching the group exactly is reused with its own name; only where none matches is one synthesized
- `QFlatComplexPath` carries the flattening separator down, so payloads are converted in both directions and `$filter` / `$orderby` / `$select` reach the service flat
- `expanding()` produces no nested clause for such a property, only the flat paths of its leaves - in V4 (no `$select=Prop(...)`) and in V2 (no `$expand`)
- integration tests in `int-test/cap` for V4 and the V2 adapter, each contrasting the reshaped client with the raw one generated from the same metadata

Docs: odata2ts/odata2ts.github.io#57

🤖 Generated with [Claude Code](https://claude.com/claude-code)
