### PR TITLE
feat(odata2ts): discover optimistic concurrency from the service metadata

### DIFF
--- a/packages/odata-service/src/ODataServiceOptions.ts
+++ b/packages/odata-service/src/ODataServiceOptions.ts
@@ -27,6 +27,14 @@ export interface ODataServiceOptionsInternal<V extends ODataVersionV4 = "4.0"> e
    * Just like bigNumbersAsString this is set internally, since it is decided by the generator.
    */
   odataVersionV4?: V;
+  /**
+   * Modifying this resource requires an ETag: the service states `Core.OptimisticConcurrency` for the
+   * entity set or singleton exposing this type - or, in V2, a `ConcurrencyMode="Fixed"` property.
+   *
+   * Set by the generator per entity type, hence internal: it is a statement about the service, not
+   * something an application chooses.
+   */
+  concurrencyControlled?: boolean;
 }
 
 export interface ODataServiceOptionsInternalV2<AsV4 extends boolean = false> extends ODataServiceOptions {
@@ -40,4 +48,12 @@ export interface ODataServiceOptionsInternalV2<AsV4 extends boolean = false> ext
    * what actually picks the converter behaviour.
    */
   v2ResponseAsV4?: AsV4;
+  /**
+   * Modifying this resource requires an ETag: the service states `Core.OptimisticConcurrency` for the
+   * entity set or singleton exposing this type - or, in V2, a `ConcurrencyMode="Fixed"` property.
+   *
+   * Set by the generator per entity type, hence internal: it is a statement about the service, not
+   * something an application chooses.
+   */
+  concurrencyControlled?: boolean;
 }

--- a/packages/odata2ts/src/OptionModel.ts
+++ b/packages/odata2ts/src/OptionModel.ts
@@ -186,6 +186,16 @@ export interface AnnotationOptions {
    * of which this switch touches.
    */
   disableManagedProperties?: boolean;
+  /**
+   * Stop deriving optimistic concurrency control from the annotations of the service. Off by default:
+   * `Core.OptimisticConcurrency` on an entity set or singleton - and, in V2, a `ConcurrencyMode="Fixed"`
+   * property - makes the generated service send `If-Match` on every write to that resource, and fail
+   * before the request where no ETag is known.
+   *
+   * Turn it on to get the previous behaviour back: no `If-Match` is ever sent, and a service which
+   * demands one answers `428 Precondition Required`.
+   */
+  disableOptimisticConcurrency?: boolean;
 }
 
 /**

--- a/packages/odata2ts/src/data-model/AnnotationResolver.ts
+++ b/packages/odata2ts/src/data-model/AnnotationResolver.ts
@@ -14,6 +14,21 @@ interface WithNavigationProps {
 }
 
 /**
+ * An element of the entity container which an annotation may address: an entity set, or - in V4 - a
+ * singleton. The base schema types its container as `any`, since the two versions declare rather
+ * different things in it; both name their children, which is all that matters here.
+ */
+interface ContainerChild extends Annotatable {
+  $: { Name: string };
+}
+
+interface EntityContainerLike {
+  $: { Name: string };
+  EntitySet?: Array<ContainerChild>;
+  Singleton?: Array<ContainerChild>;
+}
+
+/**
  * Brings the annotations of a document into one shape before anything is digested: every term name fully
  * qualified, and every externally stated annotation moved to the element it targets.
  *
@@ -37,6 +52,16 @@ export class AnnotationResolver {
    */
   private readonly targets = new Map<string, EntityType | ComplexType>();
 
+  /**
+   * Every entity set and singleton by the path an annotation addresses it with -
+   * `<namespace>.<containerName>/<name>` - under the namespace of its schema as well as under its alias.
+   *
+   * Kept apart from {@link targets} because such a path has two segments just like a property path does,
+   * and a container is not a type: looking here first is what keeps `Library.Service.EntityContainer/Copies`
+   * from being read as "property Copies of type Library.Service.EntityContainer".
+   */
+  private readonly containerChildren = new Map<string, Annotatable>();
+
   constructor(
     private readonly schemas: Array<Schema<EntityType, ComplexType>>,
     references: Array<Reference> | undefined,
@@ -57,7 +82,28 @@ export class AnnotationResolver {
           this.targets.set(withNamespace(alias, model.$.Name), model);
         }
       }
+
+      // an annotation may address a set or a singleton through the container declaring it, e.g.
+      // `Library.Service.EntityContainer/Copies` - the container's own name is whatever it was given,
+      // `EntityContainer` in CAP's metadata and `LibraryService` in the reference model's
+      for (const container of this.containersOf(schema)) {
+        for (const child of AnnotationResolver.childrenOf(container)) {
+          const path = `${container.$.Name}/${child.$.Name}`;
+          this.containerChildren.set(withNamespace(ns, path), child);
+          if (alias) {
+            this.containerChildren.set(withNamespace(alias, path), child);
+          }
+        }
+      }
     }
+  }
+
+  private containersOf(schema: Schema<EntityType, ComplexType>): Array<EntityContainerLike> {
+    return (schema.EntityContainer ?? []) as Array<EntityContainerLike>;
+  }
+
+  private static childrenOf(container: EntityContainerLike): Array<ContainerChild> {
+    return [...(container.EntitySet ?? []), ...(container.Singleton ?? [])];
   }
 
   /**
@@ -69,6 +115,11 @@ export class AnnotationResolver {
         this.qualifyTerms(model);
         for (const prop of [...(model.Property ?? []), ...((model as WithNavigationProps).NavigationProperty ?? [])]) {
           this.qualifyTerms(prop);
+        }
+      }
+      for (const container of this.containersOf(schema)) {
+        for (const child of AnnotationResolver.childrenOf(container)) {
+          this.qualifyTerms(child);
         }
       }
       this.qualifyTerms(schema);
@@ -163,6 +214,11 @@ export class AnnotationResolver {
    * deeper path yields nothing and is therefore left alone.
    */
   private findTarget(target: string): Annotatable | undefined {
+    const containerChild = this.containerChildren.get(target);
+    if (containerChild) {
+      return containerChild;
+    }
+
     const [typeName, ...path] = target.split("/");
     const model = this.targets.get(typeName);
     if (!model) {

--- a/packages/odata2ts/src/data-model/CoreAnnotations.ts
+++ b/packages/odata2ts/src/data-model/CoreAnnotations.ts
@@ -8,6 +8,8 @@ const COMPUTED_DEFAULT_VALUE = `${CORE}.ComputedDefaultValue`;
 const IMMUTABLE = `${CORE}.Immutable`;
 const PERMISSIONS = `${CORE}.Permissions`;
 
+const OPTIMISTIC_CONCURRENCY = `${CORE}.OptimisticConcurrency`;
+
 const PERMISSION_READ = `${CORE}.Permission/Read`;
 const PERMISSION_WRITE = `${CORE}.Permission/Write`;
 
@@ -84,4 +86,19 @@ export function getManagedState(allAnnotations: Array<Annotation> | undefined): 
   }
 
   return undefined;
+}
+
+/**
+ * Whether the service states that modifying this resource requires an ETag.
+ *
+ * Presence of the term is the whole statement. It is declared as `Collection(Edm.PropertyPath)` naming
+ * the properties the ETag is computed from, but a client never needs them: the value always arrives in
+ * the response. An empty collection is therefore just as good, and a legitimate form - the vocabulary
+ * documents it as "the service won't tell how it computes the ETag", and CAP emits exactly that.
+ *
+ * Unlike {@link getManagedState} this does not filter for constant annotations: a collection of property
+ * paths is none of the constant forms that check recognises.
+ */
+export function isOptimisticConcurrency(annotations: Array<Annotation> | undefined): boolean {
+  return !!annotations?.some((a) => a.$.Term === OPTIMISTIC_CONCURRENCY);
 }

