### PR TITLE
test(odata2ts): exercise the annotated keys against the servers that declare them

### DIFF
--- a/int-test/asp-net/odata2ts.config.ts
+++ b/int-test/asp-net/odata2ts.config.ts
@@ -1,4 +1,4 @@
-import { ConfigFileOptions, EmitModes, ManagedPropertyMode, Modes, TypeModel } from "@odata2ts/odata2ts";
+import { ConfigFileOptions, EmitModes, KeyProperties, ManagedPropertyMode, Modes, TypeModel } from "@odata2ts/odata2ts";
 
 /** The running server to refresh from, or `undefined` to read the committed snapshot - see below. */
 const SOURCE_URL = process.env.LIBRARY_BASE_URL;
@@ -129,6 +129,10 @@ const config: ConfigFileOptions = {
       source: SOURCE,
       output: "src-generated/library-strict",
       managedPropertyMode: ManagedPropertyMode.strictOmit,
+      // The servers now declare every generated key, so a key left bare really is the client's - which
+      // is what makes `strict` safe here and pointless anywhere else: it demands a non-nullable key on
+      // create, and after this release only `Branch` and `Copy` still are one.
+      keyProperties: KeyProperties.strict,
     },
   },
 };

--- a/int-test/asp-net/resource/library.xml
+++ b/int-test/asp-net/resource/library.xml
@@ -13,12 +13,14 @@
         /><Property Name="Country" Type="Edm.String" MaxLength="60" /></ComplexType><EntityType
         Name="Medium"
         Abstract="true"
-      ><Key><PropertyRef Name="Id" /></Key><Property Name="Id" Type="Edm.Guid" Nullable="false" /><Property
-          Name="Title"
+      ><Key><PropertyRef Name="Id" /></Key><Property Name="Id" Type="Edm.Guid" Nullable="false"><Annotation
+            Term="Org.OData.Core.V1.Computed"
+            Bool="true"
+          /></Property><Property Name="Title" Type="Edm.String" Nullable="false" MaxLength="200" /><Property
+          Name="Language"
           Type="Edm.String"
-          Nullable="false"
-          MaxLength="200"
-        /><Property Name="Language" Type="Edm.String" MaxLength="40"><Annotation
+          MaxLength="40"
+        ><Annotation
             Term="Org.OData.Core.V1.Description"
             String="Language of the medium itself, as an ISO 639-1 code."
           /></Property><Property Name="PublicationDate" Type="Edm.Date" /><Property
@@ -97,11 +99,12 @@
         ><OnDelete Action="Cascade" /></NavigationProperty></EntityType><EntityType
         Name="AudiobookChapter"
         HasStream="true"
-      ><Key><PropertyRef Name="Id" /></Key><Property Name="Id" Type="Edm.Int32" Nullable="false" /><Property
-          Name="Title"
-          Type="Edm.String"
-        /><Annotation Term="Org.OData.Core.V1.AcceptableMediaTypes"><Collection><String
-            >audio/mpeg</String></Collection></Annotation></EntityType><EntityType
+      ><Key><PropertyRef Name="Id" /></Key><Property Name="Id" Type="Edm.Int32" Nullable="false"><Annotation
+            Term="Org.OData.Core.V1.Computed"
+            Bool="true"
+          /></Property><Property Name="Title" Type="Edm.String" /><Annotation
+          Term="Org.OData.Core.V1.AcceptableMediaTypes"
+        ><Collection><String>audio/mpeg</String></Collection></Annotation></EntityType><EntityType
         Name="EBook"
         BaseType="Library.Catalog.Medium"
         HasStream="true"
@@ -177,13 +180,19 @@
           Name="Id"
           Type="Edm.Int32"
           Nullable="false"
-        /><Property Name="ActiveSince" Type="Edm.DateTimeOffset" Precision="7"><Annotation
-            Term="Org.OData.Core.V1.ComputedDefaultValue"
-            Bool="true"
-          /></Property><Property Name="Name" Type="Edm.String" Nullable="false" MaxLength="100" /><Property
-          Name="DateOfBirth"
-          Type="Edm.Date"
-        /><Property Name="Address" Type="Library.Catalog.PostalAddress" /><Property
+        ><Annotation Term="Org.OData.Core.V1.Computed" Bool="true" /></Property><Property
+          Name="ActiveSince"
+          Type="Edm.DateTimeOffset"
+          Precision="7"
+        ><Annotation Term="Org.OData.Core.V1.ComputedDefaultValue" Bool="true" /></Property><Property
+          Name="Name"
+          Type="Edm.String"
+          Nullable="false"
+          MaxLength="100"
+        /><Property Name="DateOfBirth" Type="Edm.Date" /><Property
+          Name="Address"
+          Type="Library.Catalog.PostalAddress"
+        /><Property
           Name="PreviousAddresses"
           Type="Collection(Library.Catalog.PostalAddress)"
           Nullable="false"
@@ -210,24 +219,31 @@
           Name="Id"
           Type="Edm.Guid"
           Nullable="false"
-        /><Property Name="LoanedAt" Type="Edm.DateTimeOffset" Nullable="false" Precision="7"><Annotation
-            Term="Org.OData.Core.V1.Immutable"
-            Bool="true"
-          /></Property><Property Name="ReturnedAt" Type="Edm.DateTimeOffset" Precision="7" /><Property
-          Name="DueDate"
-          Type="Edm.Date"
+        ><Annotation Term="Org.OData.Core.V1.Computed" Bool="true" /></Property><Property
+          Name="LoanedAt"
+          Type="Edm.DateTimeOffset"
           Nullable="false"
-        /><Property Name="LateFee" Type="Edm.Decimal" Precision="5" Scale="2"><Annotation
-            Term="Org.OData.Measures.V1.ISOCurrency"
-            String="EUR"
-          /></Property><NavigationProperty
+          Precision="7"
+        ><Annotation Term="Org.OData.Core.V1.Immutable" Bool="true" /></Property><Property
+          Name="ReturnedAt"
+          Type="Edm.DateTimeOffset"
+          Precision="7"
+        /><Property Name="DueDate" Type="Edm.Date" Nullable="false" /><Property
+          Name="LateFee"
+          Type="Edm.Decimal"
+          Precision="5"
+          Scale="2"
+        ><Annotation Term="Org.OData.Measures.V1.ISOCurrency" String="EUR" /></Property><NavigationProperty
           Name="Member"
           Type="Library.Circulation.Member"
           Nullable="false"
           Partner="Loans"
         /><NavigationProperty Name="Copy" Type="Library.Circulation.Copy" Nullable="false" /></EntityType><EntityType
         Name="Reservation"
-      ><Key><PropertyRef Name="Id" /></Key><Property Name="Id" Type="Edm.Guid" Nullable="false" /><Property
+      ><Key><PropertyRef Name="Id" /></Key><Property Name="Id" Type="Edm.Guid" Nullable="false"><Annotation
+            Term="Org.OData.Core.V1.Computed"
+            Bool="true"
+          /></Property><Property
           Name="ReservedAt"
           Type="Edm.DateTimeOffset"
           Nullable="false"
@@ -236,26 +252,29 @@
           Name="Id"
           Type="Edm.Guid"
           Nullable="false"
