### PR TITLE
feat: reshape V2 responses as V4 via v2ResponseAsV4

### DIFF
--- a/int-test/olingo-v2/odata2ts.config.ts
+++ b/int-test/olingo-v2/odata2ts.config.ts
@@ -97,6 +97,30 @@ const config: ConfigFileOptions = {
         },
       ],
     },
+    /**
+     * The same model a fourth time, with `v2ResponseAsV4` switched on: every response is reshaped as its
+     * V4 equivalent (`{value: [...]}` instead of `{d: {results: [...]}}`, the bare entity plus `@odata.*`
+     * control information instead of `{d: {...entity, __metadata}}`, expanded navigation properties
+     * unwrapped instead of `results`-wrapped, unexpanded ones simply absent instead of `__deferred`). See
+     * `test/feature/V2ResponseAsV4.test.ts`.
+     *
+     * Generated separately rather than replacing the raw client, for the same reason as `libraryRenamed`
+     * and `libraryConverted`: the raw V2 shape is worth pinning in its own right (`ResultsWrapping.test.ts`,
+     * `core/CrudOperations.test.ts`), so the reshaped one needs its own client to be observable at all.
+     */
+    libraryAsV4: {
+      serviceName: "LibraryAsV4",
+      source: "resource/library-v2.xml",
+      output: "src-generated/library-as-v4",
+      enablePrimitivePropertyServices: true,
+      v2ResponseAsV4: true,
+      // override the top-level wrapping options: v2ResponseAsV4 already reshapes an expanded collection
+      // valued nav prop as a plain array (dropping the `results` envelope entirely) and Olingo accepts an
+      // unwrapped deep-insert payload just as well (see ResultsWrapping.test.ts) - stating the wrapping in
+      // the generated types here would describe traffic this client no longer sends or receives
+      v2ResponseResultsWrapping: false,
+      v2PayloadResultsWrapping: false,
+    },
   },
 };
 

--- a/int-test/olingo-v2/test/LibraryTestConstants.ts
+++ b/int-test/olingo-v2/test/LibraryTestConstants.ts
@@ -1,11 +1,14 @@
 import { FetchClient } from "@odata2ts/http-client-fetch";
 import { inject } from "vitest";
-import { LibraryService } from "../src-generated/library/LibraryService.js";
+import { LibraryAsV4Service } from "../src-generated/library-as-v4/index.js";
+import { LibraryService } from "../src-generated/library/index.js";
 
 /** Base URL of the running server, provided by `globalSetup` (container or external server). */
 export const BASE_URL = inject("libraryBaseUrl");
 export const ODATA_CLIENT = new FetchClient();
 export const LIBRARY = new LibraryService(ODATA_CLIENT, BASE_URL);
+/** Same server, same model, but every response reshaped as V4 - see `feature/V2ResponseAsV4.test.ts`. */
+export const LIBRARY_AS_V4 = new LibraryAsV4Service(ODATA_CLIENT, BASE_URL);
 
 // Fixed keys from the server's in-memory seed data (`data/SeedData.java` in test-server-olingo-v2).
 // They deliberately match test-server-cap wherever the same entity exists in both.

--- a/int-test/olingo-v2/test/feature/V2ResponseAsV4.test.ts
+++ b/int-test/olingo-v2/test/feature/V2ResponseAsV4.test.ts
@@ -1,0 +1,96 @@
+import { HttpResponseModel } from "@odata2ts/http-client-api";
+import { ODataCollectionResponseV4, ODataModelResponseV4 } from "@odata2ts/odata-core";
+import { describe, expect, expectTypeOf, test } from "vitest";
+import { Book, Copy, EditableBook } from "../../src-generated/library-as-v4/index.js";
+import { BOOK_DER_PROZESS, COPY_KEY, LIBRARY_AS_V4 } from "../LibraryTestConstants.js";
+
+/**
+ * `v2ResponseAsV4`: a V2 service (Olingo here), reshaped so that every response looks like V4.
+ *
+ * Everything in `core/CrudOperations.test.ts` and `feature/ResultsWrapping.test.ts` pins the raw V2 shape
+ * this server actually sends; this suite pins what `LIBRARY_AS_V4` - the very same server, generated with
+ * the option turned on - turns that shape into. Read them side by side to see the reshaping at work.
+ */
+describe("Olingo Library: v2ResponseAsV4", () => {
+  test("an entity comes back bare, with __metadata mapped to @odata.* control information", async () => {
+    const result = await LIBRARY_AS_V4.Books(BOOK_DER_PROZESS).query().execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data).toMatchObject({
+      Id: BOOK_DER_PROZESS,
+      Title: "Der Prozess",
+      ISBN: "9783150094440",
+      PageCount: 224,
+    });
+    // no more "d" envelope, and __metadata.uri became @odata.id
+    expect((result.data as any).d).toBeUndefined();
+    expect(result.data["@odata.id"]).toContain(`Books(guid'${BOOK_DER_PROZESS}')`);
+
+    expectTypeOf(result).toEqualTypeOf<HttpResponseModel<ODataModelResponseV4<Book>>>();
+  });
+
+  test("an entity carrying a concurrency token maps it to @odata.etag", async () => {
+    const result = await LIBRARY_AS_V4.Copies(COPY_KEY).query().execute();
+
+    expect(result.data["@odata.etag"]).toMatch(/^W\//);
+  });
+
+  test("a collection comes back as { value: [...] } instead of { d: { results: [...] } }", async () => {
+    const result = await LIBRARY_AS_V4.Books().query().execute();
+
+    expect(result.status).toBe(200);
+    expect((result.data as any).d).toBeUndefined();
+    expect(Array.isArray(result.data.value)).toBe(true);
+    expect(result.data.value.length).toBeGreaterThan(0);
+    expect(result.data.value.map((book) => book.Title)).toContain("Der Prozess");
+
+    expectTypeOf(result).toEqualTypeOf<HttpResponseModel<ODataCollectionResponseV4<Book>>>();
+  });
+
+  test("$count maps __count to @odata.count", async () => {
+    const result = await LIBRARY_AS_V4.Books()
+      .query((b) => b.count())
+      .execute();
+
+    expect(typeof result.data["@odata.count"]).toBe("number");
+    expect(result.data["@odata.count"]).toBeGreaterThan(0);
+  });
+
+  test("an expanded collection valued navigation property is a plain array, not results-wrapped", async () => {
+    const result = await LIBRARY_AS_V4.Books(BOOK_DER_PROZESS)
+      .query((b) => b.expand("Copies"))
+      .execute();
+
+    expect(Array.isArray(result.data.Copies)).toBe(true);
+    const copies = result.data.Copies as Array<Copy>;
+    expect(copies.length).toBeGreaterThan(0);
+    expect(copies.every((copy) => copy.MediumId === BOOK_DER_PROZESS)).toBe(true);
+    // nested __metadata is reshaped exactly like the top-level entity's
+    expect((copies[0] as any)["@odata.id"]).toBeTypeOf("string");
+
+    expectTypeOf<Book["Copies"]>().toEqualTypeOf<Array<Copy>>();
+  });
+
+  test("an unexpanded navigation property is simply absent, not a __deferred stub", async () => {
+    const result = await LIBRARY_AS_V4.Books(BOOK_DER_PROZESS).query().execute();
+
+    expect(result.data).not.toHaveProperty("Copies");
+  });
+
+  test("create, read and delete an entity in V4 shape", async () => {
+    const newBook: EditableBook = { Title: "Reshaped As V4", Language: "de", PageCount: 111 };
+
+    const created = await LIBRARY_AS_V4.Books().create(newBook).execute();
+    expect(created.status).toBe(201);
+    expect(created.data).toMatchObject(newBook);
+    expect((created.data as any).d).toBeUndefined();
+    expectTypeOf(created).toEqualTypeOf<HttpResponseModel<ODataModelResponseV4<Book>>>();
+
+    const id = created.data.Id;
+    const read = await LIBRARY_AS_V4.Books(id).query().execute();
+    expect(read.data).toMatchObject(newBook);
+
+    const deleted = await LIBRARY_AS_V4.Books(id).delete().execute();
+    expect(deleted.status).toBe(204);
+  });
+});

--- a/packages/odata-query-objects/src/index.ts
+++ b/packages/odata-query-objects/src/index.ts
@@ -85,6 +85,8 @@ export * from "./response/v2/ValueResponseConverterV2";
 export * from "./response/v2/ComplexResponseConverterV2";
 export * from "./response/v2/EntityResponseConverterV2";
 export * from "./response/v2/CollectionResponseConverterV2";
+export * from "./response/v2/toV4ControlInfo";
+export * from "./response/v2/reshapeV2ResponseAsV4";
 export * from "./response/v4/ValueResponseConverterV4";
 export * from "./response/v4/ModelResponseConverterV4";
 export * from "./response/v4/CollectionResponseConverterV4";

--- a/packages/odata-query-objects/src/response/v2/CollectionResponseConverterV2.ts
+++ b/packages/odata-query-objects/src/response/v2/CollectionResponseConverterV2.ts
@@ -1,17 +1,61 @@
 import { HttpResponseModel } from "@odata2ts/http-client-api";
-import { ODataCollectionResponseV2 } from "@odata2ts/odata-core";
+import { ODataCollectionResponseV2, ODataCollectionResponseV4 } from "@odata2ts/odata-core";
 import { MainResponseConverter } from "../MainResponseConverter";
+import { ResponseDataConverter } from "../ResponseDataConverter";
+import { reshapeV2ResponseAsV4 } from "./reshapeV2ResponseAsV4";
 