--- a/packages/odata2ts/src/data-model/DataModelDigestion.ts
+++ b/packages/odata2ts/src/data-model/DataModelDigestion.ts
@@ -418,6 +418,9 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
         subtypes: new Set(),
         // postprocess required as well: the media entity marker is inherited from base types
         hasStream: this.isMediaEntity(model),
+        // set while digesting the entity container, which is where the entity sets and singletons
+        // exposing this type - and their `Core.OptimisticConcurrency` - are read
+        concurrencyControlled: false,
       });
     }
   }

--- a/packages/odata2ts/src/data-model/DataModelDigestionV2.ts
+++ b/packages/odata2ts/src/data-model/DataModelDigestionV2.ts
@@ -1,9 +1,9 @@
 import { loadConverters, MappedConverterChains } from "@odata2ts/converter-runtime";
 import { ODataTypesV2, ODataVersions } from "@odata2ts/odata-core";
 import { DigesterFunction, DigestionOptions } from "../FactoryFunctionModel.js";
+import { isOptimisticConcurrency } from "./CoreAnnotations.js";
 import { withNamespace } from "./DataModel.js";
 import { Digester, TypeModel } from "./DataModelDigestion.js";
-import { isOptimisticConcurrency } from "./CoreAnnotations.js";
 import { NavPropBindingType, ODataVersion, OperationTypes, PropertyModel } from "./DataTypeModel.js";
 import { ComplexType, Property, Reference } from "./edmx/ODataEdmxModelBase.js";
 import {

--- a/packages/odata2ts/src/data-model/DataModelDigestionV2.ts
+++ b/packages/odata2ts/src/data-model/DataModelDigestionV2.ts
@@ -3,6 +3,7 @@ import { ODataTypesV2, ODataVersions } from "@odata2ts/odata-core";
 import { DigesterFunction, DigestionOptions } from "../FactoryFunctionModel.js";
 import { withNamespace } from "./DataModel.js";
 import { Digester, TypeModel } from "./DataModelDigestion.js";
+import { isOptimisticConcurrency } from "./CoreAnnotations.js";
 import { NavPropBindingType, ODataVersion, OperationTypes, PropertyModel } from "./DataTypeModel.js";
 import { ComplexType, Property, Reference } from "./edmx/ODataEdmxModelBase.js";
 import {
@@ -184,11 +185,21 @@ class DigesterV3 extends Digester<SchemaV3, EntityTypeV3, ComplexTypeV3> {
           throw new Error(`Entity type "${entitySet.$.EntityType}" not found!`);
         }
 
+        // V2 states the concurrency token as a schema facet rather than as an annotation; the
+        // V2AnnotationResolver has normalized it into `Core.OptimisticConcurrency` by now, so this reads
+        // exactly like its V4 counterpart
+        const concurrencyControlled =
+          !this.options.annotations?.disableOptimisticConcurrency && isOptimisticConcurrency(entitySet.Annotation);
+        if (concurrencyControlled) {
+          entityType.concurrencyControlled = true;
+        }
+
         this.dataModel.addEntitySet(fqName, {
           fqName,
           odataName,
           name,
           entityType,
+          concurrencyControlled,
           navPropBinding: this.getNavPropBindings(container, odataName, entitySet.$.EntityType),
         });
       });

--- a/packages/odata2ts/src/data-model/DataModelDigestionV4.ts
+++ b/packages/odata2ts/src/data-model/DataModelDigestionV4.ts
@@ -3,8 +3,9 @@ import { ODataTypesV4, ODataVersions } from "@odata2ts/odata-core";
 import { DigesterFunction, DigestionOptions } from "../FactoryFunctionModel.js";
 import { NamespaceWithAlias, withNamespace } from "./DataModel.js";
 import { Digester, TypeModel } from "./DataModelDigestion.js";
+import { isOptimisticConcurrency } from "./CoreAnnotations.js";
 import { ODataVersion, OperationType, OperationTypes, PropertyModel } from "./DataTypeModel.js";
-import { ComplexType, Property, Reference } from "./edmx/ODataEdmxModelBase.js";
+import { Annotatable, ComplexType, Property, Reference } from "./edmx/ODataEdmxModelBase.js";
 import { ComplexTypeV4, EntityTypeV4, NavigationProperty, Operation, SchemaV4 } from "./edmx/ODataEdmxModelV4.js";
 import { NamingHelper } from "./NamingHelper.js";
 
