### PR TITLE
build: pin the test server images and let Renovate bump them

### DIFF
--- a/int-test/asp-net/test/globalSetup.ts
+++ b/int-test/asp-net/test/globalSetup.ts
@@ -1,4 +1,4 @@
-import { GenericContainer, PullPolicy, StartedTestContainer, Wait } from "testcontainers";
+import { GenericContainer, StartedTestContainer, Wait } from "testcontainers";
 import type { TestProject } from "vitest/node";
 
 /**
@@ -17,7 +17,10 @@ import type { TestProject } from "vitest/node";
  * standardized model and only differ in the image name, so this file is the single point that changes.
  */
 const CUSTOM_IMAGE = process.env.ASPNET_SERVER_IMAGE;
-const IMAGE = CUSTOM_IMAGE ?? "ghcr.io/odata2ts/test-server-asp-net:latest";
+// Pinned to an exact version, never `latest`: a run is then reproducible, and a new server release
+// arrives as a Renovate PR that CI runs these tests against - merging it is what accepts the new
+// server. Renovate keeps this line current, see `customManagers` in the repo's renovate.json.
+const IMAGE = CUSTOM_IMAGE ?? "ghcr.io/odata2ts/test-server-asp-net:0.1.0";
 const SERVICE_PATH = "/odata/v4/library";
 const CONTAINER_PORT = 4004;
 
