### PR TITLE
feat(odata2ts)!: restrain the deep insert props to containment on demand

### DIFF
--- a/int-test/config-variants/odata2ts.config.ts
+++ b/int-test/config-variants/odata2ts.config.ts
@@ -1,5 +1,6 @@
 import {
   ConfigFileOptions,
+  DeepInsertProps,
   EmitModes,
   KeyProperties,
   ManagedPropertyMode,
@@ -237,6 +238,39 @@ const config: ConfigFileOptions = {
       output: "src-generated/key-all-computed",
       keyProperties: KeyProperties.allComputed,
       managedPropertyMode: ManagedPropertyMode.strictOmit,
+    },
+
+    /**
+     * `deepInsertProps: "composition-only"`, which narrows the deep insert props to the navigation
+     * properties marked `ContainsTarget="true"`.
+     *
+     * The V4 source is the right one to judge it: ASP.NET Core OData states containment faithfully, so the
+     * model carries exactly one contained navigation property - `Audiobook.Chapters`, whose target has no
+     * entity set of its own - against a dozen plain ones. That asymmetry is the whole point of the option,
+     * and it is invisible to a server: nothing about the request changes, only which properties the
+     * editable models offer in the first place.
+     */
+    deepInsertComposition: {
+      serviceName: "DeepInsertComposition",
+      source: V4_SOURCE,
+      output: "src-generated/deep-insert-composition",
+      deepInsertProps: DeepInsertProps.compositionOnly,
+    },
+
+    /**
+     * The same value against a V2 service, where it must do nothing at all.
+     *
+     * V2 has no containment to state, so the narrow reading would find nothing contained and take the deep
+     * insert props away wholesale - the opposite of narrowing them. Held against `v2Wrapping`, which
+     * generates the same model without the option, this pins that a V2 service keeps every navigation
+     * property.
+     */
+    deepInsertCompositionV2: {
+      serviceName: "DeepInsertCompositionV2",
+      source: V2_SOURCE,
+      output: "src-generated/deep-insert-composition-v2",
+      mode: Modes.models,
+      deepInsertProps: DeepInsertProps.compositionOnly,
     },
 
     /**

--- a/int-test/config-variants/test/variants.type-test.ts
+++ b/int-test/config-variants/test/variants.type-test.ts
@@ -1,4 +1,11 @@
 import { expectTypeOf } from "vitest";
+import type { EditableMember as CompositionV2EditableMember } from "../src-generated/deep-insert-composition-v2/library-circulation/index.js";
+import type {
+  Audiobook as CompositionAudiobook,
+  EditableAudiobook as CompositionEditableAudiobook,
+  EditableAudiobookChapter as CompositionEditableAudiobookChapter,
+  EditableBook as CompositionEditableBook,
+} from "../src-generated/deep-insert-composition/library-catalog/index.js";
 import type { Amenities as NumericAmenities } from "../src-generated/enum-numeric/library-catalog/index.js";
 import type { Branch as NumericBranch } from "../src-generated/enum-numeric/library-circulation/index.js";
 import { Amenities as unionAmenityMembers } from "../src-generated/enum-string-union/library-catalog/index.js";
@@ -145,3 +152,27 @@ expectTypeOf<AllComputedEditableCopy>().not.toHaveProperty("MediumId");
 expectTypeOf<AllComputedEditableCopy>().not.toHaveProperty("InventoryNumber");
 // a `Core.Computed` property goes the same way, being readOnly for the same reason
 expectTypeOf<AllComputedEditableMedium>().not.toHaveProperty("PopularityScore");
+
+/* --- deepInsertComposition: containment decides which navigation property carries a deep insert ---- */
+
+// `Audiobook` is the one entity in the model with both kinds of relation, which is what makes it the
+// case worth pinning: `Chapters` is contained - the target has no entity set of its own - while `Copies`
+// is a plain navigation property to an entity standing on its own.
+expectTypeOf<CompositionEditableAudiobook["Chapters"]>().toEqualTypeOf<
+  Array<CompositionEditableAudiobookChapter> | undefined
+>();
+expectTypeOf<CompositionEditableAudiobook>().not.toHaveProperty("Copies");
+// nothing is contained anywhere else, so no editable model offers a deep insert at all
+expectTypeOf<CompositionEditableBook>().not.toHaveProperty("Copies");
+expectTypeOf<CompositionEditableBook>().not.toHaveProperty("Publisher");
+
+// The read model is untouched: containment says how an entity is addressed, not how it is read, and this
+// option speaks about write payloads alone.
+expectTypeOf<CompositionAudiobook["Copies"]>().toExtend<Array<unknown> | undefined>();
+
+/* --- deepInsertCompositionV2: the same value, doing nothing at all -------------------------------- */
+
+// V2 states no containment, so the narrow reading would find nothing contained and take the feature away
+// wholesale. A V2 service is exempt from the option instead, and keeps every navigation property.
+expectTypeOf<CompositionV2EditableMember["Loans"]>().toExtend<Array<unknown> | undefined>();
+expectTypeOf<CompositionV2EditableMember["Reservations"]>().toExtend<Array<unknown> | undefined>();

--- a/packages/odata2ts/src/FactoryFunctionModel.ts
+++ b/packages/odata2ts/src/FactoryFunctionModel.ts
@@ -47,7 +47,7 @@ export type GeneratorFunctionOptions = Pick<
   | "skipComments"
   | "enumType"
   | "disableBindingProps"
-  | "disableDeepInsertProps"
+  | "deepInsertProps"
   | "managedPropertyMode"
   | "v2"
   | "v4"

--- a/packages/odata2ts/src/OptionModel.ts
+++ b/packages/odata2ts/src/OptionModel.ts
@@ -136,6 +136,39 @@ export enum ManagedPropertyMode {
 }
 
 /**
+ * Which navigation properties of an editable model accept a related entity within the payload - a deep
+ * insert (POST) or a deep update (PATCH / PUT).
+ *
+ * The protocol permits this on **any** navigation property: §11.4.2.2 states that each included related
+ * entity is processed "as if it was posted against the original target URL extended with the navigation
+ * path to this related entity", and attaches no further condition. Hence {@link all} is the default.
+ */
+export enum DeepInsertProps {
+  /** Every navigation property carries the deep-insert shape - what the protocol allows. */
+  all = "all",
+  /**
+   * Only a navigation property marked {@code ContainsTarget="true"} carries it.
+   *
+   * **This value exists for SAP CAP**, which performs deep writes along *compositions* only: an
+   * association is a plain reference, and a nested entity sent for one is answered with a 400 or, worse,
+   * accepted and silently dropped. CAP has to be told to say which is which - either
+   * {@code cds.odata.containment: true} for all compositions, or {@code @odata.contained} on a single
+   * one - because it emits no {@code ContainsTarget} by default.
+   *
+   * **On any other server this is likely to take away more than it should.** Containment is an addressing
+   * statement, not a write permission: CSDL §8.4 makes a contained entity reachable through its container
+   * and nothing more. A server such as ASP.NET Core OData marks containment faithfully *and* accepts a
+   * deep insert on plain associations, so this value removes properties for writes that would have
+   * succeeded.
+   *
+   * V2 has no containment at all, so a V2 service is unaffected and keeps every navigation property.
+   */
+  compositionOnly = "composition-only",
+  /** No navigation property carries it. */
+  none = "none",
+}
+
+/**
  * What odata2ts reads out of the annotations a service states about itself.
  *
  * One object rather than a flat option because annotations are a whole surface - the `Org.OData.Core.V1`
@@ -488,20 +521,18 @@ export interface ConfigFileOptions extends Omit<CliOptions, "sourceUrl" | "sourc
    */
   disableBindingProps?: boolean;
   /**
-   * Adds the navigation properties to the editable models, typed as the editable model of the related
-   * entity, which is what a deep insert (POST) or a deep update (PATCH / PUT) sends: the related entities
+   * Which navigation properties the editable models carry, typed as the editable model of the related
+   * entity - which is what a deep insert (POST) or a deep update (PATCH / PUT) sends: the related entities
    * travel within the payload of the entity they belong to, instead of being created by requests of their
-   * own.
+   * own. See {@link DeepInsertProps}; {@code all} by default.
    *
    * Together with the binding props a navigation property accepts either shape - a new
    * entity or a reference to an existing one. Where a service is generated both go by the navigation
    * property itself and the {@code "@id"} property tells them apart; without one, the binding is spelled
    * as it goes on the wire, which shares the property in V2 and OData 4.01 but keeps it apart in 4.0
    * ({@code "Author@odata.bind"}).
-   *
-   * Opt-out, so the editable models carry the navigation properties unless this is switched off.
    */
-  disableDeepInsertProps?: boolean;
+  deepInsertProps?: DeepInsertProps;
 }
 
 /**

--- a/packages/odata2ts/src/data-model/DataModelDigestion.ts
+++ b/packages/odata2ts/src/data-model/DataModelDigestion.ts
@@ -182,6 +182,15 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
 
   protected abstract getNavigationProps(entityType: ET | ComplexType): Array<Property>;
 
+  /**
+   * Whether a navigation property contains its targets, which is stated by `ContainsTarget="true"`.
+   *
+   * Answered here for V2, which has no notion of containment at all, so nothing is ever contained.
+   */
+  protected isContained(p: Property): boolean {
+    return false;
+  }
+
   protected abstract digestOperations(schema: SchemaV3 | SchemaV4): void;
 
   protected abstract digestEntityContainer(schema: SchemaV3 | SchemaV4): void;