@@ -39,6 +40,14 @@ class DigesterV4 extends Digester<SchemaV4, EntityTypeV4, ComplexTypeV4> {
     // functions & actions
     this.addOperations(nsWithAlias, schema.Function, OperationTypes.Function);
     this.addOperations(nsWithAlias, schema.Action, OperationTypes.Action);
+  }
+
+  /**
+   * Whether this container child states that modifying it requires an ETag - unless the option switches
+   * the evaluation off, in which case nothing does.
+   */
+  private isConcurrencyControlled(element: Annotatable): boolean {
+    return !this.options.annotations?.disableOptimisticConcurrency && isOptimisticConcurrency(element.Annotation);
   }
 
   protected digestEntityContainer(schema: SchemaV4) {
@@ -90,11 +99,17 @@ class DigesterV4 extends Digester<SchemaV4, EntityTypeV4, ComplexTypeV4> {
           throw new Error(`Entity type "${singleton.$.Type}" not found!`);
         }
 
+        const singletonConcurrency = this.isConcurrencyControlled(singleton);
+        if (singletonConcurrency) {
+          entityType.concurrencyControlled = true;
+        }
+
         this.dataModel.addSingleton(fqName, {
           fqName,
           odataName,
           name,
           entityType,
+          concurrencyControlled: singletonConcurrency,
           navPropBinding: navPropBindings.map((binding) => ({
             path: this.namingHelper.stripServicePrefix(binding.$.Path),
             target: binding.$.Target,
@@ -113,11 +128,17 @@ class DigesterV4 extends Digester<SchemaV4, EntityTypeV4, ComplexTypeV4> {
           throw new Error(`Entity type "${entitySet.$.EntityType}" not found!`);
         }
 
+        const entitySetConcurrency = this.isConcurrencyControlled(entitySet);
+        if (entitySetConcurrency) {
+          entityType.concurrencyControlled = true;
+        }
+
         this.dataModel.addEntitySet(fqName, {
           fqName,
           odataName,
           name,
           entityType,
+          concurrencyControlled: entitySetConcurrency,
           navPropBinding: navPropBindings.map((binding) => ({
             path: this.namingHelper.stripServicePrefix(binding.$.Path),
             target: binding.$.Target,

--- a/packages/odata2ts/src/data-model/DataModelDigestionV4.ts
+++ b/packages/odata2ts/src/data-model/DataModelDigestionV4.ts
@@ -1,9 +1,9 @@
 import { loadConverters, MappedConverterChains } from "@odata2ts/converter-runtime";
 import { ODataTypesV4, ODataVersions } from "@odata2ts/odata-core";
 import { DigesterFunction, DigestionOptions } from "../FactoryFunctionModel.js";
+import { isOptimisticConcurrency } from "./CoreAnnotations.js";
 import { NamespaceWithAlias, withNamespace } from "./DataModel.js";
 import { Digester, TypeModel } from "./DataModelDigestion.js";
-import { isOptimisticConcurrency } from "./CoreAnnotations.js";
 import { ODataVersion, OperationType, OperationTypes, PropertyModel } from "./DataTypeModel.js";
 import { Annotatable, ComplexType, Property, Reference } from "./edmx/ODataEdmxModelBase.js";
 import { ComplexTypeV4, EntityTypeV4, NavigationProperty, Operation, SchemaV4 } from "./edmx/ODataEdmxModelV4.js";

--- a/packages/odata2ts/src/data-model/DataTypeModel.ts
+++ b/packages/odata2ts/src/data-model/DataTypeModel.ts
@@ -81,6 +81,14 @@ export interface EntityType extends ComplexType {
    * appending `$value` to its URL. Inherited from base types.
    */
   hasStream: boolean;
+  /**
+   * Whether modifying an entity of this type requires an ETag, derived from the entity sets and
+   * singletons exposing it.
+   *
+   * Generated services are per type rather than per set, so where several sets of one type disagree,
+   * controlled wins: failing to send `If-Match` where it is required is the worse of the two errors.
+   */
+  concurrencyControlled: boolean;
 }
 
 export interface ComplexType {
@@ -242,6 +250,10 @@ export interface SingletonType {
   name: string;
   entityType: EntityType;
   navPropBinding?: Array<NavPropBindingType>;
+  /**
+   * The service states `Core.OptimisticConcurrency` for this resource: modifying it requires an ETag.
+   */
+  concurrencyControlled: boolean;
 }
 
 export interface EntitySetType {
@@ -250,6 +262,10 @@ export interface EntitySetType {
   name: string;
   entityType: EntityType;
   navPropBinding?: Array<NavPropBindingType>;
+  /**
+   * The service states `Core.OptimisticConcurrency` for this set: modifying its entities requires an ETag.
+   */
+  concurrencyControlled: boolean;
 }
 
 export interface NavPropBindingType {

--- a/packages/odata2ts/src/data-model/V2AnnotationResolver.ts
+++ b/packages/odata2ts/src/data-model/V2AnnotationResolver.ts
@@ -78,6 +78,7 @@ export function resolveV2Annotations(model: ODataEdmxModelBase<any>): void {
   }
 
   const rootScope = extendScope(new Map(), root);
+  annotateConcurrencyControlledSets(root);
   for (const dataService of asArray(root["edmx:DataServices"])) {
     const dataServiceScope = extendScope(rootScope, dataService);
     for (const schema of asArray(dataService.Schema)) {
@@ -88,7 +89,6 @@ export function resolveV2Annotations(model: ODataEdmxModelBase<any>): void {
           annotate(property, extendScope(modelScope, property));
         }
       }
-      annotateConcurrencyControlledSets(schema);
     }
   }
 }
@@ -193,33 +193,41 @@ function asArray(value: unknown): Array<XmlElement> {
  * Unlike the attribute dialects, `ConcurrencyMode` carries no namespace - it is part of the schema
  * language, so no scope has to be threaded through here.
  */
-function annotateConcurrencyControlledSets(schema: XmlElement): void {
-  const namespace = schema.$?.Namespace;
-  const alias = schema.$?.Alias;
+function annotateConcurrencyControlledSets(root: XmlElement): void {
+  const schemas = asArray(root["edmx:DataServices"]).flatMap((dataService) => asArray(dataService.Schema));
 
+  // collected across the whole document before anything is annotated: an entity container may expose
+  // types from any schema, and regularly does - Olingo declares `Copy` in `Library.Circulation` and the
+  // container in `Library.Service`
   const controlledTypes = new Set<string>();
-  for (const entityType of asArray(schema.EntityType)) {
-    const name = entityType.$?.Name;
-    if (!name || !asArray(entityType.Property).some((prop) => prop.$?.ConcurrencyMode === "Fixed")) {
-      continue;
-    }
-    // an entity set names its type either fully qualified or through the schema alias
-    controlledTypes.add(`${namespace}.${name}`);
-    if (alias) {
-      controlledTypes.add(`${alias}.${name}`);
+  for (const schema of schemas) {
+    const namespace = schema.$?.Namespace;
+    const alias = schema.$?.Alias;
+    for (const entityType of asArray(schema.EntityType)) {
+      const name = entityType.$?.Name;
+      if (!name || !asArray(entityType.Property).some((prop) => prop.$?.ConcurrencyMode === "Fixed")) {
+        continue;
+      }
+      // an entity set names its type either fully qualified or through the schema alias
+      controlledTypes.add(`${namespace}.${name}`);
+      if (alias) {
+        controlledTypes.add(`${alias}.${name}`);
+      }
     }
   }
   if (!controlledTypes.size) {
     return;
   }
 
-  for (const container of asArray(schema.EntityContainer)) {
-    for (const entitySet of asArray(container.EntitySet)) {
-      const entityType = entitySet.$?.EntityType;
-      if (!entityType || !controlledTypes.has(entityType)) {
-        continue;
+  for (const schema of schemas) {
+    for (const container of asArray(schema.EntityContainer)) {
+      for (const entitySet of asArray(container.EntitySet)) {
+        const entityType = entitySet.$?.EntityType;
+        if (!entityType || !controlledTypes.has(entityType)) {
+          continue;
+        }
+        entitySet.Annotation = [...asArray(entitySet.Annotation), { $: { Term: OPTIMISTIC_CONCURRENCY } }];
       }
-      entitySet.Annotation = [...asArray(entitySet.Annotation), { $: { Term: OPTIMISTIC_CONCURRENCY } }];
     }
   }
 }

--- a/packages/odata2ts/src/data-model/V2AnnotationResolver.ts
+++ b/packages/odata2ts/src/data-model/V2AnnotationResolver.ts
@@ -8,6 +8,7 @@ const NS_SAP = "http://www.sap.com/Protocols/SAPData";
 const CORE = "Org.OData.Core.V1";
 const COMPUTED = `${CORE}.Computed`;
 const IMMUTABLE = `${CORE}.Immutable`;
+const OPTIMISTIC_CONCURRENCY = `${CORE}.OptimisticConcurrency`;
 
 /**
  * The local names of the terms this produces, to recognize a document which states them itself.
@@ -87,6 +88,7 @@ export function resolveV2Annotations(model: ODataEdmxModelBase<any>): void {
           annotate(property, extendScope(modelScope, property));
         }
       }
+      annotateConcurrencyControlledSets(schema);
     }
   }
 }
@@ -174,4 +176,50 @@ function tag(term: string): Annotation {
 
 function asArray(value: unknown): Array<XmlElement> {
   return Array.isArray(value) ? (value as Array<XmlElement>) : [];
+}
+
+/**
+ * Turns the V2 concurrency token into the V4 term stating the same thing.
+ *
+ * V2 has no vocabulary annotation for optimistic concurrency: the token is a facet of the schema
+ * language itself, `ConcurrencyMode="Fixed"` on the property it is computed from. V4 has to say it as a
+ * `Core.OptimisticConcurrency` annotation on the entity set instead - a different element entirely, which
+ * is why this cannot be handled by the per-property translation above.
+ *
+ * The term is synthesized without content, which is the form meaning "the service won't tell how it
+ * computes the ETag". Naming the properties would be more faithful, and entirely pointless: the value
+ * always arrives in the response.
+ *
+ * Unlike the attribute dialects, `ConcurrencyMode` carries no namespace - it is part of the schema
+ * language, so no scope has to be threaded through here.
+ */
+function annotateConcurrencyControlledSets(schema: XmlElement): void {
+  const namespace = schema.$?.Namespace;
+  const alias = schema.$?.Alias;
+
+  const controlledTypes = new Set<string>();
+  for (const entityType of asArray(schema.EntityType)) {
+    const name = entityType.$?.Name;
+    if (!name || !asArray(entityType.Property).some((prop) => prop.$?.ConcurrencyMode === "Fixed")) {
+      continue;
+    }
+    // an entity set names its type either fully qualified or through the schema alias
+    controlledTypes.add(`${namespace}.${name}`);
+    if (alias) {
+      controlledTypes.add(`${alias}.${name}`);
+    }
+  }
+  if (!controlledTypes.size) {
+    return;
+  }
+
+  for (const container of asArray(schema.EntityContainer)) {
+    for (const entitySet of asArray(container.EntitySet)) {
+      const entityType = entitySet.$?.EntityType;
+      if (!entityType || !controlledTypes.has(entityType)) {
+        continue;
+      }
+      entitySet.Annotation = [...asArray(entitySet.Annotation), { $: { Term: OPTIMISTIC_CONCURRENCY } }];
+    }
+  }
 }

--- a/packages/odata2ts/src/data-model/edmx/ODataEdmxModelBase.ts
+++ b/packages/odata2ts/src/data-model/edmx/ODataEdmxModelBase.ts
@@ -50,11 +50,14 @@ export interface Annotation {
 }
 
 /**
- * A collection valued annotation. Its entries are records where the term declares a structured type,
- * which is the only form we read.
+ * A collection valued annotation. Its entries are records where the term declares a structured type, and
+ * bare property paths where it declares `Collection(Edm.PropertyPath)` - `Core.OptimisticConcurrency`
+ * being the one we read, which may also state an empty collection, meaning that the service does not say
+ * how it computes the ETag.
  */
 export interface Collection {
   Record?: Array<AnnotationRecord>;
+  PropertyPath?: Array<string>;
 }
 
 /**
@@ -127,7 +130,7 @@ export interface EntityContainer<ES = EntitySet> {
   EntitySet?: Array<ES>;
 }
 
-export interface EntitySet {
+export interface EntitySet extends Annotatable {
   $: {
     Name: string;
     EntityType: string;

--- a/packages/odata2ts/src/data-model/edmx/ODataEdmxModelV4.ts
+++ b/packages/odata2ts/src/data-model/edmx/ODataEdmxModelV4.ts
@@ -51,7 +51,7 @@ export interface EntitySetV4 extends EntitySet {
   NavigationPropertyBinding?: Array<NavigationPropertyBinding>;
 }
 
-export interface Singleton {
+export interface Singleton extends Annotatable {
   $: {
     Name: string;
     Type: string;

--- a/packages/odata2ts/src/generator/ServiceGenerator.ts
+++ b/packages/odata2ts/src/generator/ServiceGenerator.ts
@@ -450,7 +450,9 @@ class ServiceGenerator {
               hasQuestionToken: true,
             },
           ],
-          statements: [`super(client, basePath, name, ${qObjectName}, options);`],
+          statements: [
+            `super(client, basePath, name, ${qObjectName}, ${this.getServiceRuntimeOptions(model, isComplexType)});`,
+          ],
         },
       ],
       properties,
@@ -726,6 +728,18 @@ class ServiceGenerator {
     };
   }
 
+  /**
+   * The runtime options a generated service hands to its base class.
+   *
+   * Almost always just `options`, the argument its own constructor took. A type under optimistic
+   * concurrency control adds a flag of its own, since that is decided per entity type rather than for the
+   * service as a whole - the same shape `generateCastOperations` uses to pass `subtype: true`.
+   */
+  private getServiceRuntimeOptions(model: ComplexType, isComplexType = false): string {
+    const isConcurrencyControlled = !isComplexType && (model as EntityType).concurrencyControlled;
+    return isConcurrencyControlled ? "{ ...options, concurrencyControlled: true }" : "options";
+  }
+
   private generateEntityCollectionService(file: FileHandler, model: EntityType) {
     const importContainer = file.getImports();
     // creation lives here, so this is the one service still typed on the EditableModel - and the one place
@@ -765,7 +779,9 @@ class ServiceGenerator {
               hasQuestionToken: true,
             },
           ],
-          statements: [`super(client, basePath, name, ${qObjectName}, new ${qIdFunctionName}(name), options);`],
+          statements: [
+            `super(client, basePath, name, ${qObjectName}, new ${qIdFunctionName}(name), ${this.getServiceRuntimeOptions(model)});`,
+          ],
         },
       ],
       properties,

--- a/packages/odata2ts/test/data-model/AnnotationResolver.test.ts
+++ b/packages/odata2ts/test/data-model/AnnotationResolver.test.ts
@@ -1,0 +1,113 @@
+import { ODataTypesV4 } from "@odata2ts/odata-core";
+import { describe, expect, test } from "vitest";
+import { AnnotationResolver } from "../../src/data-model/AnnotationResolver.js";
+import { propertyPaths } from "./builder/ODataAnnotationBuilder.js";
+import { ODataModelBuilderV4 } from "./builder/v4/ODataModelBuilderV4.js";
+
+const SERVICE_NAME = "Tester";
+const CONTAINER = "ENTITY_CONTAINER";
+const CONCURRENCY = "Org.OData.Core.V1.OptimisticConcurrency";
+
+/**
+ * Runs the resolver over a built model and hands back the entity container, whose sets and singletons
+ * carry whatever the resolver attached to them.
+ */
+function resolve(builder: ODataModelBuilderV4) {
+  const schemas = builder.getSchemas();
+  new AnnotationResolver(schemas as any, builder.getReferences()).resolve();
+  return (schemas[0] as any).EntityContainer[0];
+}
+
+function termsOf(element: { Annotation?: Array<{ $: { Term: string } }> }) {
+  return (element.Annotation ?? []).map((a) => a.$.Term);
+}
+
+describe("AnnotationResolver: entity container targets", () => {
+  function builderWithCopies() {
+    return new ODataModelBuilderV4(SERVICE_NAME).addEntityType("Copy", undefined, (b: any) =>
+      b.addKeyProp("Id", ODataTypesV4.Guid).addProp("Condition", ODataTypesV4.Byte),
+    );
+  }
+
+  test("inline on the entity set, fully qualified - how ASP.NET states it", () => {
+    const builder = builderWithCopies().addEntitySet(
+      "Copies",
+      `${SERVICE_NAME}.Copy`,
+      [],
+      [propertyPaths("core", "OptimisticConcurrency", ["Condition"], { fullyQualified: true })],
+    );
+
+    expect(termsOf(resolve(builder).EntitySet[0])).toContain(CONCURRENCY);
+  });
+
+  test("inline with an alias, which the resolver expands", () => {
+    const builder = builderWithCopies()
+      .enableAnnotations()
+      .addEntitySet(
+        "Copies",
+        `${SERVICE_NAME}.Copy`,
+        [],
+        [propertyPaths("core", "OptimisticConcurrency", ["Condition"])],
+      );
+
+    expect(termsOf(resolve(builder).EntitySet[0])).toContain(CONCURRENCY);
+  });
+
+  test("externally, targeting the container - how CAP states it, with an empty collection", () => {
+    const builder = builderWithCopies()
+      .enableAnnotations()
+      .addEntitySet("Copies", `${SERVICE_NAME}.Copy`)
+      .addExternalAnnotations(`${SERVICE_NAME}.${CONTAINER}/Copies`, [
+        propertyPaths("core", "OptimisticConcurrency", []),
+      ]);
+
+    expect(termsOf(resolve(builder).EntitySet[0])).toContain(CONCURRENCY);
+  });
+
+  test("externally, targeting a singleton", () => {
+    const builder = builderWithCopies()
+      .enableAnnotations()
+      .addSingleton("TheCopy", `${SERVICE_NAME}.Copy`)
+      .addExternalAnnotations(`${SERVICE_NAME}.${CONTAINER}/TheCopy`, [
+        propertyPaths("core", "OptimisticConcurrency", []),
+      ]);
+
+    expect(termsOf(resolve(builder).Singleton[0])).toContain(CONCURRENCY);
+  });
+
+  test("a qualified annotation is none of our business", () => {
+    const builder = builderWithCopies()
+      .enableAnnotations()
+      .addEntitySet("Copies", `${SERVICE_NAME}.Copy`)
+      .addExternalAnnotations(
+        `${SERVICE_NAME}.${CONTAINER}/Copies`,
+        [propertyPaths("core", "OptimisticConcurrency", [])],
+        "SomeContext",
+      );
+
+    expect(termsOf(resolve(builder).EntitySet[0])).toStrictEqual([]);
+  });
+
+  test("a target naming an unknown set resolves to nothing and throws nothing", () => {
+    const builder = builderWithCopies()
+      .enableAnnotations()
+      .addEntitySet("Copies", `${SERVICE_NAME}.Copy`)
+      .addExternalAnnotations(`${SERVICE_NAME}.${CONTAINER}/Nope`, [
+        propertyPaths("core", "OptimisticConcurrency", []),
+      ]);
+
+    expect(() => resolve(builder)).not.toThrow();
+    expect(termsOf(resolve(builder).EntitySet[0])).toStrictEqual([]);
+  });
+
+  test("the entity type of a concurrency-controlled set is left alone", () => {
+    const builder = builderWithCopies()
+      .enableAnnotations()
+      .addEntitySet("Copies", `${SERVICE_NAME}.Copy`, [], [propertyPaths("core", "OptimisticConcurrency", [])]);
+
+    const schemas = builder.getSchemas();
+    new AnnotationResolver(schemas as any, builder.getReferences()).resolve();
+
+    expect(termsOf((schemas[0] as any).EntityType[0])).toStrictEqual([]);
+  });
+});

--- a/packages/odata2ts/test/data-model/V2AnnotationResolver.test.ts
+++ b/packages/odata2ts/test/data-model/V2AnnotationResolver.test.ts
@@ -7,6 +7,7 @@ const NS_SAP = "http://www.sap.com/Protocols/SAPData";
 
 const COMPUTED = "Org.OData.Core.V1.Computed";
 const IMMUTABLE = "Org.OData.Core.V1.Immutable";
+const CONCURRENCY = "Org.OData.Core.V1.OptimisticConcurrency";
 
 type Attributes = Record<string, string>;
 
@@ -165,5 +166,134 @@ describe("V2AnnotationResolver Test", () => {
         IMMUTABLE,
       ]);
     });
+  });
+});
+
+
+describe("V2AnnotationResolver: the concurrency token", () => {
+  /**
+   * V2 has no vocabulary annotation for optimistic concurrency. It states the concurrency token as a
+   * facet of the schema language itself - `ConcurrencyMode="Fixed"` on the property computing it - which
+   * is normalized here into the V4 term, so that nothing downstream learns that V2 said it differently.
+   */
+  function buildContainerModel(
+    types: Array<{ name: string; concurrencyModes: Array<string | undefined> }>,
+    sets: Array<{ name: string; entityType: string }>,
+    schemaAttributes: Record<string, string> = {},
+  ): ODataEdmxModelBase<any> {
+    return {
+      "edmx:Edmx": {
+        $: { Version: "1.0", "xmlns:edmx": "http://schemas.microsoft.com/ado/2007/06/edmx" },
+        "edmx:DataServices": [
+          {
+            Schema: [
+              {
+                $: { Namespace: "Tester", ...schemaAttributes },
+                EntityType: types.map((type) => ({
+                  $: { Name: type.name },
+                  Property: type.concurrencyModes.map((mode, index) => ({
+                    $: {
+                      Name: `Prop${index}`,
+                      Type: "Edm.String",
+                      ...(mode ? { ConcurrencyMode: mode } : {}),
+                    },
+                  })),
+                })),
+                EntityContainer: [
+                  {
+                    $: { Name: "Container" },
+                    EntitySet: sets.map((set) => ({ $: { Name: set.name, EntityType: set.entityType } })),
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    } as unknown as ODataEdmxModelBase<any>;
+  }
+
+  function setTermsOf(model: ODataEdmxModelBase<any>, index = 0): Array<string> {
+    const dataService = model["edmx:Edmx"]["edmx:DataServices"][0] as any;
+    const entitySet = dataService.Schema[0].EntityContainer[0].EntitySet[index];
+    return (entitySet.Annotation ?? []).map((annotation: Annotation) => annotation.$.Term);
+  }
+
+  test("a Fixed property makes every set of its type concurrency-controlled", () => {
+    const model = buildContainerModel(
+      [{ name: "Copy", concurrencyModes: ["Fixed"] }],
+      [{ name: "Copies", entityType: "Tester.Copy" }],
+    );
+    resolveV2Annotations(model);
+
+    expect(setTermsOf(model)).toEqual([CONCURRENCY]);
+  });
+
+  test("ConcurrencyMode=None states the opposite", () => {
+    const model = buildContainerModel(
+      [{ name: "Copy", concurrencyModes: ["None"] }],
+      [{ name: "Copies", entityType: "Tester.Copy" }],
+    );
+    resolveV2Annotations(model);
+
+    expect(setTermsOf(model)).toEqual([]);
+  });
+
+  test("no ConcurrencyMode at all changes nothing", () => {
+    const model = buildContainerModel(
+      [{ name: "Copy", concurrencyModes: [undefined] }],
+      [{ name: "Copies", entityType: "Tester.Copy" }],
+    );
+    resolveV2Annotations(model);
+
+    expect(setTermsOf(model)).toEqual([]);
+  });
+
+  test("several Fixed properties are still one statement", () => {
+    // Olingo joins every Fixed property into a single token; for us it stays a single yes
+    const model = buildContainerModel(
+      [{ name: "Copy", concurrencyModes: ["Fixed", "Fixed"] }],
+      [{ name: "Copies", entityType: "Tester.Copy" }],
+    );
+    resolveV2Annotations(model);
+
+    expect(setTermsOf(model)).toEqual([CONCURRENCY]);
+  });
+
+  test("every set of the type is marked, and no other", () => {
+    const model = buildContainerModel(
+      [
+        { name: "Copy", concurrencyModes: ["Fixed"] },
+        { name: "Book", concurrencyModes: [undefined] },
+      ],
+      [
+        { name: "Copies", entityType: "Tester.Copy" },
+        { name: "ArchivedCopies", entityType: "Tester.Copy" },
+        { name: "Books", entityType: "Tester.Book" },
+      ],
+    );
+    resolveV2Annotations(model);
+
+    expect(setTermsOf(model, 0)).toEqual([CONCURRENCY]);
+    expect(setTermsOf(model, 1)).toEqual([CONCURRENCY]);
+    expect(setTermsOf(model, 2)).toEqual([]);
+  });
+
+  test("a set naming its type through the schema alias is marked too", () => {
+    const model = buildContainerModel(
+      [{ name: "Copy", concurrencyModes: ["Fixed"] }],
+      [{ name: "Copies", entityType: "Self.Copy" }],
+      { Alias: "Self" },
+    );
+    resolveV2Annotations(model);
+
+    expect(setTermsOf(model)).toEqual([CONCURRENCY]);
+  });
+
+  test("a document without an entity container is left alone", () => {
+    const model = buildContainerModel([{ name: "Copy", concurrencyModes: ["Fixed"] }], []);
+    delete (model["edmx:Edmx"]["edmx:DataServices"][0] as any).Schema[0].EntityContainer;
+
+    expect(() => resolveV2Annotations(model)).not.toThrow();
   });
 });

--- a/packages/odata2ts/test/data-model/V2AnnotationResolver.test.ts
+++ b/packages/odata2ts/test/data-model/V2AnnotationResolver.test.ts
@@ -169,7 +169,6 @@ describe("V2AnnotationResolver Test", () => {
   });
 });
 
-
 describe("V2AnnotationResolver: the concurrency token", () => {
   /**
    * V2 has no vocabulary annotation for optimistic concurrency. It states the concurrency token as a
@@ -288,6 +287,41 @@ describe("V2AnnotationResolver: the concurrency token", () => {
     resolveV2Annotations(model);
 
     expect(setTermsOf(model)).toEqual([CONCURRENCY]);
+  });
+
+  test("the container may live in another schema than the type - Olingo does exactly that", () => {
+    const model = {
+      "edmx:Edmx": {
+        $: { Version: "1.0", "xmlns:edmx": "http://schemas.microsoft.com/ado/2007/06/edmx" },
+        "edmx:DataServices": [
+          {
+            Schema: [
+              {
+                $: { Namespace: "Library.Circulation" },
+                EntityType: [
+                  { $: { Name: "Copy" }, Property: [{ $: { Name: "Condition", ConcurrencyMode: "Fixed" } }] },
+                ],
+              },
+              {
+                $: { Namespace: "Library.Service" },
+                EntityContainer: [
+                  {
+                    $: { Name: "LibraryService" },
+                    EntitySet: [{ $: { Name: "Copies", EntityType: "Library.Circulation.Copy" } }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    } as unknown as ODataEdmxModelBase<any>;
+
+    resolveV2Annotations(model);
+
+    const dataService = model["edmx:Edmx"]["edmx:DataServices"][0] as any;
+    const entitySet = dataService.Schema[1].EntityContainer[0].EntitySet[0];
+    expect((entitySet.Annotation ?? []).map((a: Annotation) => a.$.Term)).toEqual([CONCURRENCY]);
   });
 
   test("a document without an entity container is left alone", () => {

--- a/packages/odata2ts/test/data-model/builder/ODataAnnotationBuilder.ts
+++ b/packages/odata2ts/test/data-model/builder/ODataAnnotationBuilder.ts
@@ -85,6 +85,23 @@ export function annotation(
 }
 
 /**
+ * An annotation of type `Collection(Edm.PropertyPath)`, e.g. `Core.OptimisticConcurrency`.
+ *
+ * An empty list yields an empty collection, which is what CAP emits and what the vocabulary documents as
+ * "the service won't tell how it computes the ETag" - as valid a statement as one naming the properties.
+ */
+export function propertyPaths(
+  vocabulary: keyof typeof VOCABULARIES,
+  term: string,
+  paths: Array<string>,
+  options: Pick<AnnotationOptions, "fullyQualified" | "qualifier"> = {},
+): Annotation {
+  const result = annotation(vocabulary, term, options);
+  result.Collection = [paths.length ? { PropertyPath: paths } : {}];
+  return result;
+}
+
+/**
  * Shorthand for the vocabulary all currently evaluated terms come from.
  */
 export function core(term: string, options?: AnnotationOptions): Annotation {

--- a/packages/odata2ts/test/data-model/builder/ODataModelBuilder.ts
+++ b/packages/odata2ts/test/data-model/builder/ODataModelBuilder.ts
@@ -90,6 +90,7 @@ export abstract class ODataModelBuilder<
     name: string,
     entityType: string,
     navProps?: Array<{ path: string; target: string }>,
+    annotations?: Array<Annotation>,
   ): this;
 
   protected createSchema(name: string, alias?: string) {

--- a/packages/odata2ts/test/data-model/builder/v4/ODataModelBuilderV4.ts
+++ b/packages/odata2ts/test/data-model/builder/v4/ODataModelBuilderV4.ts
@@ -1,4 +1,5 @@
 import { ODataVersions } from "@odata2ts/odata-core";
+import { Annotation } from "../../../../src/data-model/edmx/ODataEdmxModelBase.js";
 import {
   ComplexTypeV4,
   EntitySetV4,
@@ -38,7 +39,7 @@ export class ODataModelBuilderV4 extends ODataModelBuilder<ODataEdmxModelV4, Sch
     }
   }
 
-  public addEntitySet(name: string, entityType: string, navProps: NavProps = []) {
+  public addEntitySet(name: string, entityType: string, navProps: NavProps = [], annotations?: Array<Annotation>) {
     const container = this.getEntityContainer();
     if (!container.EntitySet) {
       container.EntitySet = [];
@@ -51,12 +52,15 @@ export class ODataModelBuilderV4 extends ODataModelBuilder<ODataEdmxModelV4, Sch
       },
     };
     this.addNavProps(entitySet, navProps);
+    if (annotations?.length) {
+      entitySet.Annotation = annotations;
+    }
     container.EntitySet.push(entitySet);
 
     return this;
   }
 
-  public addSingleton(name: string, type: string, navProps: NavProps = []) {
+  public addSingleton(name: string, type: string, navProps: NavProps = [], annotations?: Array<Annotation>) {
     const container = this.getEntityContainer();
     if (!container.Singleton) {
       container.Singleton = [];
@@ -69,6 +73,9 @@ export class ODataModelBuilderV4 extends ODataModelBuilder<ODataEdmxModelV4, Sch
       },
     };
     this.addNavProps(singleton, navProps);
+    if (annotations?.length) {
+      singleton.Annotation = annotations;
+    }
     container.Singleton.push(singleton);
 
     return this;

--- a/packages/odata2ts/test/data-model/v4/EntitySetDigestion.test.ts
+++ b/packages/odata2ts/test/data-model/v4/EntitySetDigestion.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, test } from "vitest";
 import { digest } from "../../../src/data-model/DataModelDigestionV4.js";
 import { NamingHelper } from "../../../src/data-model/NamingHelper.js";
 import { getTestConfig } from "../../test.config.js";
+import { propertyPaths } from "../builder/ODataAnnotationBuilder.js";
 import { ODataModelBuilderV4 } from "../builder/v4/ODataModelBuilderV4.js";
 
 describe("EntitySet Digestion Test", () => {
@@ -20,7 +21,9 @@ describe("EntitySet Digestion Test", () => {
   }
 
   function doDigest() {
-    return digest(odataBuilder.getSchemas(), CONFIG, NAMING_HELPER);
+    // the references carry the vocabulary aliases; without them an annotation written as `Core.X`
+    // never resolves to its fully qualified term
+    return digest(odataBuilder.getSchemas(), CONFIG, NAMING_HELPER, odataBuilder.getReferences());
   }
 
   beforeEach(() => {
@@ -64,6 +67,85 @@ describe("EntitySet Digestion Test", () => {
         entityType: { name: "Product" },
         navPropBinding: navProps,
       },
+    });
+  });
+
+  describe("Optimistic concurrency", () => {
+    function addProduct() {
+      return odataBuilder.enableAnnotations().addEntityType("Product", undefined, (builder) => {
+        builder.addKeyProp("id", ODataTypesV4.String);
+        builder.addProp("condition", ODataTypesV4.Byte);
+      });
+    }
+
+    async function entitySet(name: string) {
+      return (await doDigest()).getEntityContainer().entitySets[withEc(name)];
+    }
+
+    test("no annotation means not controlled", async () => {
+      addProduct().addEntitySet("Products", withNs("Product"));
+
+      expect((await entitySet("Products")).concurrencyControlled).toBe(false);
+      expect((await doDigest()).getEntityType(withNs("Product"))!.concurrencyControlled).toBe(false);
+    });
+
+    test("the term makes the set controlled", async () => {
+      addProduct().addEntitySet("Products", withNs("Product"), [], [
+        propertyPaths("core", "OptimisticConcurrency", ["condition"]),
+      ]);
+
+      expect((await entitySet("Products")).concurrencyControlled).toBe(true);
+    });
+
+    test("an empty collection is still the term - CAP's form", async () => {
+      addProduct().addEntitySet("Products", withNs("Product"), [], [
+        propertyPaths("core", "OptimisticConcurrency", []),
+      ]);
+
+      expect((await entitySet("Products")).concurrencyControlled).toBe(true);
+    });
+
+    test("stated externally against the container", async () => {
+      addProduct()
+        .addEntitySet("Products", withNs("Product"))
+        .addExternalAnnotations(`${SERVICE_NAME}.ENTITY_CONTAINER/Products`, [
+          propertyPaths("core", "OptimisticConcurrency", []),
+        ]);
+
+      expect((await entitySet("Products")).concurrencyControlled).toBe(true);
+    });
+
+    test("the entity type learns it from its set", async () => {
+      addProduct().addEntitySet("Products", withNs("Product"), [], [
+        propertyPaths("core", "OptimisticConcurrency", []),
+      ]);
+
+      expect((await doDigest()).getEntityType(withNs("Product"))!.concurrencyControlled).toBe(true);
+    });
+
+    test("of two sets of one type, a single controlled one is enough", async () => {
+      addProduct()
+        .addEntitySet("Products", withNs("Product"))
+        .addEntitySet("ArchivedProducts", withNs("Product"), [], [
+          propertyPaths("core", "OptimisticConcurrency", []),
+        ]);
+
+      expect((await entitySet("Products")).concurrencyControlled).toBe(false);
+      expect((await entitySet("ArchivedProducts")).concurrencyControlled).toBe(true);
+      // the generated service is per type, so the stricter of the two wins there
+      expect((await doDigest()).getEntityType(withNs("Product"))!.concurrencyControlled).toBe(true);
+    });
+
+    test("the switch turns the evaluation off", async () => {
+      addProduct().addEntitySet("Products", withNs("Product"), [], [
+        propertyPaths("core", "OptimisticConcurrency", []),
+      ]);
+
+      const config = { ...CONFIG, annotations: { disableOptimisticConcurrency: true } };
+      const result = await digest(odataBuilder.getSchemas(), config, NAMING_HELPER, odataBuilder.getReferences());
+
+      expect(result.getEntityContainer().entitySets[withEc("Products")].concurrencyControlled).toBe(false);
+      expect(result.getEntityType(withNs("Product"))!.concurrencyControlled).toBe(false);
     });
   });
 });

--- a/packages/odata2ts/test/data-model/v4/EntitySetDigestion.test.ts
+++ b/packages/odata2ts/test/data-model/v4/EntitySetDigestion.test.ts
@@ -90,17 +90,23 @@ describe("EntitySet Digestion Test", () => {
     });
 
     test("the term makes the set controlled", async () => {
-      addProduct().addEntitySet("Products", withNs("Product"), [], [
-        propertyPaths("core", "OptimisticConcurrency", ["condition"]),
-      ]);
+      addProduct().addEntitySet(
+        "Products",
+        withNs("Product"),
+        [],
+        [propertyPaths("core", "OptimisticConcurrency", ["condition"])],
+      );
 
       expect((await entitySet("Products")).concurrencyControlled).toBe(true);
     });
 
     test("an empty collection is still the term - CAP's form", async () => {
-      addProduct().addEntitySet("Products", withNs("Product"), [], [
-        propertyPaths("core", "OptimisticConcurrency", []),
-      ]);
+      addProduct().addEntitySet(
+        "Products",
+        withNs("Product"),
+        [],
+        [propertyPaths("core", "OptimisticConcurrency", [])],
+      );
 
       expect((await entitySet("Products")).concurrencyControlled).toBe(true);
     });
@@ -116,9 +122,12 @@ describe("EntitySet Digestion Test", () => {
     });
 
     test("the entity type learns it from its set", async () => {
-      addProduct().addEntitySet("Products", withNs("Product"), [], [
-        propertyPaths("core", "OptimisticConcurrency", []),
-      ]);
+      addProduct().addEntitySet(
+        "Products",
+        withNs("Product"),
+        [],
+        [propertyPaths("core", "OptimisticConcurrency", [])],
+      );
 
       expect((await doDigest()).getEntityType(withNs("Product"))!.concurrencyControlled).toBe(true);
     });
@@ -126,9 +135,7 @@ describe("EntitySet Digestion Test", () => {
     test("of two sets of one type, a single controlled one is enough", async () => {
       addProduct()
         .addEntitySet("Products", withNs("Product"))
-        .addEntitySet("ArchivedProducts", withNs("Product"), [], [
-          propertyPaths("core", "OptimisticConcurrency", []),
-        ]);
+        .addEntitySet("ArchivedProducts", withNs("Product"), [], [propertyPaths("core", "OptimisticConcurrency", [])]);
 
       expect((await entitySet("Products")).concurrencyControlled).toBe(false);
       expect((await entitySet("ArchivedProducts")).concurrencyControlled).toBe(true);
@@ -137,9 +144,12 @@ describe("EntitySet Digestion Test", () => {
     });
 
     test("the switch turns the evaluation off", async () => {
-      addProduct().addEntitySet("Products", withNs("Product"), [], [
-        propertyPaths("core", "OptimisticConcurrency", []),
-      ]);
+      addProduct().addEntitySet(
+        "Products",
+        withNs("Product"),
+        [],
+        [propertyPaths("core", "OptimisticConcurrency", [])],
+      );
 
       const config = { ...CONFIG, annotations: { disableOptimisticConcurrency: true } };
       const result = await digest(odataBuilder.getSchemas(), config, NAMING_HELPER, odataBuilder.getReferences());

--- a/packages/odata2ts/test/data-model/v4/SingletonDigestion.test.ts
+++ b/packages/odata2ts/test/data-model/v4/SingletonDigestion.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, test } from "vitest";
 import { digest } from "../../../src/data-model/DataModelDigestionV4.js";
 import { NamingHelper } from "../../../src/data-model/NamingHelper.js";
 import { getTestConfig } from "../../test.config.js";
+import { propertyPaths } from "../builder/ODataAnnotationBuilder.js";
 import { ODataModelBuilderV4 } from "../builder/v4/ODataModelBuilderV4.js";
 
 describe("Singleton Digestion Test", () => {
@@ -20,7 +21,9 @@ describe("Singleton Digestion Test", () => {
   }
 
   function doDigest() {
-    return digest(odataBuilder.getSchemas(), CONFIG, NAMING_HELPER);
+    // the references carry the vocabulary aliases; without them an annotation written as `Core.X`
+    // never resolves to its fully qualified term
+    return digest(odataBuilder.getSchemas(), CONFIG, NAMING_HELPER, odataBuilder.getReferences());
   }
 
   beforeEach(() => {
@@ -68,6 +71,52 @@ describe("Singleton Digestion Test", () => {
         entityType: { name: "User" },
         navPropBinding: navProps,
       },
+    });
+  });
+
+  describe("Optimistic concurrency", () => {
+    /**
+     * `Core.OptimisticConcurrency` declares `AppliesTo="EntitySet"`, but that attribute states intent
+     * rather than a restriction - CSDL 14.1.2 asks clients to "be prepared for any term to be applied to
+     * any model element", and `Singleton` is a listed symbolic value there. A singleton is a resource
+     * with an ETag like any other, so the term is read here too.
+     */
+    function addUser() {
+      return odataBuilder.enableAnnotations().addEntityType("User", undefined, (builder) => {
+        builder.addKeyProp("id", ODataTypesV4.String);
+      });
+    }
+
+    async function singleton(name: string) {
+      return (await doDigest()).getEntityContainer().singletons[withEc(name)];
+    }
+
+    test("no annotation means not controlled", async () => {
+      addUser().addSingleton("Me", withNs("User"));
+
+      expect((await singleton("Me")).concurrencyControlled).toBe(false);
+    });
+
+    test("the term makes the singleton controlled", async () => {
+      addUser().addSingleton("Me", withNs("User"), [], [propertyPaths("core", "OptimisticConcurrency", [])]);
+
+      expect((await singleton("Me")).concurrencyControlled).toBe(true);
+    });
+
+    test("stated externally against the container", async () => {
+      addUser()
+        .addSingleton("Me", withNs("User"))
+        .addExternalAnnotations(`${SERVICE_NAME}.ENTITY_CONTAINER/Me`, [
+          propertyPaths("core", "OptimisticConcurrency", []),
+        ]);
+
+      expect((await singleton("Me")).concurrencyControlled).toBe(true);
+    });
+
+    test("the entity type learns it from its singleton", async () => {
+      addUser().addSingleton("Me", withNs("User"), [], [propertyPaths("core", "OptimisticConcurrency", [])]);
+
+      expect((await doDigest()).getEntityType(withNs("User"))!.concurrencyControlled).toBe(true);
     });
   });
 });

--- a/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
@@ -14,6 +14,7 @@ import {
   RunOptions,
 } from "../../../src/index.js";
 import { createProjectManager, ProjectManager } from "../../../src/project/ProjectManager.js";
+import { propertyPaths } from "../../data-model/builder/ODataAnnotationBuilder.js";
 import { ODataModelBuilderV4 } from "../../data-model/builder/v4/ODataModelBuilderV4.js";
 import { getTestConfig } from "../../test.config.js";
 import { createServiceHelper } from "../comparator/FixtureComparatorHelper.js";
@@ -69,6 +70,66 @@ describe("Service Generator Tests V4", () => {
       projectManager.getMainServiceFile().getFile(),
     );
   }
+
+  describe("Optimistic concurrency", () => {
+    /**
+     * The flag is per entity type rather than per service run, so it is emitted into the individual
+     * `super` call rather than into the shared runtime options. Asserted on the generated text directly:
+     * a fixture would pin the whole file, and what matters here is one argument in two constructors.
+     */
+    function generatedText() {
+      return projectManager.getMainServiceFile().getFile().getFullText();
+    }
+
+    function addCopy(concurrencyControlled: boolean) {
+      // fully qualified, the way ASP.NET states it: the fixture helper digests without the document's
+      // references, so an aliased term would have nothing to resolve against
+      odataBuilder
+        .addEntityType("Copy", undefined, (builder) => {
+          builder.addKeyProp("id", ODataTypesV4.String);
+          builder.addProp("condition", ODataTypesV4.Byte);
+        })
+        .addEntitySet(
+          "Copies",
+          withNs("Copy"),
+          [],
+          concurrencyControlled
+            ? [propertyPaths("core", "OptimisticConcurrency", [], { fullyQualified: true })]
+            : undefined,
+        );
+    }
+
+    test("a controlled type states the flag in both of its services", async () => {
+      addCopy(true);
+
+      await doGenerate();
+
+      const text = generatedText();
+      expect(text).toContain("super(client, basePath, name, qCopy, { ...options, concurrencyControlled: true });");
+      expect(text).toContain(
+        "super(client, basePath, name, qCopy, new QCopyId(name), { ...options, concurrencyControlled: true });",
+      );
+    });
+
+    test("an uncontrolled type hands its options straight through", async () => {
+      addCopy(false);
+
+      await doGenerate();
+
+      const text = generatedText();
+      expect(text).toContain("super(client, basePath, name, qCopy, options);");
+      expect(text).toContain("super(client, basePath, name, qCopy, new QCopyId(name), options);");
+      expect(text).not.toContain("concurrencyControlled");
+    });
+
+    test("the disable switch takes the flag away again", async () => {
+      addCopy(true);
+
+      await doGenerate({ annotations: { disableOptimisticConcurrency: true } });
+
+      expect(generatedText()).not.toContain("concurrencyControlled");
+    });
+  });
 
   test("Service Generator: Min Case", async () => {
     // given nothing in particular


### PR DESCRIPTION
Second step of automatic ETag handling ([#482](https://github.com/odata2ts/odata2ts/issues/482)). The generator learns which resources may only be modified with an ETag and says so in the generated services. Nothing reads the flag yet — the runtime follows once `@odata2ts/http-client-api` is released.

- **`AnnotationResolver` resolves annotations targeting the entity container.** `EntitySet` and `Singleton` become `Annotatable`, and a target like `Library.Service.EntityContainer/Copies` now finds its element. Container paths are looked up before type paths, since both have two segments — otherwise `…EntityContainer/Copies` reads as "property `Copies` of type `…EntityContainer`". This is worth more than this feature: it is the missing half of annotation support, and every `Capabilities.*` term is stated the same way.
- **`Core.OptimisticConcurrency` is read** off entity sets and singletons. Presence of the term is the whole statement — the property paths it may name are of no use to a client, since the value always arrives in the response, so CAP's empty collection says exactly as much as ASP.NET's explicit `Condition`.
- **V2's `ConcurrencyMode="Fixed"` is normalized into the same term**, so nothing downstream learns that V2 said it differently.
- **The flag reaches the generated services** as `{ ...options, concurrencyControlled: true }`, per entity type rather than per run.
- Opt out with `annotations.disableOptimisticConcurrency`.

Singletons are covered by unit tests only: `Copies` is the sole concurrency-controlled resource in the reference model, so no server exercises a singleton.

Verified against all three forms the reference servers actually emit — CAP's container-targeted annotation with an empty collection, ASP.NET's inline one, and Olingo's V2 facet. All three int-test clients regenerate and type-check.