### PR TITLE
fix(odata2ts): import the service class a singleton instantiates

### DIFF
--- a/int-test/cap/resource/library.xml
+++ b/int-test/cap/resource/library.xml
@@ -42,10 +42,7 @@
         </EntitySet>
         <EntitySet Name="Audiobooks" EntityType="Library.Service.Audiobooks">
           <NavigationPropertyBinding Path="Copies" Target="Copies" />
-          <NavigationPropertyBinding Path="Chapters" Target="AudiobookChapters" />
-        </EntitySet>
-        <EntitySet Name="AudiobookChapters" EntityType="Library.Service.AudiobookChapters">
-          <NavigationPropertyBinding Path="up_" Target="Audiobooks" />
+          <NavigationPropertyBinding Path="Chapters/up_" Target="Audiobooks" />
         </EntitySet>
         <EntitySet Name="DVDs" EntityType="Library.Service.DVDs">
           <NavigationPropertyBinding Path="Copies" Target="Copies" />
@@ -202,20 +199,19 @@
         <Property Name="Duration" Type="Edm.Duration" />
         <Property Name="Narrator" Type="Edm.String" />
         <Property Name="Sample" Type="Edm.Stream" />
-        <NavigationProperty Name="Chapters" Type="Collection(Library.Service.AudiobookChapters)" Partner="up_">
-          <OnDelete Action="Cascade" />
-        </NavigationProperty>
+        <NavigationProperty
+          Name="Chapters"
+          Type="Collection(Library.Service.AudiobookChapters)"
+          Partner="up_"
+          ContainsTarget="true"
+        />
       </EntityType>
       <EntityType Name="AudiobookChapters">
         <Key>
           <PropertyRef Name="Id" />
-          <PropertyRef Name="up__Id" />
         </Key>
         <Property Name="Id" Type="Edm.Int32" Nullable="false" />
-        <NavigationProperty Name="up_" Type="Library.Service.Audiobooks" Partner="Chapters">
-          <ReferentialConstraint Property="up__Id" ReferencedProperty="Id" />
-        </NavigationProperty>
-        <Property Name="up__Id" Type="Edm.Guid" Nullable="false" />
+        <NavigationProperty Name="up_" Type="Library.Service.Audiobooks" Partner="Chapters" />
         <Property Name="Title" Type="Edm.String" />
         <Property Name="content" Type="Edm.Stream" />
       </EntityType>

--- a/int-test/cap/test/feature/DeepInsert.test.ts
+++ b/int-test/cap/test/feature/DeepInsert.test.ts
@@ -65,9 +65,11 @@ describe("CAP Library: deep insert", () => {
         // Edm.Duration, so a string - not a number
         Duration: "PT1H",
         Narrator: "Some Narrator",
-        // up__Id is the backlink to the parent, which does not exist yet - CAP fills it in and overwrites
-        // whatever was sent, but the editable model demands it, since it is a plain required property
-        Chapters: [{ Id: chapterId, up__Id: "00000000-0000-0000-0000-000000000000", Title: "First chapter" }],
+        // No backlink to the parent here: `Chapters` is a containment navigation property, so a chapter
+        // is identified within its audiobook and CAP keeps the foreign key out of the model entirely.
+        // Before `@odata.contained` the editable model demanded a `up__Id` for an audiobook that does
+        // not exist yet, and the value was overwritten the moment the parent was created.
+        Chapters: [{ Id: chapterId, Title: "First chapter" }],
       })
       .execute();
 