@@ -805,6 +814,7 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
       isCollection: isCollection,
       // only set when it applies: a flag on every single property would be noise
       ...(odataDataType === ODataTypesV4.Stream ? { isStream: true } : undefined),
+      ...(this.isContained(p) ? { contained: true } : undefined),
       managed: toManagedState(
         typeof entityPropConfig?.managed !== "undefined" ? entityPropConfig.managed : configProp?.managed,
       ),

--- a/packages/odata2ts/src/data-model/DataModelDigestionV4.ts
+++ b/packages/odata2ts/src/data-model/DataModelDigestionV4.ts
@@ -5,7 +5,7 @@ import { NamespaceWithAlias, withNamespace } from "./DataModel.js";
 import { Digester, TypeModel } from "./DataModelDigestion.js";
 import { ODataVersion, OperationType, OperationTypes, PropertyModel } from "./DataTypeModel.js";
 import { ComplexType, Property, Reference } from "./edmx/ODataEdmxModelBase.js";
-import { ComplexTypeV4, EntityTypeV4, Operation, SchemaV4 } from "./edmx/ODataEdmxModelV4.js";
+import { ComplexTypeV4, EntityTypeV4, NavigationProperty, Operation, SchemaV4 } from "./edmx/ODataEdmxModelV4.js";
 import { NamingHelper } from "./NamingHelper.js";
 
 export const digest: DigesterFunction<SchemaV4> = async (schemas, options, namingHelper, references) => {
@@ -28,6 +28,10 @@ class DigesterV4 extends Digester<SchemaV4, EntityTypeV4, ComplexTypeV4> {
 
   protected getNavigationProps(entityType: ComplexType | EntityTypeV4): Array<Property> {
     return (entityType as EntityTypeV4).NavigationProperty || [];
+  }
+
+  protected isContained(p: Property): boolean {
+    return (p as NavigationProperty).$.ContainsTarget === "true";
   }
 
   protected digestOperations(schema: SchemaV4) {

--- a/packages/odata2ts/src/data-model/DataTypeModel.ts
+++ b/packages/odata2ts/src/data-model/DataTypeModel.ts
@@ -53,6 +53,12 @@ export interface PropertyModel {
    * gets its own service instead.
    */
   isStream?: boolean;
+  /**
+   * A containment navigation property (`ContainsTarget="true"`): the declaring type contains the targets,
+   * which are reachable through it and have no entity set of their own (CSDL §8.4). V4 only - V2 knows no
+   * containment - and never set for anything but a navigation property.
+   */
+  contained?: boolean;
 }
 
 export type ModelType = EntityType | ComplexType | EnumType;

--- a/packages/odata2ts/src/data-model/edmx/ODataEdmxModelV4.ts
+++ b/packages/odata2ts/src/data-model/edmx/ODataEdmxModelV4.ts
@@ -32,6 +32,11 @@ export interface NavigationProperty extends Annotatable {
     Type: string;
     Nullable?: "true" | "false";
     Partner?: string;
+    /**
+     * Marks a containment navigation property: the declaring type contains the targets, which are
+     * addressed through it and have no entity set of their own (CSDL §8.4). Absence means false.
+     */
+    ContainsTarget?: "true" | "false";
   };
   // TODO: OnDelete, ReferentialConstraint, etc.
 }

--- a/packages/odata2ts/src/defaultConfig.ts
+++ b/packages/odata2ts/src/defaultConfig.ts
@@ -1,6 +1,6 @@
 import deepmerge from "deepmerge";
 import { NameSettings, NamingStrategies } from "./NamingModel.js";
-import { EmitModes, KeyProperties, ManagedPropertyMode, Modes, RunOptions } from "./OptionModel.js";
+import { DeepInsertProps, EmitModes, KeyProperties, ManagedPropertyMode, Modes, RunOptions } from "./OptionModel.js";
 
 export type DefaultConfiguration = Omit<RunOptions, "sourceUrl" | "source" | "output" | "serviceName">;
 /**
@@ -118,7 +118,7 @@ const defaultConfig: DefaultConfiguration = {
   propertiesByName: [],
   byTypeAndName: [],
   disableBindingProps: false,
-  disableDeepInsertProps: false,
+  deepInsertProps: DeepInsertProps.all,
 };
 
 const { models, queryObjects, services } = defaultConfig.naming;

--- a/packages/odata2ts/src/generator/ModelGenerator.ts
+++ b/packages/odata2ts/src/generator/ModelGenerator.ts
@@ -24,7 +24,7 @@ import {
 } from "../data-model/DataTypeModel.js";
 import { NamingHelper } from "../data-model/NamingHelper.js";
 import { EntityBasedGeneratorFunction, GeneratorFunctionOptions } from "../FactoryFunctionModel.js";
-import { ManagedPropertyMode, ManagedState, Modes } from "../OptionModel.js";
+import { DeepInsertProps, ManagedPropertyMode, ManagedState, Modes } from "../OptionModel.js";
 import { FileHandler } from "../project/FileHandler.js";
 import { ProjectManager } from "../project/ProjectManager.js";
 import { CoreImports } from "./import/ImportObjects.js";
@@ -583,6 +583,25 @@ class ModelGenerator {
   }
 
   /**
+   * Whether a navigation property accepts a related entity within the payload - see
+   * {@link DeepInsertProps}.
+   *
+   * {@code compositionOnly} asks for containment, which only V4 states and only some services state at
+   * all. A V2 service is therefore exempt from it rather than emptied by it: nothing there is contained,
+   * so the narrow reading would take the feature away wholesale instead of narrowing it.
+   */
+  private carriesDeepInsert(prop: PropertyModel): boolean {
+    switch (this.options.deepInsertProps) {
+      case DeepInsertProps.none:
+        return false;
+      case DeepInsertProps.compositionOnly:
+        return this.version === ODataVersions.V2 || !!prop.contained;
+      default:
+        return true;
+    }
+  }
+
+  /**
    * The navigation properties of an editable model, which carry two independent, opt-in features:
    *
    * - binding an existing entity to the navigation property (issue #38)
@@ -612,7 +631,7 @@ class ModelGenerator {
     const byKey = this.bindsByKey();
 
     return props.flatMap((prop) => {
-      const deepInsert = !this.options.disableDeepInsertProps;
+      const deepInsert = this.carriesDeepInsert(prop);
       const bindable = this.isBindableNavProp(ownerFqName, prop);
 
       // one entry per resulting property name, so that renaming cannot merge what belongs apart

--- a/packages/odata2ts/test/data-model/builder/v4/ODataBuilderV4Helper.ts
+++ b/packages/odata2ts/test/data-model/builder/v4/ODataBuilderV4Helper.ts
@@ -1,6 +1,6 @@
 import { NavigationProperty } from "../../../../src/data-model/edmx/ODataEdmxModelV4.js";
 
-export function createNavProp(name: string, type: string, partner?: string, nullable?: boolean) {
+export function createNavProp(name: string, type: string, partner?: string, nullable?: boolean, contained?: boolean) {
   const navProp: NavigationProperty = {
     $: {
       Name: name,
@@ -12,6 +12,9 @@ export function createNavProp(name: string, type: string, partner?: string, null
   }
   if (typeof nullable === "boolean") {
     navProp.$.Nullable = nullable ? "true" : "false";
+  }
+  if (contained) {
+    navProp.$.ContainsTarget = "true";
   }
 
   return navProp;

--- a/packages/odata2ts/test/data-model/builder/v4/ODataEntityTypeBuilderV4.ts
+++ b/packages/odata2ts/test/data-model/builder/v4/ODataEntityTypeBuilderV4.ts
@@ -7,11 +7,11 @@ export class ODataEntityTypeBuilderV4 extends ODataEntityTypeBuilderBase<EntityT
     return this.createEntityType();
   }
 
-  public addNavProp(name: string, type: string, partner?: string, nullable?: boolean) {
+  public addNavProp(name: string, type: string, partner?: string, nullable?: boolean, contained?: boolean) {
     if (!this.entityType.NavigationProperty) {
       this.entityType.NavigationProperty = [];
     }
-    this.entityType.NavigationProperty.push(createNavProp(name, type, partner, nullable));
+    this.entityType.NavigationProperty.push(createNavProp(name, type, partner, nullable, contained));
 
     return this;
   }

--- a/packages/odata2ts/test/evaluateConfig.test.ts
+++ b/packages/odata2ts/test/evaluateConfig.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, test } from "vitest";
 import { evaluateConfigOptions } from "../src/evaluateConfig.js";
-import { CliOptions, ConfigFileOptions, EmitModes, getDefaultConfig, Modes, NamingStrategies } from "../src/index.js";
+import {
+  CliOptions,
+  ConfigFileOptions,
+  DeepInsertProps,
+  EmitModes,
+  getDefaultConfig,
+  Modes,
+  NamingStrategies,
+} from "../src/index.js";
 
 describe("Config Evaluation Tests", () => {
   const defaultConfig = getDefaultConfig();
@@ -298,9 +306,9 @@ describe("Config Evaluation Tests", () => {
     const cliOpts: CliOptions = { source: "source", output: "output" };
 
     [Modes.service, Modes.qobjects, Modes.all, Modes.models].forEach((mode) => {
-      const result = evaluateConfigOptions(cliOpts, { mode, disableDeepInsertProps: true });
+      const result = evaluateConfigOptions(cliOpts, { mode, deepInsertProps: DeepInsertProps.compositionOnly });
 
-      expect(result[0], `mode ${mode}`).toMatchObject({ disableDeepInsertProps: true });
+      expect(result[0], `mode ${mode}`).toMatchObject({ deepInsertProps: DeepInsertProps.compositionOnly });
     });
   });
 });

--- a/packages/odata2ts/test/fixture/generator/model/entity-relationships-composition-only.ts
+++ b/packages/odata2ts/test/fixture/generator/model/entity-relationships-composition-only.ts
@@ -1,0 +1,29 @@
+export interface Author {
+  id: number;
+  name: boolean | null;
+}
+
+export type AuthorId = number | { id: number };
+
+export interface EditableAuthor extends Partial<Pick<Author, "id" | "name">> {}
+
+export interface Chapter {
+  id: number;
+  title: string | null;
+}
+
+export type ChapterId = number | { id: number };
+
+export interface EditableChapter extends Partial<Pick<Chapter, "id" | "title">> {}
+
+export interface Book {
+  id: number;
+  author?: Author | null;
+  chapters?: Array<Chapter>;
+}
+
+export type BookId = number | { id: number };
+
+export interface EditableBook extends Partial<Pick<Book, "id">> {
+  chapters?: Array<EditableChapter>;
+}

--- a/packages/odata2ts/test/fixture/generator/model/entity-relationships-containment.ts
+++ b/packages/odata2ts/test/fixture/generator/model/entity-relationships-containment.ts
@@ -1,0 +1,30 @@
+export interface Author {
+  id: number;
+  name: boolean | null;
+}
+
+export type AuthorId = number | { id: number };
+
+export interface EditableAuthor extends Partial<Pick<Author, "id" | "name">> {}
+
+export interface Chapter {
+  id: number;
+  title: string | null;
+}
+
+export type ChapterId = number | { id: number };
+
+export interface EditableChapter extends Partial<Pick<Chapter, "id" | "title">> {}
+
+export interface Book {
+  id: number;
+  author?: Author | null;
+  chapters?: Array<Chapter>;
+}
+
+export type BookId = number | { id: number };
+
+export interface EditableBook extends Partial<Pick<Book, "id">> {
+  author?: EditableAuthor;
+  chapters?: Array<EditableChapter>;
+}

--- a/packages/odata2ts/test/generator/v2/ModelGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v2/ModelGenerator.test.ts
@@ -2,7 +2,7 @@ import { ODataTypesV2, ODataVersions } from "@odata2ts/odata-core";
 import { beforeAll, beforeEach, describe, test } from "vitest";
 import { digest } from "../../../src/data-model/DataModelDigestionV2.js";
 import { generateModels } from "../../../src/generator/index.js";
-import { EmitModes, Modes } from "../../../src/index.js";
+import { DeepInsertProps, EmitModes, Modes } from "../../../src/index.js";
 import { createProjectManager } from "../../../src/project/ProjectManager.js";
 import { ODataModelBuilderV2 } from "../../data-model/builder/v2/ODataModelBuilderV2.js";
 import {
@@ -129,7 +129,7 @@ describe("Model Generator Tests V2", () => {
     // when generating without a service
     // then the editable model uses the __metadata uri notation
     await generateAndCompare("entity-relationships-binding-v2.ts", {
-      disableDeepInsertProps: true,
+      deepInsertProps: DeepInsertProps.none,
       mode: Modes.models,
       skipEditableModels: false,
       skipIdModels: false,
@@ -155,6 +155,20 @@ describe("Model Generator Tests V2", () => {
     // then the navigation properties show up on the editable model, typed as the editable model of the
     // related entity
     await generateAndCompare("entity-relationships-deep-insert-v2.ts", {
+      skipEditableModels: false,
+      skipIdModels: false,
+    });
+  });
+
+  test(`${TEST_SUITE_NAME}: composition-only leaves a V2 service alone`, async () => {
+    // given entities related to each other
+    addRelatedEntities();
+
+    // when narrowing the deep insert props to containment, which V2 cannot state at all
+    // then every navigation property keeps it: the narrow reading would find nothing contained and take
+    // the feature away wholesale, so a V2 service is exempt rather than emptied
+    await generateAndCompare("entity-relationships-deep-insert-v2.ts", {
+      deepInsertProps: DeepInsertProps.compositionOnly,
       skipEditableModels: false,
       skipIdModels: false,
     });
@@ -228,7 +242,7 @@ describe("Model Generator Tests V2", () => {
     // then the binding goes by the navigation property itself and carries the key of the entity to bind,
     // which the query objects turn into the __metadata uri notation
     await generateAndCompare("entity-relationships-binding-by-key-v2.ts", {
-      disableDeepInsertProps: true,
+      deepInsertProps: DeepInsertProps.none,
       skipEditableModels: false,
       skipIdModels: false,
     });

--- a/packages/odata2ts/test/generator/v4/EntityBasedGenerationTests.ts
+++ b/packages/odata2ts/test/generator/v4/EntityBasedGenerationTests.ts
@@ -1,7 +1,7 @@
 import { ODataTypesV4 } from "@odata2ts/odata-core";
 import { beforeAll, beforeEach, test } from "vitest";
 import { digest } from "../../../src/data-model/DataModelDigestionV4.js";
-import { ConfigFileOptions, NamingStrategies, TypeModel } from "../../../src/index.js";
+import { ConfigFileOptions, DeepInsertProps, NamingStrategies, TypeModel } from "../../../src/index.js";
 import { ODataModelBuilderV4 } from "../../data-model/builder/v4/ODataModelBuilderV4.js";
 import {
   createHelper,
@@ -151,7 +151,7 @@ export function createEntityBasedGenerationTests(
     // then match fixture text
     await generateAndCompare("entity-relationships.ts", {
       disableBindingProps: true,
-      disableDeepInsertProps: true,
+      deepInsertProps: DeepInsertProps.none,
       skipEditableModels: false,
       skipIdModels: false,
     });
@@ -176,7 +176,7 @@ export function createEntityBasedGenerationTests(
     // then match fixture text
     await generateAndCompare("entity-relationships.ts", {
       disableBindingProps: true,
-      disableDeepInsertProps: true,
+      deepInsertProps: DeepInsertProps.none,
       skipEditableModels: false,
       skipIdModels: false,
     });

--- a/packages/odata2ts/test/generator/v4/ModelGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/ModelGenerator.test.ts
@@ -2,7 +2,14 @@ import { ODataTypesV4, ODataVersions } from "@odata2ts/odata-core";
 import { beforeAll, beforeEach, describe, test } from "vitest";
 import { digest } from "../../../src/data-model/DataModelDigestionV4.js";
 import { generateModels } from "../../../src/generator/index.js";
-import { EmitModes, EnumSynthesis, KeyProperties, ManagedPropertyMode, Modes } from "../../../src/index.js";
+import {
+  DeepInsertProps,
+  EmitModes,
+  EnumSynthesis,
+  KeyProperties,
+  ManagedPropertyMode,
+  Modes,
+} from "../../../src/index.js";
 import { createProjectManager } from "../../../src/project/ProjectManager.js";
 import { allowedValues, core, corePermissions } from "../../data-model/builder/ODataAnnotationBuilder.js";
 import { ODataModelBuilderV4 } from "../../data-model/builder/v4/ODataModelBuilderV4.js";
@@ -161,7 +168,7 @@ describe("Model Generator Tests V4", () => {
     // then match original fixture => config option has no effect
     await generateAndCompare("entity-relationships.ts", {
       disableBindingProps: true,
-      disableDeepInsertProps: true,
+      deepInsertProps: DeepInsertProps.none,
       v2: { responseResultsWrapping: true },
       skipEditableModels: false,
       skipIdModels: false,
@@ -522,7 +529,7 @@ describe("Model Generator Tests V4", () => {
     // when generating for 4.01 without a service
     // then the editable model uses the short form instead of the @odata.bind notation
     await generateAndCompare("entity-relationships-v401.ts", {
-      disableDeepInsertProps: true,
+      deepInsertProps: DeepInsertProps.none,
       mode: Modes.models,
       v4: { odataVersion: "4.01" },
       skipEditableModels: false,
@@ -550,7 +557,7 @@ describe("Model Generator Tests V4", () => {
     await generateAndCompare("entity-relationships.ts", {
       v4: { odataVersion: "4.01" },
       disableBindingProps: true,
-      disableDeepInsertProps: true,
+      deepInsertProps: DeepInsertProps.none,
       skipEditableModels: false,
       skipIdModels: false,
     });
@@ -573,7 +580,7 @@ describe("Model Generator Tests V4", () => {
     // when opting into the binding props without a service
     // then the editable model allows to bind an existing entity via the @odata.bind notation
     await generateAndCompare("entity-relationships-binding.ts", {
-      disableDeepInsertProps: true,
+      deepInsertProps: DeepInsertProps.none,
       mode: Modes.models,
       skipEditableModels: false,
       skipIdModels: false,
@@ -616,7 +623,7 @@ describe("Model Generator Tests V4", () => {
     // then the binding goes by the navigation property itself and carries the key of the entity to bind,
     // which the query objects turn into the URL the wire notation asks for
     await generateAndCompare("entity-relationships-binding-by-key.ts", {
-      disableDeepInsertProps: true,
+      deepInsertProps: DeepInsertProps.none,
       skipEditableModels: false,
       skipIdModels: false,
     });
@@ -644,7 +651,7 @@ describe("Model Generator Tests V4", () => {
     // then no binding prop at all: the URL of the referenced entity could not be built
     await generateAndCompare("entity-relationships.ts", {
       disableBindingProps: true,
-      disableDeepInsertProps: true,
+      deepInsertProps: DeepInsertProps.none,
       skipEditableModels: false,
       skipIdModels: false,
     });
@@ -659,6 +666,55 @@ describe("Model Generator Tests V4", () => {
     // related entity - which is what travels within the payload of a deep insert or deep update
     await generateAndCompare("entity-relationships-deep-insert.ts", {
       disableBindingProps: true,
+      skipEditableModels: false,
+      skipIdModels: false,
+    });
+  });
+
+  /**
+   * Both kinds of relation a V4 service can state, declared as real navigation properties, since only
+   * those carry `ContainsTarget`: `chapters` is contained - part of the book - while `author` points at
+   * an entity standing on its own.
+   */
+  function addContainedAndPlainNavProps() {
+    odataBuilder
+      .addEntityType("Author", undefined, (builder) =>
+        builder.addKeyProp("id", ODataTypesV4.Int32).addProp("name", ODataTypesV4.Boolean, true),
+      )
+      .addEntityType("Chapter", undefined, (builder) =>
+        builder.addKeyProp("id", ODataTypesV4.Int32).addProp("title", ODataTypesV4.String, true),
+      )
+      .addEntityType(ENTITY_NAME, undefined, (builder) =>
+        builder
+          .addKeyProp("id", ODataTypesV4.Int32)
+          .addNavProp("author", withNs("Author"), undefined, true)
+          .addNavProp("chapters", `Collection(${withNs("Chapter")})`, undefined, undefined, true),
+      );
+  }
+
+  test(`${TEST_SUITE_NAME}: containment changes nothing by default`, async () => {
+    // given a contained and a plain navigation property
+    addContainedAndPlainNavProps();
+
+    // when leaving the deep insert props alone
+    // then both carry it - the protocol permits a deep insert on any navigation property
+    await generateAndCompare("entity-relationships-containment.ts", {
+      disableBindingProps: true,
+      skipEditableModels: false,
+      skipIdModels: false,
+    });
+  });
+
+  test(`${TEST_SUITE_NAME}: composition-only leaves it to the contained navigation property`, async () => {
+    // given a contained and a plain navigation property
+    addContainedAndPlainNavProps();
+
+    // when narrowing the deep insert props to containment
+    // then only the contained one accepts a related entity within the payload; the plain one is gone
+    // from the editable model entirely
+    await generateAndCompare("entity-relationships-composition-only.ts", {
+      disableBindingProps: true,
+      deepInsertProps: DeepInsertProps.compositionOnly,
       skipEditableModels: false,
       skipIdModels: false,
     });


### PR DESCRIPTION
- `disableDeepInsertProps` is replaced by `deepInsertProps`, a named strategy rather than a switch: `all` (default, unchanged), `none` (the former `true`) and `composition-only`
- `composition-only` offers the deep insert shape only where a navigation property carries `ContainsTarget="true"`, parsed into `PropertyModel.contained` by the V4 digester
- V2 is exempt from it rather than emptied by it — V2 states no containment, so the narrow reading would remove the feature wholesale instead of narrowing it
- binding props are untouched: a contained target already gets none, a containment navigation property being ineligible as the last segment of a `NavigationPropertyBinding` (CSDL §8.4)
- `int-test/config-variants` gains two variants — the V4 one over ASP.NET's metadata, which states containment faithfully, and a V2 one pinning that the option does nothing there

`composition-only` exists for SAP CAP, which performs deep writes along compositions only. It is deliberately narrower than §11.4.2.2, which permits a deep insert on any navigation property, and the option documents that it will take away more than it should on a server that accepts deep insert on plain associations.

BREAKING CHANGE: `disableDeepInsertProps: true` becomes `deepInsertProps: "none"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)