@@ -30,19 +33,10 @@ export default async function setup(project: TestProject) {
 
   let container: StartedTestContainer;
   try {
-    let candidate = new GenericContainer(IMAGE)
+    container = await new GenericContainer(IMAGE)
       .withExposedPorts(CONTAINER_PORT)
-      .withWaitStrategy(Wait.forHttp(`${SERVICE_PATH}/`, CONTAINER_PORT).forStatusCode(200));
-
-    // Testcontainers keeps a locally present image, and `latest` moves - so once the tag has been pulled,
-    // every later run silently tests against that old server. The failures this produces look exactly
-    // like client bugs, which costs far more than the digest check this saves. An image named explicitly
-    // is left alone: that one may well have been built locally and not exist in any registry.
-    if (!CUSTOM_IMAGE) {
-      candidate = candidate.withPullPolicy(PullPolicy.alwaysPull());
-    }
-
-    container = await candidate.start();
+      .withWaitStrategy(Wait.forHttp(`${SERVICE_PATH}/`, CONTAINER_PORT).forStatusCode(200))
+      .start();
   } catch (e) {
     throw new Error(
       `Could not start the test server container "${IMAGE}".\n` +

--- a/int-test/cap/test/globalSetup.ts
+++ b/int-test/cap/test/globalSetup.ts
@@ -1,4 +1,4 @@
-import { GenericContainer, PullPolicy, StartedTestContainer, Wait } from "testcontainers";
+import { GenericContainer, StartedTestContainer, Wait } from "testcontainers";
 import type { TestProject } from "vitest/node";
 
 /**
@@ -21,7 +21,10 @@ import type { TestProject } from "vitest/node";
  * from the V4 one rather than configured separately - there is only ever one server, see test/v2/.
  */
 const CUSTOM_IMAGE = process.env.CAP_SERVER_IMAGE;
-const IMAGE = CUSTOM_IMAGE ?? "ghcr.io/odata2ts/test-server-cap:latest";
+// Pinned to an exact version, never `latest`: a run is then reproducible, and a new server release
+// arrives as a Renovate PR that CI runs these tests against - merging it is what accepts the new
+// server. Renovate keeps this line current, see `customManagers` in the repo's renovate.json.
+const IMAGE = CUSTOM_IMAGE ?? "ghcr.io/odata2ts/test-server-cap:0.1.0";
 const SERVICE_PATH = "/odata/v4/library";
 const SERVICE_PATH_V2 = "/odata/v2/library";
 const CONTAINER_PORT = 4004;
@@ -42,19 +45,10 @@ export default async function setup(project: TestProject) {
 
   let container: StartedTestContainer;
   try {
-    let candidate = new GenericContainer(IMAGE)
+    container = await new GenericContainer(IMAGE)
       .withExposedPorts(CONTAINER_PORT)
-      .withWaitStrategy(Wait.forHttp(`${SERVICE_PATH}/`, CONTAINER_PORT).forStatusCode(200));
-
-    // Testcontainers keeps a locally present image, and `latest` moves - so once the tag has been pulled,
-    // every later run silently tests against that old server. The failures this produces look exactly
-    // like client bugs, which costs far more than the digest check this saves. An image named explicitly
-    // is left alone: that one may well have been built locally and not exist in any registry.
-    if (!CUSTOM_IMAGE) {
-      candidate = candidate.withPullPolicy(PullPolicy.alwaysPull());
-    }
-
-    container = await candidate.start();
+      .withWaitStrategy(Wait.forHttp(`${SERVICE_PATH}/`, CONTAINER_PORT).forStatusCode(200))
+      .start();
   } catch (e) {
     throw new Error(
       `Could not start the test server container "${IMAGE}".\n` +

--- a/int-test/olingo-v2/README.md
+++ b/int-test/olingo-v2/README.md
@@ -37,9 +37,10 @@ while odata2ts types it as a string; that settles where the bug is.
 
 `globalSetup` has the same two modes as the other server packages:
 
-- **managed container** (default): pulls `ghcr.io/odata2ts/test-server-olingo-v2:latest`, waits for the
-  service, maps a dynamic port and removes the container afterwards. Override the image with
-  `OLINGO_SERVER_IMAGE`.
+- **managed container** (default): pulls the exact version of `ghcr.io/odata2ts/test-server-olingo-v2`
+  pinned in `test/globalSetup.ts`, waits for the service, maps a dynamic port and removes the container
+  afterwards. Renovate raises a PR when the server publishes a new release, so the version moves only
+  with a green integration-test run behind it. Override the image with `OLINGO_SERVER_IMAGE`.
 - **external server**: if `LIBRARY_BASE_URL` is set, that URL is used as-is:
 
   ```bash

--- a/int-test/olingo-v2/test/globalSetup.ts
+++ b/int-test/olingo-v2/test/globalSetup.ts
@@ -1,4 +1,4 @@
-import { GenericContainer, PullPolicy, StartedTestContainer, Wait } from "testcontainers";
+import { GenericContainer, StartedTestContainer, Wait } from "testcontainers";
 import type { TestProject } from "vitest/node";
 
 /**
@@ -15,7 +15,10 @@ import type { TestProject } from "vitest/node";
  * process, so a restart is a full reset.
  */
 const CUSTOM_IMAGE = process.env.OLINGO_SERVER_IMAGE;
-const IMAGE = CUSTOM_IMAGE ?? "ghcr.io/odata2ts/test-server-olingo-v2:latest";
+// Pinned to an exact version, never `latest`: a run is then reproducible, and a new server release
+// arrives as a Renovate PR that CI runs these tests against - merging it is what accepts the new
+// server. Renovate keeps this line current, see `customManagers` in the repo's renovate.json.
+const IMAGE = CUSTOM_IMAGE ?? "ghcr.io/odata2ts/test-server-olingo-v2:0.1.0";
 const SERVICE_PATH = "/odata/v2/library";
 const CONTAINER_PORT = 4004;
 
@@ -28,17 +31,10 @@ export default async function setup(project: TestProject) {
 
   let container: StartedTestContainer;
   try {
-    let candidate = new GenericContainer(IMAGE)
+    container = await new GenericContainer(IMAGE)
       .withExposedPorts(CONTAINER_PORT)
-      .withWaitStrategy(Wait.forHttp(`${SERVICE_PATH}/`, CONTAINER_PORT).forStatusCode(200));
-
-    // `latest` moves, and testcontainers keeps a locally present image - so without this every later
-    // run would silently test against whatever was pulled first. See int-test/cap for the full reasoning.
-    if (!CUSTOM_IMAGE) {
-      candidate = candidate.withPullPolicy(PullPolicy.alwaysPull());
-    }
-
-    container = await candidate.start();
+      .withWaitStrategy(Wait.forHttp(`${SERVICE_PATH}/`, CONTAINER_PORT).forStatusCode(200))
+      .start();
   } catch (e) {
     throw new Error(
       `Could not start the test server container "${IMAGE}".\n` +

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,16 @@
   "lockFileMaintenance": {
     "enabled": true
   },
+  "customManagers": [
+    {
+      "description": "The int-test packages pin the test server image they run against inside their globalSetup.ts. Renovate has no manager for TypeScript, so the image reference is matched directly - deliberately without depending on the surrounding code, which would break the match silently if the file were refactored.",
+      "customType": "regex",
+      "managerFilePatterns": ["int-test/*/test/globalSetup.ts"],
+      "matchStrings": ["\"(?<depName>ghcr\\.io/odata2ts/test-server-[a-z0-9-]+):(?<currentValue>[^\"]+)\""],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "semver"
+    }
+  ],
   "packageRules": [
     {
       "description": "Internal @odata2ts/* sibling packages are managed via release-please and the other odata2ts repos, not Renovate",
@@ -49,6 +59,13 @@
       "matchPackageNames": ["typescript", "ts-morph", "@ts-morph/common"],
       "groupName": "typescript & ts-morph (core, manual)",
       "dependencyDashboardApproval": true,
+      "automerge": false
+    },
+    {
+      "description": "A new release of a test server becomes its own PR, which CI runs that server's integration tests against - merging it is what accepts the new server. Deliberately not grouped: one server regressing must not hold back the other two. The schedule overrides the repo-wide weekly window, since a server release should reach the integration tests promptly, and automerge stays off because accepting a server is a review decision.",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/odata2ts/test-server-**"],
+      "schedule": ["at any time"],
       "automerge": false
     }
   ]


### PR DESCRIPTION
The int-test packages ran against `:latest` and forced a pull on every run, so a run was never reproducible and a new server arrived unannounced. They now pin an exact version, and Renovate raises a PR per server release — merging that PR is what accepts the new server.

- pin `:0.1.0` in the three `int-test/*/test/globalSetup.ts` instead of `:latest`
- drop the `PullPolicy.alwaysPull()` workaround, which existed only because `latest` moves; an exact version tag is stable, so local runs stop re-pulling
- `renovate.json`: add a `customManagers` regex for the image reference (Renovate has no TypeScript manager), matching the image string directly rather than the surrounding code so a refactor cannot break the match silently
- `renovate.json`: add a package rule with `schedule: ["at any time"]` to override the repo-wide weekly window, and `automerge: false`. Deliberately not grouped, so one server regressing does not hold back the other two
- `int-test/olingo-v2/README.md`: describe the pin instead of `latest`

**Merge order:** `0.1.0` does not exist yet. This must merge only after odata2ts/test-server-cap#30, odata2ts/test-server-asp-net#13 and odata2ts/test-server-olingo-v2#4 are merged *and* each repo's release PR has been merged so the version is published. Merging earlier turns all three integration-test legs red with `manifest unknown`.

Verified locally against the current images via the `*_SERVER_IMAGE` escape hatch: asp-net 112/112, olingo-v2 115/115, cap 182 passed / 2 skipped.