-export class CollectionResponseConverterV2<T> extends MainResponseConverter<ODataCollectionResponseV2<T>, T> {
-  public convert(response: HttpResponseModel<any>): HttpResponseModel<ODataCollectionResponseV2<T>> {
+/**
+ * Converts a V2 collection response.
+ *
+ * By default, the V2 envelope (`{ d: { results: [...] } }`) is handed through untouched, only the entities
+ * inside are converted. Pass `asV4: true` to reshape the whole response as its V4 equivalent instead -
+ * `{ value: [...], "@odata.count"?, "@odata.nextLink"? }` - see {@link reshapeV2ResponseAsV4}.
+ */
+export class CollectionResponseConverterV2<T, AsV4 extends boolean = false> extends MainResponseConverter<
+  AsV4 extends true ? ODataCollectionResponseV4<T> : ODataCollectionResponseV2<T>,
+  T
+> {
+  public constructor(
+    converter: ResponseDataConverter<T>,
+    private asV4?: AsV4,
+  ) {
+    super(converter);
+  }
+
+  public convert(response: HttpResponseModel<any>): HttpResponseModel<any> {
     const data = response.data;
     const value = data?.d?.results;
+
+    if (!this.asV4) {
+      if (value && typeof value === "object") {
+        data.d.results = this.applyConverter(value);
+      }
+      // support for V1
+      else if (data?.d && typeof data.d === "object") {
+        data.d = this.applyConverter(data.d);
+      }
+
+      return response;
+    }
+
+    let convertedValue: Array<T> | undefined;
     if (value && typeof value === "object") {
-      data.d.results = this.applyConverter(value);
+      convertedValue = reshapeV2ResponseAsV4(this.applyConverter(value));
     }
     // support for V1
     else if (data?.d && typeof data.d === "object") {
-      data.d = this.applyConverter(data.d);
+      convertedValue = reshapeV2ResponseAsV4(this.applyConverter(data.d));
+    }
+
+    if (convertedValue !== undefined) {
+      const result: ODataCollectionResponseV4<T> = { value: convertedValue };
+      if (data.d.__count !== undefined) {
+        result["@odata.count"] = Number(data.d.__count);
+      }
+      if (data.d.__next) {
+        result["@odata.nextLink"] = data.d.__next;
+      }
+      response.data = result;
     }
 
     return response;

--- a/packages/odata-query-objects/src/response/v2/ComplexResponseConverterV2.ts
+++ b/packages/odata-query-objects/src/response/v2/ComplexResponseConverterV2.ts
@@ -1,14 +1,39 @@
 import { HttpResponseModel } from "@odata2ts/http-client-api";
-import { ODataComplexModelResponseV2 } from "@odata2ts/odata-core";
+import { ODataComplexModelResponseV2, ODataModelResponseV4 } from "@odata2ts/odata-core";
 import { MainResponseConverter } from "../MainResponseConverter";
+import { ResponseDataConverter } from "../ResponseDataConverter";
+import { reshapeV2ResponseAsV4 } from "./reshapeV2ResponseAsV4";
 
-export class ComplexResponseConverterV2<T> extends MainResponseConverter<ODataComplexModelResponseV2<T>, T> {
-  public convert(response: HttpResponseModel<any>): HttpResponseModel<ODataComplexModelResponseV2<T>> {
+/**
+ * Converts a V2 complex-type response.
+ *
+ * By default the V2 envelope (`{ d: { <propName>: { ...value, __metadata } } }`) is handed through
+ * untouched, only the value itself is converted. Pass `asV4: true` to reshape the whole response as its V4
+ * equivalent instead - the bare value plus `@odata.*` control information - see
+ * {@link reshapeV2ResponseAsV4}.
+ */
+export class ComplexResponseConverterV2<T, AsV4 extends boolean = false> extends MainResponseConverter<
+  AsV4 extends true ? ODataModelResponseV4<T> : ODataComplexModelResponseV2<T>,
+  T
+> {
+  public constructor(
+    converter: ResponseDataConverter<T>,
+    private asV4?: AsV4,
+  ) {
+    super(converter);
+  }
+
+  public convert(response: HttpResponseModel<any>): HttpResponseModel<any> {
     const data = response.data;
     if (typeof data?.d === "object") {
       const values = Object.values(data.d);
       if (values.length === 1 && typeof values[0] === "object") {
-        data.d = this.applyConverter(values[0] as T);
+        const converted = this.applyConverter(values[0] as T);
+        if (this.asV4) {
+          response.data = reshapeV2ResponseAsV4(converted);
+        } else {
+          data.d = converted;
+        }
       }
     }
 

--- a/packages/odata-query-objects/src/response/v2/EntityResponseConverterV2.ts
+++ b/packages/odata-query-objects/src/response/v2/EntityResponseConverterV2.ts
@@ -1,12 +1,37 @@
 import { HttpResponseModel } from "@odata2ts/http-client-api";
-import { ODataEntityModelResponseV2 } from "@odata2ts/odata-core";
+import { ODataEntityModelResponseV2, ODataModelResponseV4 } from "@odata2ts/odata-core";
 import { MainResponseConverter } from "../MainResponseConverter";
+import { ResponseDataConverter } from "../ResponseDataConverter";
+import { reshapeV2ResponseAsV4 } from "./reshapeV2ResponseAsV4";
 
-export class EntityResponseConverterV2<T> extends MainResponseConverter<ODataEntityModelResponseV2<T>, T> {
-  public convert(response: HttpResponseModel<any>): HttpResponseModel<ODataEntityModelResponseV2<T>> {
+/**
+ * Converts a V2 entity response.
+ *
+ * By default the V2 envelope (`{ d: { ...entity, __metadata } }`) is handed through untouched, only the
+ * entity's own properties are converted. Pass `asV4: true` to reshape the whole response as its V4
+ * equivalent instead - the bare entity plus `@odata.*` control information - see
+ * {@link reshapeV2ResponseAsV4}.
+ */
+export class EntityResponseConverterV2<T, AsV4 extends boolean = false> extends MainResponseConverter<
+  AsV4 extends true ? ODataModelResponseV4<T> : ODataEntityModelResponseV2<T>,
+  T
+> {
+  public constructor(
+    converter: ResponseDataConverter<T>,
+    private asV4?: AsV4,
+  ) {
+    super(converter);
+  }
+
+  public convert(response: HttpResponseModel<any>): HttpResponseModel<any> {
     const data = response.data;
     if (data?.d && typeof data.d === "object") {
-      data.d = this.applyConverter(data.d);
+      const converted = this.applyConverter(data.d);
+      if (this.asV4) {
+        response.data = reshapeV2ResponseAsV4(converted);
+      } else {
+        data.d = converted;
+      }
     }
 
     return response;

--- a/packages/odata-query-objects/src/response/v2/ValueResponseConverterV2.ts
+++ b/packages/odata-query-objects/src/response/v2/ValueResponseConverterV2.ts
@@ -1,28 +1,59 @@
 import { HttpResponseModel } from "@odata2ts/http-client-api";
-import { ODataValueResponseV2 } from "@odata2ts/odata-core";
+import { ODataValueResponseV2, ODataValueResponseV4 } from "@odata2ts/odata-core";
 import { MainResponseConverter } from "../MainResponseConverter";
 import { ResponseValueConverterV2 } from "../ResponseDataConverter";
+import { reshapeV2ResponseAsV4 } from "./reshapeV2ResponseAsV4";
 
-export class ValueResponseConverterV2<T> extends MainResponseConverter<ODataValueResponseV2<T>, T> {
-  public convert(response: HttpResponseModel<any>): HttpResponseModel<ODataValueResponseV2<T>> {
+/**
+ * Converts a V2 value response.
+ *
+ * By default the V2 envelope (`{ d: { <propName>: value } }`) is handed through untouched, only the value
+ * itself is converted. Pass `asV4: true` to reshape the whole response as its V4 equivalent instead -
+ * `{ value: ... }` - see {@link reshapeV2ResponseAsV4}.
+ */
+export class ValueResponseConverterV2<T, AsV4 extends boolean = false> extends MainResponseConverter<
+  AsV4 extends true ? ODataValueResponseV4<T> : ODataValueResponseV2<T>,
+  T
+> {
+  public constructor(
+    converter: ResponseValueConverterV2<T>,
+    private asV4?: AsV4,
+  ) {
+    super(converter);
+  }
+
+  public convert(response: HttpResponseModel<any>): HttpResponseModel<any> {
     const data = response.data;
     const value = data?.d;
-    if (typeof value === "object") {
-      const converter = this.converter as ResponseValueConverterV2<T>;
-      // we try to match by known attribute name
-      const name = typeof converter.getName === "function" ? converter.getName() : undefined;
-      const mappedName = typeof converter.getMappedName === "function" ? converter.getMappedName() : name;
-      if (name && mappedName && value.hasOwnProperty(name)) {
-        // map attribute name and convert the attribute value
-        data.d = { [mappedName]: this.applyConverter(value[name]) };
+    if (typeof value !== "object") {
+      return response;
+    }
+
+    const converter = this.converter as ResponseValueConverterV2<T>;
+    // we try to match by known attribute name
+    const name = typeof converter.getName === "function" ? converter.getName() : undefined;
+    const mappedName = typeof converter.getMappedName === "function" ? converter.getMappedName() : name;
+
+    if (name && mappedName && value.hasOwnProperty(name)) {
+      // map attribute name and convert the attribute value
+      const converted = this.applyConverter(value[name]);
+      if (this.asV4) {
+        response.data = { value: reshapeV2ResponseAsV4(converted) };
+      } else {
+        data.d = { [mappedName]: converted };
       }
-      // alternatively, if single attribute is given, then we use that one
-      else {
-        const keyValue = Object.entries(value);
-        if (keyValue.length === 1) {
-          const [key, val] = keyValue[0];
+    }
+    // alternatively, if single attribute is given, then we use that one
+    else {
+      const keyValue = Object.entries(value);
+      if (keyValue.length === 1) {
+        const [key, val] = keyValue[0];
+        const converted = this.applyConverter(val as T);
+        if (this.asV4) {
+          response.data = { value: reshapeV2ResponseAsV4(converted) };
+        } else {
           // convert value only
-          data.d[key] = this.applyConverter(val as T);
+          data.d[key] = converted;
         }
       }
     }

--- a/packages/odata-query-objects/src/response/v2/reshapeV2ResponseAsV4.ts
+++ b/packages/odata-query-objects/src/response/v2/reshapeV2ResponseAsV4.ts
@@ -1,0 +1,50 @@
+import { toV4ControlInfo } from "./toV4ControlInfo";
+
+function isDeferred(value: any): boolean {
+  return !!value && typeof value === "object" && !Array.isArray(value) && "__deferred" in value;
+}
+
+function isResultsWrapped(value: any): value is { results: Array<any> } {
+  return !!value && typeof value === "object" && !Array.isArray(value) && Array.isArray(value.results);
+}
+
+/**
+ * Reshapes an already type-/name-converted V2 payload (as produced by {@link QueryObjectModel.convertFromOData})
+ * into the structure a V4 payload would have:
+ * - `__metadata` (uri, type, etag) is turned into `@odata.id` / `@odata.type` / `@odata.etag`, see
+ *   {@link toV4ControlInfo}.
+ * - A collection-valued navigation property wrapped as `{ results: [...] }` (see issue #237) becomes a plain
+ *   array, as V4 has no equivalent wrapping.
+ * - A deferred navigation property (`{ __deferred: { uri } }`) is dropped entirely, since V4 simply omits any
+ *   navigation property that hasn't been expanded, rather than stating a placeholder for it.
+ *
+ * Applies recursively, so that navigation properties expanded to any depth are reshaped the same way as the
+ * top-level entity or collection.
+ */
+export function reshapeV2ResponseAsV4(value: any): any {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(reshapeV2ResponseAsV4);
+  }
+  if (isDeferred(value)) {
+    return undefined;
+  }
+  if (isResultsWrapped(value)) {
+    return value.results.map(reshapeV2ResponseAsV4);
+  }
+
+  const { __metadata, ...ownProps } = value;
+  const result: Record<string, any> = __metadata ? toV4ControlInfo(__metadata) : {};
+
+  for (const [key, propValue] of Object.entries(ownProps)) {
+    const reshaped = reshapeV2ResponseAsV4(propValue);
+    // a dropped deferred nav prop yields undefined here, while a genuinely undefined/null value should stay
+    if (reshaped !== undefined || propValue === undefined || propValue === null) {
+      result[key] = reshaped;
+    }
+  }
+
+  return result;
+}

--- a/packages/odata-query-objects/src/response/v2/toV4ControlInfo.ts
+++ b/packages/odata-query-objects/src/response/v2/toV4ControlInfo.ts
@@ -1,0 +1,22 @@
+import { ComplexMetaModelV2, EntityMetaModelV2, ModelControlInfoV4 } from "@odata2ts/odata-core";
+
+/**
+ * Maps V2's `__metadata` (uri, type, etag) onto the closest V4 control information, so that a V2 response
+ * reshaped as V4 carries the same information under the names a V4 consumer expects.
+ */
+export function toV4ControlInfo(metadata: EntityMetaModelV2 | ComplexMetaModelV2): ModelControlInfoV4 {
+  const { uri, type, etag } = metadata as EntityMetaModelV2;
+  const result: ModelControlInfoV4 = {};
+
+  if (uri) {
+    result["@odata.id"] = uri;
+  }
+  if (type) {
+    result["@odata.type"] = type;
+  }
+  if (etag) {
+    result["@odata.etag"] = etag;
+  }
+
+  return result;
+}

--- a/packages/odata-query-objects/test/response/v2/CollectionResponseConverterV2.test.ts
+++ b/packages/odata-query-objects/test/response/v2/CollectionResponseConverterV2.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { CollectionResponseConverterV2 } from "../../../src";
+import { QBookV2 } from "../../fixture/BindingModel";
 import { BookModel, QBook } from "../../fixture/operation/BookModel";
 import { createResponse } from "../../test-infra/TestResponseHelper";
 
@@ -76,6 +77,73 @@ describe("CollectionResponseConverterV2 tests", () => {
     nonMatching.forEach((nm) => {
       const result = MAIN_CONVERTER.convert(createResponse(nm));
       expect(result.data).toStrictEqual(nm);
+    });
+  });
+
+  describe("asV4", () => {
+    const AS_V4_CONVERTER = new CollectionResponseConverterV2(TYPE_CONVERTER, true);
+
+    test("convert into V4 shaped { value: [...] }", () => {
+      const result = AS_V4_CONVERTER.convert(createResponse({ d: { results: MODEL_INPUT } }));
+
+      expect(result.data).toStrictEqual({ value: MODEL_CONVERTED });
+    });
+
+    test("maps __count and __next to @odata.count / @odata.nextLink", () => {
+      const result = AS_V4_CONVERTER.convert(
+        createResponse({
+          d: {
+            results: MODEL_INPUT,
+            __count: "2",
+            __next: "https://services.odata.org/OData/OData.svc$skiptoken=12",
+          },
+        }),
+      );
+
+      expect(result.data).toStrictEqual({
+        value: MODEL_CONVERTED,
+        "@odata.count": 2,
+        "@odata.nextLink": "https://services.odata.org/OData/OData.svc$skiptoken=12",
+      });
+    });
+
+    test("supports V1 responses (no results wrapper)", () => {
+      const result = AS_V4_CONVERTER.convert(createResponse({ d: MODEL_INPUT }));
+
+      expect(result.data).toStrictEqual({ value: MODEL_CONVERTED });
+    });
+
+    test("reshapes __metadata and drops deferred navigation properties of each entity", () => {
+      const converter = new CollectionResponseConverterV2(new QBookV2(), true);
+
+      const result = converter.convert(
+        createResponse({
+          d: {
+            results: [
+              {
+                ID: 1,
+                __metadata: { uri: "Books(1)", type: "NS.Book" },
+                Author: { __deferred: { uri: "Books(1)/Author" } },
+              },
+            ],
+          },
+        }),
+      );
+
+      expect(result.data).toStrictEqual({
+        value: [{ id: 1, "@odata.id": "Books(1)", "@odata.type": "NS.Book" }],
+      });
+    });
+
+    test("return non matching input unchanged", () => {
+      // { d: { results: 123 } } is deliberately not part of this list: since "results" is not an object,
+      // the V1 fallback kicks in and treats { results: 123 } itself as the (nonsensical) V1 body.
+      const nonMatching = [{ d: "test" }, { test: 123 }, true, undefined];
+
+      nonMatching.forEach((nm) => {
+        const result = AS_V4_CONVERTER.convert(createResponse(nm));
+        expect(result.data).toStrictEqual(nm);
+      });
     });
   });
 });

--- a/packages/odata-query-objects/test/response/v2/ComplexModelResponseConverterV2.test.ts
+++ b/packages/odata-query-objects/test/response/v2/ComplexModelResponseConverterV2.test.ts
@@ -52,4 +52,23 @@ describe("ComplexModelResponseConverterV2 tests", () => {
       expect(result.data).toStrictEqual(nm);
     });
   });
+
+  describe("asV4", () => {
+    const AS_V4_CONVERTER = new ComplexResponseConverterV2(TYPE_CONVERTER, true);
+
+    test("convert into the bare value, keyed by the arbitrary V2 property name", () => {
+      const result = AS_V4_CONVERTER.convert(createResponse({ d: { Address: MODEL_INPUT } }));
+
+      expect(result.data).toStrictEqual(MODEL_CONVERTED);
+    });
+
+    test("return non matching input unchanged", () => {
+      const nonMatching = [{ d: { x: 3, y: "hey" } }, { d: "test" }, { test: 123 }, null];
+
+      nonMatching.forEach((nm) => {
+        const result = AS_V4_CONVERTER.convert(createResponse(nm));
+        expect(result.data).toStrictEqual(nm);
+      });
+    });
+  });
 });

--- a/packages/odata-query-objects/test/response/v2/EntityModelResponseConverterV2.test.ts
+++ b/packages/odata-query-objects/test/response/v2/EntityModelResponseConverterV2.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { EntityResponseConverterV2 } from "../../../src";
+import { QBookV2 } from "../../fixture/BindingModel";
 import { BookModel, QBook } from "../../fixture/operation/BookModel";
 import { createResponse } from "../../test-infra/TestResponseHelper";
 
@@ -51,6 +52,135 @@ describe("EntityModelResponseConverterV2 tests", () => {
     nonMatching.forEach((nm) => {
       const result = MAIN_CONVERTER.convert(createResponse(nm));
       expect(result.data).toStrictEqual(nm);
+    });
+  });
+
+  describe("asV4", () => {
+    test("convert plain entity", () => {
+      const converter = new EntityResponseConverterV2(new QBook(), true);
+
+      const result = converter.convert(createResponse({ d: MODEL_INPUT }));
+
+      expect(result.data).toStrictEqual(MODEL_CONVERTED);
+    });
+
+    test("maps __metadata to @odata.* control information", () => {
+      const converter = new EntityResponseConverterV2(new QBookV2(), true);
+
+      const result = converter.convert(
+        createResponse({
+          d: {
+            ID: 1,
+            __metadata: {
+              uri: "Books(1)",
+              type: "NS.Book",
+              etag: 'W/"1"',
+            },
+          },
+        }),
+      );
+
+      expect(result.data).toStrictEqual({
+        id: 1,
+        "@odata.id": "Books(1)",
+        "@odata.type": "NS.Book",
+        "@odata.etag": 'W/"1"',
+      });
+    });
+
+    test("reshapes an expanded single-valued navigation property recursively", () => {
+      const converter = new EntityResponseConverterV2(new QBookV2(), true);
+
+      const result = converter.convert(
+        createResponse({
+          d: {
+            ID: 1,
+            Author: {
+              ID: 2,
+              NAME: "Jane Austen",
+              __metadata: { uri: "Authors(2)", type: "NS.Author" },
+            },
+          },
+        }),
+      );
+
+      expect(result.data).toStrictEqual({
+        id: 1,
+        author: {
+          id: 2,
+          name: "Jane Austen",
+          "@odata.id": "Authors(2)",
+          "@odata.type": "NS.Author",
+        },
+      });
+    });
+
+    test("drops a deferred single-valued navigation property", () => {
+      const converter = new EntityResponseConverterV2(new QBookV2(), true);
+
+      const result = converter.convert(
+        createResponse({
+          d: {
+            ID: 1,
+            Author: { __deferred: { uri: "Books(1)/Author" } },
+          },
+        }),
+      );
+
+      expect(result.data).toStrictEqual({ id: 1 });
+      expect(result.data).not.toHaveProperty("author");
+    });
+
+    test("unwraps an expanded collection-valued navigation property instead of keeping the 'results' envelope", () => {
+      const converter = new EntityResponseConverterV2(new QBookV2(), true);
+
+      const result = converter.convert(
+        createResponse({
+          d: {
+            ID: 1,
+            RelatedAuthors: {
+              results: [
+                { ID: 2, NAME: "Jane Austen", __metadata: { uri: "Authors(2)" } },
+                { ID: 3, NAME: "Mark Twain", __metadata: { uri: "Authors(3)" } },
+              ],
+            },
+          },
+        }),
+      );
+
+      expect(result.data).toStrictEqual({
+        id: 1,
+        relatedAuthors: [
+          { id: 2, name: "Jane Austen", "@odata.id": "Authors(2)" },
+          { id: 3, name: "Mark Twain", "@odata.id": "Authors(3)" },
+        ],
+      });
+    });
+
+    test("drops a deferred collection-valued navigation property", () => {
+      const converter = new EntityResponseConverterV2(new QBookV2(), true);
+
+      const result = converter.convert(
+        createResponse({
+          d: {
+            ID: 1,
+            RelatedAuthors: { __deferred: { uri: "Books(1)/RelatedAuthors" } },
+          },
+        }),
+      );
+
+      expect(result.data).toStrictEqual({ id: 1 });
+      expect(result.data).not.toHaveProperty("relatedAuthors");
+    });
+
+    test("return non matching input unchanged", () => {
+      const converter = new EntityResponseConverterV2(new QBook(), true);
+      const nonMatching = [{ d: "test" }, { test: 123 }, null, undefined];
+
+      nonMatching.forEach((nm) => {
+        const result = converter.convert(createResponse(nm));
+        expect(result.data).toStrictEqual(nm);
+      });
     });
   });
 });

--- a/packages/odata-query-objects/test/response/v2/ValueResponseConverterV2.test.ts
+++ b/packages/odata-query-objects/test/response/v2/ValueResponseConverterV2.test.ts
@@ -42,4 +42,32 @@ describe("ValueResponseConverterV2 tests", () => {
       expect(result.data).toStrictEqual(nm);
     });
   });
+
+  describe("asV4", () => {
+    const AS_V4_CONVERTER = new ValueResponseConverterV2(qValueParam, true);
+
+    test("convert into V4 shaped { value: ... }", () => {
+      const converter2 = new ValueResponseConverterV2(booleanToNumberConverter, true);
+
+      const result = AS_V4_CONVERTER.convert(createResponse({ d: { myResult: VALUE_INPUT } }));
+      const result2 = converter2.convert(createResponse({ d: { myResult: VALUE_INPUT } }));
+
+      expect(result.data).toStrictEqual({ value: VALUE_CONVERTED });
+      expect(result2).toStrictEqual(result);
+    });
+
+    test("convert with attribute mapping", () => {
+      const result = AS_V4_CONVERTER.convert(createResponse({ d: { TEST: VALUE_INPUT } }));
+      expect(result.data).toStrictEqual({ value: VALUE_CONVERTED });
+    });
+
+    test("return non matching input unchanged", () => {
+      const nonMatching = [{ d: { x: VALUE_INPUT, y: VALUE_INPUT } }, { d: "test" }, { test: 123 }, undefined];
+
+      nonMatching.forEach((nm) => {
+        const result = AS_V4_CONVERTER.convert(createResponse(nm));
+        expect(result.data).toStrictEqual(nm);
+      });
+    });
+  });
 });

--- a/packages/odata-service/src/ODataServiceOptions.ts
+++ b/packages/odata-service/src/ODataServiceOptions.ts
@@ -28,3 +28,16 @@ export interface ODataServiceOptionsInternal<V extends ODataVersionV4 = "4.0"> e
    */
   odataVersionV4?: V;
 }
+
+export interface ODataServiceOptionsInternalV2<AsV4 extends boolean = false> extends ODataServiceOptions {
+  /**
+   * Reshapes every response of this V2 service as its V4 equivalent - see {@link EntityResponseConverterV2},
+   * {@link CollectionResponseConverterV2}, {@link ComplexResponseConverterV2} and
+   * {@link ValueResponseConverterV2}, which all take the very same flag.
+   *
+   * Set internally, since it is decided by the generator: the response types every V2 service class is
+   * generic over (`AsV4`) are baked in at generation time and must agree with this runtime flag, which is
+   * what actually picks the converter behaviour.
+   */
+  v2ResponseAsV4?: AsV4;
+}

--- a/packages/odata-service/src/v2/CollectionServiceV2.ts
+++ b/packages/odata-service/src/v2/CollectionServiceV2.ts
@@ -1,5 +1,5 @@
 import { ODataHttpClient, ODataHttpMethods } from "@odata2ts/http-client-api";
-import { ODataCollectionResponseV2 } from "@odata2ts/odata-core";
+import { ODataCollectionResponseV2, ODataCollectionResponseV4 } from "@odata2ts/odata-core";
 import { CollectionQueryBuilderV2, ModelQueryBuilderV2 } from "@odata2ts/odata-query-builder";
 import {
   CollectionResponseConverterV2,
@@ -7,22 +7,27 @@ import {
   PrimitiveCollectionType,
   QueryObjectModel,
 } from "@odata2ts/odata-query-objects";
-import { ODataServiceOptions } from "../ODataServiceOptions";
+import { ODataServiceOptionsInternalV2 } from "../ODataServiceOptions";
 import { UrlBuilderRequestCmdV2, UrlRequestCmd } from "../request";
 import { CollectionModificationResponseV2 } from "./ResponseTypeChoicesV2";
 import { ServiceStateHelperV2 } from "./ServiceStateHelperV2.js";
 
 type PrimitiveExtractor<T> = T extends PrimitiveCollectionType<infer E> ? E : T;
 
-export class CollectionServiceV2<T, Q extends QueryObjectModel, PrimitiveT = PrimitiveExtractor<T>> {
-  protected readonly __base: ServiceStateHelperV2<Q>;
+export class CollectionServiceV2<
+  T,
+  Q extends QueryObjectModel,
+  PrimitiveT = PrimitiveExtractor<T>,
+  AsV4 extends boolean = false,
+> {
+  protected readonly __base: ServiceStateHelperV2<Q, AsV4>;
 
   public constructor(
     client: ODataHttpClient,
     basePath: string,
     name: string,
     qModel: Q,
-    options?: ODataServiceOptions,
+    options?: ODataServiceOptionsInternalV2<AsV4>,
   ) {
     this.__base = new ServiceStateHelperV2(client, basePath, name, qModel, options);
   }
@@ -52,15 +57,15 @@ export class CollectionServiceV2<T, Q extends QueryObjectModel, PrimitiveT = Pri
     const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
 
     return new UrlBuilderRequestCmdV2<
-      CollectionModificationResponseV2<Response, PrimitiveT>,
+      CollectionModificationResponseV2<Response, PrimitiveT, AsV4>,
       Q,
       ModelQueryBuilderV2<Q>,
       PrimitiveT
     >(client, ODataHttpMethods.Post, createModelQueryBuilder(queryFn), qModel, model, {
       headers: getDefaultHeaders(),
       mainRequestConverter: qModel,
-      mainResponseConverter: new CollectionResponseConverterV2(qModel) as MainResponseConverter<
-        CollectionModificationResponseV2<Response, PrimitiveT>,
+      mainResponseConverter: new CollectionResponseConverterV2(qModel, this.__base.isAsV4()) as MainResponseConverter<
+        CollectionModificationResponseV2<Response, PrimitiveT, AsV4>,
         T
       >,
     });
@@ -87,15 +92,15 @@ export class CollectionServiceV2<T, Q extends QueryObjectModel, PrimitiveT = Pri
     const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
 
     return new UrlBuilderRequestCmdV2<
-      CollectionModificationResponseV2<Response, PrimitiveT>,
+      CollectionModificationResponseV2<Response, PrimitiveT, AsV4>,
       Q,
       ModelQueryBuilderV2<Q>,
       Array<PrimitiveT>
     >(client, ODataHttpMethods.Put, createModelQueryBuilder(queryFn), qModel, models, {
       headers: getDefaultHeaders(),
       mainRequestConverter: qModel,
-      mainResponseConverter: new CollectionResponseConverterV2(qModel) as MainResponseConverter<
-        CollectionModificationResponseV2<Response, PrimitiveT>,
+      mainResponseConverter: new CollectionResponseConverterV2(qModel, this.__base.isAsV4()) as MainResponseConverter<
+        CollectionModificationResponseV2<Response, PrimitiveT, AsV4>,
         T
       >,
     });
@@ -116,16 +121,12 @@ export class CollectionServiceV2<T, Q extends QueryObjectModel, PrimitiveT = Pri
   public query<ReturnType = T>(queryFn?: (builder: CollectionQueryBuilderV2<Q>, qObject: Q) => void) {
     const { client, qModel, getDefaultHeaders, createQueryBuilder } = this.__base;
 
-    return new UrlBuilderRequestCmdV2<ODataCollectionResponseV2<ReturnType>, Q>(
-      client,
-      ODataHttpMethods.Get,
-      createQueryBuilder(queryFn),
-      qModel,
-      undefined,
-      {
-        headers: getDefaultHeaders(),
-        mainResponseConverter: new CollectionResponseConverterV2(qModel),
-      },
-    );
+    return new UrlBuilderRequestCmdV2<
+      AsV4 extends true ? ODataCollectionResponseV4<ReturnType> : ODataCollectionResponseV2<ReturnType>,
+      Q
+    >(client, ODataHttpMethods.Get, createQueryBuilder(queryFn), qModel, undefined, {
+      headers: getDefaultHeaders(),
+      mainResponseConverter: new CollectionResponseConverterV2<ReturnType, AsV4>(qModel, this.__base.isAsV4()),
+    });
   }
 }

--- a/packages/odata-service/src/v2/ComplexTypeServiceV2.ts
+++ b/packages/odata-service/src/v2/ComplexTypeServiceV2.ts
@@ -1,21 +1,21 @@
 import { ODataHttpClient, ODataHttpMethods } from "@odata2ts/http-client-api";
-import { ODataComplexModelResponseV2 } from "@odata2ts/odata-core";
+import { ODataComplexModelResponseV2, ODataModelResponseV4 } from "@odata2ts/odata-core";
 import { ModelQueryBuilderV2 } from "@odata2ts/odata-query-builder";
 import { ComplexResponseConverterV2, QueryObjectModel } from "@odata2ts/odata-query-objects";
-import { ODataServiceOptions } from "../ODataServiceOptions";
+import { ODataServiceOptionsInternalV2 } from "../ODataServiceOptions";
 import { UrlBuilderRequestCmdV2, UrlRequestCmd } from "../request";
 import { MERGE_HEADERS } from "../RequestHeaders.js";
 import { ServiceStateHelperV2 } from "./ServiceStateHelperV2.js";
 
-export class ComplexTypeServiceV2<T, EditableT, Q extends QueryObjectModel> {
-  protected readonly __base: ServiceStateHelperV2<Q>;
+export class ComplexTypeServiceV2<T, EditableT, Q extends QueryObjectModel, AsV4 extends boolean = false> {
+  protected readonly __base: ServiceStateHelperV2<Q, AsV4>;
 
   protected constructor(
     client: ODataHttpClient,
     basePath: string,
     name: string,
     qModel: Q,
-    options?: ODataServiceOptions,
+    options?: ODataServiceOptionsInternalV2<AsV4>,
   ) {
     this.__base = new ServiceStateHelperV2(client, basePath, name, qModel, options);
   }
@@ -66,16 +66,13 @@ export class ComplexTypeServiceV2<T, EditableT, Q extends QueryObjectModel> {
   public query<ReturnType extends Partial<T> = T>(queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void) {
     const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
 
-    return new UrlBuilderRequestCmdV2<ODataComplexModelResponseV2<ReturnType>, Q, ModelQueryBuilderV2<Q>>(
-      client,
-      ODataHttpMethods.Get,
-      createModelQueryBuilder(queryFn),
-      qModel,
-      undefined,
-      {
-        headers: getDefaultHeaders(),
-        mainResponseConverter: new ComplexResponseConverterV2(qModel),
-      },
-    );
+    return new UrlBuilderRequestCmdV2<
+      AsV4 extends true ? ODataModelResponseV4<ReturnType> : ODataComplexModelResponseV2<ReturnType>,
+      Q,
+      ModelQueryBuilderV2<Q>
+    >(client, ODataHttpMethods.Get, createModelQueryBuilder(queryFn), qModel, undefined, {
+      headers: getDefaultHeaders(),
+      mainResponseConverter: new ComplexResponseConverterV2<ReturnType, AsV4>(qModel, this.__base.isAsV4()),
+    });
   }
 }

--- a/packages/odata-service/src/v2/EntitySetServiceV2.ts
+++ b/packages/odata-service/src/v2/EntitySetServiceV2.ts
@@ -1,5 +1,10 @@
 import { ODataHttpClient, ODataHttpMethods } from "@odata2ts/http-client-api";
-import { ODataCollectionResponseV2, ODataCollectionResponseV4, ODataEntityModelResponseV2, ODataModelResponseV4 } from "@odata2ts/odata-core";
+import {
+  ODataCollectionResponseV2,
+  ODataCollectionResponseV4,
+  ODataEntityModelResponseV2,
+  ODataModelResponseV4,
+} from "@odata2ts/odata-core";
 import { CollectionQueryBuilderV2, ModelQueryBuilderV2 } from "@odata2ts/odata-query-builder";
 import {
   CollectionResponseConverterV2,
@@ -78,7 +83,8 @@ export abstract class EntitySetServiceV2<
    *
    * The service should respond with 201 (Created) and the newly created model.
    *
-   * @param model
+   * @param model the entity to create
+   * @param queryFn additional query after the entity has been created, only $select and $expand apply here
    * @return
    */
   public create(model: EditableT, queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void) {

--- a/packages/odata-service/src/v2/EntitySetServiceV2.ts
+++ b/packages/odata-service/src/v2/EntitySetServiceV2.ts
@@ -1,5 +1,5 @@
 import { ODataHttpClient, ODataHttpMethods } from "@odata2ts/http-client-api";
-import { ODataCollectionResponseV2, ODataEntityModelResponseV2 } from "@odata2ts/odata-core";
+import { ODataCollectionResponseV2, ODataCollectionResponseV4, ODataEntityModelResponseV2, ODataModelResponseV4 } from "@odata2ts/odata-core";
 import { CollectionQueryBuilderV2, ModelQueryBuilderV2 } from "@odata2ts/odata-query-builder";
 import {
   CollectionResponseConverterV2,
@@ -7,12 +7,18 @@ import {
   QId,
   QueryObjectModel,
 } from "@odata2ts/odata-query-objects";
-import { ODataServiceOptions } from "../ODataServiceOptions";
+import { ODataServiceOptionsInternalV2 } from "../ODataServiceOptions";
 import { UrlBuilderRequestCmdV2 } from "../request";
 import { ServiceStateHelperV2 } from "./ServiceStateHelperV2.js";
 
-export abstract class EntitySetServiceV2<T, EditableT, Q extends QueryObjectModel, EIdType> {
-  protected readonly __base: ServiceStateHelperV2<Q>;
+export abstract class EntitySetServiceV2<
+  T,
+  EditableT,
+  Q extends QueryObjectModel,
+  EIdType,
+  AsV4 extends boolean = false,
+> {
+  protected readonly __base: ServiceStateHelperV2<Q, AsV4>;
   protected readonly __idFunction: QId<EIdType>;
 
   protected constructor(
@@ -21,7 +27,7 @@ export abstract class EntitySetServiceV2<T, EditableT, Q extends QueryObjectMode
     name: string,
     qModel: Q,
     idFunction: QId<EIdType>,
-    options?: ODataServiceOptions,
+    options?: ODataServiceOptionsInternalV2<AsV4>,
   ) {
     this.__base = new ServiceStateHelperV2(client, basePath, name, qModel, options);
     this.__idFunction = idFunction;
@@ -78,18 +84,16 @@ export abstract class EntitySetServiceV2<T, EditableT, Q extends QueryObjectMode
   public create(model: EditableT, queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void) {
     const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
 
-    return new UrlBuilderRequestCmdV2<ODataEntityModelResponseV2<T>, Q, ModelQueryBuilderV2<Q>, EditableT>(
-      client,
-      ODataHttpMethods.Post,
-      createModelQueryBuilder(queryFn),
-      qModel,
-      model,
-      {
-        headers: getDefaultHeaders(),
-        mainRequestConverter: qModel,
-        mainResponseConverter: new EntityResponseConverterV2(qModel),
-      },
-    );
+    return new UrlBuilderRequestCmdV2<
+      AsV4 extends true ? ODataModelResponseV4<T> : ODataEntityModelResponseV2<T>,
+      Q,
+      ModelQueryBuilderV2<Q>,
+      EditableT
+    >(client, ODataHttpMethods.Post, createModelQueryBuilder(queryFn), qModel, model, {
+      headers: getDefaultHeaders(),
+      mainRequestConverter: qModel,
+      mainResponseConverter: new EntityResponseConverterV2<T, AsV4>(qModel, this.__base.isAsV4()),
+    });
   }
 
   /**
@@ -102,16 +106,12 @@ export abstract class EntitySetServiceV2<T, EditableT, Q extends QueryObjectMode
   ) {
     const { client, qModel, getDefaultHeaders, createQueryBuilder } = this.__base;
 
-    return new UrlBuilderRequestCmdV2<ODataCollectionResponseV2<ReturnType>, Q>(
-      client,
-      ODataHttpMethods.Get,
-      createQueryBuilder(queryFn),
-      qModel,
-      undefined,
-      {
-        headers: getDefaultHeaders(),
-        mainResponseConverter: new CollectionResponseConverterV2(qModel),
-      },
-    );
+    return new UrlBuilderRequestCmdV2<
+      AsV4 extends true ? ODataCollectionResponseV4<ReturnType> : ODataCollectionResponseV2<ReturnType>,
+      Q
+    >(client, ODataHttpMethods.Get, createQueryBuilder(queryFn), qModel, undefined, {
+      headers: getDefaultHeaders(),
+      mainResponseConverter: new CollectionResponseConverterV2<ReturnType, AsV4>(qModel, this.__base.isAsV4()),
+    });
   }
 }

--- a/packages/odata-service/src/v2/EntityTypeServiceV2.ts
+++ b/packages/odata-service/src/v2/EntityTypeServiceV2.ts
@@ -1,21 +1,21 @@
 import { ODataHttpClient, ODataHttpMethods } from "@odata2ts/http-client-api";
-import { ODataEntityModelResponseV2 } from "@odata2ts/odata-core";
+import { ODataEntityModelResponseV2, ODataModelResponseV4 } from "@odata2ts/odata-core";
 import { ModelQueryBuilderV2 } from "@odata2ts/odata-query-builder";
 import { EntityResponseConverterV2, QueryObjectModel } from "@odata2ts/odata-query-objects";
-import { ODataServiceOptions } from "../ODataServiceOptions";
+import { ODataServiceOptionsInternalV2 } from "../ODataServiceOptions";
 import { UrlBuilderRequestCmdV2, UrlRequestCmd } from "../request";
 import { MERGE_HEADERS } from "../RequestHeaders.js";
 import { ServiceStateHelperV2 } from "./ServiceStateHelperV2.js";
 
-export class EntityTypeServiceV2<T, EditableT, Q extends QueryObjectModel> {
-  protected readonly __base: ServiceStateHelperV2<Q>;
+export class EntityTypeServiceV2<T, EditableT, Q extends QueryObjectModel, AsV4 extends boolean = false> {
+  protected readonly __base: ServiceStateHelperV2<Q, AsV4>;
 
   protected constructor(
     client: ODataHttpClient,
     basePath: string,
     name: string,
     qModel: Q,
-    options?: ODataServiceOptions,
+    options?: ODataServiceOptionsInternalV2<AsV4>,
   ) {
     this.__base = new ServiceStateHelperV2(client, basePath, name, qModel, options);
   }
@@ -88,16 +88,13 @@ export class EntityTypeServiceV2<T, EditableT, Q extends QueryObjectModel> {
   public query<ReturnType extends Partial<T> = T>(queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void) {
     const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
 
-    return new UrlBuilderRequestCmdV2<ODataEntityModelResponseV2<ReturnType>, Q, ModelQueryBuilderV2<Q>>(
-      client,
-      ODataHttpMethods.Get,
-      createModelQueryBuilder(queryFn),
-      qModel,
-      undefined,
-      {
-        headers: getDefaultHeaders(),
-        mainResponseConverter: new EntityResponseConverterV2(qModel),
-      },
-    );
+    return new UrlBuilderRequestCmdV2<
+      AsV4 extends true ? ODataModelResponseV4<ReturnType> : ODataEntityModelResponseV2<ReturnType>,
+      Q,
+      ModelQueryBuilderV2<Q>
+    >(client, ODataHttpMethods.Get, createModelQueryBuilder(queryFn), qModel, undefined, {
+      headers: getDefaultHeaders(),
+      mainResponseConverter: new EntityResponseConverterV2<ReturnType, AsV4>(qModel, this.__base.isAsV4()),
+    });
   }
 }

--- a/packages/odata-service/src/v2/MediaEntityServiceV2.ts
+++ b/packages/odata-service/src/v2/MediaEntityServiceV2.ts
@@ -16,13 +16,16 @@ const VALUE_SEGMENT = "$value";
  * which is what makes the URL predictable enough to build without asking first.
  *
  * Everything an ordinary entity service does stays available - the media link entry still has regular
- * properties, which are read and written as JSON; only its content is separate.
+ * properties, which are read and written as JSON; only its content is separate. Its own response reshaping
+ * (`AsV4`) is inherited from {@link EntityTypeServiceV2}; the binary content itself is untouched by any
+ * response shaping, so {@link content} keeps using the very same {@link StreamServiceV2} regardless.
  */
-export class MediaEntityServiceV2<T, EditableT, Q extends QueryObjectModel> extends EntityTypeServiceV2<
+export class MediaEntityServiceV2<
   T,
   EditableT,
-  Q
-> {
+  Q extends QueryObjectModel,
+  AsV4 extends boolean = false,
+> extends EntityTypeServiceV2<T, EditableT, Q, AsV4> {
   private _content?: StreamServiceV2;
 
   /**

--- a/packages/odata-service/src/v2/PrimitiveTypeServiceV2.ts
+++ b/packages/odata-service/src/v2/PrimitiveTypeServiceV2.ts
@@ -1,6 +1,6 @@
 import { ConverterOptions, ValueConverter } from "@odata2ts/converter-api";
 import { ODataHttpClient, ODataHttpMethods } from "@odata2ts/http-client-api";
-import { ODataValueResponseV2 } from "@odata2ts/odata-core";
+import { ODataValueResponseV2, ODataValueResponseV4 } from "@odata2ts/odata-core";
 import {
   FlexibleConversionModel,
   getIdentityConverter,
@@ -8,7 +8,7 @@ import {
   ResponseValueConverterV2,
   ValueResponseConverterV2,
 } from "@odata2ts/odata-query-objects";
-import { ODataServiceOptions } from "../ODataServiceOptions";
+import { ODataServiceOptionsInternalV2 } from "../ODataServiceOptions";
 import { UrlRequestCmd } from "../request";
 import { ServiceStateHelper } from "../ServiceStateHelper.js";
 
@@ -27,9 +27,10 @@ class ValueRequestConverter<T> {
   }
 }
 
-export class PrimitiveTypeServiceV2<T> {
+export class PrimitiveTypeServiceV2<T, AsV4 extends boolean = false> {
   protected readonly __base: ServiceStateHelper;
   protected readonly __converter: RequestResponseConverter<T>;
+  private readonly __asV4?: AsV4;
 
   public constructor(
     client: ODataHttpClient,
@@ -37,9 +38,10 @@ export class PrimitiveTypeServiceV2<T> {
     name: string,
     converter: ValueConverter<any, T> = getIdentityConverter(),
     mappedName?: string,
-    options?: ODataServiceOptions,
+    options?: ODataServiceOptionsInternalV2<AsV4>,
   ) {
     this.__base = new ServiceStateHelper(client, basePath, name, options);
+    this.__asV4 = options?.v2ResponseAsV4;
     /*
      * The two conversion methods are delegated to rather than pulled off the converter, because a
      * converter may be a class with instance state: destructuring `{ convertFrom, convertTo }` strips
@@ -73,10 +75,16 @@ export class PrimitiveTypeServiceV2<T> {
     const { client, path, getDefaultHeaders } = this.__base;
     const converter = this.__converter;
 
-    return new UrlRequestCmd<ODataValueResponseV2<T>>(client, ODataHttpMethods.Get, path, undefined, {
-      headers: getDefaultHeaders(),
-      mainResponseConverter: new ValueResponseConverterV2(converter),
-    });
+    return new UrlRequestCmd<AsV4 extends true ? ODataValueResponseV4<T> : ODataValueResponseV2<T>>(
+      client,
+      ODataHttpMethods.Get,
+      path,
+      undefined,
+      {
+        headers: getDefaultHeaders(),
+        mainResponseConverter: new ValueResponseConverterV2<T, AsV4>(converter, this.__asV4 as AsV4),
+      },
+    );
   }
 
   /**

--- a/packages/odata-service/src/v2/ResponseTypeChoicesV2.ts
+++ b/packages/odata-service/src/v2/ResponseTypeChoicesV2.ts
@@ -1,5 +1,4 @@
-import { ODataCollectionResponseV2 } from "@odata2ts/odata-core";
+import { ODataCollectionResponseV2, ODataCollectionResponseV4 } from "@odata2ts/odata-core";
 
-export type CollectionModificationResponseV2<Response extends boolean, T> = Response extends true
-  ? ODataCollectionResponseV2<T>
-  : undefined;
+export type CollectionModificationResponseV2<Response extends boolean, T, AsV4 extends boolean = false> =
+  Response extends true ? (AsV4 extends true ? ODataCollectionResponseV4<T> : ODataCollectionResponseV2<T>) : undefined;

--- a/packages/odata-service/src/v2/ResponseTypeChoicesV2.ts
+++ b/packages/odata-service/src/v2/ResponseTypeChoicesV2.ts
@@ -1,4 +1,11 @@
 import { ODataCollectionResponseV2, ODataCollectionResponseV4 } from "@odata2ts/odata-core";
 
-export type CollectionModificationResponseV2<Response extends boolean, T, AsV4 extends boolean = false> =
-  Response extends true ? (AsV4 extends true ? ODataCollectionResponseV4<T> : ODataCollectionResponseV2<T>) : undefined;
+export type CollectionModificationResponseV2<
+  Response extends boolean,
+  T,
+  AsV4 extends boolean = false,
+> = Response extends true
+  ? AsV4 extends true
+    ? ODataCollectionResponseV4<T>
+    : ODataCollectionResponseV2<T>
+  : undefined;

--- a/packages/odata-service/src/v2/ServiceStateHelperV2.ts
+++ b/packages/odata-service/src/v2/ServiceStateHelperV2.ts
@@ -1,18 +1,31 @@
 import { ODataHttpClient } from "@odata2ts/http-client-api";
 import { CollectionQueryBuilderV2, createQueryBuilderV2, ModelQueryBuilderV2 } from "@odata2ts/odata-query-builder";
 import { QueryObjectModel } from "@odata2ts/odata-query-objects";
-import { ODataServiceOptions } from "../ODataServiceOptions";
+import { ODataServiceOptionsInternalV2 } from "../ODataServiceOptions";
 import { ServiceStateHelper } from "../ServiceStateHelper";
 
-export class ServiceStateHelperV2<Q extends QueryObjectModel> extends ServiceStateHelper {
+export class ServiceStateHelperV2<Q extends QueryObjectModel, AsV4 extends boolean = false> extends ServiceStateHelper {
+  /**
+   * Whether every response of this service is reshaped as V4 - see {@link ODataServiceOptionsInternalV2}.
+   *
+   * Kept as its own field rather than widening the inherited (V4-shaped) {@link ServiceStateHelper.options},
+   * since `v2ResponseAsV4` has no place in that type.
+   */
+  private readonly asV4: AsV4;
+
   public constructor(
     client: ODataHttpClient,
     basePath: string,
     name: string,
     public qModel: Q,
-    options?: ODataServiceOptions,
+    options?: ODataServiceOptionsInternalV2<AsV4>,
   ) {
     super(client, basePath, name, options);
+    this.asV4 = !!options?.v2ResponseAsV4 as AsV4;
+  }
+
+  public isAsV4(): AsV4 {
+    return this.asV4;
   }
 
   public createQueryBuilder = (

--- a/packages/odata2ts/src/FactoryFunctionModel.ts
+++ b/packages/odata2ts/src/FactoryFunctionModel.ts
@@ -47,6 +47,7 @@ export type GeneratorFunctionOptions = Pick<
   | "disableBindingProps"
   | "disableDeepInsertProps"
   | "v2PayloadResultsWrapping"
+  | "v2ResponseAsV4"
 >;
 
 export type EntityBasedGeneratorFunction = (

--- a/packages/odata2ts/src/OptionModel.ts
+++ b/packages/odata2ts/src/OptionModel.ts
@@ -245,6 +245,31 @@ export interface ConfigFileOptions extends Omit<CliOptions, "sourceUrl" | "sourc
    */
   v2PayloadResultsWrapping?: boolean;
   /**
+   * A V2 service answers in its own JSON verbose shape: collections come wrapped as
+   * <code>{d: {results: [...], __count?, __next?}}</code>, entities as
+   * <code>{d: {...entity, __metadata: {uri, type, etag}}}</code>, and unexpanded navigation properties carry
+   * a <code>{__deferred: {uri}}</code> placeholder instead of simply being absent.
+   *
+   * Setting this option to <code>true</code> (default: false) reshapes every response of that service as its
+   * V4 equivalent instead: collections become <code>{value: [...], "@odata.count"?, "@odata.nextLink"?}</code>,
+   * entities are returned bare with <code>__metadata</code> turned into <code>@odata.id</code> /
+   * <code>@odata.type</code> / <code>@odata.etag</code>, and a navigation property that hasn't been expanded
+   * is simply left out - exactly as a real V4 service would send it. Applies recursively to expanded
+   * navigation properties of any depth.
+   *
+   * The generated response types change accordingly (`ODataCollectionResponseV4` / `ODataModelResponseV4` /
+   * `ODataValueResponseV4` instead of their V2 counterparts), so a consumer of the generated client only ever
+   * deals with the V4 shape, regardless of which OData version the actual service speaks.
+   *
+   * Only relevant for V2 services and ignored for V4, where the response is already in that shape.
+   *
+   * Turned on, this option reshapes an expanded collection valued navigation property as a plain array
+   * regardless of <code>v2ResponseResultsWrapping</code> / <code>v2PayloadResultsWrapping</code> - stating
+   * the `results` wrapping in the generated types would describe traffic this client no longer sends or
+   * receives. Leave both of those off (the default) when turning this on.
+   */
+  v2ResponseAsV4?: boolean;
+  /**
    * Numbers of type `Edm.Int64` and `Edm.Decimal` are represented as `number` in V4.
    * However, these numbers might not fit into JS' number type, which might result in precision loss.
    *

--- a/packages/odata2ts/src/defaultConfig.ts
+++ b/packages/odata2ts/src/defaultConfig.ts
@@ -107,6 +107,7 @@ const defaultConfig: DefaultConfiguration = {
   disableBindingProps: false,
   disableDeepInsertProps: false,
   v2PayloadResultsWrapping: false,
+  v2ResponseAsV4: false,
 };
 
 const { models, queryObjects, services } = defaultConfig.naming;

--- a/packages/odata2ts/src/generator/ModelGenerator.ts
+++ b/packages/odata2ts/src/generator/ModelGenerator.ts
@@ -217,9 +217,10 @@ class ModelGenerator {
   }
 
   private getPropType(imports: ImportContainer, prop: PropertyModel): string {
-    // V2 entity special: deferred content
+    // V2 entity special: deferred content - not for v2ResponseAsV4, which reshapes a V2 response as V4,
+    // and V4 has no equivalent placeholder: an unexpanded navigation property is simply absent
     let suffix = "";
-    if (this.dataModel.isV2() && prop.dataType == DataTypes.ModelType) {
+    if (this.dataModel.isV2() && !this.options.v2ResponseAsV4 && prop.dataType == DataTypes.ModelType) {
       const defContent = imports.addCoreLib(this.version, CoreImports.DeferredContent);
       suffix = ` | ${defContent}`;
     }

--- a/packages/odata2ts/src/generator/QueryObjectGenerator.ts
+++ b/packages/odata2ts/src/generator/QueryObjectGenerator.ts
@@ -49,6 +49,10 @@ class QueryObjectGenerator {
     private namingHelper: NamingHelper,
   ) {}
 
+  private isV2AsV4() {
+    return this.options.v2ResponseAsV4 && this.version === ODataVersions.V2;
+  }
+
   public async generate(): Promise<void> {
     this.project.initQObjects();
 
@@ -456,20 +460,24 @@ class QueryObjectGenerator {
           returnType.typeModule
           ? imports.addCustomType(returnType.typeModule, returnType.type, true)
           : returnType.type;
-    const responseStructure = returnType ? importReturnType(this.version, imports, returnType) : undefined;
+    const responseStructure = returnType
+      ? importReturnType(this.version, imports, returnType, this.isV2AsV4())
+      : undefined;
     const completeResponseStructure = responseStructure && rtType ? `${responseStructure}<${rtType}>` : undefined;
+
+    const asV4Arg = this.isV2AsV4() ? ", true" : "";
 
     let returnTypeOpStmt: string = "";
     if (returnType) {
       if (returnType.dataType === DataTypes.ComplexType || returnType.dataType === DataTypes.ModelType) {
         // without converter no conversion
         if (returnType.qObject) {
-          returnTypeOpStmt = `new ${importMainResponseConverter(this.version, imports, returnType)}(new ${imports.addGeneratedQObject(returnType.fqType, returnType.qObject)})`;
+          returnTypeOpStmt = `new ${importMainResponseConverter(this.version, imports, returnType)}(new ${imports.addGeneratedQObject(returnType.fqType, returnType.qObject)}${asV4Arg})`;
         }
       }
       // Primitive Types: without converter no conversion
       else if (returnType.converters) {
-        returnTypeOpStmt = `new ${importMainResponseConverter(this.version, imports, returnType)}(${this.generateConverterStmt(imports, returnType.converters)})`;
+        returnTypeOpStmt = `new ${importMainResponseConverter(this.version, imports, returnType)}(${this.generateConverterStmt(imports, returnType.converters)}${asV4Arg})`;
       }
     }
 

--- a/packages/odata2ts/src/generator/ServiceGenerator.ts
+++ b/packages/odata2ts/src/generator/ServiceGenerator.ts
@@ -34,7 +34,7 @@ export interface PropsAndOps extends Required<Pick<ClassDeclarationStructure, "p
 
 export interface ServiceGeneratorOptions extends Pick<
   ConfigFileOptions,
-  "enablePrimitivePropertyServices" | "v4BigNumberAsString" | "enumType" | "odataVersionV4"
+  "enablePrimitivePropertyServices" | "v4BigNumberAsString" | "enumType" | "odataVersionV4" | "v2ResponseAsV4"
 > {}
 
 export async function generateServices(
@@ -65,24 +65,53 @@ class ServiceGenerator {
     return this.options.odataVersionV4 === "4.01" && this.version === ODataVersions.V4;
   }
 
+  private isV2AsV4() {
+    return !!this.options.v2ResponseAsV4 && this.version === ODataVersions.V2;
+  }
+
   /**
    * The version type argument list as seen from the main service, which pins it: the main service does not
-   * declare V itself, everything it hands out infers the version from the options.
+   * declare the extra type parameter itself, everything it hands out infers it from the options.
    *
-   * Empty unless the version is actually pinned, since V defaults to 4.0.
+   * Empty unless something is actually pinned, since both V4's `V` and V2's `AsV4` default appropriately
+   * on their own (`"4.0"`, `false`).
    */
   private getMainVersionArg() {
+    if (this.isV401()) {
+      return `<"4.01">`;
+    }
+    if (this.isV2AsV4()) {
+      return `<true>`;
+    }
+    return "";
+  }
+
+  /**
+   * {@link getMainVersionArg} for the one place it must not be used: the main service's own `extends`
+   * clause. `ODataService` is the single, unversioned base class every main service extends, V2 and V4
+   * alike, and it is generic only over the V4 minor version - there is no `AsV4` for it to accept.
+   * `v2ResponseAsV4` still reaches every sub-service, just via the runtime option
+   * ({@link getRuntimeOptions}) rather than this type argument.
+   */
+  private getRootServiceVersionArg() {
     return this.isV401() ? `<"4.01">` : "";
   }
 
   /**
-   * The version type argument list as seen from a generated service class, which declares V itself and
-   * passes it on, so that nested services keep the version of the client they belong to.
+   * The version type argument list as seen from a generated service class, which declares the extra type
+   * parameter itself and passes it on, so that nested services keep the shape of the client they belong to:
+   * `V` for a V4 service (4.0 vs 4.01), `AsV4` for a V2 service generated with `v2ResponseAsV4`.
    *
-   * Empty for V2, which knows no such type parameter.
+   * Empty for a plain V2 service, which knows no such type parameter.
    */
   private getServiceVersionArg() {
-    return this.version === ODataVersions.V4 ? "<V>" : "";
+    if (this.version === ODataVersions.V4) {
+      return "<V>";
+    }
+    if (this.isV2AsV4()) {
+      return "<AsV4>";
+    }
+    return "";
   }
 
   /**
@@ -90,17 +119,28 @@ class ServiceGenerator {
    * version reads as the last argument instead of the only one.
    */
   private getServiceVersionArgSuffix() {
-    return this.version === ODataVersions.V4 ? ", V" : "";
+    if (this.version === ODataVersions.V4) {
+      return ", V";
+    }
+    if (this.isV2AsV4()) {
+      return ", AsV4";
+    }
+    return "";
   }
 
   /**
-   * Type parameters of a generated service class. V4 services are generic over the OData version; V2
-   * services have no type parameter at all.
+   * Type parameters of a generated service class: V4 services are generic over the OData version, a V2
+   * service generated with `v2ResponseAsV4` over whether it reshapes its response as V4. A plain V2 service
+   * has no type parameter at all.
    */
   private getServiceTypeParams(imports: ImportContainer) {
-    return this.version === ODataVersions.V4
-      ? [`V extends ${imports.addCoreLib(ODataVersions.V4, CoreImports.ODataVersionV4)} = "4.0"`]
-      : [];
+    if (this.version === ODataVersions.V4) {
+      return [`V extends ${imports.addCoreLib(ODataVersions.V4, CoreImports.ODataVersionV4)} = "4.0"`];
+    }
+    if (this.isV2AsV4()) {
+      return [`AsV4 extends boolean = false`];
+    }
+    return [];
   }
 
   /**
@@ -115,7 +155,27 @@ class ServiceGenerator {
     if (this.isV401()) {
       options.push(`odataVersionV4: "4.01"`);
     }
+    if (this.isV2AsV4()) {
+      options.push("v2ResponseAsV4: true");
+    }
     return options;
+  }
+
+  /**
+   * The runtime options type of a generated service class - the counterpart of {@link getServiceTypeParams}.
+   * V4 always uses `ODataServiceOptionsInternal<V>`, generic over the very type parameter the class itself
+   * declares, since it already needs it for the 4.0/4.01 axis regardless. A plain V2 service has nothing
+   * of the sort to declare, so it keeps the public `ODataServiceOptions` unless `v2ResponseAsV4` actually
+   * introduces the `AsV4` type parameter, in which case the options type has to keep up with it too.
+   */
+  private getServiceOptionsType(imports: ImportContainer) {
+    if (this.version === ODataVersions.V4) {
+      return imports.addServiceObject(this.version, ServiceImports.ODataServiceOptionsInternal);
+    }
+    return imports.addServiceObject(
+      this.version,
+      this.isV2AsV4() ? ServiceImports.ODataServiceOptionsInternalV2 : ServiceImports.ODataServiceOptions,
+    );
   }
 
   public async generate(): Promise<void> {
@@ -152,7 +212,7 @@ class ServiceGenerator {
     mainServiceFile.getFile().addClass({
       isExported: true,
       name: mainServiceName,
-      extends: `${rootService}${this.getMainVersionArg()}`,
+      extends: `${rootService}${this.getRootServiceVersionArg()}`,
       ctors: runtimeOptions.length
         ? [
             {
@@ -161,11 +221,18 @@ class ServiceGenerator {
                 { name: "basePath", type: "string" },
                 {
                   name: "options",
+                  // deliberately the public type, not getServiceOptionsType(): the fields merged in below
+                  // are internal, decided by the generator - a caller of the main service never states them
                   type: importContainer.addServiceObject(this.version, ServiceImports.ODataServiceOptions),
                   hasQuestionToken: true,
                 },
               ],
-              statements: [`super(client, basePath, { ...options, ${runtimeOptions.join(", ")} });`],
+              statements: [
+                // ODataService itself knows nothing about v2ResponseAsV4 - it is generic only over the V4
+                // minor version, shared as it is between V2 and V4 main services - so passing it on to
+                // every sub-service via this merge needs a cast where it is the field actually set
+                `super(client, basePath, { ...options, ${runtimeOptions.join(", ")} }${this.isV2AsV4() ? " as any" : ""});`,
+              ],
             },
           ]
         : [],
@@ -254,8 +321,12 @@ class ServiceGenerator {
         `const fieldName = "${odataPropName}";`,
         `const { client, path, options, isUrlNotEncoded } = this.__base;`,
         'return typeof id === "undefined" || id === null',
-        `? new ${collectionName}(client, path, fieldName, options)`,
-        `: new ${serviceName}(client, path, new ${idFunctionName}(fieldName).buildUrl(id, isUrlNotEncoded()), options);`,
+        // the version argument is only spelled out on the constructor call for v2ResponseAsV4: without it,
+        // "new Type(...)" infers AsV4's default (false), which mismatches the declared return type above
+        // wherever it isn't itself the abstract AsV4 - concretely, on every getter of the main service,
+        // which pins the literal true rather than passing an abstract type parameter along
+        `? new ${collectionName}${this.isV2AsV4() ? versionArg : ""}(client, path, fieldName, options)`,
+        `: new ${serviceName}${this.isV2AsV4() ? versionArg : ""}(client, path, new ${idFunctionName}(fieldName).buildUrl(id, isUrlNotEncoded()), options);`,
       ],
     };
   }
@@ -329,12 +400,7 @@ class ServiceGenerator {
     const editableModelName = importContainer.addGeneratedModel(model.fqName, model.editableName);
     const qName = importContainer.addGeneratedQObject(model.fqName, model.qName, true);
     const qObjectName = importContainer.addGeneratedQObject(model.fqName, firstCharLowerCase(model.qName));
-    const serviceOptions = importContainer.addServiceObject(
-      this.version,
-      this.version === ODataVersions.V4
-        ? ServiceImports.ODataServiceOptionsInternal
-        : ServiceImports.ODataServiceOptions,
-    );
+    const serviceOptions = this.getServiceOptionsType(importContainer);
 
     const { properties, methods }: PropsAndOps = deepmerge(
       deepmerge(
@@ -646,12 +712,7 @@ class ServiceGenerator {
     const entitySetServiceType = importContainer.addServiceObject(this.version, ServiceImports.EntitySetService);
     const paramsModelName = importContainer.addGeneratedModel(model.id.fqName, model.id.modelName);
     const qIdFunctionName = importContainer.addGeneratedQObject(model.id.fqName, model.id.qName);
-    const serviceOptions = importContainer.addServiceObject(
-      this.version,
-      this.version === ODataVersions.V4
-        ? ServiceImports.ODataServiceOptionsInternal
-        : ServiceImports.ODataServiceOptions,
-    );
+    const serviceOptions = this.getServiceOptionsType(importContainer);
 
     const collectionOperations = this.dataModel.getEntitySetOperations(model.fqName);
 
@@ -754,7 +815,9 @@ class ServiceGenerator {
           ? ServiceImports.UrlGetRequestCmd
           : ServiceImports.UrlRequestCmd,
     );
-    const responseStructure = returnType ? importReturnType(this.version, importContainer, returnType) : undefined;
+    const responseStructure = returnType
+      ? importReturnType(this.version, importContainer, returnType, this.isV2AsV4())
+      : undefined;
     const responseService = responseServiceName
       ? importContainer.addGeneratedService(returnType!.fqType, responseServiceName)
       : undefined;

--- a/packages/odata2ts/src/generator/import/ImportObjects.ts
+++ b/packages/odata2ts/src/generator/import/ImportObjects.ts
@@ -50,6 +50,7 @@ export enum QueryObjectImports {
   ModelResponseConverterV4 = "ModelResponseConverterV4",
   EntityResponseConverterV2 = "EntityResponseConverterV2",
   ComplexResponseConverterV2 = "ComplexResponseConverterV2",
+  ComplexResponseConverterV2AsV4 = "ComplexResponseConverterV2AsV4",
 }
 
 /**
@@ -69,6 +70,7 @@ export enum ServiceImports {
   ODataService,
   ODataServiceOptions,
   ODataServiceOptionsInternal,
+  ODataServiceOptionsInternalV2,
   EntityTypeService,
   PrimitiveTypeService,
   CollectionService,

--- a/packages/odata2ts/src/generator/import/ImportResponseHelper.ts
+++ b/packages/odata2ts/src/generator/import/ImportResponseHelper.ts
@@ -49,7 +49,11 @@ function importReturnTypeV2(imports: ImportContainer, returnType: ReturnTypeMode
  * unlike {@link importReturnType}: the caller appends the literal `true` to the constructor call itself
  * where the operation's owning service was generated with `v2ResponseAsV4`.
  */
-export function importMainResponseConverter(version: ODataVersions, imports: ImportContainer, returnType: ReturnTypeModel) {
+export function importMainResponseConverter(
+  version: ODataVersions,
+  imports: ImportContainer,
+  returnType: ReturnTypeModel,
+) {
   return version === ODataVersions.V2
     ? importMainResponseConverterV2(imports, returnType)
     : importMainResponseConverterV4(imports, returnType);

--- a/packages/odata2ts/src/generator/import/ImportResponseHelper.ts
+++ b/packages/odata2ts/src/generator/import/ImportResponseHelper.ts
@@ -7,7 +7,12 @@ export function importReturnType(
   version: ODataVersions,
   imports: ImportContainer,
   returnType: ReturnTypeModel,
+  asV4 = false,
 ): string {
+  // the V4 response shape is identical whether it actually came from a V4 service or was reshaped from V2,
+  // so a V2 service opting into v2ResponseAsV4 simply takes the V4 branch
+  const effectiveVersion = asV4 && version === ODataVersions.V2 ? ODataVersions.V4 : version;
+
   const typeToImport: CoreImports | undefined = returnType.isCollection
     ? CoreImports.ODataCollectionResponse
     : returnType.dataType === DataTypes.PrimitiveType
@@ -15,10 +20,10 @@ export function importReturnType(
       : undefined;
 
   if (typeToImport) {
-    return imports.addCoreLib(version, typeToImport);
+    return imports.addCoreLib(effectiveVersion, typeToImport);
   }
 
-  return version === ODataVersions.V2 ? importReturnTypeV2(imports, returnType) : importReturnTypeV4(imports);
+  return effectiveVersion === ODataVersions.V2 ? importReturnTypeV2(imports, returnType) : importReturnTypeV4(imports);
 }
 
 function importReturnTypeV4(imports: ImportContainer) {
@@ -37,11 +42,14 @@ function importReturnTypeV2(imports: ImportContainer, returnType: ReturnTypeMode
   );
 }
 
-export function importMainResponseConverter(
-  version: ODataVersions,
-  imports: ImportContainer,
-  returnType: ReturnTypeModel,
-) {
+/**
+ * The main response converter class for an operation's return type. The very same class serves a plain V2
+ * response and one reshaped as V4 (see {@link CollectionResponseConverterV2} & co.) - which of the two a
+ * given instance produces is a constructor argument, not a different import, so this needs no `asV4` flag
+ * unlike {@link importReturnType}: the caller appends the literal `true` to the constructor call itself
+ * where the operation's owning service was generated with `v2ResponseAsV4`.
+ */
+export function importMainResponseConverter(version: ODataVersions, imports: ImportContainer, returnType: ReturnTypeModel) {
   return version === ODataVersions.V2
     ? importMainResponseConverterV2(imports, returnType)
     : importMainResponseConverterV4(imports, returnType);

--- a/packages/odata2ts/test/fixture/generator/service/v2/complex-type-v2-response-as-v4.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/complex-type-v2-response-as-v4.ts
@@ -1,0 +1,71 @@
+import type { ODataHttpClient } from "@odata2ts/http-client-api";
+import {
+  ComplexTypeServiceV2,
+  EntitySetServiceV2,
+  EntityTypeServiceV2,
+  ODataService,
+  ODataServiceOptions,
+  ODataServiceOptionsInternalV2,
+} from "@odata2ts/odata-service";
+// @ts-ignore
+import type { QBook, QReviewer } from "./QTester.js";
+// @ts-ignore
+import { qBook, QBookId, qReviewer } from "./QTester.js";
+// @ts-ignore
+import type { Book, BookId, EditableBook, EditableReviewer, Reviewer } from "./TesterModel.js";
+
+export class TesterService extends ODataService {
+  constructor(client: ODataHttpClient, basePath: string, options?: ODataServiceOptions) {
+    super(client, basePath, { ...options, v2ResponseAsV4: true } as any);
+  }
+
+  public books(): BookCollectionService<true>;
+  public books(id: BookId): BookService<true>;
+  public books(id?: BookId | undefined) {
+    const fieldName = "Books";
+    const { client, path, options, isUrlNotEncoded } = this.__base;
+    return typeof id === "undefined" || id === null
+      ? new BookCollectionService<true>(client, path, fieldName, options)
+      : new BookService<true>(client, path, new QBookId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+  }
+}
+
+export class BookService<AsV4 extends boolean = false> extends EntityTypeServiceV2<Book, EditableBook, QBook, AsV4> {
+  private _lector?: ReviewerService<AsV4>;
+
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternalV2<AsV4>) {
+    super(client, basePath, name, qBook, options);
+  }
+
+  public lector(): ReviewerService<AsV4> {
+    if (!this._lector) {
+      const { client, path, options } = this.__base;
+      this._lector = new ReviewerService(client, path, "lector", options);
+    }
+
+    return this._lector;
+  }
+}
+
+export class BookCollectionService<AsV4 extends boolean = false> extends EntitySetServiceV2<
+  Book,
+  EditableBook,
+  QBook,
+  BookId,
+  AsV4
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternalV2<AsV4>) {
+    super(client, basePath, name, qBook, new QBookId(name), options);
+  }
+}
+
+export class ReviewerService<AsV4 extends boolean = false> extends ComplexTypeServiceV2<
+  Reviewer,
+  EditableReviewer,
+  QReviewer,
+  AsV4
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternalV2<AsV4>) {
+    super(client, basePath, name, qReviewer, options);
+  }
+}

--- a/packages/odata2ts/test/fixture/generator/service/v2/one-entityset-v2-response-as-v4.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/one-entityset-v2-response-as-v4.ts
@@ -1,0 +1,80 @@
+import type { ODataHttpClient } from "@odata2ts/http-client-api";
+import {
+  EntitySetServiceV2,
+  EntityTypeServiceV2,
+  ODataService,
+  ODataServiceOptions,
+  ODataServiceOptionsInternalV2,
+  PrimitiveTypeServiceV2,
+} from "@odata2ts/odata-service";
+// @ts-ignore
+import type { QTestEntity } from "./QTester.js";
+// @ts-ignore
+import { qTestEntity, QTestEntityId } from "./QTester.js";
+// @ts-ignore
+import type { EditableTestEntity, TestEntity, TestEntityId } from "./TesterModel.js";
+
+export class TesterService extends ODataService {
+  constructor(client: ODataHttpClient, basePath: string, options?: ODataServiceOptions) {
+    super(client, basePath, { ...options, v2ResponseAsV4: true } as any);
+  }
+
+  public ents(): TestEntityCollectionService<true>;
+  public ents(id: TestEntityId): TestEntityService<true>;
+  public ents(id?: TestEntityId | undefined) {
+    const fieldName = "Ents";
+    const { client, path, options, isUrlNotEncoded } = this.__base;
+    return typeof id === "undefined" || id === null
+      ? new TestEntityCollectionService<true>(client, path, fieldName, options)
+      : new TestEntityService<true>(
+          client,
+          path,
+          new QTestEntityId(fieldName).buildUrl(id, isUrlNotEncoded()),
+          options,
+        );
+  }
+}
+
+export class TestEntityService<AsV4 extends boolean = false> extends EntityTypeServiceV2<
+  TestEntity,
+  EditableTestEntity,
+  QTestEntity,
+  AsV4
+> {
+  private _id?: PrimitiveTypeServiceV2<string, AsV4>;
+  private _test?: PrimitiveTypeServiceV2<string, AsV4>;
+
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternalV2<AsV4>) {
+    super(client, basePath, name, qTestEntity, options);
+  }
+
+  public id() {
+    if (!this._id) {
+      const { client, path, qModel, options } = this.__base;
+      this._id = new PrimitiveTypeServiceV2(client, path, "id", qModel.id.converter, undefined, options);
+    }
+
+    return this._id;
+  }
+
+  public test() {
+    if (!this._test) {
+      const { client, path, qModel, options } = this.__base;
+      this._test = new PrimitiveTypeServiceV2(client, path, "test", qModel.test.converter, undefined, options);
+    }
+
+    return this._test;
+  }
+}
+
+export class TestEntityCollectionService<AsV4 extends boolean = false> extends EntitySetServiceV2<
+  TestEntity,
+  EditableTestEntity,
+  QTestEntity,
+  TestEntityId,
+  AsV4
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternalV2<AsV4>) {
+    super(client, basePath, name, qTestEntity, new QTestEntityId(name), options);
+  }
+}

--- a/packages/odata2ts/test/generator/v2/ServiceGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v2/ServiceGenerator.test.ts
@@ -240,6 +240,40 @@ describe("Service Generator Tests V2", () => {
     await compareMainService("abstract-and-open-types.ts");
   });
 
+  test("Service Generator: one EntitySet with v2ResponseAsV4", async () => {
+    // given one EntitySet, same as the plain "one EntitySet" test
+    odataBuilder
+      .addEntityType("TestEntity", undefined, (builder) =>
+        builder.addKeyProp("id", ODataTypesV2.Guid).addProp("test", ODataTypesV2.String),
+      )
+      .addEntitySet("Ents", withNs("TestEntity"));
+
+    // when generating with v2ResponseAsV4 turned on
+    runOptions.enablePrimitivePropertyServices = true;
+    runOptions.v2ResponseAsV4 = true;
+    await doGenerate();
+
+    // then the generated service classes are the *V2AsV4 siblings, reshaping every response as V4
+    await compareMainService("one-entityset-v2-response-as-v4.ts");
+  });
+
+  test("Service Generator: Complex Type with v2ResponseAsV4", async () => {
+    // given one EntitySet with a complex-type property, same as the plain "Complex Type" test
+    odataBuilder
+      .addComplexType("Reviewer", undefined, (builder) => builder.addProp("name", ODataTypesV2.String, false))
+      .addEntityType("Book", undefined, (builder) =>
+        builder.addKeyProp("id", ODataTypesV2.String).addProp("lector", withNs("Reviewer")),
+      )
+      .addEntitySet("Books", withNs("Book"));
+
+    // when generating with v2ResponseAsV4 turned on
+    runOptions.v2ResponseAsV4 = true;
+    await doGenerate();
+
+    // then the complex-typed property's service is ComplexTypeServiceV2AsV4
+    await compareMainService("complex-type-v2-response-as-v4.ts");
+  });
+
   test("Service Generator: media link entry", async () => {
     // given a media link entry, i.e. an entity pointing at the binary content which is its own
     odataBuilder


### PR DESCRIPTION
- New opt-in generator option `v2ResponseAsV4`, reshaping every response of a V2 service as its V4 equivalent: collections as `{value: [...]}`, entities bare with `__metadata` mapped to `@odata.id`/`@odata.type`/`@odata.etag`, expanded navigation properties reshaped recursively, unexpanded ones simply absent instead of `__deferred`
- Four new/extended response converters in `odata-query-objects` (`CollectionResponseConverterV2`, `EntityResponseConverterV2`, `ComplexResponseConverterV2`, `ValueResponseConverterV2`) each take an `asV4` flag rather than gaining a sibling class
- The six V2 service base classes in `odata-service` grow an `AsV4` type parameter, mirroring the existing 4.0/4.01 pattern on `EntitySetServiceV4` - a plain V2 client stays byte-for-byte unaffected
- Generator wiring in `odata2ts` bakes the type parameter into generated classes and threads the matching runtime option down from the main service
- Unit tests for both converter branches, two new generator fixture tests, and a new `int-test/olingo-v2` suite verified against the real Apache Olingo 2 server