### PR TITLE
refactor(odata2ts)!: bundle v2 and v4 options

### DIFF
--- a/int-test/asp-net/odata2ts.config.ts
+++ b/int-test/asp-net/odata2ts.config.ts
@@ -55,7 +55,7 @@ const config: ConfigFileOptions = {
       serviceName: "Library401",
       source: "resource/library.xml",
       output: "src-generated/library-401",
-      odataVersionV4: "4.01",
+      v4: { odataVersion: "4.01" },
     },
     /**
      * The same model a second time, with renaming switched on.

--- a/int-test/asp-net/test/Library401Constants.ts
+++ b/int-test/asp-net/test/Library401Constants.ts
@@ -1,4 +1,4 @@
-import { Library401Service } from "../src-generated/library-401/Library401Service.js";
+import { Library401Service } from "../src-generated/library-401/index.js";
 import { BASE_URL, ODATA_CLIENT } from "./LibraryTestConstants.js";
 
 /**

--- a/int-test/asp-net/test/feature/ODataVersion401.test.ts
+++ b/int-test/asp-net/test/feature/ODataVersion401.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, describe, expect, expectTypeOf, test } from "vitest";
-import { qCopy } from "../../src-generated/library-401/library-circulation/copy/QCopy.js";
-import { qCopy as qCopy40 } from "../../src-generated/library/library-circulation/copy/QCopy.js";
+import { qCopy } from "../../src-generated/library-401/library-circulation/index.js";
+import { qCopy as qCopy40 } from "../../src-generated/library/library-circulation/index.js";
 import { LIBRARY_401 } from "../Library401Constants.js";
 import { BOOK_DER_PROZESS, BRANCH_CENTRAL, LIBRARY } from "../LibraryTestConstants.js";
 

--- a/int-test/asp-net/tsconfig.json
+++ b/int-test/asp-net/tsconfig.json
@@ -5,5 +5,5 @@
     "noEmit": true,
     "lib": ["ESNext", "DOM"]
   },
-  "include": ["src-generated", "test"]
+  "include": ["src-generated", "test", "odata2ts.config.ts"]
 }

--- a/int-test/cap/odata2ts.config.ts
+++ b/int-test/cap/odata2ts.config.ts
@@ -38,7 +38,7 @@ const config: ConfigFileOptions = {
       // option has exactly two states and both are worth having against a real server, so they are split
       // across the two V4 packages instead of duplicating a suite. `test/core/QueryFunctionality.test.ts`
       // covers it on either side - the assertion differs only in the URL that reaches the server.
-      enableNativeInOperator: true,
+      v4: { enableNativeInOperator: true },
     },
     /**
      * The V4 model with `unflattenComplexTypes`, which is what this whole server is the case for:
@@ -64,8 +64,10 @@ const config: ConfigFileOptions = {
       source: "resource/library-v2.xml",
       output: "src-generated/library-shaped-v2",
       unflattenComplexTypes: true,
-      v2ResponseResultsWrapping: true,
-      v2PayloadResultsWrapping: false,
+      v2: {
+        responseResultsWrapping: true,
+        payloadResultsWrapping: false,
+      },
     },
     /**
      * The V4 model a second time, with converters switched on.
@@ -89,7 +91,7 @@ const config: ConfigFileOptions = {
       serviceName: "LibraryConverted",
       source: "resource/library.xml",
       output: "src-generated/library-converted",
-      v4BigNumberAsString: true,
+      v4: { bigNumberAsString: true },
       converters: [
         "@odata2ts/converter-luxon",
         "@odata2ts/converter-big-number",
@@ -110,8 +112,10 @@ const config: ConfigFileOptions = {
        * `{"Keywords": {"results": [...]}}` comes back as 400 "Value must be an array". Olingo accepts
        * either, so only this side settles the question - see test/v2/feature/ResultsWrapping.test.ts.
        */
-      v2ResponseResultsWrapping: true,
-      v2PayloadResultsWrapping: false,
+      v2: {
+        responseResultsWrapping: true,
+        payloadResultsWrapping: false,
+      },
     },
   },
 };

--- a/int-test/cap/tsconfig.json
+++ b/int-test/cap/tsconfig.json
@@ -5,5 +5,5 @@
     "noEmit": true,
     "lib": ["ESNext", "DOM"]
   },
-  "include": ["src-generated", "test"]
+  "include": ["src-generated", "test", "odata2ts.config.ts"]
 }

--- a/int-test/config-variants/odata2ts.config.ts
+++ b/int-test/config-variants/odata2ts.config.ts
@@ -182,8 +182,10 @@ const config: ConfigFileOptions = {
       source: V2_SOURCE,
       output: "src-generated/v2-wrapping",
       mode: Modes.models,
-      v2ResponseResultsWrapping: true,
-      v2PayloadResultsWrapping: true,
+      v2: {
+        responseResultsWrapping: true,
+        payloadResultsWrapping: true,
+      },
     },
 
     /**
@@ -204,9 +206,11 @@ const config: ConfigFileOptions = {
       byTypeAndName: [{ name: "PublisherRegistry.Branch", type: TypeModel.EntityType, mappedName: "PublisherBranch" }],
       enumType: "numeric",
       enablePrimitivePropertyServices: true,
-      enableNativeInOperator: true,
-      v4BigNumberAsString: true,
-      odataVersionV4: "4.01",
+      v4: {
+        enableNativeInOperator: true,
+        bigNumberAsString: true,
+        odataVersion: "4.01",
+      },
       disableAutoManagedKey: true,
       skipComments: true,
     },

--- a/int-test/olingo-v2/odata2ts.config.ts
+++ b/int-test/olingo-v2/odata2ts.config.ts
@@ -34,8 +34,7 @@ const config: ConfigFileOptions = {
    * necessarily expect it (odata2ts#237); Olingo happens to accept both, which is exactly why the option
    * cannot be derived from the response side.
    */