@@ -79,8 +81,6 @@ describe("CAP Library: deep insert", () => {
 
     expect(read.data.Chapters).toHaveLength(1);
     expect(read.data.Chapters?.[0].Title).toBe("First chapter");
-    // the backlink CAP maintains for a composition, filled in from the parent
-    expect(read.data.Chapters?.[0].up__Id).toBe(created.data.Id);
   });
 
   test("an association is accepted and then dropped", async () => {

--- a/int-test/config-variants/odata2ts.config.ts
+++ b/int-test/config-variants/odata2ts.config.ts
@@ -53,6 +53,12 @@ import {
 const V4_SOURCE = "../asp-net/resource/library.xml";
 /** V2: the same model as Apache Olingo 2 emits it. */
 const V2_SOURCE = "../olingo-v2/resource/library-v2.xml";
+/**
+ * V4 again, as SAP CAP emits it - a second shape of the same model, not a second model. Used where a
+ * variant is about something CAP states differently, which is why `deepInsertCompositionCap` reads this
+ * one: `@odata.contained` on `Audiobook.Chapters` is CAP's, and the option that acts on it exists for CAP.
+ */
+const V4_SOURCE_CAP = "../cap/resource/library.xml";
 
 /**
  * `Location_` (a shelf mark) and `Location` (the branch an item sits in) are distinct OData names which
@@ -254,6 +260,25 @@ const config: ConfigFileOptions = {
       serviceName: "DeepInsertComposition",
       source: V4_SOURCE,
       output: "src-generated/deep-insert-composition",
+      deepInsertProps: DeepInsertProps.compositionOnly,
+    },
+
+    /**
+     * The same value against the metadata of the server it exists for.
+     *
+     * The ASP.NET variant above proves the rule; this one proves it where it is meant to bite. CAP states
+     * containment for `Audiobook.Chapters` alone - it is the one composition annotated `@odata.contained`
+     * - while `Copies` and `Publisher` are associations along which CAP performs no deep write at all.
+     * The narrowing therefore removes exactly the properties whose payload that server answers with a 400
+     * or drops in silence, which is the entire reason the value exists.
+     *
+     * Containment reshapes the contained type as well, and that is worth having compiled: a contained
+     * entity is identified within its container, so CAP leaves the foreign key out of the model.
+     */
+    deepInsertCompositionCap: {
+      serviceName: "DeepInsertCompositionCap",
+      source: V4_SOURCE_CAP,
+      output: "src-generated/deep-insert-composition-cap",
       deepInsertProps: DeepInsertProps.compositionOnly,
     },
 

--- a/int-test/config-variants/test/variants.type-test.ts
+++ b/int-test/config-variants/test/variants.type-test.ts
@@ -1,4 +1,11 @@
 import { expectTypeOf } from "vitest";
+import type {
+  CopiesId as CapCopiesId,
+  EditableAudiobookChapters as CapEditableAudiobookChapters,
+  EditableAudiobooks as CapEditableAudiobooks,
+  EditableBooks as CapEditableBooks,
+  PublishersId as CapPublishersId,
+} from "../src-generated/deep-insert-composition-cap/library-service/index.js";
 import type { EditableMember as CompositionV2EditableMember } from "../src-generated/deep-insert-composition-v2/library-circulation/index.js";
 import type {
   Audiobook as CompositionAudiobook,
@@ -176,3 +183,20 @@ expectTypeOf<CompositionAudiobook["Copies"]>().toExtend<Array<unknown> | undefin
 // wholesale. A V2 service is exempt from the option instead, and keeps every navigation property.
 expectTypeOf<CompositionV2EditableMember["Loans"]>().toExtend<Array<unknown> | undefined>();
 expectTypeOf<CompositionV2EditableMember["Reservations"]>().toExtend<Array<unknown> | undefined>();
+
+/* --- deepInsertCompositionCap: the same value against the server it exists for -------------------- */
+
+// The composition CAP marks `@odata.contained` keeps the deep insert shape, because that is the one
+// relationship CAP writes deeply.
+expectTypeOf<CapEditableAudiobooks["Chapters"]>().toEqualTypeOf<Array<CapEditableAudiobookChapters> | undefined>();
+
+// The associations keep their binding and lose the nested entity - which is the point of the option
+// here: a nested payload on `Copies` is answered by CAP with a silent no-op and one on `Publisher` with a
+// 400, while binding an existing entity works on both. The type now permits only the half that works.
+expectTypeOf<CapEditableAudiobooks["Copies"]>().toEqualTypeOf<Array<{ "@id": CapCopiesId }> | undefined>();
+expectTypeOf<CapEditableBooks["Publisher"]>().toEqualTypeOf<{ "@id": CapPublishersId } | null | undefined>();
+
+// Containment reshapes the contained type as well: a chapter is identified within its audiobook, so CAP
+// drops the foreign key to the parent. Before the composition was annotated, the editable model demanded
+// an `up__Id` for an audiobook that did not exist yet.
+expectTypeOf<CapEditableAudiobookChapters>().not.toHaveProperty("up__Id");

--- a/packages/odata2ts/src/generator/ServiceGenerator.ts
+++ b/packages/odata2ts/src/generator/ServiceGenerator.ts
@@ -268,7 +268,7 @@ class ServiceGenerator {
 
     Object.values(container.singletons).forEach((singleton) => {
       result.properties.push(this.generateSingletonProp(importContainer, singleton));
-      result.methods.push(this.generateSingletonGetter(singleton));
+      result.methods.push(this.generateSingletonGetter(importContainer, singleton));
     });
 
     return result;
@@ -349,7 +349,10 @@ class ServiceGenerator {
     singleton: SingletonType,
   ): OptionalKind<PropertyDeclarationStructure> {
     const { name, entityType } = singleton;
-    const type = entityType.serviceName;
+    // Registered rather than merely named: where the singleton's type has an entity set of its own, the
+    // import is already there from the entity set's getter, but a type reachable *only* as a singleton
+    // has nothing else to bring it in - and unbundled output then references a class it never imported.
+    const type = importContainer.addGeneratedService(entityType.fqName, entityType.serviceName);
 
     return {
       scope: Scope.Private,
@@ -368,10 +371,15 @@ class ServiceGenerator {
     };
   };
 
-  private generateSingletonGetter(singleton: SingletonType): OptionalKind<MethodDeclarationStructure> {
+  private generateSingletonGetter(
+    importContainer: ImportContainer,
+    singleton: SingletonType,
+  ): OptionalKind<MethodDeclarationStructure> {
     const { name, odataName, entityType } = singleton;
     const propName = "this." + this.namingHelper.getPrivatePropName(name);
-    const serviceType = entityType.serviceName;
+    // the registered name rather than the plain one: an import may have been aliased to avoid a clash,
+    // and the property declaration above went through the same call, so the two agree
+    const serviceType = importContainer.addGeneratedService(entityType.fqName, entityType.serviceName);
 
     return {
       scope: Scope.Public,

--- a/packages/odata2ts/test/fixture/generator/service/v4/singleton-unbundled.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/singleton-unbundled.ts
@@ -1,0 +1,16 @@
+import { ODataService } from "@odata2ts/odata-service";
+// @ts-ignore
+import { TestEntityService } from "./tester/test-entity/TestEntityService.js";
+
+export class TesterService extends ODataService {
+  private _currentUser?: TestEntityService;
+
+  public currentUser() {
+    if (!this._currentUser) {
+      const { client, path, options } = this.__base;
+      this._currentUser = new TestEntityService(client, path, "CURRENT_USER", options);
+    }
+
+    return this._currentUser;
+  }
+}

--- a/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
@@ -41,7 +41,12 @@ describe("Service Generator Tests V4", () => {
     runOptions = getTestConfig();
   });
 
-  async function doGenerate(options?: ConfigFileOptions) {
+  /**
+   * The fixtures are bundled output, where every service class sits in the file being compared and no
+   * import is needed to reach it. `bundled: false` is for the cases where that is precisely what hides
+   * the thing under test - see the unbundled singleton case below.
+   */
+  async function doGenerate(options?: ConfigFileOptions, { bundled = true }: { bundled?: boolean } = {}) {
     runOptions = options ? deepmerge(runOptions, options) : runOptions;
     const namingHelper = new NamingHelper(runOptions, SERVICE_NAME);
     const dataModel = await fixtureComparatorHelper.createDataModel(
@@ -50,7 +55,7 @@ describe("Service Generator Tests V4", () => {
       runOptions,
     );
     projectManager = await createProjectManager("build", EmitModes.ts, namingHelper, dataModel, {
-      bundledFileGeneration: true,
+      bundledFileGeneration: bundled,
       noOutput: true,
       allowTypeChecking: true,
     });
@@ -130,6 +135,20 @@ describe("Service Generator Tests V4", () => {
 
     // then main service file encompasses a singleton
     await compareMainService("singleton.ts");
+  });
+
+  test("Service Generator: unbundled, a singleton brings in its own service", async () => {
+    // given a singleton whose entity type has no entity set, so nothing else refers to that service
+    odataBuilder
+      .addEntityType("TestEntity", undefined, (builder) => builder.addKeyProp("id", ODataTypesV4.String))
+      .addSingleton("CURRENT_USER", withNs("TestEntity"));
+
+    // when generating one file per model instead of one bundle
+    await doGenerate(undefined, { bundled: false });
+
+    // then the main service imports the service class it instantiates. Bundled output cannot show this:
+    // the class is declared in the very file, so a missing import is invisible there.
+    await compareMainService("singleton-unbundled.ts");
   });
 
   test("Service Generator: bound & unbound functions", async () => {


### PR DESCRIPTION
Three things, in the order they turned up.

**The CAP metadata snapshot is refreshed to `test-server-cap` 0.4.0.** It still described 0.3.0 — the bump PR only ever raised the pin. The diff is small and entirely containment: `AudiobookChapters` leaves the entity container, `Chapters` gains `ContainsTarget="true"`, and the contained type loses its composite key and its `up__Id` foreign key, since a contained entity is identified within its container. `library-v2.xml` is untouched, V2 having no containment to express.

`test/feature/DeepInsert.test.ts` follows: the payload no longer carries a backlink to a parent that does not exist yet, which the editable model used to demand and CAP used to overwrite.

**`composition-only` now has coverage against the server it exists for.** `int-test/config-variants` gains a variant generated from CAP's own metadata, where the option does what it was written to do: `Audiobooks/Chapters` keeps the deep-insert shape, while `Copies` and `Publisher` are reduced to bindings — the half CAP actually accepts, against payloads it answers with a silent no-op or a 400. The assertions also pin that containment removes `up__Id` from the contained type.

**That variant exposed a generator bug, which is what this PR is named after.** A singleton whose entity type has no entity set of its own — CAP's `MainBranch` — produced a main service referencing a service class it never imported. ASP.NET's singleton is typed `Branch`, which has an entity set, so its import arrived anyway; that is why no existing variant caught it. Bundled output cannot show it either, and the generator tests are bundled, so the new unit test runs unbundled. Verified to fail without the fix.

All suites green: 1836 unit tests, and the cap / asp-net / olingo-v2 integration suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)