-        /><Property Name="UploadedAt" Type="Edm.DateTimeOffset" Nullable="false" Precision="7" /><Property
-          Name="Scan"
-          Type="Edm.Binary"
-        /></EntityType><EntityType Name="Branch"><Key><PropertyRef Name="Id" /></Key><Property
-          Name="Id"
-          Type="Edm.Int32"
+        ><Annotation Term="Org.OData.Core.V1.Computed" Bool="true" /></Property><Property
+          Name="UploadedAt"
+          Type="Edm.DateTimeOffset"
           Nullable="false"
-        /><Property Name="Name" Type="Edm.String" Nullable="false" MaxLength="100" /><Property
-          Name="Address"
-          Type="Library.Catalog.PostalAddress"
-        /><Property Name="Location" Type="Edm.GeographyPoint" /><Property
-          Name="CatchmentArea"
-          Type="Edm.GeographyPolygon"
-        /><Property Name="LowestFloor" Type="Edm.SByte" Nullable="false" /><Property
-          Name="FloorPlanOrigin"
-          Type="Edm.GeometryPoint"
-        /><Property Name="FloorPlanShapes" Type="Edm.GeometryCollection" /><Property
-          Name="OpensAt"
-          Type="Edm.TimeOfDay"
-        /><Property Name="ClosesAt" Type="Edm.TimeOfDay" /><Property
+          Precision="7"
+        /><Property Name="Scan" Type="Edm.Binary" /></EntityType><EntityType Name="Branch"><Key><PropertyRef
+            Name="Id"
+          /></Key><Property Name="Id" Type="Edm.Int32" Nullable="false" /><Property
+          Name="Name"
+          Type="Edm.String"
+          Nullable="false"
+          MaxLength="100"
+        /><Property Name="Address" Type="Library.Catalog.PostalAddress" /><Property
+          Name="Location"
+          Type="Edm.GeographyPoint"
+        /><Property Name="CatchmentArea" Type="Edm.GeographyPolygon" /><Property
+          Name="LowestFloor"
+          Type="Edm.SByte"
+          Nullable="false"
+        /><Property Name="FloorPlanOrigin" Type="Edm.GeometryPoint" /><Property
+          Name="FloorPlanShapes"
+          Type="Edm.GeometryCollection"
+        /><Property Name="OpensAt" Type="Edm.TimeOfDay" /><Property Name="ClosesAt" Type="Edm.TimeOfDay" /><Property
           Name="Amenities"
           Type="Library.Catalog.Amenities"
         /><Property Name="Population" Type="Edm.Int64" Nullable="false"><Annotation
@@ -265,23 +284,27 @@
           Name="Id"
           Type="Edm.Int32"
           Nullable="false"
-        /><Property Name="LicensePlate" Type="Edm.String" MaxLength="12" /><Property
-          Name="Route"
-          Type="Edm.GeographyLineString"
-        /><Property Name="CurrentPosition" Type="Edm.GeographyPoint" /></EntityType><EntityType Name="Copy"><Key
-        ><PropertyRef Name="InventoryNumber" /><PropertyRef Name="MediumId" /></Key><Property
-          Name="MediumId"
-          Type="Edm.Guid"
+        ><Annotation Term="Org.OData.Core.V1.Computed" Bool="true" /></Property><Property
+          Name="LicensePlate"
+          Type="Edm.String"
+          MaxLength="12"
+        /><Property Name="Route" Type="Edm.GeographyLineString" /><Property
+          Name="CurrentPosition"
+          Type="Edm.GeographyPoint"
+        /></EntityType><EntityType Name="Copy"><Key><PropertyRef Name="InventoryNumber" /><PropertyRef
+            Name="MediumId"
+          /></Key><Property Name="MediumId" Type="Edm.Guid" Nullable="false" /><Property
+          Name="InventoryNumber"
+          Type="Edm.Int32"
           Nullable="false"
-        /><Property Name="InventoryNumber" Type="Edm.Int32" Nullable="false" /><Property
-          Name="IsLoanable"
-          Type="Edm.Boolean"
-          DefaultValue="true"
+        /><Property Name="IsLoanable" Type="Edm.Boolean" DefaultValue="true" Nullable="false" /><Property
+          Name="Condition"
+          Type="Edm.Byte"
           Nullable="false"
-        /><Property Name="Condition" Type="Edm.Byte" Nullable="false"><Annotation
-            Term="Org.OData.Validation.V1.Minimum"
-            Int="0"
-          /><Annotation Term="Org.OData.Validation.V1.Maximum" Int="5" /><Annotation
+        ><Annotation Term="Org.OData.Validation.V1.Minimum" Int="0" /><Annotation
+            Term="Org.OData.Validation.V1.Maximum"
+            Int="5"
+          /><Annotation
             Term="Org.OData.Core.V1.Description"
             String="Physical condition on a 0-5 scale, 5 being as new. Doubles as the ETag."
           /></Property><Property Name="Status" Type="Library.Catalog.AvailabilityStatus" /><Property
@@ -462,11 +485,15 @@
           Name="Id"
           Type="Edm.Int32"
           Nullable="false"
-        /><Property Name="Name" Type="Edm.String" Nullable="false" MaxLength="100" /><Property
-          Name="Country"
+        ><Annotation Term="Org.OData.Core.V1.Computed" Bool="true" /></Property><Property
+          Name="Name"
           Type="Edm.String"
-          MaxLength="60"
-        /><Property Name="Founded" Type="Edm.Date" /><NavigationProperty
+          Nullable="false"
+          MaxLength="100"
+        /><Property Name="Country" Type="Edm.String" MaxLength="60" /><Property
+          Name="Founded"
+          Type="Edm.Date"
+        /><NavigationProperty
           Name="Books"
           Type="Collection(Library.Catalog.Book)"
           Partner="Publisher"
@@ -474,11 +501,11 @@
           Name="Id"
           Type="Edm.Int32"
           Nullable="false"
-        /><Property Name="City" Type="Edm.String" MaxLength="80" /><Property
-          Name="Country"
+        ><Annotation Term="Org.OData.Core.V1.Computed" Bool="true" /></Property><Property
+          Name="City"
           Type="Edm.String"
-          MaxLength="60"
-        /></EntityType></Schema><Schema
+          MaxLength="80"
+        /><Property Name="Country" Type="Edm.String" MaxLength="60" /></EntityType></Schema><Schema
       Namespace="Library.Service"
       xmlns="http://docs.oasis-open.org/odata/ns/edm"
     ><EntityContainer Name="LibraryService"><EntitySet

--- a/int-test/asp-net/test/feature/Annotations.test.ts
+++ b/int-test/asp-net/test/feature/Annotations.test.ts
@@ -4,6 +4,7 @@ import type {
   EditableMedium as StrictEditableMedium,
 } from "../../src-generated/library-strict/library-catalog/index.js";
 import type { EditableBook, EditableMedium } from "../../src-generated/library/library-catalog/index.js";