-  v2ResponseResultsWrapping: true,
-  v2PayloadResultsWrapping: true,
+  v2: { responseResultsWrapping: true, payloadResultsWrapping: true },
   services: {
     library: {
       serviceName: "Library",
@@ -113,13 +112,11 @@ const config: ConfigFileOptions = {
       source: "resource/library-v2.xml",
       output: "src-generated/library-as-v4",
       enablePrimitivePropertyServices: true,
-      v2ResponseAsV4: true,
-      // override the top-level wrapping options: v2ResponseAsV4 already reshapes an expanded collection
+      // override the top-level wrapping options: responseAsV4 already reshapes an expanded collection
       // valued nav prop as a plain array (dropping the `results` envelope entirely) and Olingo accepts an
       // unwrapped deep-insert payload just as well (see ResultsWrapping.test.ts) - stating the wrapping in
       // the generated types here would describe traffic this client no longer sends or receives
-      v2ResponseResultsWrapping: false,
-      v2PayloadResultsWrapping: false,
+      v2: { responseAsV4: true, responseResultsWrapping: false, payloadResultsWrapping: false },
     },
   },
 };

--- a/int-test/olingo-v2/test/LibraryConvertedConstants.ts
+++ b/int-test/olingo-v2/test/LibraryConvertedConstants.ts
@@ -1,6 +1,6 @@
 import { FetchClient } from "@odata2ts/http-client-fetch";
 import { inject } from "vitest";
-import { LibraryConvertedService } from "../src-generated/library-converted/LibraryConvertedService.js";
+import { LibraryConvertedService } from "../src-generated/library-converted/index.js";
 
 /**
  * The same server through the converter-enabled client.

--- a/int-test/olingo-v2/test/LibraryRenamedConstants.ts
+++ b/int-test/olingo-v2/test/LibraryRenamedConstants.ts
@@ -1,4 +1,4 @@
-import { LibraryRenamedService } from "../src-generated/library-renamed/LibraryRenamedService.js";
+import { LibraryRenamedService } from "../src-generated/library-renamed/index.js";
 import { BASE_URL, ODATA_CLIENT } from "./LibraryTestConstants.js";
 
 /**

--- a/int-test/olingo-v2/test/core/CrudOperations.test.ts
+++ b/int-test/olingo-v2/test/core/CrudOperations.test.ts
@@ -1,7 +1,7 @@
 import { HttpResponseModel } from "@odata2ts/http-client-api";
 import { ODataCollectionResponseV2, ODataEntityModelResponseV2 } from "@odata2ts/odata-core";
 import { describe, expect, expectTypeOf, test } from "vitest";
-import { Book, EditableBook } from "../../src-generated/library/LibraryModel.js";
+import { Book, EditableBook } from "../../src-generated/library/index.js";
 import { expectODataError } from "../expectODataError.js";
 import { BASE_URL, BOOK_DER_PROZESS, COPY_KEY, LIBRARY, UNKNOWN_ID } from "../LibraryTestConstants.js";
 

--- a/int-test/olingo-v2/tsconfig.json
+++ b/int-test/olingo-v2/tsconfig.json
@@ -5,5 +5,5 @@
     "noEmit": true,
     "lib": ["ESNext", "DOM"]
   },
-  "include": ["src-generated", "test"]
+  "include": ["src-generated", "test", "odata2ts.config.ts"]
 }

--- a/packages/odata2ts/src/FactoryFunctionModel.ts
+++ b/packages/odata2ts/src/FactoryFunctionModel.ts
@@ -11,8 +11,8 @@ export type DigestionOptions = Pick<
   | "disableAutoManagedKey"
   | "propertiesByName"
   | "byTypeAndName"
-  | "v2ResponseResultsWrapping"
-  | "v4BigNumberAsString"
+  | "v2"
+  | "v4"
   | "skipEditableModels"
   | "skipComments"
   | "skipIdModels"
@@ -20,7 +20,6 @@ export type DigestionOptions = Pick<
   | "bundledFileGeneration"
   | "unflattenComplexTypes"
   | "enumType"
-  | "enableNativeInOperator"
 >;
 
 /**
@@ -40,14 +39,11 @@ export type GeneratorFunctionOptions = Pick<
   | "skipIdModels"
   | "skipOperations"
   | "skipComments"
-  | "v2ResponseResultsWrapping"
   | "enumType"
-  | "enableNativeInOperator"
-  | "odataVersionV4"
   | "disableBindingProps"
   | "disableDeepInsertProps"
-  | "v2PayloadResultsWrapping"
-  | "v2ResponseAsV4"
+  | "v2"
+  | "v4"
 >;
 
 export type EntityBasedGeneratorFunction = (

--- a/packages/odata2ts/src/OptionModel.ts
+++ b/packages/odata2ts/src/OptionModel.ts
@@ -218,70 +218,15 @@ export interface ConfigFileOptions extends Omit<CliOptions, "sourceUrl" | "sourc
   naming?: OverridableNamingOptions;
 
   /**
-   * OData V2 services wrap an entity collection into an extra object carrying the property "results":
-   * <code>trips: {results: [...]}</code>. So instead of an array of entities you receive an object which
-   * holds that array.
-   *
-   * Setting this configuration option to <code>true</code> (default: false) states that structure in
-   * the generated models, so that they describe what the service actually sends.
-   *
-   * It applies to navigation properties only, because that wrapping is how V2 serialises a feed: a
-   * collection of a primitive or of a complex type is a plain array either way.
-   *
-   * The option applies to every generation mode. The client passes the response structure through
-   * untouched, so with the option turned off the generated models will not match the response of a
-   * service which wraps.
+   * Special generation options targeting only V2 services, ignored for V4.
    */
