### PR TITLE
build: open the test server bump PR from the release instead of Renovate

### DIFF
--- a/.github/workflows/bump-test-server.yml
+++ b/.github/workflows/bump-test-server.yml
@@ -1,0 +1,96 @@
+name: Bump Test Server Pin
+
+# Raises the pinned test server version in int-test/<server>/server-image.json and opens a PR for it.
+#
+# Push, not poll: the server repo dispatches this the moment its release is published, so the PR exists
+# within seconds instead of whenever a scheduled scan happens to come round. See `notify-odata2ts` in
+# publish-image.yml over in test-server-asp-net / -cap / -olingo-v2.
+#
+# The PR is opened with a GitHub App token rather than GITHUB_TOKEN, and that is not incidental: GitHub
+# does not start workflows from GITHUB_TOKEN events, so a PR opened with it would never run the
+# integration tests - and running them against the new server is the only reason the PR exists.
+# merge-test-server-bump.yml merges it once they pass.
+
+on:
+  repository_dispatch:
+    types: [test-server-released]
+
+concurrency:
+  # Two releases of the same server in quick succession: let the newer one supersede the older.
+  group: bump-test-server-${{ github.event.client_payload.server }}
+  cancel-in-progress: true
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+
+    steps:
+      # The payload comes from another repository, so it is checked before it reaches a shell or a path.
+      # Sending a dispatch needs write access here, so this is a guard against a mistake rather than an
+      # attacker - but the server name becomes a file path and the version becomes a branch name.
+      - name: Validate the payload
+        env:
+          SERVER: ${{ github.event.client_payload.server }}
+          VERSION: ${{ github.event.client_payload.version }}
+        run: |
+          set -euo pipefail
+          case "$SERVER" in
+            asp-net | cap | olingo-v2) ;;
+            *)
+              echo "::error::Unknown test server '$SERVER'."
+              exit 1
+              ;;
+          esac
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::'$VERSION' is not a release version."
+            exit 1
+          fi
+
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.ODATA2TS_PR_BOT_APP_ID }}
+          private-key: ${{ secrets.ODATA2TS_PR_BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Raise the pin and open the pull request
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SERVER: ${{ github.event.client_payload.server }}
+          VERSION: ${{ github.event.client_payload.version }}
+        run: |
+          set -euo pipefail
+          file="int-test/$SERVER/server-image.json"
+
+          current=$(jq -r .version "$file")
+          if [ "$current" = "$VERSION" ]; then
+            echo "int-test/$SERVER already runs against $VERSION - nothing to do." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          branch="chore/test-server-$SERVER-$VERSION"
+          git switch -c "$branch"
+
+          jq --arg version "$VERSION" '.version = $version' "$file" > "$file.tmp"
+          mv "$file.tmp" "$file"
+
+          git config user.name "odata2ts-bot[bot]"
+          git config user.email "odata2ts-bot[bot]@users.noreply.github.com"
+          git commit -am "test(int-test-$SERVER): run against test-server-$SERVER $VERSION"
+          git push --force -u origin "$branch"
+
+          # A rerun for the same version updates the branch rather than failing on an existing PR.
+          if ! gh pr view "$branch" --json number > /dev/null 2>&1; then
+            gh pr create \
+              --title "test(int-test-$SERVER): run against test-server-$SERVER $VERSION" \
+              --body "$(printf '%s\n' \
+                "\`test-server-$SERVER\` released **$VERSION**, up from \`$current\`." \
+                "" \
+                "The integration tests in \`int-test/$SERVER\` run against it here. Merging accepts the new server;" \
+                "a red run means the release changed behaviour this client depends on, and the PR is the place to see it." \
+                "" \
+                "Opened automatically from the server repo's release - see \`.github/workflows/bump-test-server.yml\`.")"
+          fi

--- a/.github/workflows/merge-test-server-bump.yml
+++ b/.github/workflows/merge-test-server-bump.yml
@@ -1,0 +1,53 @@
+name: Merge Test Server Bump
+
+# Merges a bump PR from bump-test-server.yml once "Build & Test" has passed on it - the integration
+# tests are what accept the new server, so a green run is the acceptance.
+#
+# `workflow_run` rather than GitHub's own auto-merge: auto-merge waits for *required* status checks, and
+# with no branch protection on main there are none, so it would merge the PR immediately - before a single
+# integration test had run. Reacting to the finished run instead keeps the gate real without imposing
+# branch protection on every other pull request in this repo.
+
+on:
+  workflow_run:
+    workflows: ["Build & Test"]
+    types: [completed]
+
+jobs:
+  merge:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      startsWith(github.event.workflow_run.head_branch, 'chore/test-server-')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.ODATA2TS_PR_BOT_APP_ID }}
+          private-key: ${{ secrets.ODATA2TS_PR_BOT_PRIVATE_KEY }}
+
+      - name: Merge the bump
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # The branch name alone is not proof of origin - anyone able to push could pick that prefix.
+          # Only a pull request opened by an app is merged unreviewed. Tested by `is_bot` rather than by
+          # login, so renaming the app does not silently turn this job into a no-op.
+          pr=$(gh pr view "$BRANCH" --repo "$REPO" --json author,number 2>/dev/null || true)
+          if [ -z "$pr" ]; then
+            echo "No open pull request for $BRANCH - nothing to merge."
+            exit 0
+          fi
+          if [ "$(printf '%s' "$pr" | jq -r .author.is_bot)" != "true" ]; then
+            echo "::notice::$BRANCH was opened by $(printf '%s' "$pr" | jq -r .author.login), not by the bot - leaving it to be merged by hand."
+            exit 0
+          fi
+
+          gh pr merge "$BRANCH" --repo "$REPO" --squash --delete-branch
+          echo "Merged $BRANCH after a green Build & Test." >> "$GITHUB_STEP_SUMMARY"

--- a/int-test/asp-net/server-image.json
+++ b/int-test/asp-net/server-image.json
@@ -1,0 +1,4 @@
+{
+  "image": "ghcr.io/odata2ts/test-server-asp-net",
+  "version": "0.2.1"
+}

--- a/int-test/asp-net/test/globalSetup.ts
+++ b/int-test/asp-net/test/globalSetup.ts
@@ -1,5 +1,6 @@
 import { GenericContainer, StartedTestContainer, Wait } from "testcontainers";
 import type { TestProject } from "vitest/node";
+import serverImage from "../server-image.json" with { type: "json" };
 
 /**
  * Provisions the ASP.NET Core "Library" OData server for the integration tests and tears it down afterwards.
@@ -18,9 +19,10 @@ import type { TestProject } from "vitest/node";
  */
 const CUSTOM_IMAGE = process.env.ASPNET_SERVER_IMAGE;
 // Pinned to an exact version, never `latest`: a run is then reproducible, and a new server release
-// arrives as a Renovate PR that CI runs these tests against - merging it is what accepts the new
-// server. Renovate keeps this line current, see `customManagers` in the repo's renovate.json.
-const IMAGE = CUSTOM_IMAGE ?? "ghcr.io/odata2ts/test-server-asp-net:0.2.1";
+// arrives as a PR that CI runs these tests against - merging it is what accepts the new server. The pin
+// lives in its own JSON file because a bot maintains it: the server repo dispatches its release here and
+// `.github/workflows/bump-test-server.yml` edits that file. Nothing parses this expression.
+const IMAGE = CUSTOM_IMAGE ?? `${serverImage.image}:${serverImage.version}`;
 const SERVICE_PATH = "/odata/v4/library";
 const CONTAINER_PORT = 4004;
 

--- a/int-test/cap/server-image.json
+++ b/int-test/cap/server-image.json
@@ -1,0 +1,4 @@
+{
+  "image": "ghcr.io/odata2ts/test-server-cap",
+  "version": "0.2.0"
+}

--- a/int-test/cap/test/globalSetup.ts
+++ b/int-test/cap/test/globalSetup.ts
@@ -1,5 +1,6 @@
 import { GenericContainer, StartedTestContainer, Wait } from "testcontainers";
 import type { TestProject } from "vitest/node";
+import serverImage from "../server-image.json" with { type: "json" };
 
 /**
  * Provisions the "Library" OData server for the integration tests and tears it down afterwards.
@@ -22,9 +23,10 @@ import type { TestProject } from "vitest/node";
  */
 const CUSTOM_IMAGE = process.env.CAP_SERVER_IMAGE;
 // Pinned to an exact version, never `latest`: a run is then reproducible, and a new server release
-// arrives as a Renovate PR that CI runs these tests against - merging it is what accepts the new
-// server. Renovate keeps this line current, see `customManagers` in the repo's renovate.json.
-const IMAGE = CUSTOM_IMAGE ?? "ghcr.io/odata2ts/test-server-cap:0.2.0";
+// arrives as a PR that CI runs these tests against - merging it is what accepts the new server. The pin
+// lives in its own JSON file because a bot maintains it: the server repo dispatches its release here and
+// `.github/workflows/bump-test-server.yml` edits that file. Nothing parses this expression.
+const IMAGE = CUSTOM_IMAGE ?? `${serverImage.image}:${serverImage.version}`;
 const SERVICE_PATH = "/odata/v4/library";
 const SERVICE_PATH_V2 = "/odata/v2/library";
 const CONTAINER_PORT = 4004;

--- a/int-test/olingo-v2/README.md
+++ b/int-test/olingo-v2/README.md
@@ -38,9 +38,10 @@ while odata2ts types it as a string; that settles where the bug is.
 `globalSetup` has the same two modes as the other server packages:
 
 - **managed container** (default): pulls the exact version of `ghcr.io/odata2ts/test-server-olingo-v2`
-  pinned in `test/globalSetup.ts`, waits for the service, maps a dynamic port and removes the container
-  afterwards. Renovate raises a PR when the server publishes a new release, so the version moves only
-  with a green integration-test run behind it. Override the image with `OLINGO_SERVER_IMAGE`.
+  pinned in `server-image.json`, waits for the service, maps a dynamic port and removes the container
+  afterwards. The server repo dispatches each release here, which opens a PR raising that pin; the
+  version moves only with a green integration-test run behind it. Override the image with
+  `OLINGO_SERVER_IMAGE`.
 - **external server**: if `LIBRARY_BASE_URL` is set, that URL is used as-is:
 
   ```bash

--- a/int-test/olingo-v2/server-image.json
+++ b/int-test/olingo-v2/server-image.json
@@ -1,0 +1,4 @@
+{
+  "image": "ghcr.io/odata2ts/test-server-olingo-v2",
+  "version": "0.2.0"
+}

--- a/int-test/olingo-v2/test/globalSetup.ts
+++ b/int-test/olingo-v2/test/globalSetup.ts
@@ -1,5 +1,6 @@
 import { GenericContainer, StartedTestContainer, Wait } from "testcontainers";
 import type { TestProject } from "vitest/node";
+import serverImage from "../server-image.json" with { type: "json" };
 
 /**
  * Provisions the Apache Olingo 2 "Library" server for the integration tests and tears it down afterwards.
@@ -16,9 +17,10 @@ import type { TestProject } from "vitest/node";
  */
 const CUSTOM_IMAGE = process.env.OLINGO_SERVER_IMAGE;
 // Pinned to an exact version, never `latest`: a run is then reproducible, and a new server release
-// arrives as a Renovate PR that CI runs these tests against - merging it is what accepts the new
-// server. Renovate keeps this line current, see `customManagers` in the repo's renovate.json.
-const IMAGE = CUSTOM_IMAGE ?? "ghcr.io/odata2ts/test-server-olingo-v2:0.2.0";
+// arrives as a PR that CI runs these tests against - merging it is what accepts the new server. The pin
+// lives in its own JSON file because a bot maintains it: the server repo dispatches its release here and
+// `.github/workflows/bump-test-server.yml` edits that file. Nothing parses this expression.
+const IMAGE = CUSTOM_IMAGE ?? `${serverImage.image}:${serverImage.version}`;
 const SERVICE_PATH = "/odata/v2/library";
 const CONTAINER_PORT = 4004;
 

--- a/renovate.json
+++ b/renovate.json
@@ -5,16 +5,6 @@
   "lockFileMaintenance": {
     "enabled": true
   },
-  "customManagers": [
-    {
-      "description": "The int-test packages pin the test server image they run against inside their globalSetup.ts. Renovate has no manager for TypeScript, so the image reference is matched directly - deliberately without depending on the surrounding code, which would break the match silently if the file were refactored.",
-      "customType": "regex",
-      "managerFilePatterns": ["int-test/*/test/globalSetup.ts"],
-      "matchStrings": ["\"(?<depName>ghcr\\.io/odata2ts/test-server-[a-z0-9-]+):(?<currentValue>[^\"]+)\""],
-      "datasourceTemplate": "docker",
-      "versioningTemplate": "semver"
-    }
-  ],
   "packageRules": [
     {
       "description": "Internal @odata2ts/* sibling packages are managed via release-please and the other odata2ts repos, not Renovate",
@@ -59,13 +49,6 @@
       "matchPackageNames": ["typescript", "ts-morph", "@ts-morph/common"],
       "groupName": "typescript & ts-morph (core, manual)",
       "dependencyDashboardApproval": true,
-      "automerge": false
-    },
-    {
-      "description": "A new release of a test server becomes its own PR, which CI runs that server's integration tests against - merging it is what accepts the new server. Deliberately not grouped: one server regressing must not hold back the other two. The schedule overrides the repo-wide weekly window, since a server release should reach the integration tests promptly, and automerge stays off because accepting a server is a review decision.",
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["ghcr.io/odata2ts/test-server-**"],
-      "schedule": ["at any time"],
       "automerge": false
     }
   ]


### PR DESCRIPTION
Renovate never detected the pinned images — the [dependency dashboard](https://github.com/odata2ts/odata2ts/issues/438) lists `github-actions` and `npm` and no regex manager at all, so `test-server-asp-net` reaching 0.2.1 while this repo pinned 0.1.0 produced neither a PR nor a warning. Replaced by a push from the server repos.

- move the pin into `int-test/<server>/server-image.json`, consumed by `globalSetup.ts` via a JSON import. A bot edits JSON instead of parsing a version out of a TypeScript expression — the interface that failed silently
- add `bump-test-server.yml`: handles the `repository_dispatch` a server release sends, validates the payload before it reaches a path or a branch name, raises the pin and opens the PR
- add `merge-test-server-bump.yml`: merges that PR once **Build & Test** passes. A `workflow_run` merger rather than GitHub auto-merge, because auto-merge waits for *required* checks and `main` has no branch protection — it would merge before a single integration test ran
- drop the dead `customManagers` block and the test-server `packageRule`

Both new workflows are inert until a dispatch arrives, so this is safe to merge before the server repos.

The PR is opened by a GitHub App rather than `GITHUB_TOKEN`: GitHub does not start workflows from `GITHUB_TOKEN` events, so a PR opened with it would never run the integration tests that are its entire reason for existing.

Verified: actionlint reports no findings in either new workflow; the JSON import type-checks and resolves at runtime; `is_bot` discriminates a bot-opened PR from a human one.