+import type { EditableBranch } from "../../src-generated/library/library-circulation/index.js";
 import { BOOK_DER_PROZESS, LIBRARY } from "../LibraryTestConstants.js";
 
 /**
@@ -55,28 +56,27 @@ describe("ASP.NET Library: Core annotations", () => {
     }
   });
 
-  test("an unannotated key falls back to the key rule and stays writable", async () => {
+  test("a key the service declares computed is the server's", () => {
     /*
-     * Nothing in this model says anything about `Id`, so `managedPropertyDetection: "auto"` falls through
-     * to the key rule - which now makes it createOnly rather than readOnly. The property is therefore part
-     * of the editable model, optional under the default `lenient` mode.
+     * Since 0.2.0 the keys are annotated, so nothing here falls through to `keyProperties` any more.
+     * `Core.Computed` makes `Medium.Id` readOnly, and under the default `lenient` mode a readOnly
+     * property stays in the write model but is never required - the client may send one, and the server
+     * is obliged to disregard it.
      */
     expectTypeOf<EditableMedium["Id"]>().toEqualTypeOf<string | undefined>();
     expectTypeOf<EditableBook["Id"]>().toEqualTypeOf<string | undefined>();
+    // ... and `strictOmit` takes it out altogether, since sending it achieves nothing
+    expectTypeOf<StrictEditableBook>().not.toHaveProperty("Id");
+  });
 
-    // and the decisive half a type check cannot give: the server takes the key the client chose, so
-    // keeping it in the payload is right. Under the old readOnly default this was not expressible at all.
-    const Id = "44444444-4444-4444-4444-444444444401";
-    const created = await LIBRARY.Media()
-      .asBookCollectionService()
-      .create({ Id, Title: "Client Assigned Key", PageCount: 1, AgeRating: 0 })
-      .execute();
-
-    try {
-      expect(created.status).toBe(201);
-      expect(created.data.Id).toBe(Id);
-    } finally {
-      await LIBRARY.Media(Id).delete().execute();
-    }
+  test("the one key left bare is the one the client owns", () => {
+    // `Branch/Id` is a code the organisation allocates, so the service says nothing about it - which,
+    // now that every generated key does say something, is itself the statement.
+    //
+    // What the *client* makes of that silence is its own choice. This client runs the default
+    // `keyProperties: "interoperable"`, which will not demand a key it cannot be sure of, so the
+    // property is optional here. The strict client requires it - see feature/ImmutableProperties.test.ts,
+    // which is the pairing that gives the two settings their meaning.
+    expectTypeOf<EditableBranch["Id"]>().toEqualTypeOf<number | undefined>();
   });
 });

--- a/int-test/asp-net/test/feature/ImmutableProperties.test.ts
+++ b/int-test/asp-net/test/feature/ImmutableProperties.test.ts
@@ -1,51 +1,47 @@
 import { describe, expect, expectTypeOf, test } from "vitest";
 import type {
+  EditableBranch,
   EditableLoan,
   EditableMember,
+  UpdatableBranch,
   UpdatableLoan,
-  UpdatableMember,
 } from "../../src-generated/library-strict/library-circulation/index.js";
 import { LIBRARY_STRICT } from "../LibraryTestConstants.js";
 
 /**
- * `managedPropertyMode: "strictOmit"` against ASP.NET, the counterpart of the same file in `int-test/cap`
- * and `int-test/olingo-v2`.
+ * `managedPropertyMode: "strictOmit"` with `keyProperties: "strict"` against ASP.NET, the counterpart of
+ * the same file in `int-test/cap` and `int-test/olingo-v2`.
  *
- * The mode makes two claims about a `createOnly` property - `Loan.LoanedAt`, which carries
- * `Core.Immutable`, and every key without an annotation of its own, which the key rule makes createOnly:
+ * Since 0.2.0 the server declares who owns every key: nine carry `Core.Computed` and `Branch/Id` carries
+ * nothing, because a branch code is the organisation's to allocate. That is what makes `strict` usable
+ * here at all - it demands a non-nullable key on create, which is only right once a bare key genuinely
+ * means "yours to supply". Before, it would have demanded nine keys no client can know.
  *
- * 1. it belongs in a create payload, required or optional per `nullable`, and
- * 2. it belongs in no update payload at all.
- *
- * Only the first is a type-level statement. The second is a claim about the *server*, and the pinned
- * version does not yet keep it: it applies a `LoanedAt` sent on a PATCH. That is a gap in our own server
- * rather than a trait of ASP.NET Core OData - the spec is unambiguous that such a value MUST be ignored -
- * and it is fixed in test-server-asp-net#16. The last test pins what the pinned image really does, so
- * raising the version makes it fail and the expectation gets corrected as a reviewed step.
- *
- * The split between which entity carries which test is the server's doing: `LoansController` implements
- * GET and PATCH only (deliberately - see its own source), so PUT is asked of `Members`, whose key is
- * createOnly by the key rule rather than by annotation.
+ * So both halves of the story sit side by side in one client: a **generated** key is absent from both
+ * write models and discarded if sent anyway, while the **client-assigned** one is required on create and
+ * absent from the update model, since it cannot change once the entity exists.
  */