-  v2ResponseResultsWrapping?: boolean;
+  v2?: V2GenerationOptions;
+
   /**
-   * The counterpart of <code>v2ResponseResultsWrapping</code> for the editable models: collection
-   * valued navigation properties of a deep insert are wrapped into an extra object with the property
-   * "results", as some V2 services expect it.
-   *
-   * Deliberately its own option, since a service which answers with the extra wrapping does not
-   * necessarily expect it in a request payload - see odata2ts issue #237.
-   *
-   * Like its counterpart the option applies to every generation mode.
+   * Special generation options targeting only V4 services, ignored for V2.
    */
-  v2PayloadResultsWrapping?: boolean;
-  /**
-   * A V2 service answers in its own JSON verbose shape: collections come wrapped as
-   * <code>{d: {results: [...], __count?, __next?}}</code>, entities as
-   * <code>{d: {...entity, __metadata: {uri, type, etag}}}</code>, and unexpanded navigation properties carry
-   * a <code>{__deferred: {uri}}</code> placeholder instead of simply being absent.
-   *
-   * Setting this option to <code>true</code> (default: false) reshapes every response of that service as its
-   * V4 equivalent instead: collections become <code>{value: [...], "@odata.count"?, "@odata.nextLink"?}</code>,
-   * entities are returned bare with <code>__metadata</code> turned into <code>@odata.id</code> /
-   * <code>@odata.type</code> / <code>@odata.etag</code>, and a navigation property that hasn't been expanded
-   * is simply left out - exactly as a real V4 service would send it. Applies recursively to expanded
-   * navigation properties of any depth.
-   *
-   * The generated response types change accordingly (`ODataCollectionResponseV4` / `ODataModelResponseV4` /
-   * `ODataValueResponseV4` instead of their V2 counterparts), so a consumer of the generated client only ever
-   * deals with the V4 shape, regardless of which OData version the actual service speaks.
-   *
-   * Only relevant for V2 services and ignored for V4, where the response is already in that shape.
-   *
-   * Turned on, this option reshapes an expanded collection valued navigation property as a plain array
-   * regardless of <code>v2ResponseResultsWrapping</code> / <code>v2PayloadResultsWrapping</code> - stating
-   * the `results` wrapping in the generated types would describe traffic this client no longer sends or
-   * receives. Leave both of those off (the default) when turning this on.
-   */
-  v2ResponseAsV4?: boolean;
-  /**
-   * Numbers of type `Edm.Int64` and `Edm.Decimal` are represented as `number` in V4.
-   * However, these numbers might not fit into JS' number type, which might result in precision loss.
-   *
-   * OData offers a special IEEE754 format option to get those types as `string` instead to prevent any
-   * precision loss. So if you're handling very large or very small numbers (JS roughly supports 15 digits),
-   * then you should use this option and, probably, also an appropriate converter (see available converters).
-   *
-   * Activating this option affects the type generation and will use `string` for both mentioned types.
-   * All requests are executed with the "accept" header set to "application/json;IEEE754Compatible=true".
-   * Additionally, when sending data the very same value will be set for the "content-type" header.
-   */
-  v4BigNumberAsString?: boolean;
+  v4?: V4GenerationOptions;
+
   /**
    * OData allows for namespaces so any entity is unique by virtue of it's name within a namespace.
    * odata2ts works with these fully qualified names internally, but only uses the plain name when generating
@@ -339,24 +284,6 @@ export interface ConfigFileOptions extends Omit<CliOptions, "sourceUrl" | "sourc
    */
   unflattenComplexTypes?: boolean;
   /**
-   * By default, odata2ts emulates the in operator by rolling it out as a series of equals-or-expressions.
-   * This allows for maximum compatibility with all V4 services, as well as V2 services.
-   *
-   * Setting this value to true will instead use the native in operator, resulting in smaller queries
-   * on V4 services that support it.
-   */
-  enableNativeInOperator?: boolean;
-  /**
-   * The OData version to target. It is declared via the OData-Version header on each request carrying a body,
-   * which governs how the service interprets the request payload, and it selects the response types to generate:
-   * 4.0 payloads must use the "odata." prefix for control information, while 4.01 and greater use the short form
-   * ("@count" instead of "@odata.count").
-   *
-   * Only relevant for V4 services and ignored for V2. Defaults to "4.0", the more widely deployed and more
-   * compatible version.
-   */
-  odataVersionV4?: "4.0" | "4.01";
-  /**
    * Allows to bind an already existing entity to a navigation property of the editable models.
    *
    * Where a service is generated (mode {@code service} or {@code all}), the binding goes by the
@@ -393,6 +320,98 @@ export interface ConfigFileOptions extends Omit<CliOptions, "sourceUrl" | "sourc
    * Opt-out, so the editable models carry the navigation properties unless this is switched off.
    */
   disableDeepInsertProps?: boolean;
