### PR TITLE
feat(odata-query-objects): add substring for strings and has for enums

### DIFF
--- a/int-test/asp-net/test/core/QueryFunctionality.test.ts
+++ b/int-test/asp-net/test/core/QueryFunctionality.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { Amenities } from "../../src-generated/library/library-catalog/index.js";
 import { expectODataError } from "../expectODataError.js";
 import { BASE_URL, BOOK_DER_PROZESS, LIBRARY } from "../LibraryTestConstants.js";
 
@@ -139,6 +140,92 @@ describe("ASP.NET Library: query functionality", () => {
     expect(result.status).toBe(200);
     // every medium qualifies, since no keyword has that value - the point is that the server evaluates it
     expect(result.data.value.length).toBeGreaterThan(0);
+  });
+
+  test("$filter with substring", async () => {
+    // `substring` counts characters, and a server that counted from 1 or read the third argument as an
+    // end position would answer with a different row - so the expectation is derived from the titles the
+    // server itself delivers, applying the OData semantics (start, length) client-side.
+    const all = await LIBRARY.Media()
+      .query((builder) => builder.select("Title"))
+      .execute();
+    const expectedTitles = all.data.value
+      .map((medium) => medium.Title)
+      .filter((title) => title.substring(0, 3) === "Der")
+      .sort();
+    expect(expectedTitles.length).toBeGreaterThan(0);
+    expect(expectedTitles.length).toBeLessThan(all.data.value.length);
+
+    const request = LIBRARY.Media().query((builder, qMedium) => {
+      builder.select("Title").filter(qMedium.Title.substring(0, 3).eq("Der"));
+    });
+
+    expect(decodeURIComponent(request.getUrl())).toContain("$filter=substring(Title,0,3) eq 'Der'");
+
+    const result = await request.execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.value.map((medium) => medium.Title).sort()).toStrictEqual(expectedTitles);
+  });
+
+  test("$filter with substring without a length, running to the end of the value", async () => {
+    const request = LIBRARY.Media().query((builder, qMedium) => {
+      builder.select("Title").filter(qMedium.Title.substring(4).eq("Prozess"));
+    });
+
+    expect(decodeURIComponent(request.getUrl())).toContain("$filter=substring(Title,4) eq 'Prozess'");
+
+    const result = await request.execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.value.map((medium) => medium.Title)).toStrictEqual(["Der Prozess"]);
+  });
+
+  test("$filter with has on a flag enum", async () => {
+    // `Amenities` is the one `IsFlags="true"` enum in the model, and this is the only server which offers
+    // an enum type at all: CAP emits none, and V2 has no such thing - so `has` is out of reach in
+    // int-test/cap and int-test/olingo-v2.
+    const all = await LIBRARY.Branches()
+      .query((builder) => builder.select("Name", "Amenities"))
+      .execute();
+    // a flag value arrives as the comma-separated list of its members
+    const expectedNames = all.data.value
+      .filter((branch) => branch.Amenities?.split(", ").includes(Amenities.Parking))
+      .map((branch) => branch.Name)
+      .sort();
+    expect(expectedNames.length).toBeGreaterThan(0);
+    expect(expectedNames.length).toBeLessThan(all.data.value.length);
+
+    const request = LIBRARY.Branches().query((builder, qBranch) => {
+      builder.select("Name").filter(qBranch.Amenities.has(Amenities.Parking));
+    });
+
+    // the bare member name, exactly as `eq` spells it - the server infers the enum type from the property
+    // and does not need the qualified `Library.Catalog.Amenities'Parking'` literal
+    expect(decodeURIComponent(request.getUrl())).toContain("$filter=Amenities has 'Parking'");
+
+    const result = await request.execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.value.map((branch) => branch.Name).sort()).toStrictEqual(expectedNames);
+  });
+
+  test("has against a non-flag enum is not refused, it just does bit arithmetic", async () => {
+    // Nothing in the metadata carries `IsFlags` into the generated code, so `has` is offered on every enum
+    // path - and this is what a caller gets when using it where it does not belong. `AvailabilityStatus`
+    // has no flags, but the server still evaluates `has` bitwise over the underlying `Edm.Byte` values,
+    // and `Available` is 0: every row matches, silently and without an error to react to.
+    const all = await LIBRARY.Copies()
+      .query((builder) => builder.select("Status"))
+      .execute();
+
+    const result = await LIBRARY.Copies()
+      .query((builder, qCopy) => builder.select("Status").filter(qCopy.Status.has("Available")))
+      .execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.value.length).toBe(all.data.value.length);
+    expect(result.data.value.some((copy) => copy.Status !== "Available")).toBe(true);
   });
 
   test("an invalid query option is refused with 400, and the message says why", async () => {

--- a/int-test/cap/test/core/QueryFunctionality.test.ts
+++ b/int-test/cap/test/core/QueryFunctionality.test.ts
@@ -135,6 +135,42 @@ describe("CAP Library: query functionality", () => {
     expect(result.status).toBe(200);
   });
 
+  test("$filter with substring", async () => {
+    const all = await LIBRARY.Books()
+      .query((b) => b.select("Title"))
+      .execute();
+    const expectedTitles = all.data.value
+      .map((book) => book.Title)
+      .filter((title) => title.substring(0, 3) === "Der")
+      .sort();
+    expect(expectedTitles.length).toBeGreaterThan(0);
+    expect(expectedTitles.length).toBeLessThan(all.data.value.length);
+
+    const request = LIBRARY.Books().query((builder, qBook) => {
+      builder.select("Title").filter(qBook.Title.substring(0, 3).eq("Der"));
+    });
+
+    expect(decodeURIComponent(request.getUrl())).toContain("$filter=substring(Title,0,3) eq 'Der'");
+
+    const result = await request.execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.value.map((book) => book.Title).sort()).toStrictEqual(expectedTitles);
+  });
+
+  test("$filter with substring without a length, running to the end of the value", async () => {
+    const request = LIBRARY.Books().query((builder, qBook) => {
+      builder.select("Title").filter(qBook.Title.substring(4).eq("Prozess"));
+    });
+
+    expect(decodeURIComponent(request.getUrl())).toContain("$filter=substring(Title,4) eq 'Prozess'");
+
+    const result = await request.execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.value.map((book) => book.Title)).toStrictEqual(["Der Prozess"]);
+  });
+
   test("an invalid query option is silently ignored here", async () => {
     // A negative $top is refused with 400 by ASP.NET; CAP accepts the request and answers with the
     // unrestricted set. Asserted because the difference matters to a client: there is no error to react

--- a/int-test/cap/test/v2/core/QueryFunctionality.test.ts
+++ b/int-test/cap/test/v2/core/QueryFunctionality.test.ts
@@ -72,6 +72,29 @@ describe("CAP Library V2: query functionality", () => {
     expect(result.data.d.results.map((book) => book.Title)).toStrictEqual(["Der Prozess"]);
   });
 
+  test("$filter with substring", async () => {
+    // `substring` is one of the few string functions V2 and V4 spell identically, so the same call renders
+    // the same URL here as in the V4 file - and the olingo-v2 twin of this test shows that a native V2
+    // server accepting that URL is no guarantee of it computing the same answer.
+    const cmd = LIBRARY_V2.Books().query((b, q) => b.select("Title").filter(q.Title.substring(0, 3).eq("Der")));
+    expect(decodeURIComponent(cmd.getUrl())).toContain("$filter=substring(Title,0,3) eq 'Der'");
+
+    const result = await cmd.execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.d.results.map((book) => book.Title)).toStrictEqual(["Der Prozess"]);
+  });
+
+  test("$filter with substring without a length, running to the end of the value", async () => {
+    const cmd = LIBRARY_V2.Books().query((b, q) => b.select("Title").filter(q.Title.substring(4).eq("Prozess")));
+    expect(decodeURIComponent(cmd.getUrl())).toContain("$filter=substring(Title,4) eq 'Prozess'");
+
+    const result = await cmd.execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.d.results.map((book) => book.Title)).toStrictEqual(["Der Prozess"]);
+  });
+
   test("$top and $skip", async () => {
     const all = await LIBRARY_V2.Books()
       .query((b, q) => b.orderBy(q.Title.asc()))

--- a/int-test/olingo-v2/test/core/QueryFunctionality.test.ts
+++ b/int-test/olingo-v2/test/core/QueryFunctionality.test.ts
@@ -61,6 +61,51 @@ describe("Olingo Library: query functionality", () => {
     expect(result.data.d.results.map((book) => book.Title)).toStrictEqual(["Der Prozess"]);
   });
 
+  /**
+   * `substring` is spelled the same in V2 and V4, so the client sends the identical URL to all three
+   * servers - and this is the one that answers differently. ASP.NET and the CAP V2 adapter both return
+   * "Der Prozess"; Olingo accepts the request with 200 and matches nothing.
+   *
+   * The defect is Olingo's expression evaluator, not the URL. Measured against constants on this server:
+   *
+   * - `substring('abcdef',2,4)` yields `cd`, `substring('abcdef',3,5)` yields `def` - the third argument
+   *   is ignored and the **start doubles as the length**, so the result is `n` characters from position
+   *   `n` instead of `length` characters
+   * - the two-argument form always yields the empty string
+   *
+   * Asserted rather than skipped, because a client cannot distinguish this from an empty result set: there
+   * is no error, so these two tests are what makes the difference visible at all.
+   */
+  test("$filter with substring is accepted but evaluated wrongly by this server", async () => {
+    const cmd = LIBRARY.Books().query((b, q) => b.select("Title").filter(q.Title.substring(0, 3).eq("Der")));
+    expect(decodeURIComponent(cmd.getUrl())).toContain("$filter=substring(Title,0,3) eq 'Der'");
+
+    const result = await cmd.execute();
+
+    expect(result.status).toBe(200);
+    // "Der Prozess" is in the data and every other server returns it here
+    expect(result.data.d.results).toStrictEqual([]);
+  });
+
+  test("what this server computes for substring instead", async () => {
+    // start 3 with any length gives three characters from position 3: "Der Prozess" -> " Pr"
+    const threeFromThree = await LIBRARY.Books()
+      .query((b, q) => b.select("Title").filter(q.Title.substring(3, 99).eq(" Pr")))
+      .execute();
+    expect(threeFromThree.data.d.results.map((book) => book.Title)).toStrictEqual(["Der Prozess"]);
+
+    // and without a length there is nothing left at all - the empty string, for every row
+    const all = await LIBRARY.Books()
+      .query((b) => b.select("Title"))
+      .execute();
+    const withoutLength = await LIBRARY.Books()
+      .query((b, q) => b.select("Title").filter(q.Title.substring(4).eq("")))
+      .execute();
+
+    expect(all.data.d.results.length).toBeGreaterThan(0);
+    expect(withoutLength.data.d.results.length).toBe(all.data.d.results.length);
+  });
+
   test("$top and $skip", async () => {
     const all = await LIBRARY.Books()
       .query((b, q) => b.orderBy(q.Title.asc()))

--- a/packages/odata-query-objects/src/odata/ODataModel.ts
+++ b/packages/odata-query-objects/src/odata/ODataModel.ts
@@ -5,7 +5,7 @@ export const enum StandardFilterOperators {
   LOWER_EQUALS = "le",
   GREATER_THAN = "gt",
   GREATER_EQUALS = "ge",
-  // HAS = "has",
+  HAS = "has", // v4 only; tests a flag enum for a member
   IN = "in",
 }
 
@@ -17,7 +17,7 @@ export const enum StringFilterFunctions {
   INDEX_OF = "indexof",
   LENGTH = "length",
   STARTS_WITH = "startswith",
-  // SUBSTRING = "substring"
+  SUBSTRING = "substring",
   MATCHES_PATTERN = "matchesPattern", // v4 only; introduced in 4.01, but we don't differentiate 4.0 and 4.01
   TO_LOWER = "tolower",
   TO_UPPER = "toupper",

--- a/packages/odata-query-objects/src/param/UrlParamHelper.ts
+++ b/packages/odata-query-objects/src/param/UrlParamHelper.ts
@@ -134,10 +134,9 @@ export function buildOperatorExpression(
 
 export function buildFunctionExpression(
   functionName: CollectionFilterFunctions | StringFilterFunctions | NumberFilterFunctions | DateTimeFilterFunctions,
-  param1: string,
-  param2?: string,
+  ...params: Array<string>
 ) {
-  return `${functionName}(${param1}${param2 ? `,${param2}` : ""})`;
+  return `${functionName}(${params.join(",")})`;
 }
 
 export function buildQFilterOperation(

--- a/packages/odata-query-objects/src/path/base/BaseFunctions.ts
+++ b/packages/odata-query-objects/src/path/base/BaseFunctions.ts
@@ -93,6 +93,19 @@ export function filterGreaterEquals<T>(path: string, mapValue: MapValue<T>) {
   };
 }
 
+export function filterHas<T>(path: string, mapValue: MapValue<T>) {
+  /**
+   * Base filter function (V4): the flag enum property must contain the given member.
+   *
+   * Only meaningful for an enum declared `IsFlags="true"`. Elsewhere a service will not necessarily
+   * refuse it - it may just do bit arithmetic on the underlying numbers and answer with something the
+   * caller did not ask for.
+   */
+  return (value: T) => {
+    return buildQFilterOperation(path, StandardFilterOperators.HAS, mapValue(value));
+  };
+}
+
 export function filterInEmulated<T>(path: string, mapValue: MapValue<T>) {
   /**
    * Base filter function: property must equal one of the given values.

--- a/packages/odata-query-objects/src/path/base/QStringBasePath.ts
+++ b/packages/odata-query-objects/src/path/base/QStringBasePath.ts
@@ -1,7 +1,18 @@
 import { StringFilterFunctions } from "../../odata/ODataModel";
-import { buildFunctionExpression, formatWithQuotes } from "../../param/UrlParamHelper";
+import { buildFunctionExpression, formatWithQuotes, isPathValue } from "../../param/UrlParamHelper";
 import { QFilterExpression } from "../../QFilterExpression";
+import { QValuePathModel } from "../QPathModel";
 import { InputModel, QBasePath } from "./QBasePath";
+
+/**
+ * The character positions `substring` takes. They are `Edm.Int32` and therefore untouched by this path's
+ * converter, which only ever applies to the string value itself.
+ */
+export type PositionModel = QValuePathModel | number;
+
+function formatPosition(position: PositionModel): string {
+  return isPathValue(position) ? position.getPath() : String(position);
+}
 
 export abstract class QStringBasePath<SubClass extends QStringBasePath<any, any>, ConvertedType> extends QBasePath<
   string,
@@ -39,6 +50,21 @@ export abstract class QStringBasePath<SubClass extends QStringBasePath<any, any>
 
   public endsWith(value: InputModel<this["converter"]>) {
     return this.buildFunctionFilter(StringFilterFunctions.ENDS_WITH, value);
+  }
+
+  /**
+   * Cut out a part of the value string, starting at the given zero-based character position and running
+   * to the end - or, with the second argument, spanning that number of characters. Note that the second
+   * argument is a **length**, unlike the end position JS's `String.prototype.substring` expects.
+   *
+   * V4 knows the length argument only since 4.01, but V2 has had it from the start; we don't differentiate
+   * 4.0 and 4.01, so both forms are offered for either version.
+   */
+  public substring(start: PositionModel, length?: PositionModel) {
+    const positions = length === undefined ? [start] : [start, length];
+    return this.create(
+      buildFunctionExpression(StringFilterFunctions.SUBSTRING, this.path, ...positions.map(formatPosition)),
+    );
   }
 
   public toLower() {

--- a/packages/odata-query-objects/src/path/enum/BaseEnumPath.ts
+++ b/packages/odata-query-objects/src/path/enum/BaseEnumPath.ts
@@ -2,6 +2,7 @@ import {
   filterEquals,
   filterGreaterEquals,
   filterGreaterThan,
+  filterHas,
   filterInEmulated,
   filterIsNotNull,
   filterIsNull,
@@ -57,4 +58,11 @@ export abstract class BaseEnumPath<EnumMemberType> implements QPathModel {
   public ge = this.greaterEquals;
 
   public in = filterInEmulated<EnumMemberType>(this.path, this.mapValue.bind(this));
+
+  /**
+   * V4 only, and only for an enum declared `IsFlags="true"`. Nothing in the metadata carries that flag
+   * into the generated code, so the method exists on every enum path and it is on the caller to use it
+   * where the enum actually is a flag set.
+   */
+  public has = filterHas<EnumMemberType>(this.path, this.mapValue.bind(this));
 }

--- a/packages/odata-query-objects/test/param/UrlParamHelper.test.ts
+++ b/packages/odata-query-objects/test/param/UrlParamHelper.test.ts
@@ -157,6 +157,7 @@ describe("UrlParamHelper Tests", () => {
   test("buildFunctionExpression", () => {
     expect(buildFunctionExpression(StringFilterFunctions.LENGTH, "test")).toBe("length(test)");
     expect(buildFunctionExpression(StringFilterFunctions.CONTAINS, "Test", "ttt")).toBe("contains(Test,ttt)");
+    expect(buildFunctionExpression(StringFilterFunctions.SUBSTRING, "Test", "0", "3")).toBe("substring(Test,0,3)");
   });
 
   test("buildQFilterOperation", () => {

--- a/packages/odata-query-objects/test/path/StringBaseTests.ts
+++ b/packages/odata-query-objects/test/path/StringBaseTests.ts
@@ -218,6 +218,37 @@ export function createStringTests<T extends QStringPath | QStringV2Path>(toTest:
     expect(result.toString()).toBe("length(Country) eq 6");
   });
 
+  test("substring", () => {
+    const result = toTest.substring(3).equals("nce");
+
+    expect(result.toString()).toBe("substring(Country,3) eq 'nce'");
+  });
+
+  test("substring from the very first character", () => {
+    // a start of 0 is the one position which is falsy in JS - it still has to reach the URL
+    const result = toTest.substring(0).equals("France");
+
+    expect(result.toString()).toBe("substring(Country,0) eq 'France'");
+  });
+
+  test("substring with length", () => {
+    const result = toTest.substring(1, 2).equals("ra");
+
+    expect(result.toString()).toBe("substring(Country,1,2) eq 'ra'");
+  });
+
+  test("substring with positions taken from a property", () => {
+    const result = toTest.substring(otherProp.length()).equals("ce");
+
+    expect(result.toString()).toBe("substring(Country,length(Language)) eq 'ce'");
+  });
+
+  test("substring is chainable, being a manipulation function", () => {
+    const result = toTest.substring(0, 3).toLower().startsWith("fr");
+
+    expect(result.toString()).toBe("startswith(tolower(substring(Country,0,3)),'fr')");
+  });
+
   test("toLower", () => {
     const result = toTest.toLower().equals("france");
 

--- a/packages/odata-query-objects/test/path/enum/QEnumPath.test.ts
+++ b/packages/odata-query-objects/test/path/enum/QEnumPath.test.ts
@@ -84,4 +84,17 @@ describe("QEnumPath test", () => {
 
     expect(result).toBe(`(feature eq 'Feature2' or feature eq 'Feature3')`);
   });
+
+  test("has", () => {
+    const result = toTest.has(FeatureEnum.Feature2);
+
+    expect(result.toString()).toBe("feature has 'Feature2'");
+    expect(result.toString()).toBe(toTest.has("Feature2").toString());
+  });
+
+  test("has combines with the logical operators like any other expression", () => {
+    const result = toTest.has(FeatureEnum.Feature1).and(toTest.has(FeatureEnum.Feature3));
+
+    expect(result.toString()).toBe("feature has 'Feature1' and feature has 'Feature3'");
+  });
 });

--- a/packages/odata-query-objects/test/path/enum/QNumericEnumPath.test.ts
+++ b/packages/odata-query-objects/test/path/enum/QNumericEnumPath.test.ts
@@ -77,6 +77,13 @@ describe("QNumericEnumPath test", () => {
     expect(result).toBe(`(feature eq 'Feature1' or feature eq 'Feature2')`);
   });
 
+  test("has", () => {
+    // the member name goes on the wire, not its number - same as for equals
+    const result = toTest.has(FeatureEnum.Feature2);
+
+    expect(result.toString()).toBe("feature has 'Feature2'");
+  });
+
   test("fails with non enum values", () => {
     // @ts-expect-error
     toTest.eq(99);


### PR DESCRIPTION
- `substring(start, length?)` on every string path (V2 and V4), returning a string path so it chains like the other manipulation functions. Positions take a number or another property.
- `has` on the enum paths (`QEnumPath`, `QNumericEnumPath`), rendering `Amenities has 'Parking'`. It is the flag-enum test, not a string function — the feature-support table listing it under string functions was wrong. `IsFlags` is read nowhere in the generator, so it is offered on every enum property.
- `buildFunctionExpression` is variadic now, for `substring`'s third parameter. Its old truthiness check would have dropped a `0`, which the new tests pin down.
- Integration tests in all three server packages, asserting the URL and the rows.

Two findings from the servers:

- ASP.NET accepts the bare member name (`Amenities has 'Parking'`), so no qualified enum literal is needed — and it does not refuse `has` on a non-flag enum, it silently does bit arithmetic.
- Apache Olingo 2 computes `substring` wrongly: the length argument is ignored and the start doubles as the length, while the two-argument form always yields the empty string. It answers 200, so a caller cannot tell it from an empty result set. Asserted and explained in `int-test/olingo-v2`.

Docs are in https://github.com/odata2ts/odata2ts.github.io/pull/67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