-describe("ASP.NET Library: immutable properties under strictOmit", () => {
+describe("ASP.NET Library: managed keys and immutable properties", () => {
   const LOANED_AT = "2026-05-01T10:00:00Z";
 
   /**
-   * A loan comes into existence through its member: this server answers a POST to `/Loans` with 405, so a
-   * deep insert is the only way to create one. Which suits the question here - the point is what the loan
-   * looks like *afterwards*, and its key is the client's to choose either way.
+   * A loan comes into existence through its member: this server answers a POST to `/Loans` with 405. Its
+   * key is generated now, so nothing here supplies one and the loan is read back to find it.
    */
-  async function givenLoan(Id: string, memberId: number) {
+  async function givenLoan() {
     const member = await LIBRARY_STRICT.Members()
       .create({
-        Id: memberId,
         Name: "Immutable Test",
         PreviousAddresses: [],
-        Loans: [{ Id, LoanedAt: LOANED_AT, DueDate: "2026-06-01" }],
+        Loans: [{ LoanedAt: LOANED_AT, DueDate: "2026-06-01" }],
       })
       .execute();
     expect(member.status).toBe(201);
-    return { memberId: member.data.Id };
+
+    const loans = await LIBRARY_STRICT.Members(member.data.Id)
+      .query((builder) => builder.expanding("Loans", (loan) => loan))
+      .execute();
+    return { memberId: member.data.Id, loanId: loans.data.Loans![0].Id };
   }
 
   /** Deleting the member takes its loans with it - `Member.Loans` cascades, and `/Loans(…)` has no DELETE. */
@@ -53,48 +49,54 @@ describe("ASP.NET Library: immutable properties under strictOmit", () => {
     await LIBRARY_STRICT.Members(memberId).delete().execute();
   }
 
-  test("the create model keeps immutable properties, and the annotated one follows nullable", () => {
-    // `LoanedAt` carries `Core.Immutable` and is `Nullable="false"`, so the service itself says it is
-    // required on create
-    expectTypeOf<EditableLoan["LoanedAt"]>().toEqualTypeOf<string>();
-
-    // the keys are non-nullable too, but nothing describes them - and this package generates under the
-    // default `keyProperties`, which will not demand a key the server may well be generating
-    expectTypeOf<EditableLoan["Id"]>().toEqualTypeOf<string | undefined>();
-    expectTypeOf<EditableMember["Id"]>().toEqualTypeOf<number | undefined>();
-  });
-
-  test("the update model drops them entirely", () => {
-    // absent, not optional: there is no value the caller could put here that the server would honour
+  test("a generated key is in no write model at all", () => {
+    // `Core.Computed` makes it readOnly, and strictOmit takes a readOnly property out of both - there is
+    // no operation in which a value the client sends would count for anything
+    expectTypeOf<EditableLoan>().not.toHaveProperty("Id");
     expectTypeOf<UpdatableLoan>().not.toHaveProperty("Id");
-    expectTypeOf<UpdatableLoan>().not.toHaveProperty("LoanedAt");
-    expectTypeOf<UpdatableMember>().not.toHaveProperty("Id");
-    // everything else stays exactly as it is in the create model
-    expectTypeOf<UpdatableLoan["DueDate"]>().toEqualTypeOf<string>();
-    expectTypeOf<UpdatableLoan["LateFee"]>().toEqualTypeOf<number | null | undefined>();
+    expectTypeOf<EditableMember>().not.toHaveProperty("Id");
   });
 
-  test("a client-assigned key really is taken by the server", async () => {
-    const Id = "55555555-5555-5555-5555-555555555501";
-    const { memberId } = await givenLoan(Id, 9901);
+  test("the client-assigned key is required on create and gone from the update model", () => {
+    // `Branch/Id` carries no annotation, which after 0.2.0 is a statement rather than a silence: every
+    // key the server generates says so, so what stays bare is the client's. `strict` therefore requires
+    // it - the property is non-nullable, and nothing else will supply it.
+    expectTypeOf<EditableBranch["Id"]>().toEqualTypeOf<number>();
+
+    // and it cannot change afterwards, so the update model has no place for it
+    expectTypeOf<UpdatableBranch>().not.toHaveProperty("Id");
+    expectTypeOf<UpdatableBranch["Name"]>().toEqualTypeOf<string>();
+  });
+
+  test("an annotated immutable property follows nullable on create", () => {
+    // `Loan.LoanedAt` carries `Core.Immutable` and is non-nullable, so the service itself says it is
+    // required on create - and `strictOmit` drops it from the update model
+    expectTypeOf<EditableLoan["LoanedAt"]>().toEqualTypeOf<string>();
+    expectTypeOf<UpdatableLoan>().not.toHaveProperty("LoanedAt");
+  });
+
+  test("the client-assigned key really is stored as sent", async () => {
+    const Id = 4201;
+    const created = await LIBRARY_STRICT.Branches()
+      .create({ Id, Name: "Client Assigned Branch", LowestFloor: 0, Population: 1000 })
+      .execute();
 
     try {
-      // the point of createOnly rather than readOnly: the key was the client's to choose, and requiring it
-      // in the create payload is only right if the server actually stores what was sent
-      const read = await LIBRARY_STRICT.Loans(Id).query().execute();
-      expect(read.data.Id).toBe(Id);
-      expect(read.data.LoanedAt).toContain("2026-05-01T10:00:00");
+      // the point of leaving the key bare: requiring it in the create payload is only right if the
+      // server actually stores what was sent, rather than generating over it
+      expect(created.status).toBe(201);
+      expect(created.data.Id).toBe(Id);
+      expect((await LIBRARY_STRICT.Branches(Id).query().execute()).data.Name).toBe("Client Assigned Branch");
     } finally {
-      await cleanUp(memberId);
+      await LIBRARY_STRICT.Branches(Id).delete().execute();
     }
   });
 
   test("PATCH without the immutable properties changes only what it names", async () => {
-    const Id = "55555555-5555-5555-5555-555555555503";
-    const { memberId } = await givenLoan(Id, 9903);
+    const { memberId, loanId } = await givenLoan();
 
     try {
-      const patched = await LIBRARY_STRICT.Loans(Id)
+      const patched = await LIBRARY_STRICT.Loans(loanId)
         .patch<true>({ ReturnedAt: "2026-05-20T14:00:00Z" })
         .execute({ headers: { Prefer: "return=representation" } });
 
@@ -106,52 +108,45 @@ describe("ASP.NET Library: immutable properties under strictOmit", () => {
     }
   });
 
-  test("PUT without the key replaces the rest and keeps it", async () => {
-    const memberId = 9905;
-    const member = await LIBRARY_STRICT.Members()
-      .create({ Id: memberId, Name: "Put Target", PreviousAddresses: [] })
-      .execute();
-
-    try {
-      // `update` takes UpdatableMember, so the key cannot be written here at all. A PUT is a full replace,
-      // and this pins that the entity keeps the identity it was created with regardless.
-      const updated = await LIBRARY_STRICT.Members(member.data.Id)
-        .update({ Name: "Replaced", PreviousAddresses: [] })
-        .execute();
-      expect(updated.status).toBe(204);
-
-      const read = await LIBRARY_STRICT.Members(member.data.Id).query().execute();
-      expect(read.data.Name).toBe("Replaced");
-      expect(read.data.Id).toBe(member.data.Id);
-    } finally {
-      await cleanUp(member.data.Id);
-    }
-  });
-
-  test("the pinned server still applies a changed immutable property", async () => {
-    const Id = "55555555-5555-5555-5555-555555555504";
-    const { memberId } = await givenLoan(Id, 9904);
+  test("a changed immutable property sent anyway is disregarded", async () => {
+    const { memberId, loanId } = await givenLoan();
 
     try {
       /*
-       * Casting past `UpdatableLoan` is the only way to ask this question, and the answer is why the type
-       * is worth generating at all. Protocol 11.4.3 leaves no room - "the service MUST ignore that value
-       * when applying the update" - and the pinned image does not: it stores 2020 and answers 204, so a
-       * caller reading the response cannot tell that a value was overwritten.
+       * Casting past `UpdatableLoan` is the only way to ask this, and 0.2.0 is the release where the
+       * answer became the right one: the server ignores the value, as Protocol 11.4.3 requires of a
+       * property it declares managed. It used to apply it.
        *
-       * Recorded rather than worked around: the fix is test-server-asp-net#16, and when the image pin
-       * moves to a release carrying it this expectation inverts to the value staying put. Its counterpart
-       * in `int-test/cap` already shows the correct behaviour, which is what makes this one a defect and
-       * not a difference.
+       * The response says nothing either way - 204, exactly as a request that changed everything it
+       * asked for. Which is the whole argument for keeping the property out of the payload: a caller
+       * reading only the response cannot tell a discarded value from an applied one.
        */
       const payload = { LoanedAt: "2020-01-01T00:00:00Z" } as unknown as UpdatableLoan;
-      const patched = await LIBRARY_STRICT.Loans(Id).patch(payload).execute();
+      const patched = await LIBRARY_STRICT.Loans(loanId).patch(payload).execute();
       expect(patched.status).toBe(204);
 
-      const read = await LIBRARY_STRICT.Loans(Id).query().execute();
-      expect(read.data.LoanedAt).toContain("2020-01-01T00:00:00");
+      const read = await LIBRARY_STRICT.Loans(loanId).query().execute();
+      expect(read.data.LoanedAt).toContain("2026-05-01T10:00:00");
     } finally {
       await cleanUp(memberId);
+    }
+  });
+
+  test("a generated key sent anyway is disregarded too", async () => {
+    /*
+     * The same rule reaching the other kind of managed property. `Medium.Id` is `Core.Computed` since
+     * 0.2.0, so the Guid below goes nowhere and the server assigns its own - which is what the type was
+     * saying by not offering the property at all.
+     */
+    const wanted = "12121212-1212-1212-1212-121212121212";
+    const payload = { Title: "Key Probe", PageCount: 1, AgeRating: 0, Id: wanted } as never;
+    const created = await LIBRARY_STRICT.Media().asBookCollectionService().create(payload).execute();
+
+    try {
+      expect(created.status).toBe(201);
+      expect(created.data.Id).not.toBe(wanted);
+    } finally {
+      await LIBRARY_STRICT.Media(created.data.Id).delete().execute();
     }
   });
 });

--- a/int-test/asp-net/test/globalSetup.ts
+++ b/int-test/asp-net/test/globalSetup.ts
@@ -20,7 +20,7 @@ const CUSTOM_IMAGE = process.env.ASPNET_SERVER_IMAGE;
 // Pinned to an exact version, never `latest`: a run is then reproducible, and a new server release
 // arrives as a Renovate PR that CI runs these tests against - merging it is what accepts the new
 // server. Renovate keeps this line current, see `customManagers` in the repo's renovate.json.
-const IMAGE = CUSTOM_IMAGE ?? "ghcr.io/odata2ts/test-server-asp-net:0.1.0";
+const IMAGE = CUSTOM_IMAGE ?? "ghcr.io/odata2ts/test-server-asp-net:0.2.1";
 const SERVICE_PATH = "/odata/v4/library";
 const CONTAINER_PORT = 4004;
 

--- a/int-test/cap/odata2ts.config.ts
+++ b/int-test/cap/odata2ts.config.ts
@@ -1,4 +1,11 @@
-import { ConfigFileOptions, EmitModes, EnumSynthesis, ManagedPropertyMode, Modes } from "@odata2ts/odata2ts";
+import {
+  ConfigFileOptions,
+  EmitModes,
+  EnumSynthesis,
+  KeyProperties,
+  ManagedPropertyMode,
+  Modes,
+} from "@odata2ts/odata2ts";
 
 /** The running server to refresh from, or `undefined` to read the committed snapshots - see below. */
 const SOURCE_URL = process.env.LIBRARY_BASE_URL;
@@ -173,6 +180,10 @@ const config: ConfigFileOptions = {
       source: SOURCE,
       output: "src-generated/library-strict",
       managedPropertyMode: ManagedPropertyMode.strictOmit,
+      // The servers now declare every generated key, so a key left bare really is the client's - which
+      // is what makes `strict` safe here and pointless anywhere else: it demands a non-nullable key on
+      // create, and after this release only `Branch` and `Copy` still are one.
+      keyProperties: KeyProperties.strict,
     },
     libraryV2: {
       serviceName: "LibraryV2",

--- a/int-test/cap/resource/library-v2.xml
+++ b/int-test/cap/resource/library-v2.xml
@@ -1156,6 +1156,9 @@
           </Collection>
         </Annotation>
       </Annotations>
+      <Annotations Target="Library.Service.Publishers/Id" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.ComputedDefaultValue" Bool="true" />
+      </Annotations>
       <Annotations Target="Library.Service.Magazines" xmlns="http://docs.oasis-open.org/odata/ns/edm">
         <Annotation Term="Core.AlternateKeys">
           <Collection>
@@ -1263,6 +1266,9 @@
       <Annotations Target="Library.Service.AudiobookChapters" xmlns="http://docs.oasis-open.org/odata/ns/edm">
         <Annotation Term="Core.MediaType" String="audio/mpeg" />
       </Annotations>
+      <Annotations Target="Library.Service.AudiobookChapters/Id" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.ComputedDefaultValue" Bool="true" />
+      </Annotations>
       <Annotations Target="Library.Service.EntityContainer/DVDs" xmlns="http://docs.oasis-open.org/odata/ns/edm">
         <Annotation Term="Capabilities.SearchRestrictions">
           <Record Type="Capabilities.SearchRestrictionsType">
@@ -1311,6 +1317,9 @@
       >
         <Annotation Term="Core.Computed" Bool="true" />
       </Annotations>
+      <Annotations Target="Library.Service.Members/Id" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.ComputedDefaultValue" Bool="true" />
+      </Annotations>
       <Annotations Target="Library.Service.Members/ActiveSince" xmlns="http://docs.oasis-open.org/odata/ns/edm">
         <Annotation Term="Core.ComputedDefaultValue" Bool="true" />
       </Annotations>
@@ -1327,6 +1336,9 @@
         <Annotation Term="Core.ComputedDefaultValue" Bool="true" />
       </Annotations>
       <Annotations Target="Library.Service.IdDocuments/Id" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.ComputedDefaultValue" Bool="true" />
+      </Annotations>
+      <Annotations Target="Library.Service.Bookmobiles/Id" xmlns="http://docs.oasis-open.org/odata/ns/edm">
         <Annotation Term="Core.ComputedDefaultValue" Bool="true" />
       </Annotations>
       <Annotations Target="Library.Service.MainBranch/Amenities" xmlns="http://docs.oasis-open.org/odata/ns/edm">
@@ -1358,6 +1370,9 @@
             </Record>
           </Collection>
         </Annotation>
+      </Annotations>
+      <Annotations Target="Library.Service.PublisherBranches/Id" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+        <Annotation Term="Core.ComputedDefaultValue" Bool="true" />
       </Annotations>
     </Schema>
   </edmx:DataServices>

--- a/int-test/cap/resource/library.xml
+++ b/int-test/cap/resource/library.xml
@@ -738,6 +738,9 @@
           </Collection>
         </Annotation>
       </Annotations>
+      <Annotations Target="Library.Service.Publishers/Id">
+        <Annotation Term="Core.ComputedDefaultValue" Bool="true" />
+      </Annotations>
       <Annotations Target="Library.Service.Magazines">
         <Annotation Term="Core.AlternateKeys">
           <Collection>
@@ -836,6 +839,9 @@
       <Annotations Target="Library.Service.Audiobooks/Sample">
         <Annotation Term="Core.MediaType" String="audio/mpeg" />
       </Annotations>
+      <Annotations Target="Library.Service.AudiobookChapters/Id">
+        <Annotation Term="Core.ComputedDefaultValue" Bool="true" />
+      </Annotations>
       <Annotations Target="Library.Service.AudiobookChapters/content">
         <Annotation Term="Core.MediaType" String="audio/mpeg" />
       </Annotations>
@@ -881,6 +887,9 @@
       <Annotations Target="Library.Service.CollectorsItems/PopularityScore">
         <Annotation Term="Core.Computed" Bool="true" />
       </Annotations>
+      <Annotations Target="Library.Service.Members/Id">
+        <Annotation Term="Core.ComputedDefaultValue" Bool="true" />
+      </Annotations>
       <Annotations Target="Library.Service.Members/ActiveSince">
         <Annotation Term="Core.ComputedDefaultValue" Bool="true" />
       </Annotations>
@@ -897,6 +906,9 @@
         <Annotation Term="Core.ComputedDefaultValue" Bool="true" />
       </Annotations>
       <Annotations Target="Library.Service.IdDocuments/Id">
+        <Annotation Term="Core.ComputedDefaultValue" Bool="true" />
+      </Annotations>
+      <Annotations Target="Library.Service.Bookmobiles/Id">
         <Annotation Term="Core.ComputedDefaultValue" Bool="true" />
       </Annotations>
       <Annotations Target="Library.Service.MainBranch/Amenities">
@@ -928,6 +940,9 @@
             </Record>
           </Collection>
         </Annotation>
+      </Annotations>
+      <Annotations Target="Library.Service.PublisherBranches/Id">
+        <Annotation Term="Core.ComputedDefaultValue" Bool="true" />
       </Annotations>
       <Annotations Target="Library.Service.LoanStatistics(Library.Service.Library_Circulation_DateRange)/Period">
         <Annotation Term="Core.OptionalParameter">

--- a/int-test/cap/test/globalSetup.ts
+++ b/int-test/cap/test/globalSetup.ts
@@ -24,7 +24,7 @@ const CUSTOM_IMAGE = process.env.CAP_SERVER_IMAGE;
 // Pinned to an exact version, never `latest`: a run is then reproducible, and a new server release
 // arrives as a Renovate PR that CI runs these tests against - merging it is what accepts the new
 // server. Renovate keeps this line current, see `customManagers` in the repo's renovate.json.
-const IMAGE = CUSTOM_IMAGE ?? "ghcr.io/odata2ts/test-server-cap:0.1.0";
+const IMAGE = CUSTOM_IMAGE ?? "ghcr.io/odata2ts/test-server-cap:0.2.0";
 const SERVICE_PATH = "/odata/v4/library";
 const SERVICE_PATH_V2 = "/odata/v2/library";
 const CONTAINER_PORT = 4004;

--- a/int-test/config-variants/test/variants.type-test.ts
+++ b/int-test/config-variants/test/variants.type-test.ts
@@ -14,10 +14,10 @@ import type { EditablePostalAddress as StrictEditablePostalAddress } from "../sr
 import type {
   CopyCollectionService as StrictCopyCollectionService,
   CopyService as StrictCopyService,
+  EditableBranch as StrictEditableBranch,
   EditableCopy as StrictEditableCopy,
-  EditableIdDocument as StrictEditableIdDocument,
+  UpdatableBranch as StrictUpdatableBranch,
   UpdatableCopy as StrictUpdatableCopy,
-  UpdatableMember as StrictUpdatableMember,
 } from "../src-generated/managed-strict/library-circulation/index.js";
 import type { Medium as ModelsOnlyMedium } from "../src-generated/models-only/library-catalog/index.js";
 import type {
@@ -106,15 +106,19 @@ expectTypeOf<StrictUpdatableCopy>().not.toHaveProperty("InventoryNumber");
 // everything not createOnly is untouched by the mode
 expectTypeOf<StrictUpdatableCopy["IsLoanable"]>().toEqualTypeOf<boolean>();
 
+// Only three types have an updatable model at all, and that is the point: `Branch` and `Copy` because
+// their keys are the client's and therefore immutable, `Loan` because of `Core.Immutable` on LoanedAt.
+// Every other key is `Core.Computed` - readOnly, dropped from both write models, so nothing differs.
+
 // A complex property resolves to the nested type's *editable* model, since `PostalAddress` has no
 // immutable property of its own and a second, identical type for it would be noise.
-expectTypeOf<StrictUpdatableMember["PreviousAddresses"]>().toEqualTypeOf<Array<StrictEditablePostalAddress>>();
+expectTypeOf<StrictUpdatableBranch["Address"]>().toEqualTypeOf<StrictEditablePostalAddress | null | undefined>();
 
 // A navigation property always resolves to the referenced entity's editable model, in both write models
 // alike - a binding names an entity that exists in its own right, so the create/update split does not
 // apply to it. This is also what keeps a self-referential entity graph from ever reaching Updatable.
-expectTypeOf<StrictUpdatableMember["IdDocument"]>().toExtend<
-  StrictEditableIdDocument | { "@id": unknown } | null | undefined
+expectTypeOf<StrictUpdatableCopy["Location"]>().toExtend<
+  StrictEditableBranch | { "@id": unknown } | null | undefined
 >();
 
 // The entity service writes with the updatable model, while the collection service, where creation

--- a/int-test/olingo-v2/odata2ts.config.ts
+++ b/int-test/olingo-v2/odata2ts.config.ts
@@ -1,4 +1,4 @@
-import { ConfigFileOptions, EmitModes, ManagedPropertyMode, Modes, TypeModel } from "@odata2ts/odata2ts";
+import { ConfigFileOptions, EmitModes, KeyProperties, ManagedPropertyMode, Modes, TypeModel } from "@odata2ts/odata2ts";
 
 /** The running server to refresh from, or `undefined` to read the committed snapshot - see below. */
 const SOURCE_URL = process.env.LIBRARY_BASE_URL;
@@ -156,6 +156,10 @@ const config: ConfigFileOptions = {
       source: SOURCE,
       output: "src-generated/library-strict",
       managedPropertyMode: ManagedPropertyMode.strictOmit,
+      // The servers now declare every generated key, so a key left bare really is the client's - which
+      // is what makes `strict` safe here and pointless anywhere else: it demands a non-nullable key on
+      // create, and after this release only `Branch` and `Copy` still are one.
+      keyProperties: KeyProperties.strict,
     },
   },
 };

--- a/int-test/olingo-v2/resource/library-v2.xml
+++ b/int-test/olingo-v2/resource/library-v2.xml
@@ -5,15 +5,20 @@
   ><Schema Namespace="Library.Catalog" xmlns="http://schemas.microsoft.com/ado/2008/09/edm"><EntityType
         Name="Medium"
         Abstract="true"
-      ><Key><PropertyRef Name="Id" /></Key><Property Name="Id" Type="Edm.Guid" Nullable="false" /><Property
-          Name="Title"
-          Type="Edm.String"
+      ><Key><PropertyRef Name="Id" /></Key><Property
+          Name="Id"
+          Type="Edm.Guid"
           Nullable="false"
-          MaxLength="200"
-        /><Property Name="Language" Type="Edm.String" MaxLength="40" /><Property
-          Name="PublicationDate"
-          Type="Edm.DateTime"
-        /><Property
+          annotation:StoreGeneratedPattern="Identity"
+          xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation"
+          sap:creatable="false"
+          xmlns:sap="http://www.sap.com/Protocols/SAPData"
+          sap:updatable="false"
+        /><Property Name="Title" Type="Edm.String" Nullable="false" MaxLength="200" /><Property
+          Name="Language"
+          Type="Edm.String"
+          MaxLength="40"
+        /><Property Name="PublicationDate" Type="Edm.DateTime" /><Property
           Name="PopularityScore"
           Type="Edm.Double"
           annotation:StoreGeneratedPattern="Computed"
@@ -57,10 +62,16 @@
           ToRole="Chapter"
         /></EntityType><EntityType Name="AudiobookChapter" m:HasStream="true"><Key><PropertyRef
             Name="Id"
-          /></Key><Property Name="Id" Type="Edm.Int32" Nullable="false" /><Property
-          Name="Title"
-          Type="Edm.String"
-        /><NavigationProperty
+          /></Key><Property
+          Name="Id"
+          Type="Edm.Int32"
+          Nullable="false"
+          annotation:StoreGeneratedPattern="Identity"
+          xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation"
+          sap:creatable="false"
+          xmlns:sap="http://www.sap.com/Protocols/SAPData"
+          sap:updatable="false"
+        /><Property Name="Title" Type="Edm.String" /><NavigationProperty
           Name="Audiobook"
           Relationship="Library.Catalog.Audiobook_Chapters"
           FromRole="Chapter"
@@ -106,6 +117,11 @@
           Name="Id"
           Type="Edm.Int32"
           Nullable="false"
+          annotation:StoreGeneratedPattern="Identity"
+          xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation"
+          sap:creatable="false"
+          xmlns:sap="http://www.sap.com/Protocols/SAPData"
+          sap:updatable="false"
         /><Property Name="Name" Type="Edm.String" Nullable="false" MaxLength="100" /><Property
           Name="DateOfBirth"
           Type="Edm.DateTime"
@@ -156,6 +172,11 @@
           Name="Id"
           Type="Edm.Guid"
           Nullable="false"
+          annotation:StoreGeneratedPattern="Identity"
+          xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation"
+          sap:creatable="false"
+          xmlns:sap="http://www.sap.com/Protocols/SAPData"
+          sap:updatable="false"
         /><Property
           Name="LoanedAt"
           Type="Edm.DateTimeOffset"
@@ -181,32 +202,47 @@
           Name="Id"
           Type="Edm.Guid"
           Nullable="false"
+          annotation:StoreGeneratedPattern="Identity"
+          xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation"
+          sap:creatable="false"
+          xmlns:sap="http://www.sap.com/Protocols/SAPData"
+          sap:updatable="false"
         /><Property Name="ReservedAt" Type="Edm.DateTimeOffset" Precision="7" /></EntityType><EntityType
         Name="IdDocument"
-      ><Key><PropertyRef Name="Id" /></Key><Property Name="Id" Type="Edm.Guid" Nullable="false" /><Property
-          Name="Scan"
-          Type="Edm.Binary"
-        /><Property Name="UploadedAt" Type="Edm.DateTimeOffset" Precision="7" /></EntityType><EntityType
-        Name="Branch"
-      ><Key><PropertyRef Name="Id" /></Key><Property Name="Id" Type="Edm.Int32" Nullable="false" /><Property
-          Name="Name"
-          Type="Edm.String"
+      ><Key><PropertyRef Name="Id" /></Key><Property
+          Name="Id"
+          Type="Edm.Guid"
           Nullable="false"
-          MaxLength="100"
-        /><Property Name="Address" Type="Library.Catalog.PostalAddress" /><Property
-          Name="LowestFloor"
-          Type="Edm.SByte"
-        /><Property Name="OpensAt" Type="Edm.Time" /><Property Name="ClosesAt" Type="Edm.Time" /><Property
-          Name="Amenities"
-          Type="Edm.Int32"
-        /><Property Name="Population" Type="Edm.Int64" /></EntityType><ComplexType Name="OverdueNotice"><Property
-          Name="Reason"
-          Type="Edm.String"
-        /><Property Name="Amount" Type="Edm.Decimal" Precision="5" Scale="2" /><Property
-          Name="CreatedAt"
+          annotation:StoreGeneratedPattern="Identity"
+          xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation"
+          sap:creatable="false"
+          xmlns:sap="http://www.sap.com/Protocols/SAPData"
+          sap:updatable="false"
+        /><Property Name="Scan" Type="Edm.Binary" /><Property
+          Name="UploadedAt"
           Type="Edm.DateTimeOffset"
           Precision="7"
-        /></ComplexType><ComplexType Name="LoanStats"><Property Name="TotalLoans" Type="Edm.Int64" /><Property
+        /></EntityType><EntityType Name="Branch"><Key><PropertyRef Name="Id" /></Key><Property
+          Name="Id"
+          Type="Edm.Int32"
+          Nullable="false"
+        /><Property Name="Name" Type="Edm.String" Nullable="false" MaxLength="100" /><Property
+          Name="Address"
+          Type="Library.Catalog.PostalAddress"
+        /><Property Name="LowestFloor" Type="Edm.SByte" /><Property Name="OpensAt" Type="Edm.Time" /><Property
+          Name="ClosesAt"
+          Type="Edm.Time"
+        /><Property Name="Amenities" Type="Edm.Int32" /><Property
+          Name="Population"
+          Type="Edm.Int64"
+        /></EntityType><ComplexType Name="OverdueNotice"><Property Name="Reason" Type="Edm.String" /><Property
+          Name="Amount"
+          Type="Edm.Decimal"
+          Precision="5"
+          Scale="2"
+        /><Property Name="CreatedAt" Type="Edm.DateTimeOffset" Precision="7" /></ComplexType><ComplexType
+        Name="LoanStats"
+      ><Property Name="TotalLoans" Type="Edm.Int64" /><Property
           Name="AverageLoanDuration"
           Type="Edm.Time"
         /></ComplexType><ComplexType Name="BranchStats"><Property Name="BranchId" Type="Edm.Int32" /><Property
@@ -256,6 +292,11 @@
           Name="Id"
           Type="Edm.Int32"
           Nullable="false"
+          annotation:StoreGeneratedPattern="Identity"
+          xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation"
+          sap:creatable="false"
+          xmlns:sap="http://www.sap.com/Protocols/SAPData"
+          sap:updatable="false"
         /><Property Name="Name" Type="Edm.String" Nullable="false" MaxLength="100" /><Property
           Name="Country"
           Type="Edm.String"
@@ -269,6 +310,11 @@
           Name="Id"
           Type="Edm.Int32"
           Nullable="false"
+          annotation:StoreGeneratedPattern="Identity"
+          xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation"
+          sap:creatable="false"
+          xmlns:sap="http://www.sap.com/Protocols/SAPData"
+          sap:updatable="false"
         /><Property Name="City" Type="Edm.String" MaxLength="80" /><Property
           Name="Country"
           Type="Edm.String"

--- a/int-test/olingo-v2/test/feature/ImmutableProperties.test.ts
+++ b/int-test/olingo-v2/test/feature/ImmutableProperties.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, expectTypeOf, test } from "vitest";
-import type { EditableLoan, UpdatableLoan } from "../../src-generated/library-strict/index.js";
+import type {
+  EditableBranch,
+  EditableLoan,
+  UpdatableBranch,
+  UpdatableLoan,
+} from "../../src-generated/library-strict/index.js";
 import { LIBRARY_STRICT } from "../LibraryTestConstants.js";
 
 /**
@@ -18,27 +23,48 @@ import { LIBRARY_STRICT } from "../LibraryTestConstants.js";
 describe("Olingo V2 Library: immutable properties under strictOmit", () => {
   const LOANED_AT = "/Date(1777622400000)/";
 
-  async function givenLoan(Id: string) {
+  /** The key is generated since 0.2.0, so the loan is found by what the create answers with. */
+  async function givenLoan() {
     const created = await LIBRARY_STRICT.Loans()
-      .create({ Id, LoanedAt: LOANED_AT, DueDate: "/Date(1780214400000)/" })
+      .create({ LoanedAt: LOANED_AT, DueDate: "/Date(1780214400000)/" })
       .execute();
     expect(created.status).toBe(201);
+    return created.data.d.Id;
   }
 
-  test("the create model keeps the immutable properties, the update model drops them", () => {
+  test("the create model keeps the immutable property, the update model drops it", () => {
     // `LoanedAt` comes from `sap:updatable="false"` and is `Nullable="false"`, so the service itself
-    // says it is required on create; the key is non-nullable too but nothing describes it, and the
-    // default `keyProperties` will not demand one the server may be generating
+    // says it is required on create - and `strictOmit` takes it out of the update model
     expectTypeOf<EditableLoan["LoanedAt"]>().toEqualTypeOf<string>();
-    expectTypeOf<EditableLoan["Id"]>().toEqualTypeOf<string | undefined>();
-
-    expectTypeOf<UpdatableLoan>().not.toHaveProperty("Id");
     expectTypeOf<UpdatableLoan>().not.toHaveProperty("LoanedAt");
   });
 
+  test("a generated key is in no write model, a client-assigned one is required on create", () => {
+    // `Loan.Id` carries StoreGeneratedPattern="Identity" and the SAP pair since 0.2.0, both of which
+    // normalize to `Core.Computed` - so it is readOnly and strictOmit drops it from both models
+    expectTypeOf<EditableLoan>().not.toHaveProperty("Id");
+    expectTypeOf<UpdatableLoan>().not.toHaveProperty("Id");
+
+    // `Branch/Id` is the one key left bare, which after 0.2.0 says it is the client's. V2 cannot express
+    // "may be supplied, otherwise generated" at all, so a bare key here is the only way to say this.
+    expectTypeOf<EditableBranch["Id"]>().toEqualTypeOf<number>();
+    expectTypeOf<UpdatableBranch>().not.toHaveProperty("Id");
+  });
+
+  test("the client-assigned key really is stored as sent", async () => {
+    const Id = 4203;
+    const created = await LIBRARY_STRICT.Branches().create({ Id, Name: "Client Assigned Branch" }).execute();
+
+    try {
+      expect(created.status).toBe(201);
+      expect(created.data.d.Id).toBe(Id);
+    } finally {
+      await LIBRARY_STRICT.Branches(Id).delete().execute();
+    }
+  });
+
   test("a client-assigned key really is taken by the server", async () => {
-    const Id = "bbbbbbbb-0000-0000-0000-0000000009c1";
-    await givenLoan(Id);
+    const Id = await givenLoan();
 
     try {
       const read = await LIBRARY_STRICT.Loans(Id).query().execute();
@@ -50,8 +76,7 @@ describe("Olingo V2 Library: immutable properties under strictOmit", () => {
   });
 
   test("PUT without the immutable properties replaces the rest and keeps them", async () => {
-    const Id = "bbbbbbbb-0000-0000-0000-0000000009c2";
-    await givenLoan(Id);
+    const Id = await givenLoan();
 
     try {
       // `update` takes UpdatableLoan, so `LoanedAt` cannot be written here at all
@@ -69,8 +94,7 @@ describe("Olingo V2 Library: immutable properties under strictOmit", () => {
   });
 
   test("MERGE without the immutable properties changes only what it names", async () => {
-    const Id = "bbbbbbbb-0000-0000-0000-0000000009c3";
-    await givenLoan(Id);
+    const Id = await givenLoan();
 
     try {
       // V2 has no PATCH: `patch()` sends MERGE, which is the same question put a different way
@@ -86,8 +110,7 @@ describe("Olingo V2 Library: immutable properties under strictOmit", () => {
   });
 
   test("a changed immutable property sent anyway is silently dropped", async () => {
-    const Id = "bbbbbbbb-0000-0000-0000-0000000009c4";
-    await givenLoan(Id);
+    const Id = await givenLoan();
 
     try {
       /*

--- a/int-test/olingo-v2/test/globalSetup.ts
+++ b/int-test/olingo-v2/test/globalSetup.ts
@@ -18,7 +18,7 @@ const CUSTOM_IMAGE = process.env.OLINGO_SERVER_IMAGE;
 // Pinned to an exact version, never `latest`: a run is then reproducible, and a new server release
 // arrives as a Renovate PR that CI runs these tests against - merging it is what accepts the new
 // server. Renovate keeps this line current, see `customManagers` in the repo's renovate.json.
-const IMAGE = CUSTOM_IMAGE ?? "ghcr.io/odata2ts/test-server-olingo-v2:0.1.0";
+const IMAGE = CUSTOM_IMAGE ?? "ghcr.io/odata2ts/test-server-olingo-v2:0.2.0";
 const SERVICE_PATH = "/odata/v2/library";
 const CONTAINER_PORT = 4004;
 


### PR DESCRIPTION
Since the 0.2.x server releases, all three implementations declare who owns every key — generated ones carry `Core.Computed` (ASP.NET, and Olingo through the two V2 attribute dialects) or `Core.ComputedDefaultValue` (CAP), while `Branch` stays bare because a branch code is the organisation's to allocate. `Copy` is the same case with a composite key. See [test-reference-model#4](https://github.com/odata2ts/test-reference-model/pull/4) for why the reference itself stays silent and leaves the statement to each server.

That is what finally makes `keyProperties: "strict"` usable: it demands a non-nullable key on create, which is only right once a bare key genuinely means "yours to supply". Before these releases it would have demanded nine keys no client can know.

- Image pins move to `test-server-asp-net:0.2.1`, `test-server-cap:0.2.0`, `test-server-olingo-v2:0.2.0`, and the four metadata snapshots are refreshed
- The three `libraryStrict` clients add `keyProperties: "strict"` alongside `managedPropertyMode: "strictOmit"`
- The suites now show both halves side by side: a **generated** key is in neither write model and is discarded when sent anyway; the **client-assigned** one is required on create, absent from the update model, and stored exactly as sent
- `Annotations.test.ts` no longer claims `Medium.Id` is unannotated and client-writable — 0.2.0 made that false. It states the pairing instead: the lenient client leaves a bare key optional, the strict one requires it, which is what gives the two settings their meaning
- The asp-net `ImmutableProperties` expectation inverts as promised: a changed `Core.Immutable` value is now **disregarded** rather than applied, which is what Protocol 11.4.3 requires of a property the service declares managed

One consequence worth reading in `int-test/config-variants`: only three types still get an `UpdatableModel` at all — `Branch` and `Copy` because their keys are the client's and therefore immutable, `Loan` because of `Core.Immutable` on `LoanedAt`. Every other key is `Core.Computed`, hence readOnly, hence dropped from both write models, so there is nothing for a second model to say. The nested complex- and navigation-property assertions moved onto those types.

Verified against the pinned images: asp-net 121, cap 188 (+2 skipped), olingo-v2 122, plus 1832 unit tests, `test-compile`, format, constraints and circular-deps all clean.