+}
+
+/**
+ * Special generation options targeting only V2 services.
+ */
+export interface V2GenerationOptions {
+  /**
+   * OData V2 services wrap an entity collection into an extra object carrying the property "results":
+   * `trips: {results: [...]}`. So instead of an array of entities you receive an object which
+   * holds that array.
+   *
+   * Setting this configuration option to `true` (default: false) states that structure in
+   * the generated models, so that they describe what the service actually sends.
+   *
+   * It applies to navigation properties only, because that wrapping is how V2 serialises a feed: a
+   * collection of a primitive or of a complex type is a plain array either way.
+   *
+   * The option applies to every generation mode. The client passes the response structure through
+   * untouched, so with the option turned off the generated models will not match the response of a
+   * service which wraps.
+   */
+  responseResultsWrapping?: boolean;
+  /**
+   * The counterpart of `responseResultsWrapping` for the editable models: collection
+   * valued navigation properties of a deep insert are wrapped into an extra object with the property
+   * "results", as some V2 services expect it.
+   *
+   * Deliberately its own option, since a service which answers with the extra wrapping does not
+   * necessarily expect it in a request payload - see odata2ts issue #237.
+   *
+   * Like its counterpart the option applies to every generation mode.
+   */
+  payloadResultsWrapping?: boolean;
+  /**
+   * A V2 service answers in its own JSON verbose shape: collections come wrapped as
+   * `{d: {results: [...], __count?, __next?}}`, entities as
+   * `{d: {...entity, __metadata: {uri, type, etag}}}`, and unexpanded navigation properties carry
+   * a `{__deferred: {uri}}` placeholder instead of simply being absent.
+   *
+   * Setting this option to `true` (default: false) reshapes every response of that service as its
+   * V4 equivalent instead: collections become `{value: [...], "@odata.count"?, "@odata.nextLink"?}`,
+   * entities are returned bare with `__metadata` turned into `@odata.id` /
+   * `@odata.type` / `@odata.etag`, and a navigation property that hasn't been expanded
+   * is simply left out - exactly as a real V4 service would send it. Applies recursively to expanded
+   * navigation properties of any depth.
+   *
+   * The generated response types change accordingly (`ODataCollectionResponseV4` / `ODataModelResponseV4` /
+   * `ODataValueResponseV4` instead of their V2 counterparts), so a consumer of the generated client only ever
+   * deals with the V4 shape, regardless of which OData version the actual service speaks.
+   *
+   * Turned on, this option reshapes an expanded collection valued navigation property as a plain array
+   * regardless of `responseResultsWrapping` / `payloadResultsWrapping` - stating
+   * the `results` wrapping in the generated types would describe traffic this client no longer sends or
+   * receives. Leave both of those off (the default) when turning this on.
+   */
+  responseAsV4?: boolean;
+}
+
+/**
+ * Special generation options targeting only V4 services.
+ */
+export interface V4GenerationOptions {
+  /**
+   * Numbers of type `Edm.Int64` and `Edm.Decimal` are represented as `number` in V4.
+   * However, these numbers might not fit into JS' number type, which might result in precision loss.
+   *
+   * OData offers a special IEEE754 format option to get those types as `string` instead to prevent any
+   * precision loss. So if you're handling very large or very small numbers (JS roughly supports 15 digits),
+   * then you should use this option and, probably, also an appropriate converter (see available converters).
+   *
+   * Activating this option affects the type generation and will use `string` for both mentioned types.
+   * All requests are executed with the "accept" header set to "application/json;IEEE754Compatible=true".
+   * Additionally, when sending data the very same value will be set for the "content-type" header.
+   */
+  bigNumberAsString?: boolean;
+  /**
+   * The OData version to target. It is declared via the OData-Version header on each request carrying a body,
+   * which governs how the service interprets the request payload, and it selects the response types to generate:
+   * 4.0 payloads must use the "odata." prefix for control information, while 4.01 and greater use the short form
+   * ("@count" instead of "@odata.count").
+   *
+   * Defaults to "4.0", the more widely deployed and more compatible version.
+   */
+  odataVersion?: "4.0" | "4.01";
+  /**
+   * By default, odata2ts emulates the in operator by rolling it out as a series of equals-or-expressions.
+   * This allows for maximum compatibility with all V4 services, as well as V2 services.
+   *
+   * Setting this value to true will instead use the native in operator, resulting in smaller queries
+   * on V4 services that support it.
+   */
+  enableNativeInOperator?: boolean;
 }
 
 /**

--- a/packages/odata2ts/src/app.ts
+++ b/packages/odata2ts/src/app.ts
@@ -87,7 +87,7 @@ export async function runApp(metadataJson: ODataEdmxModelBase<any>, options: Run
     tsConfigPath: options.tsconfig,
     bundledFileGeneration: options.bundledFileGeneration,
     allowTypeChecking: options.debug,
-    odataVersionV4: options.odataVersionV4,
+    odataVersionV4: options.v4.odataVersion,
   });
 
   // const promises: Array<Promise<void>> = [

--- a/packages/odata2ts/src/data-model/DataModelDigestionV4.ts
+++ b/packages/odata2ts/src/data-model/DataModelDigestionV4.ts
@@ -133,7 +133,7 @@ class DigesterV4 extends Digester<SchemaV4, EntityTypeV4, ComplexTypeV4> {
         };
       case ODataTypesV4.Int64:
       case ODataTypesV4.Decimal:
-        if (this.options.v4BigNumberAsString) {
+        if (this.options.v4.bigNumberAsString) {
           return {
             outputType: "string",
             qPath: "QBigNumberPath",

--- a/packages/odata2ts/src/defaultConfig.ts
+++ b/packages/odata2ts/src/defaultConfig.ts
@@ -22,8 +22,16 @@ const defaultConfig: DefaultConfiguration = {
   enablePrimitivePropertyServices: false,
   disableAutoManagedKey: false,
   allowRenaming: false,
-  v2ResponseResultsWrapping: false,
-  v4BigNumberAsString: false,
+  v2: {
+    responseResultsWrapping: false,
+    payloadResultsWrapping: false,
+    responseAsV4: false,
+  },
+  v4: {
+    bigNumberAsString: false,
+    odataVersion: "4.0",
+    enableNativeInOperator: false,
+  },
   disableAutomaticNameClashResolution: false,
   bundledFileGeneration: false,
   unflattenComplexTypes: false,
@@ -102,12 +110,8 @@ const defaultConfig: DefaultConfiguration = {
   },
   propertiesByName: [],
   byTypeAndName: [],
-  enableNativeInOperator: false,
-  odataVersionV4: "4.0",
   disableBindingProps: false,
   disableDeepInsertProps: false,
-  v2PayloadResultsWrapping: false,
-  v2ResponseAsV4: false,
 };
 
 const { models, queryObjects, services } = defaultConfig.naming;

--- a/packages/odata2ts/src/generator/ModelGenerator.ts
+++ b/packages/odata2ts/src/generator/ModelGenerator.ts
@@ -220,7 +220,7 @@ class ModelGenerator {
     // V2 entity special: deferred content - not for v2ResponseAsV4, which reshapes a V2 response as V4,
     // and V4 has no equivalent placeholder: an unexpanded navigation property is simply absent
     let suffix = "";
-    if (this.dataModel.isV2() && !this.options.v2ResponseAsV4 && prop.dataType == DataTypes.ModelType) {
+    if (this.dataModel.isV2() && !this.options.v2.responseAsV4 && prop.dataType == DataTypes.ModelType) {
       const defContent = imports.addCoreLib(this.version, CoreImports.DeferredContent);
       suffix = ` | ${defContent}`;
     }
@@ -239,7 +239,7 @@ class ModelGenerator {
       // the extra results object is how V2 serialises a *feed*, so it is an entity collection's business
       // alone - a collection of a complex or primitive type arrives as a plain array (verified against
       // CAP's V2 adapter, which wraps `Copies` and hands over `PreviousAddresses` and `Keywords` bare)
-      if (this.dataModel.isV2() && this.options.v2ResponseResultsWrapping && prop.dataType === DataTypes.ModelType) {
+      if (this.dataModel.isV2() && this.options.v2.responseResultsWrapping && prop.dataType === DataTypes.ModelType) {
         return `{ results: ${type} }` + suffix;
       } else {
         return type + suffix;
@@ -367,7 +367,7 @@ class ModelGenerator {
     props: Array<PropertyModel>,
   ): Array<OptionalKind<PropertySignatureStructure>> {
     const isV2 = this.version === ODataVersions.V2;
-    const isV401 = !isV2 && this.options.odataVersionV4 === "4.01";
+    const isV401 = !isV2 && this.options.v4.odataVersion === "4.01";
     // in these versions a binding has no name of its own, so it shares the property with a deep insert
     const bindingByPropName = isV2 || isV401;
     const byKey = this.bindsByKey();
@@ -442,7 +442,7 @@ class ModelGenerator {
     if (prop.isCollection) {
       const collectionType = `Array<${singleType}>`;
       // some V2 services expect the extra results wrapping in the payload as well, see issue #237
-      return this.version === ODataVersions.V2 && this.options.v2PayloadResultsWrapping
+      return this.version === ODataVersions.V2 && this.options.v2.payloadResultsWrapping
         ? `{ results: ${collectionType} }`
         : collectionType;
     }

--- a/packages/odata2ts/src/generator/QueryObjectGenerator.ts
+++ b/packages/odata2ts/src/generator/QueryObjectGenerator.ts
@@ -50,7 +50,7 @@ class QueryObjectGenerator {
   ) {}
 
   private isV2AsV4() {
-    return this.options.v2ResponseAsV4 && this.version === ODataVersions.V2;
+    return this.options.v2.responseAsV4 && this.version === ODataVersions.V2;
   }
 
   public async generate(): Promise<void> {
@@ -74,7 +74,7 @@ class QueryObjectGenerator {
     const file = this.project.createOrGetMainQObjectFile();
 
     // for now assume only enableNativeInOperator requires options to be processed
-    if (!this.options.enableNativeInOperator) {
+    if (!this.options.v4.enableNativeInOperator) {
       return;
     }
 
@@ -256,7 +256,7 @@ class QueryObjectGenerator {
     // there would be no point either: there is no `in` to render natively.
     const takesOptions = (prop: PropertyModel) =>
       !prop.isCollection && !isModelType(prop) && !isEnumType(prop) && prop.qPath !== "QBinaryPath";
-    const addOptions = this.options.enableNativeInOperator; // limited to hardcoded enableNativeIn for now
+    const addOptions = this.options.v4.enableNativeInOperator; // limited to hardcoded enableNativeIn for now
 
     if (addOptions && props.some(takesOptions)) {
       importContainer.addFromMainQObject(OPTIONS_STATEMENT);
@@ -342,7 +342,8 @@ class QueryObjectGenerator {
 
     const qBinding = importContainer.addQObject(QueryObjectImports.QBinding);
     const qId = importContainer.addGeneratedQObject(target.id.fqName, target.id.qName);
-    const notation = this.version === ODataVersions.V2 ? "V2" : this.options.odataVersionV4 === "4.01" ? "4.01" : "4.0";
+    const notation =
+      this.version === ODataVersions.V2 ? "V2" : this.options.v4.odataVersion === "4.01" ? "4.01" : "4.0";
 
     return `, new ${qBinding}(() => new ${qId}("${targetSet.odataName}"), "${notation}")`;
   }
@@ -439,7 +440,7 @@ class QueryObjectGenerator {
     const isV2 = this.version === ODataVersions.V2;
     const returnType = operation.returnType;
     const hasParams = operation.parameters.length > 0 || operation.overrides?.length;
-    const isParamsOptional = !![operation.parameters, ...(operation.overrides ?? [])].find((pSet) => pSet.length === 0);
+    //const isParamsOptional = !![operation.parameters, ...(operation.overrides ?? [])].find((pSet) => pSet.length === 0);
 
     // imports
     const qOp =

--- a/packages/odata2ts/src/generator/ServiceGenerator.ts
+++ b/packages/odata2ts/src/generator/ServiceGenerator.ts
@@ -34,8 +34,11 @@ export interface PropsAndOps extends Required<Pick<ClassDeclarationStructure, "p
 
 export interface ServiceGeneratorOptions extends Pick<
   ConfigFileOptions,
-  "enablePrimitivePropertyServices" | "v4BigNumberAsString" | "enumType" | "odataVersionV4" | "v2ResponseAsV4"
-> {}
+  "enablePrimitivePropertyServices" | "enumType"
+> {
+  v2: Pick<NonNullable<ConfigFileOptions["v2"]>, "responseAsV4">;
+  v4: Pick<NonNullable<ConfigFileOptions["v4"]>, "bigNumberAsString" | "odataVersion">;
+}
 
 export async function generateServices(
   project: ProjectManager,
@@ -54,19 +57,19 @@ class ServiceGenerator {
     private dataModel: DataModel,
     private version: ODataVersions,
     private namingHelper: NamingHelper,
-    private options: ServiceGeneratorOptions = {},
+    private options: ServiceGeneratorOptions = { v2: {}, v4: {} },
   ) {}
 
   private isV4BigNumber() {
-    return this.options.v4BigNumberAsString && this.version === ODataVersions.V4;
+    return this.options.v4.bigNumberAsString && this.version === ODataVersions.V4;
   }
 
   private isV401() {
-    return this.options.odataVersionV4 === "4.01" && this.version === ODataVersions.V4;
+    return this.options.v4.odataVersion === "4.01" && this.version === ODataVersions.V4;
   }
 
   private isV2AsV4() {
-    return !!this.options.v2ResponseAsV4 && this.version === ODataVersions.V2;
+    return !!this.options.v2.responseAsV4 && this.version === ODataVersions.V2;
   }
 
   /**

--- a/packages/odata2ts/src/project/ProjectManager.ts
+++ b/packages/odata2ts/src/project/ProjectManager.ts
@@ -303,7 +303,7 @@ export class ProjectManager {
    * Generates the barrel files, re-exporting everything that has been generated: one index file per
    * namespace and one at the root of the output directory.
    *
-   * The files of a folder are always re-exported by the index of its <em>parent</em> - the namespace level
+   * The files of a folder are always re-exported by the index of its *parent* - the namespace level
    * for the model folders, the output root for everything else. Model folders therefore get no index of
    * their own, which means no generated artefact can ever collide with one: a model literally named "index"
    * is simply re-exported like any other.

--- a/packages/odata2ts/test/data-model/ServiceConfigHelper.test.ts
+++ b/packages/odata2ts/test/data-model/ServiceConfigHelper.test.ts
@@ -15,14 +15,13 @@ describe("ServiceConfigHelper Tests", function () {
       byTypeAndName: [],
       propertiesByName: propsSetting || [],
       skipEditableModels: false,
-      v2ResponseResultsWrapping: false,
-      v4BigNumberAsString: false,
+      v2: { responseResultsWrapping: false },
+      v4: { bigNumberAsString: false, enableNativeInOperator: false },
       skipComments: true,
       skipIdModels: true,
       disableAutomaticNameClashResolution: false,
       bundledFileGeneration: false,
       enumType: "string",
-      enableNativeInOperator: false,
       unflattenComplexTypes: false,
     });
   }
@@ -34,14 +33,13 @@ describe("ServiceConfigHelper Tests", function () {
       byTypeAndName: entsSetting || [],
       propertiesByName: [],
       skipEditableModels: false,
-      v2ResponseResultsWrapping: false,
-      v4BigNumberAsString: false,
+      v2: { responseResultsWrapping: false },
+      v4: { bigNumberAsString: false, enableNativeInOperator: false },
       skipComments: true,
       skipIdModels: true,
       disableAutomaticNameClashResolution: false,
       bundledFileGeneration: false,
       enumType: "string",
-      enableNativeInOperator: false,
       unflattenComplexTypes: false,
     });
   }

--- a/packages/odata2ts/test/generator/v2/ModelGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v2/ModelGenerator.test.ts
@@ -90,7 +90,7 @@ describe("Model Generator Tests V2", () => {
     // when generating model
     // then match fixture text
     await generateAndCompare("entity-relationships-v2-extra-wrapping.ts", {
-      v2ResponseResultsWrapping: true,
+      v2: { responseResultsWrapping: true },
     });
   });
 
@@ -110,8 +110,7 @@ describe("Model Generator Tests V2", () => {
     // entity collection alone - CAP's V2 adapter wraps an expanded navigation property and hands over a
     // primitive or complex collection bare
     await generateAndCompare("entity-collections-v2-extra-wrapping.ts", {
-      v2ResponseResultsWrapping: true,
-      v2PayloadResultsWrapping: true,
+      v2: { responseResultsWrapping: true, payloadResultsWrapping: true },
       skipEditableModels: false,
     });
   });
@@ -170,7 +169,7 @@ describe("Model Generator Tests V2", () => {
     // when opting into the extra wrapping for editable models
     // then only the collection valued navigation property carries the extra results object
     await generateAndCompare("entity-relationships-deep-insert-v2-extra-wrapping.ts", {
-      v2PayloadResultsWrapping: true,
+      v2: { payloadResultsWrapping: true },
       skipEditableModels: false,
       skipIdModels: false,
       disableAutoManagedKey: true,
@@ -185,7 +184,7 @@ describe("Model Generator Tests V2", () => {
     // then the deep insert props stay unwrapped: a service answering with the wrapping does not
     // necessarily expect it in a request payload, see issue #237
     await generateAndCompare("entity-relationships-deep-insert-v2-response-wrapping.ts", {
-      v2ResponseResultsWrapping: true,
+      v2: { responseResultsWrapping: true },
       skipEditableModels: false,
       skipIdModels: false,
       disableAutoManagedKey: true,

--- a/packages/odata2ts/test/generator/v2/ServiceGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v2/ServiceGenerator.test.ts
@@ -250,7 +250,7 @@ describe("Service Generator Tests V2", () => {
 
     // when generating with v2ResponseAsV4 turned on
     runOptions.enablePrimitivePropertyServices = true;
-    runOptions.v2ResponseAsV4 = true;
+    runOptions.v2.responseAsV4 = true;
     await doGenerate();
 
     // then the generated service classes are the *V2AsV4 siblings, reshaping every response as V4
@@ -267,7 +267,7 @@ describe("Service Generator Tests V2", () => {
       .addEntitySet("Books", withNs("Book"));
 
     // when generating with v2ResponseAsV4 turned on
-    runOptions.v2ResponseAsV4 = true;
+    runOptions.v2.responseAsV4 = true;
     await doGenerate();
 
     // then the complex-typed property's service is ComplexTypeServiceV2AsV4

--- a/packages/odata2ts/test/generator/v4/EntityBasedGenerationTests.ts
+++ b/packages/odata2ts/test/generator/v4/EntityBasedGenerationTests.ts
@@ -1,8 +1,7 @@
 import { ODataTypesV4 } from "@odata2ts/odata-core";
 import { beforeAll, beforeEach, test } from "vitest";
 import { digest } from "../../../src/data-model/DataModelDigestionV4.js";
-import { ConfigFileOptions, NamingStrategies } from "../../../src/index.js";
-import { TypeModel } from "../../../src/TypeModel.js";
+import { ConfigFileOptions, NamingStrategies, TypeModel } from "../../../src/index.js";
 import { ODataModelBuilderV4 } from "../../data-model/builder/v4/ODataModelBuilderV4.js";
 import {
   createHelper,
@@ -396,7 +395,7 @@ export function createEntityBasedGenerationTests(
     // when generating model
     // then match fixture text
     await generateAndCompare("entity-big-number-v4.ts", {
-      v4BigNumberAsString: true,
+      v4: { bigNumberAsString: true },
     });
   });
 

--- a/packages/odata2ts/test/generator/v4/ModelGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/ModelGenerator.test.ts
@@ -161,7 +161,7 @@ describe("Model Generator Tests V4", () => {
     await generateAndCompare("entity-relationships.ts", {
       disableBindingProps: true,
       disableDeepInsertProps: true,
-      v2ResponseResultsWrapping: true,
+      v2: { responseResultsWrapping: true },
       skipEditableModels: false,
       skipIdModels: false,
       disableAutoManagedKey: true,
@@ -269,7 +269,7 @@ describe("Model Generator Tests V4", () => {
     await generateAndCompare("entity-relationships-v401.ts", {
       disableDeepInsertProps: true,
       mode: Modes.models,
-      odataVersionV4: "4.01",
+      v4: { odataVersion: "4.01" },
       skipEditableModels: false,
       skipIdModels: false,
       disableAutoManagedKey: true,
@@ -294,7 +294,7 @@ describe("Model Generator Tests V4", () => {
     // then no binding prop at all: in 4.01 it goes by the name of the navigation property itself,
     // so it must be absent rather than show up with the binding type
     await generateAndCompare("entity-relationships.ts", {
-      odataVersionV4: "4.01",
+      v4: { odataVersion: "4.01" },
       disableBindingProps: true,
       disableDeepInsertProps: true,
       skipEditableModels: false,
@@ -439,7 +439,7 @@ describe("Model Generator Tests V4", () => {
     // because 4.01 addresses a binding by the very name of the navigation property
     await generateAndCompare("entity-relationships-deep-insert-binding-v401.ts", {
       mode: Modes.models,
-      odataVersionV4: "4.01",
+      v4: { odataVersion: "4.01" },
       skipEditableModels: false,
       skipIdModels: false,
       disableAutoManagedKey: true,
@@ -454,7 +454,7 @@ describe("Model Generator Tests V4", () => {
     // then it has no effect at all - the wrapping is a V2 speciality
     await generateAndCompare("entity-relationships-deep-insert.ts", {
       disableBindingProps: true,
-      v2PayloadResultsWrapping: true,
+      v2: { payloadResultsWrapping: true },
       skipEditableModels: false,
       skipIdModels: false,
       disableAutoManagedKey: true,

--- a/packages/odata2ts/test/generator/v4/QueryObjectGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/QueryObjectGenerator.test.ts
@@ -212,7 +212,7 @@ describe("Query Object Generator Tests V4", () => {
     // when generating model
     // then match fixture text
     await generateAndCompare("entity-with-native-in.ts", {
-      enableNativeInOperator: true,
+      v4: { enableNativeInOperator: true },
     });
   });
 
@@ -224,7 +224,7 @@ describe("Query Object Generator Tests V4", () => {
     // when generating model
     // then match fixture text of main qobject
     await generateAndCompare("unbundled-main-native-in.ts", {
-      enableNativeInOperator: true,
+      v4: { enableNativeInOperator: true },
       bundledFileGeneration: false,
     });
     // when generating model
@@ -232,7 +232,7 @@ describe("Query Object Generator Tests V4", () => {
     await generateAndCompare(
       "unbundled-file-native-in.ts",
       {
-        enableNativeInOperator: true,
+        v4: { enableNativeInOperator: true },
         bundledFileGeneration: false,
       },
       `${SERVICE_NAME.toLowerCase()}/${ENTITY_NAME.toLowerCase()}/Q${ENTITY_NAME}`,

--- a/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
@@ -75,7 +75,7 @@ describe("Service Generator Tests V4", () => {
 
   test("Service Generator: Min Big Number", async () => {
     // given big numbers setting
-    const options: ConfigFileOptions = { v4BigNumberAsString: true };
+    const options: ConfigFileOptions = { v4: { bigNumberAsString: true } };
 
     // when generating
     await doGenerate(options);
@@ -86,7 +86,7 @@ describe("Service Generator Tests V4", () => {
 
   test("Service Generator: Min OData 4.01", async () => {
     // given the 4.01 setting
-    const options: ConfigFileOptions = { odataVersionV4: "4.01" };
+    const options: ConfigFileOptions = { v4: { odataVersion: "4.01" } };
 
     // when generating
     await doGenerate(options);
@@ -275,7 +275,7 @@ describe("Service Generator Tests V4", () => {
       .addActionImport("pingDecimalCollection", withNs("pingDecimalCollection"));
 
     // when generating
-    await doGenerate({ v4BigNumberAsString: true });
+    await doGenerate({ v4: { bigNumberAsString: true } });
 
     await compareMainService("big-number-return-types.ts");
   });
@@ -415,7 +415,7 @@ describe("Service Generator Tests V4", () => {
       .addEntitySet("Ents", withNs("TestEntity"));
 
     // when generating
-    await doGenerate({ v4BigNumberAsString: true });
+    await doGenerate({ v4: { bigNumberAsString: true } });
 
     // then we get one additional service file
     await compareMainService("big-numbers.ts");


### PR DESCRIPTION
Currently we have 3 options which only apply to V2 and 3 options which only apply to V4; this creates a v2 and v4 option block to hold the respective options

BREAKING CHANGE: v2ResponseResultsWrapping, v2PayloadResultsWrapping, v2ResponseAsV4 are now under prop "v2" and renamed to "responseResultsWrapping", "payloadResultsWrapping", "responseAsV4"; v4BigNumberAsString, enableNativeInOperator, odataVersionV4 are now under prop "v4" and renamed to "bigNumberAsString", "odataVersion" and still "enableNativeInOperator"