### PR TITLE
chore: format the committed $metadata snapshots

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -14,11 +14,6 @@ coverage
 CHANGELOG.md
 .gitignore
 
-# Committed $metadata snapshots: byte-faithful copies of what the server emits.
-# Reformatting them would make them stop being a snapshot.
-int-test/*/resource/
-examples/*/resource/
-
 # Generated clients: the generator formats them itself (option `prettier`), and they are gitignored -
 # checking them would only make the result depend on whether a build has run.
 src-generated

--- a/examples/main/resource/odata-v2.xml
+++ b/examples/main/resource/odata-v2.xml
@@ -1,38 +1,94 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <edmx:Edmx Version="1.0" xmlns:edmx="http://schemas.microsoft.com/ado/2007/06/edmx">
-  <edmx:DataServices xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" m:DataServiceVersion="2.0">
-    <Schema Namespace="ODataDemo" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns="http://schemas.microsoft.com/ado/2007/05/edm">
+  <edmx:DataServices
+    xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"
+    m:DataServiceVersion="2.0"
+  >
+    <Schema
+      Namespace="ODataDemo"
+      xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices"
+      xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"
+      xmlns="http://schemas.microsoft.com/ado/2007/05/edm"
+    >
       <EntityType Name="Product">
         <Key>
           <PropertyRef Name="ID" />
         </Key>
         <Property Name="ID" Type="Edm.Int32" Nullable="false" />
-        <Property Name="Name" Type="Edm.String" Nullable="true" m:FC_TargetPath="SyndicationTitle" m:FC_ContentKind="text" m:FC_KeepInContent="false" />
-        <Property Name="Description" Type="Edm.String" Nullable="true" m:FC_TargetPath="SyndicationSummary" m:FC_ContentKind="text" m:FC_KeepInContent="false" />
+        <Property
+          Name="Name"
+          Type="Edm.String"
+          Nullable="true"
+          m:FC_TargetPath="SyndicationTitle"
+          m:FC_ContentKind="text"
+          m:FC_KeepInContent="false"
+        />
+        <Property
+          Name="Description"
+          Type="Edm.String"
+          Nullable="true"
+          m:FC_TargetPath="SyndicationSummary"
+          m:FC_ContentKind="text"
+          m:FC_KeepInContent="false"
+        />
         <Property Name="ReleaseDate" Type="Edm.DateTime" Nullable="false" />
         <Property Name="DiscontinuedDate" Type="Edm.DateTime" Nullable="true" />
         <Property Name="Rating" Type="Edm.Int32" Nullable="false" />
         <Property Name="Price" Type="Edm.Decimal" Nullable="false" />
-        <NavigationProperty Name="Category" Relationship="ODataDemo.Product_Category_Category_Products" FromRole="Product_Category" ToRole="Category_Products" />
-        <NavigationProperty Name="Supplier" Relationship="ODataDemo.Product_Supplier_Supplier_Products" FromRole="Product_Supplier" ToRole="Supplier_Products" />
+        <NavigationProperty
+          Name="Category"
+          Relationship="ODataDemo.Product_Category_Category_Products"
+          FromRole="Product_Category"
+          ToRole="Category_Products"
+        />
+        <NavigationProperty
+          Name="Supplier"
+          Relationship="ODataDemo.Product_Supplier_Supplier_Products"
+          FromRole="Product_Supplier"
+          ToRole="Supplier_Products"
+        />
       </EntityType>
       <EntityType Name="Category">
         <Key>
           <PropertyRef Name="ID" />
         </Key>
         <Property Name="ID" Type="Edm.Int32" Nullable="false" />
-        <Property Name="Name" Type="Edm.String" Nullable="true" m:FC_TargetPath="SyndicationTitle" m:FC_ContentKind="text" m:FC_KeepInContent="true" />
-        <NavigationProperty Name="Products" Relationship="ODataDemo.Product_Category_Category_Products" FromRole="Category_Products" ToRole="Product_Category" />
+        <Property
+          Name="Name"
+          Type="Edm.String"
+          Nullable="true"
+          m:FC_TargetPath="SyndicationTitle"
+          m:FC_ContentKind="text"
+          m:FC_KeepInContent="true"
+        />
+        <NavigationProperty
+          Name="Products"
+          Relationship="ODataDemo.Product_Category_Category_Products"
+          FromRole="Category_Products"
+          ToRole="Product_Category"
+        />
       </EntityType>
       <EntityType Name="Supplier">
         <Key>
           <PropertyRef Name="ID" />
         </Key>
         <Property Name="ID" Type="Edm.Int32" Nullable="false" />
-        <Property Name="Name" Type="Edm.String" Nullable="true" m:FC_TargetPath="SyndicationTitle" m:FC_ContentKind="text" m:FC_KeepInContent="true" />
+        <Property
+          Name="Name"
+          Type="Edm.String"
+          Nullable="true"
+          m:FC_TargetPath="SyndicationTitle"
+          m:FC_ContentKind="text"
+          m:FC_KeepInContent="true"
+        />
         <Property Name="Address" Type="ODataDemo.Address" Nullable="false" />
         <Property Name="Concurrency" Type="Edm.Int32" Nullable="false" ConcurrencyMode="Fixed" />
-        <NavigationProperty Name="Products" Relationship="ODataDemo.Product_Supplier_Supplier_Products" FromRole="Supplier_Products" ToRole="Product_Supplier" />
+        <NavigationProperty
+          Name="Products"
+          Relationship="ODataDemo.Product_Supplier_Supplier_Products"
+          FromRole="Supplier_Products"
+          ToRole="Product_Supplier"
+        />
       </EntityType>
       <ComplexType Name="Address">
         <Property Name="Street" Type="Edm.String" Nullable="true" />
@@ -61,7 +117,12 @@
           <End Role="Product_Supplier" EntitySet="Products" />
           <End Role="Supplier_Products" EntitySet="Suppliers" />
         </AssociationSet>
-        <FunctionImport Name="GetProductsByRating" EntitySet="Products" ReturnType="Collection(ODataDemo.Product)" m:HttpMethod="GET">
+        <FunctionImport
+          Name="GetProductsByRating"
+          EntitySet="Products"
+          ReturnType="Collection(ODataDemo.Product)"
+          m:HttpMethod="GET"
+        >
           <Parameter Name="rating" Type="Edm.Int32" Mode="In" />
         </FunctionImport>
       </EntityContainer>

--- a/int-test/asp-net/resource/library.xml
+++ b/int-test/asp-net/resource/library.xml
@@ -1,618 +1,640 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx"><edmx:DataServices><Schema
-      Namespace="Library.Catalog"
-      xmlns="http://docs.oasis-open.org/odata/ns/edm"
-    ><ComplexType Name="Address" Abstract="true"><Property Name="Street" Type="Edm.String" MaxLength="120" /><Property
-          Name="City"
-          Type="Edm.String"
-          MaxLength="80"
-        /></ComplexType><ComplexType Name="PostalAddress" BaseType="Library.Catalog.Address"><Property
-          Name="PostalCode"
-          Type="Edm.String"
-          MaxLength="10"
-        /><Property Name="Country" Type="Edm.String" MaxLength="60" /></ComplexType><EntityType
-        Name="Medium"
-        Abstract="true"
-      ><Key><PropertyRef Name="Id" /></Key><Property Name="Id" Type="Edm.Guid" Nullable="false"><Annotation
-            Term="Org.OData.Core.V1.Computed"
-            Bool="true"
-          /></Property><Property Name="Title" Type="Edm.String" Nullable="false" MaxLength="200" /><Property
-          Name="Language"
-          Type="Edm.String"
-          MaxLength="40"
-        ><Annotation
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="Library.Catalog" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <ComplexType Name="Address" Abstract="true">
+        <Property Name="Street" Type="Edm.String" MaxLength="120" />
+        <Property Name="City" Type="Edm.String" MaxLength="80" />
+      </ComplexType>
+      <ComplexType Name="PostalAddress" BaseType="Library.Catalog.Address">
+        <Property Name="PostalCode" Type="Edm.String" MaxLength="10" />
+        <Property Name="Country" Type="Edm.String" MaxLength="60" />
+      </ComplexType>
+      <EntityType Name="Medium" Abstract="true">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property Name="Id" Type="Edm.Guid" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
+        </Property>
+        <Property Name="Title" Type="Edm.String" Nullable="false" MaxLength="200" />
+        <Property Name="Language" Type="Edm.String" MaxLength="40">
+          <Annotation
             Term="Org.OData.Core.V1.Description"
             String="Language of the medium itself, as an ISO 639-1 code."
-          /></Property><Property Name="PublicationDate" Type="Edm.Date" /><Property
-          Name="Keywords"
-          Type="Collection(Edm.String)"
-        ><Annotation Term="Org.OData.Validation.V1.MaxItems" Int="20" /><Annotation
-            Term="Org.OData.Core.V1.Description"
-            String="Free-text subject keywords for cataloguing."
-          /></Property><Property Name="PopularityScore" Type="Edm.Double"><Annotation
-            Term="Org.OData.Core.V1.Computed"
-            Bool="true"
-          /><Annotation Term="Org.OData.Validation.V1.Minimum" Float="0" /><Annotation
-            Term="Org.OData.Validation.V1.Maximum"
-            Float="10"
-          /><Annotation
+          />
+        </Property>
+        <Property Name="PublicationDate" Type="Edm.Date" />
+        <Property Name="Keywords" Type="Collection(Edm.String)">
+          <Annotation Term="Org.OData.Validation.V1.MaxItems" Int="20" />
+          <Annotation Term="Org.OData.Core.V1.Description" String="Free-text subject keywords for cataloguing." />
+        </Property>
+        <Property Name="PopularityScore" Type="Edm.Double">
+          <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
+          <Annotation Term="Org.OData.Validation.V1.Minimum" Float="0" />
+          <Annotation Term="Org.OData.Validation.V1.Maximum" Float="10" />
+          <Annotation
             Term="Org.OData.Core.V1.Description"
             String="How often the medium is borrowed, on a 0-10 scale."
-          /></Property><NavigationProperty
-          Name="Copies"
-          Type="Collection(Library.Circulation.Copy)"
-          Partner="Medium"
-        ><OnDelete Action="Cascade" /></NavigationProperty><Annotation
+          />
+        </Property>
+        <NavigationProperty Name="Copies" Type="Collection(Library.Circulation.Copy)" Partner="Medium">
+          <OnDelete Action="Cascade" />
+        </NavigationProperty>
+        <Annotation
           Term="Org.OData.Core.V1.Description"
           String="Anything the library holds and lends out, in any form."
-        /></EntityType><EntityType Name="PrintMedium" BaseType="Library.Catalog.Medium" Abstract="true"><Property
-          Name="ISBN"
-          Type="Edm.String"
-          MaxLength="13"
-        ><Annotation Term="Org.OData.Validation.V1.Pattern" String="^[0-9]{13}$" /><Annotation
-            Term="Org.OData.Core.V1.Description"
-            String="ISBN-13, digits only and without separators."
-          /></Property></EntityType><EntityType Name="Book" BaseType="Library.Catalog.PrintMedium"><Property
-          Name="PageCount"
-          Type="Edm.Int16"
-          Nullable="false"
-        ><Annotation Term="Org.OData.Validation.V1.Minimum" Int="1" /></Property><Property
-          Name="AgeRating"
-          Type="Edm.Byte"
-          Nullable="false"
-        ><Annotation Term="Org.OData.Validation.V1.Minimum" Int="0" /><Annotation
-            Term="Org.OData.Validation.V1.Maximum"
-            Int="18"
-          /><Annotation
+        />
+      </EntityType>
+      <EntityType Name="PrintMedium" BaseType="Library.Catalog.Medium" Abstract="true">
+        <Property Name="ISBN" Type="Edm.String" MaxLength="13">
+          <Annotation Term="Org.OData.Validation.V1.Pattern" String="^[0-9]{13}$" />
+          <Annotation Term="Org.OData.Core.V1.Description" String="ISBN-13, digits only and without separators." />
+        </Property>
+      </EntityType>
+      <EntityType Name="Book" BaseType="Library.Catalog.PrintMedium">
+        <Property Name="PageCount" Type="Edm.Int16" Nullable="false">
+          <Annotation Term="Org.OData.Validation.V1.Minimum" Int="1" />
+        </Property>
+        <Property Name="AgeRating" Type="Edm.Byte" Nullable="false">
+          <Annotation Term="Org.OData.Validation.V1.Minimum" Int="0" />
+          <Annotation Term="Org.OData.Validation.V1.Maximum" Int="18" />
+          <Annotation
             Term="Org.OData.Core.V1.Description"
             String="Lowest age in years the book is released for; 0 means no restriction."
-          /></Property><NavigationProperty
-          Name="Publisher"
-          Type="PublisherRegistry.Publisher"
-          Partner="Books"
-        /></EntityType><EntityType Name="Magazine" BaseType="Library.Catalog.PrintMedium"><Property
-          Name="IssueNumber"
-          Type="Edm.Int32"
-          Nullable="false"
-        /></EntityType><EntityType Name="TradeJournal" BaseType="Library.Catalog.Magazine"><Property
-          Name="Field"
-          Type="Edm.String"
-        /></EntityType><EntityType Name="AudioMedium" BaseType="Library.Catalog.Medium" Abstract="true"><Property
-          Name="Duration"
-          Type="Edm.Duration"
-        ><Annotation
-            Term="Org.OData.Measures.V1.DurationGranularity"
-            String="minutes"
-          /></Property></EntityType><EntityType Name="DVD" BaseType="Library.Catalog.AudioMedium"><Property
-          Name="RegionCode"
-          Type="Edm.Byte"
-          Nullable="false"
-        /></EntityType><EntityType Name="Audiobook" BaseType="Library.Catalog.AudioMedium"><Property
-          Name="Narrator"
-          Type="Edm.String"
-        /><Property Name="Sample" Type="Edm.Stream"><Annotation
-            Term="Org.OData.Core.V1.AcceptableMediaTypes"
-          ><Collection><String>audio/mpeg</String></Collection></Annotation></Property><NavigationProperty
-          Name="Chapters"
-          Type="Collection(Library.Catalog.AudiobookChapter)"
-          ContainsTarget="true"
-        ><OnDelete Action="Cascade" /></NavigationProperty></EntityType><EntityType
-        Name="AudiobookChapter"
-        HasStream="true"
-      ><Key><PropertyRef Name="Id" /></Key><Property Name="Id" Type="Edm.Int32" Nullable="false"><Annotation
-            Term="Org.OData.Core.V1.Computed"
-            Bool="true"
-          /></Property><Property Name="Title" Type="Edm.String" /><Annotation
-          Term="Org.OData.Core.V1.AcceptableMediaTypes"
-        ><Collection><String>audio/mpeg</String></Collection></Annotation></EntityType><EntityType
-        Name="EBook"
-        BaseType="Library.Catalog.Medium"
-        HasStream="true"
-      ><Property Name="FileFormat" Type="Edm.String" MaxLength="20" /><Annotation
-          Term="Org.OData.Core.V1.AcceptableMediaTypes"
-        ><Collection><String>application/epub+zip</String></Collection></Annotation></EntityType><EntityType
-        Name="CollectorsItem"
-        BaseType="Library.Catalog.Medium"
-        OpenType="true"
-      ><Property Name="ExtraData" Type="Edm.Untyped" /><NavigationProperty
-          Name="StorageLocation"
-          Type="Library.Circulation.Branch"
-        /><Annotation Term="Org.OData.Core.V1.AdditionalProperties" Bool="true" /><Annotation
+          />
+        </Property>
+        <NavigationProperty Name="Publisher" Type="PublisherRegistry.Publisher" Partner="Books" />
+      </EntityType>
+      <EntityType Name="Magazine" BaseType="Library.Catalog.PrintMedium">
+        <Property Name="IssueNumber" Type="Edm.Int32" Nullable="false" />
+      </EntityType>
+      <EntityType Name="TradeJournal" BaseType="Library.Catalog.Magazine">
+        <Property Name="Field" Type="Edm.String" />
+      </EntityType>
+      <EntityType Name="AudioMedium" BaseType="Library.Catalog.Medium" Abstract="true">
+        <Property Name="Duration" Type="Edm.Duration">
+          <Annotation Term="Org.OData.Measures.V1.DurationGranularity" String="minutes" />
+        </Property>
+      </EntityType>
+      <EntityType Name="DVD" BaseType="Library.Catalog.AudioMedium">
+        <Property Name="RegionCode" Type="Edm.Byte" Nullable="false" />
+      </EntityType>
+      <EntityType Name="Audiobook" BaseType="Library.Catalog.AudioMedium">
+        <Property Name="Narrator" Type="Edm.String" />
+        <Property Name="Sample" Type="Edm.Stream">
+          <Annotation Term="Org.OData.Core.V1.AcceptableMediaTypes">
+            <Collection>
+              <String>audio/mpeg</String>
+            </Collection>
+          </Annotation>
+        </Property>
+        <NavigationProperty Name="Chapters" Type="Collection(Library.Catalog.AudiobookChapter)" ContainsTarget="true">
+          <OnDelete Action="Cascade" />
+        </NavigationProperty>
+      </EntityType>
+      <EntityType Name="AudiobookChapter" HasStream="true">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
+        </Property>
+        <Property Name="Title" Type="Edm.String" />
+        <Annotation Term="Org.OData.Core.V1.AcceptableMediaTypes">
+          <Collection>
+            <String>audio/mpeg</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+      <EntityType Name="EBook" BaseType="Library.Catalog.Medium" HasStream="true">
+        <Property Name="FileFormat" Type="Edm.String" MaxLength="20" />
+        <Annotation Term="Org.OData.Core.V1.AcceptableMediaTypes">
+          <Collection>
+            <String>application/epub+zip</String>
+          </Collection>
+        </Annotation>
+      </EntityType>
+      <EntityType Name="CollectorsItem" BaseType="Library.Catalog.Medium" OpenType="true">
+        <Property Name="ExtraData" Type="Edm.Untyped" />
+        <NavigationProperty Name="StorageLocation" Type="Library.Circulation.Branch" />
+        <Annotation Term="Org.OData.Core.V1.AdditionalProperties" Bool="true" />
+        <Annotation
           Term="Org.OData.Core.V1.Description"
           String="A rarity whose describing properties are not known in advance."
-        /></EntityType><ComplexType Name="MediumStats"><Property
-          Name="TotalLoanCount"
-          Type="Edm.Int64"
-          Nullable="false"
-        /><Property Name="AverageLoanDuration" Type="Edm.Duration" Nullable="false" /></ComplexType><ComplexType
-        Name="ConditionReport"
-      ><Property Name="ConditionBefore" Type="Edm.Byte" Nullable="false" /><Property
-          Name="ConditionAfter"
-          Type="Edm.Byte"
-          Nullable="false"
-        /><Property Name="Remark" Type="Edm.String" /></ComplexType><EnumType Name="Amenities" IsFlags="true"><Member
-          Name="WheelchairAccessible"
-          Value="1"
-        ><Annotation
-            Term="Org.OData.Core.V1.Description"
-            String="Step-free access to every public area."
-          /></Member><Member Name="Parking" Value="2" /><Member Name="Café" Value="4" /><Member
-          Name="KidsArea"
-          Value="8"
-        /><Member Name="StudyRoom" Value="16" /><Member Name="FullService" Value="31"><Annotation
+        />
+      </EntityType>
+      <ComplexType Name="MediumStats">
+        <Property Name="TotalLoanCount" Type="Edm.Int64" Nullable="false" />
+        <Property Name="AverageLoanDuration" Type="Edm.Duration" Nullable="false" />
+      </ComplexType>
+      <ComplexType Name="ConditionReport">
+        <Property Name="ConditionBefore" Type="Edm.Byte" Nullable="false" />
+        <Property Name="ConditionAfter" Type="Edm.Byte" Nullable="false" />
+        <Property Name="Remark" Type="Edm.String" />
+      </ComplexType>
+      <EnumType Name="Amenities" IsFlags="true">
+        <Member Name="WheelchairAccessible" Value="1">
+          <Annotation Term="Org.OData.Core.V1.Description" String="Step-free access to every public area." />
+        </Member>
+        <Member Name="Parking" Value="2" />
+        <Member Name="Café" Value="4" />
+        <Member Name="KidsArea" Value="8" />
+        <Member Name="StudyRoom" Value="16" />
+        <Member Name="FullService" Value="31">
+          <Annotation
             Term="Org.OData.Core.V1.Description"
             String="All of the above - every amenity this library records."
-          /></Member></EnumType><EnumType Name="AvailabilityStatus" UnderlyingType="Edm.Byte"><Member
-          Name="Available"
-          Value="0"
-        ><Annotation Term="Org.OData.Core.V1.Description" String="On the shelf and loanable." /></Member><Member
-          Name="OnLoan"
-          Value="1"
-        ><Annotation
-            Term="Org.OData.Core.V1.Description"
-            String="Borrowed; due back on the loan's due date."
-          /></Member><Member Name="InRepair" Value="2"><Annotation
-            Term="Org.OData.Core.V1.Description"
-            String="With the bindery or the repair desk."
-          /></Member><Member Name="Missing" Value="3"><Annotation
-            Term="Org.OData.Core.V1.Description"
-            String="Not found at the last inventory."
-          /></Member><Annotation
+          />
+        </Member>
+      </EnumType>
+      <EnumType Name="AvailabilityStatus" UnderlyingType="Edm.Byte">
+        <Member Name="Available" Value="0">
+          <Annotation Term="Org.OData.Core.V1.Description" String="On the shelf and loanable." />
+        </Member>
+        <Member Name="OnLoan" Value="1">
+          <Annotation Term="Org.OData.Core.V1.Description" String="Borrowed; due back on the loan's due date." />
+        </Member>
+        <Member Name="InRepair" Value="2">
+          <Annotation Term="Org.OData.Core.V1.Description" String="With the bindery or the repair desk." />
+        </Member>
+        <Member Name="Missing" Value="3">
+          <Annotation Term="Org.OData.Core.V1.Description" String="Not found at the last inventory." />
+        </Member>
+        <Annotation
           Term="Org.OData.Core.V1.Description"
           String="Whether a copy can be borrowed right now, and if not, why not."
-        /></EnumType><Annotations Target="Library.Catalog.PrintMedium"><Annotation
-          Term="Org.OData.Core.V1.AlternateKeys"
-        ><Collection><Record><PropertyValue Property="Key"><Collection><Record><PropertyValue
-                      Property="Name"
-                      PropertyPath="ISBN"
-                    /><PropertyValue
-                      Property="Alias"
-                      String="ISBN"
-                    /></Record></Collection></PropertyValue></Record></Collection></Annotation></Annotations><Annotations
-        Target="Library.Service.LibraryService/Media"
-      ><Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions"><Record><PropertyValue
-              Property="Searchable"
-              Bool="true"
-            /></Record></Annotation></Annotations></Schema><Schema
-      Namespace="Library.Circulation"
-      xmlns="http://docs.oasis-open.org/odata/ns/edm"
-    ><EntityType Name="Member"><Key><PropertyRef Name="Id" /></Key><Property
-          Name="Id"
-          Type="Edm.Int32"
-          Nullable="false"
-        ><Annotation Term="Org.OData.Core.V1.Computed" Bool="true" /></Property><Property
-          Name="ActiveSince"
-          Type="Edm.DateTimeOffset"
-          Precision="7"
-        ><Annotation Term="Org.OData.Core.V1.ComputedDefaultValue" Bool="true" /></Property><Property
-          Name="Name"
-          Type="Edm.String"
-          Nullable="false"
-          MaxLength="100"
-        /><Property Name="DateOfBirth" Type="Edm.Date" /><Property
-          Name="Address"
-          Type="Library.Catalog.PostalAddress"
-        /><Property
-          Name="PreviousAddresses"
-          Type="Collection(Library.Catalog.PostalAddress)"
-          Nullable="false"
-        /><Property Name="Balance" Type="Edm.Decimal" Nullable="false" Precision="9" Scale="2"><Annotation
-            Term="Org.OData.Core.V1.Permissions"
-          ><EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember></Annotation><Annotation
-            Term="Org.OData.Measures.V1.ISOCurrency"
-            String="EUR"
-          /><Annotation
+        />
+      </EnumType>
+      <Annotations Target="Library.Catalog.PrintMedium">
+        <Annotation Term="Org.OData.Core.V1.AlternateKeys">
+          <Collection>
+            <Record>
+              <PropertyValue Property="Key">
+                <Collection>
+                  <Record>
+                    <PropertyValue Property="Name" PropertyPath="ISBN" />
+                    <PropertyValue Property="Alias" String="ISBN" />
+                  </Record>
+                </Collection>
+              </PropertyValue>
+            </Record>
+          </Collection>
+        </Annotation>
+      </Annotations>
+      <Annotations Target="Library.Service.LibraryService/Media">
+        <Annotation Term="Org.OData.Capabilities.V1.SearchRestrictions">
+          <Record>
+            <PropertyValue Property="Searchable" Bool="true" />
+          </Record>
+        </Annotation>
+      </Annotations>
+    </Schema>
+    <Schema Namespace="Library.Circulation" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="Member">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
+        </Property>
+        <Property Name="ActiveSince" Type="Edm.DateTimeOffset" Precision="7">
+          <Annotation Term="Org.OData.Core.V1.ComputedDefaultValue" Bool="true" />
+        </Property>
+        <Property Name="Name" Type="Edm.String" Nullable="false" MaxLength="100" />
+        <Property Name="DateOfBirth" Type="Edm.Date" />
+        <Property Name="Address" Type="Library.Catalog.PostalAddress" />
+        <Property Name="PreviousAddresses" Type="Collection(Library.Catalog.PostalAddress)" Nullable="false" />
+        <Property Name="Balance" Type="Edm.Decimal" Nullable="false" Precision="9" Scale="2">
+          <Annotation Term="Org.OData.Core.V1.Permissions">
+            <EnumMember>Org.OData.Core.V1.Permission/Read</EnumMember>
+          </Annotation>
+          <Annotation Term="Org.OData.Measures.V1.ISOCurrency" String="EUR" />
+          <Annotation
             Term="Org.OData.Core.V1.Description"
             String="Outstanding late fees; settled at the desk, never through this service."
-          /></Property><NavigationProperty
-          Name="Reservations"
-          Type="Collection(Library.Circulation.Reservation)"
-        ><OnDelete Action="Cascade" /></NavigationProperty><NavigationProperty
-          Name="IdDocument"
-          Type="Library.Circulation.IdDocument"
-        /><NavigationProperty Name="Loans" Type="Collection(Library.Circulation.Loan)" Partner="Member"><OnDelete
-            Action="Cascade"
-          /></NavigationProperty><Annotation
+          />
+        </Property>
+        <NavigationProperty Name="Reservations" Type="Collection(Library.Circulation.Reservation)">
+          <OnDelete Action="Cascade" />
+        </NavigationProperty>
+        <NavigationProperty Name="IdDocument" Type="Library.Circulation.IdDocument" />
+        <NavigationProperty Name="Loans" Type="Collection(Library.Circulation.Loan)" Partner="Member">
+          <OnDelete Action="Cascade" />
+        </NavigationProperty>
+        <Annotation
           Term="Org.OData.Core.V1.Description"
           String="A person registered with the library, with their loans and reservations."
-        /></EntityType><EntityType Name="Loan"><Key><PropertyRef Name="Id" /></Key><Property
-          Name="Id"
-          Type="Edm.Guid"
-          Nullable="false"
-        ><Annotation Term="Org.OData.Core.V1.Computed" Bool="true" /></Property><Property
-          Name="LoanedAt"
-          Type="Edm.DateTimeOffset"
-          Nullable="false"
-          Precision="7"
-        ><Annotation Term="Org.OData.Core.V1.Immutable" Bool="true" /></Property><Property
-          Name="ReturnedAt"
-          Type="Edm.DateTimeOffset"
-          Precision="7"
-        /><Property Name="DueDate" Type="Edm.Date" Nullable="false" /><Property
-          Name="LateFee"
-          Type="Edm.Decimal"
-          Precision="5"
-          Scale="2"
-        ><Annotation Term="Org.OData.Measures.V1.ISOCurrency" String="EUR" /></Property><NavigationProperty
-          Name="Member"
-          Type="Library.Circulation.Member"
-          Nullable="false"
-          Partner="Loans"
-        /><NavigationProperty Name="Copy" Type="Library.Circulation.Copy" Nullable="false" /></EntityType><EntityType
-        Name="Reservation"
-      ><Key><PropertyRef Name="Id" /></Key><Property Name="Id" Type="Edm.Guid" Nullable="false"><Annotation
-            Term="Org.OData.Core.V1.Computed"
-            Bool="true"
-          /></Property><Property
-          Name="ReservedAt"
-          Type="Edm.DateTimeOffset"
-          Nullable="false"
-          Precision="7"
-        /></EntityType><EntityType Name="IdDocument"><Key><PropertyRef Name="Id" /></Key><Property
-          Name="Id"
-          Type="Edm.Guid"
-          Nullable="false"
-        ><Annotation Term="Org.OData.Core.V1.Computed" Bool="true" /></Property><Property
-          Name="UploadedAt"
-          Type="Edm.DateTimeOffset"
-          Nullable="false"
-          Precision="7"
-        /><Property Name="Scan" Type="Edm.Binary" /></EntityType><EntityType Name="Branch"><Key><PropertyRef
-            Name="Id"
-          /></Key><Property Name="Id" Type="Edm.Int32" Nullable="false" /><Property
-          Name="Name"
-          Type="Edm.String"
-          Nullable="false"
-          MaxLength="100"
-        /><Property Name="Address" Type="Library.Catalog.PostalAddress" /><Property
-          Name="Location"
-          Type="Edm.GeographyPoint"
-        /><Property Name="CatchmentArea" Type="Edm.GeographyPolygon" /><Property
-          Name="LowestFloor"
-          Type="Edm.SByte"
-          Nullable="false"
-        /><Property Name="FloorPlanOrigin" Type="Edm.GeometryPoint" /><Property
-          Name="FloorPlanShapes"
-          Type="Edm.GeometryCollection"
-        /><Property Name="OpensAt" Type="Edm.TimeOfDay" /><Property Name="ClosesAt" Type="Edm.TimeOfDay" /><Property
-          Name="Amenities"
-          Type="Library.Catalog.Amenities"
-        /><Property Name="Population" Type="Edm.Int64" Nullable="false"><Annotation
-            Term="Org.OData.Core.V1.Description"
-            String="Inhabitants of the area the branch serves."
-          /></Property></EntityType><EntityType Name="Bookmobile"><Key><PropertyRef Name="Id" /></Key><Property
-          Name="Id"
-          Type="Edm.Int32"
-          Nullable="false"
-        ><Annotation Term="Org.OData.Core.V1.Computed" Bool="true" /></Property><Property
-          Name="LicensePlate"
-          Type="Edm.String"
-          MaxLength="12"
-        /><Property Name="Route" Type="Edm.GeographyLineString" /><Property
-          Name="CurrentPosition"
-          Type="Edm.GeographyPoint"
-        /></EntityType><EntityType Name="Copy"><Key><PropertyRef Name="InventoryNumber" /><PropertyRef
-            Name="MediumId"
-          /></Key><Property Name="MediumId" Type="Edm.Guid" Nullable="false" /><Property
-          Name="InventoryNumber"
-          Type="Edm.Int32"
-          Nullable="false"
-        /><Property Name="IsLoanable" Type="Edm.Boolean" DefaultValue="true" Nullable="false" /><Property
-          Name="Condition"
-          Type="Edm.Byte"
-          Nullable="false"
-        ><Annotation Term="Org.OData.Validation.V1.Minimum" Int="0" /><Annotation
-            Term="Org.OData.Validation.V1.Maximum"
-            Int="5"
-          /><Annotation
+        />
+      </EntityType>
+      <EntityType Name="Loan">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property Name="Id" Type="Edm.Guid" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
+        </Property>
+        <Property Name="LoanedAt" Type="Edm.DateTimeOffset" Nullable="false" Precision="7">
+          <Annotation Term="Org.OData.Core.V1.Immutable" Bool="true" />
+        </Property>
+        <Property Name="ReturnedAt" Type="Edm.DateTimeOffset" Precision="7" />
+        <Property Name="DueDate" Type="Edm.Date" Nullable="false" />
+        <Property Name="LateFee" Type="Edm.Decimal" Precision="5" Scale="2">
+          <Annotation Term="Org.OData.Measures.V1.ISOCurrency" String="EUR" />
+        </Property>
+        <NavigationProperty Name="Member" Type="Library.Circulation.Member" Nullable="false" Partner="Loans" />
+        <NavigationProperty Name="Copy" Type="Library.Circulation.Copy" Nullable="false" />
+      </EntityType>
+      <EntityType Name="Reservation">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property Name="Id" Type="Edm.Guid" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
+        </Property>
+        <Property Name="ReservedAt" Type="Edm.DateTimeOffset" Nullable="false" Precision="7" />
+      </EntityType>
+      <EntityType Name="IdDocument">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property Name="Id" Type="Edm.Guid" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
+        </Property>
+        <Property Name="UploadedAt" Type="Edm.DateTimeOffset" Nullable="false" Precision="7" />
+        <Property Name="Scan" Type="Edm.Binary" />
+      </EntityType>
+      <EntityType Name="Branch">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false" />
+        <Property Name="Name" Type="Edm.String" Nullable="false" MaxLength="100" />
+        <Property Name="Address" Type="Library.Catalog.PostalAddress" />
+        <Property Name="Location" Type="Edm.GeographyPoint" />
+        <Property Name="CatchmentArea" Type="Edm.GeographyPolygon" />
+        <Property Name="LowestFloor" Type="Edm.SByte" Nullable="false" />
+        <Property Name="FloorPlanOrigin" Type="Edm.GeometryPoint" />
+        <Property Name="FloorPlanShapes" Type="Edm.GeometryCollection" />
+        <Property Name="OpensAt" Type="Edm.TimeOfDay" />
+        <Property Name="ClosesAt" Type="Edm.TimeOfDay" />
+        <Property Name="Amenities" Type="Library.Catalog.Amenities" />
+        <Property Name="Population" Type="Edm.Int64" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Description" String="Inhabitants of the area the branch serves." />
+        </Property>
+      </EntityType>
+      <EntityType Name="Bookmobile">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
+        </Property>
+        <Property Name="LicensePlate" Type="Edm.String" MaxLength="12" />
+        <Property Name="Route" Type="Edm.GeographyLineString" />
+        <Property Name="CurrentPosition" Type="Edm.GeographyPoint" />
+      </EntityType>
+      <EntityType Name="Copy">
+        <Key>
+          <PropertyRef Name="InventoryNumber" />
+          <PropertyRef Name="MediumId" />
+        </Key>
+        <Property Name="MediumId" Type="Edm.Guid" Nullable="false" />
+        <Property Name="InventoryNumber" Type="Edm.Int32" Nullable="false" />
+        <Property Name="IsLoanable" Type="Edm.Boolean" DefaultValue="true" Nullable="false" />
+        <Property Name="Condition" Type="Edm.Byte" Nullable="false">
+          <Annotation Term="Org.OData.Validation.V1.Minimum" Int="0" />
+          <Annotation Term="Org.OData.Validation.V1.Maximum" Int="5" />
+          <Annotation
             Term="Org.OData.Core.V1.Description"
             String="Physical condition on a 0-5 scale, 5 being as new. Doubles as the ETag."
-          /></Property><Property Name="Status" Type="Library.Catalog.AvailabilityStatus" /><Property
-          Name="AcquisitionDate"
-          Type="Edm.Date"
-        /><Property Name="WeightKg" Type="Edm.Single" Nullable="false"><Annotation
-            Term="Org.OData.Measures.V1.Unit"
-            String="kg"
-          /><Annotation Term="Org.OData.Measures.V1.Scale" Int="2" /></Property><Property
-          Name="Location_"
-          Type="Edm.String"
-          MaxLength="10"
-        ><Annotation
-            Term="Org.OData.Core.V1.Description"
-            String="Shelf mark within the branch."
-          /></Property><NavigationProperty
-          Name="Medium"
-          Type="Library.Catalog.Medium"
-          Nullable="false"
-          Partner="Copies"
-        ><ReferentialConstraint Property="MediumId" ReferencedProperty="Id" /></NavigationProperty><NavigationProperty
-          Name="Location"
-          Type="Library.Circulation.Branch"
-        /></EntityType><ComplexType Name="OverdueNotice"><Property
-          Name="Amount"
-          Type="Edm.Decimal"
-          Nullable="false"
-          Precision="5"
-          Scale="2"
-        ><Annotation Term="Org.OData.Measures.V1.ISOCurrency" String="EUR" /></Property><Property
-          Name="CreatedAt"
-          Type="Edm.DateTimeOffset"
-          Nullable="false"
-          Precision="7"
-        /><Property Name="Reason" Type="Edm.String" /></ComplexType><ComplexType Name="AnnualReport"><Property
-          Name="TotalLateFees"
-          Type="Edm.Decimal"
-          Nullable="false"
-          Precision="12"
-          Scale="2"
-        ><Annotation Term="Org.OData.Measures.V1.ISOCurrency" String="EUR" /></Property><Property
-          Name="Year"
-          Type="Edm.Int32"
-          Nullable="false"
-        /><Property Name="TotalLoans" Type="Edm.Int64" Nullable="false" /></ComplexType><ComplexType
-        Name="DateRange"
-      ><Property Name="From" Type="Edm.Date" /><Property Name="To" Type="Edm.Date" /></ComplexType><ComplexType
-        Name="LoanStats"
-      ><Property Name="TotalLoans" Type="Edm.Int64" Nullable="false" /><Property
-          Name="AverageLoanDuration"
-          Type="Edm.Duration"
-          Nullable="false"
-        /></ComplexType><ComplexType Name="BranchStats"><Property
-          Name="BranchId"
-          Type="Edm.Int32"
-          Nullable="false"
-        /><Property Name="LoanCount" Type="Edm.Int64" Nullable="false" /></ComplexType><Function
-        Name="TotalMediaCount"
-      ><ReturnType Type="Edm.Int64" Nullable="false" /><Annotation
+          />
+        </Property>
+        <Property Name="Status" Type="Library.Catalog.AvailabilityStatus" />
+        <Property Name="AcquisitionDate" Type="Edm.Date" />
+        <Property Name="WeightKg" Type="Edm.Single" Nullable="false">
+          <Annotation Term="Org.OData.Measures.V1.Unit" String="kg" />
+          <Annotation Term="Org.OData.Measures.V1.Scale" Int="2" />
+        </Property>
+        <Property Name="Location_" Type="Edm.String" MaxLength="10">
+          <Annotation Term="Org.OData.Core.V1.Description" String="Shelf mark within the branch." />
+        </Property>
+        <NavigationProperty Name="Medium" Type="Library.Catalog.Medium" Nullable="false" Partner="Copies">
+          <ReferentialConstraint Property="MediumId" ReferencedProperty="Id" />
+        </NavigationProperty>
+        <NavigationProperty Name="Location" Type="Library.Circulation.Branch" />
+      </EntityType>
+      <ComplexType Name="OverdueNotice">
+        <Property Name="Amount" Type="Edm.Decimal" Nullable="false" Precision="5" Scale="2">
+          <Annotation Term="Org.OData.Measures.V1.ISOCurrency" String="EUR" />
+        </Property>
+        <Property Name="CreatedAt" Type="Edm.DateTimeOffset" Nullable="false" Precision="7" />
+        <Property Name="Reason" Type="Edm.String" />
+      </ComplexType>
+      <ComplexType Name="AnnualReport">
+        <Property Name="TotalLateFees" Type="Edm.Decimal" Nullable="false" Precision="12" Scale="2">
+          <Annotation Term="Org.OData.Measures.V1.ISOCurrency" String="EUR" />
+        </Property>
+        <Property Name="Year" Type="Edm.Int32" Nullable="false" />
+        <Property Name="TotalLoans" Type="Edm.Int64" Nullable="false" />
+      </ComplexType>
+      <ComplexType Name="DateRange">
+        <Property Name="From" Type="Edm.Date" />
+        <Property Name="To" Type="Edm.Date" />
+      </ComplexType>
+      <ComplexType Name="LoanStats">
+        <Property Name="TotalLoans" Type="Edm.Int64" Nullable="false" />
+        <Property Name="AverageLoanDuration" Type="Edm.Duration" Nullable="false" />
+      </ComplexType>
+      <ComplexType Name="BranchStats">
+        <Property Name="BranchId" Type="Edm.Int32" Nullable="false" />
+        <Property Name="LoanCount" Type="Edm.Int64" Nullable="false" />
+      </ComplexType>
+      <Function Name="TotalMediaCount">
+        <ReturnType Type="Edm.Int64" Nullable="false" />
+        <Annotation
           Term="Org.OData.Core.V1.Description"
           String="How many media the library holds, all types together."
-        /></Function><Function Name="AllLanguages"><ReturnType Type="Collection(Edm.String)" /></Function><Function
-        Name="LoanStatistics"
-      ><Parameter Name="Period" Type="Library.Circulation.DateRange"><Annotation
+        />
+      </Function>
+      <Function Name="AllLanguages">
+        <ReturnType Type="Collection(Edm.String)" />
+      </Function>
+      <Function Name="LoanStatistics">
+        <Parameter Name="Period" Type="Library.Circulation.DateRange">
+          <Annotation
             Term="Org.OData.Core.V1.Description"
             String="Restricts the statistics to a period; omit it for all time."
-          /></Parameter><ReturnType Type="Library.Circulation.LoanStats" /></Function><Function
-        Name="StatsPerBranch"
-      ><ReturnType Type="Collection(Library.Circulation.BranchStats)" /></Function><Function
-        Name="MostReadMedium"
-      ><ReturnType Type="Library.Catalog.Medium" /></Function><Function
-        Name="NewReleases"
-        IsComposable="true"
-      ><ReturnType Type="Collection(Library.Catalog.Medium)" /></Function><Function Name="Search"><Parameter
-          Name="Term"
-          Type="Edm.String"
-        ><Annotation
-            Term="Org.OData.Core.V1.Description"
-            String="Matched against title and keywords."
-          /></Parameter><ReturnType Type="Collection(Library.Catalog.Medium)" /><Annotation
-          Term="Org.OData.Core.V1.Description"
-          String="Media whose title or keywords match the term."
-        /></Function><Function Name="Search"><Parameter Name="Term" Type="Edm.String"><Annotation
-            Term="Org.OData.Core.V1.Description"
-            String="Matched against title and keywords."
-          /></Parameter><Parameter Name="MaxResults" Type="Edm.Int32" Nullable="false"><Annotation
-            Term="Org.OData.Validation.V1.Minimum"
-            Int="1"
-          /></Parameter><ReturnType Type="Collection(Library.Catalog.Medium)" /><Annotation
+          />
+        </Parameter>
+        <ReturnType Type="Library.Circulation.LoanStats" />
+      </Function>
+      <Function Name="StatsPerBranch">
+        <ReturnType Type="Collection(Library.Circulation.BranchStats)" />
+      </Function>
+      <Function Name="MostReadMedium">
+        <ReturnType Type="Library.Catalog.Medium" />
+      </Function>
+      <Function Name="NewReleases" IsComposable="true">
+        <ReturnType Type="Collection(Library.Catalog.Medium)" />
+      </Function>
+      <Function Name="Search">
+        <Parameter Name="Term" Type="Edm.String">
+          <Annotation Term="Org.OData.Core.V1.Description" String="Matched against title and keywords." />
+        </Parameter>
+        <ReturnType Type="Collection(Library.Catalog.Medium)" />
+        <Annotation Term="Org.OData.Core.V1.Description" String="Media whose title or keywords match the term." />
+      </Function>
+      <Function Name="Search">
+        <Parameter Name="Term" Type="Edm.String">
+          <Annotation Term="Org.OData.Core.V1.Description" String="Matched against title and keywords." />
+        </Parameter>
+        <Parameter Name="MaxResults" Type="Edm.Int32" Nullable="false">
+          <Annotation Term="Org.OData.Validation.V1.Minimum" Int="1" />
+        </Parameter>
+        <ReturnType Type="Collection(Library.Catalog.Medium)" />
+        <Annotation
           Term="Org.OData.Core.V1.Description"
           String="As Search(Term), but returns at most MaxResults media."
-        /></Function><Action Name="ClosureDay"><Parameter Name="Date" Type="Edm.Date" Nullable="false"><Annotation
-            Term="Org.OData.Core.V1.Description"
-            String="The day the library stays shut."
-          /></Parameter><Annotation
+        />
+      </Function>
+      <Action Name="ClosureDay">
+        <Parameter Name="Date" Type="Edm.Date" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Description" String="The day the library stays shut." />
+        </Parameter>
+        <Annotation
           Term="Org.OData.Core.V1.Description"
           String="Marks a day as a closure day; due dates move past it."
-        /></Action><Action Name="NextInventoryNumber"><ReturnType Type="Edm.Int32" Nullable="false" /></Action><Action
-        Name="CleanUpKeywords"
-      ><Parameter Name="Obsolete" Type="Collection(Edm.String)" /><ReturnType
-          Type="Collection(Edm.String)"
-        /></Action><Action Name="YearEndClosing"><Parameter Name="Year" Type="Edm.Int32" Nullable="false" /><ReturnType
-          Type="Library.Circulation.AnnualReport"
-        /></Action><Action Name="RunOverdueNotices"><ReturnType
-          Type="Collection(Library.Circulation.OverdueNotice)"
-        /></Action><Action Name="AcquireCollectorsItem"><Parameter Name="Title" Type="Edm.String" /><Parameter
-          Name="Description"
-          Type="Edm.String"
-        /><ReturnType Type="Library.Catalog.Medium" /></Action><Action Name="RunStockCheck"><ReturnType
-          Type="Collection(Library.Catalog.Medium)"
-        /></Action><Function Name="OutstandingBalance" IsBound="true"><Parameter
-          Name="member"
-          Type="Library.Circulation.Member"
-        /><ReturnType Type="Edm.Decimal" Nullable="false" Scale="variable" /></Function><Function
-        Name="AvailableLanguages"
-        IsBound="true"
-      ><Parameter Name="media" Type="Collection(Library.Catalog.Medium)" /><ReturnType
-          Type="Collection(Edm.String)"
-        /></Function><Function Name="LoanMetrics" IsBound="true"><Parameter
-          Name="medium"
-          Type="Library.Catalog.Medium"
-        /><ReturnType Type="Library.Catalog.MediumStats" /></Function><Function
-        Name="NoticeHistory"
-        IsBound="true"
-      ><Parameter Name="member" Type="Library.Circulation.Member" /><ReturnType
-          Type="Collection(Library.Circulation.OverdueNotice)"
-        /></Function><Function Name="AvailableCopy" IsBound="true"><Parameter
-          Name="medium"
-          Type="Library.Catalog.Medium"
-        /><ReturnType Type="Library.Circulation.Copy" /></Function><Function
-        Name="AvailableCopies"
-        IsBound="true"
-        IsComposable="true"
-      ><Parameter Name="medium" Type="Library.Catalog.Medium" /><ReturnType
-          Type="Collection(Library.Circulation.Copy)"
-        /></Function><Function Name="AvailableCopies" IsBound="true" IsComposable="true"><Parameter
-          Name="media"
-          Type="Collection(Library.Catalog.Medium)"
-        /><ReturnType Type="Collection(Library.Circulation.Copy)" /></Function><Action
-        Name="CheckOut"
-        IsBound="true"
-      ><Parameter Name="copy" Type="Library.Circulation.Copy" /><Parameter
-          Name="MemberId"
-          Type="Edm.Int32"
-          Nullable="false"
-        /></Action><Action Name="Reserve" IsBound="true"><Parameter
-          Name="medium"
-          Type="Library.Catalog.Medium"
-        /><Parameter Name="MemberId" Type="Edm.Int32" Nullable="false" /><ReturnType Type="Edm.Int32" /></Action><Action
-        Name="BulkRenew"
-        IsBound="true"
-      ><Parameter Name="loans" Type="Collection(Library.Circulation.Loan)" /><ReturnType
-          Type="Collection(Edm.String)"
-        /></Action><Action Name="AssessCondition" IsBound="true"><Parameter
-          Name="copy"
-          Type="Library.Circulation.Copy"
-        /><Parameter Name="NewCondition" Type="Edm.Byte" Nullable="false" /><Parameter
-          Name="Remark"
-          Type="Edm.String"
-        /><ReturnType Type="Library.Catalog.ConditionReport" /></Action><Action
-        Name="RunReminders"
-        IsBound="true"
-      ><Parameter Name="member" Type="Library.Circulation.Member" /><ReturnType
-          Type="Collection(Library.Circulation.OverdueNotice)"
-        /></Action><Action Name="Renew" IsBound="true"><Parameter
-          Name="loan"
-          Type="Library.Circulation.Loan"
-        /><ReturnType Type="Library.Circulation.Loan" /><Annotation
+        />
+      </Action>
+      <Action Name="NextInventoryNumber">
+        <ReturnType Type="Edm.Int32" Nullable="false" />
+      </Action>
+      <Action Name="CleanUpKeywords">
+        <Parameter Name="Obsolete" Type="Collection(Edm.String)" />
+        <ReturnType Type="Collection(Edm.String)" />
+      </Action>
+      <Action Name="YearEndClosing">
+        <Parameter Name="Year" Type="Edm.Int32" Nullable="false" />
+        <ReturnType Type="Library.Circulation.AnnualReport" />
+      </Action>
+      <Action Name="RunOverdueNotices">
+        <ReturnType Type="Collection(Library.Circulation.OverdueNotice)" />
+      </Action>
+      <Action Name="AcquireCollectorsItem">
+        <Parameter Name="Title" Type="Edm.String" />
+        <Parameter Name="Description" Type="Edm.String" />
+        <ReturnType Type="Library.Catalog.Medium" />
+      </Action>
+      <Action Name="RunStockCheck">
+        <ReturnType Type="Collection(Library.Catalog.Medium)" />
+      </Action>
+      <Function Name="OutstandingBalance" IsBound="true">
+        <Parameter Name="member" Type="Library.Circulation.Member" />
+        <ReturnType Type="Edm.Decimal" Nullable="false" Scale="variable" />
+      </Function>
+      <Function Name="AvailableLanguages" IsBound="true">
+        <Parameter Name="media" Type="Collection(Library.Catalog.Medium)" />
+        <ReturnType Type="Collection(Edm.String)" />
+      </Function>
+      <Function Name="LoanMetrics" IsBound="true">
+        <Parameter Name="medium" Type="Library.Catalog.Medium" />
+        <ReturnType Type="Library.Catalog.MediumStats" />
+      </Function>
+      <Function Name="NoticeHistory" IsBound="true">
+        <Parameter Name="member" Type="Library.Circulation.Member" />
+        <ReturnType Type="Collection(Library.Circulation.OverdueNotice)" />
+      </Function>
+      <Function Name="AvailableCopy" IsBound="true">
+        <Parameter Name="medium" Type="Library.Catalog.Medium" />
+        <ReturnType Type="Library.Circulation.Copy" />
+      </Function>
+      <Function Name="AvailableCopies" IsBound="true" IsComposable="true">
+        <Parameter Name="medium" Type="Library.Catalog.Medium" />
+        <ReturnType Type="Collection(Library.Circulation.Copy)" />
+      </Function>
+      <Function Name="AvailableCopies" IsBound="true" IsComposable="true">
+        <Parameter Name="media" Type="Collection(Library.Catalog.Medium)" />
+        <ReturnType Type="Collection(Library.Circulation.Copy)" />
+      </Function>
+      <Action Name="CheckOut" IsBound="true">
+        <Parameter Name="copy" Type="Library.Circulation.Copy" />
+        <Parameter Name="MemberId" Type="Edm.Int32" Nullable="false" />
+      </Action>
+      <Action Name="Reserve" IsBound="true">
+        <Parameter Name="medium" Type="Library.Catalog.Medium" />
+        <Parameter Name="MemberId" Type="Edm.Int32" Nullable="false" />
+        <ReturnType Type="Edm.Int32" />
+      </Action>
+      <Action Name="BulkRenew" IsBound="true">
+        <Parameter Name="loans" Type="Collection(Library.Circulation.Loan)" />
+        <ReturnType Type="Collection(Edm.String)" />
+      </Action>
+      <Action Name="AssessCondition" IsBound="true">
+        <Parameter Name="copy" Type="Library.Circulation.Copy" />
+        <Parameter Name="NewCondition" Type="Edm.Byte" Nullable="false" />
+        <Parameter Name="Remark" Type="Edm.String" />
+        <ReturnType Type="Library.Catalog.ConditionReport" />
+      </Action>
+      <Action Name="RunReminders" IsBound="true">
+        <Parameter Name="member" Type="Library.Circulation.Member" />
+        <ReturnType Type="Collection(Library.Circulation.OverdueNotice)" />
+      </Action>
+      <Action Name="Renew" IsBound="true">
+        <Parameter Name="loan" Type="Library.Circulation.Loan" />
+        <ReturnType Type="Library.Circulation.Loan" />
+        <Annotation
           Term="Org.OData.Core.V1.Description"
           String="Extends the loan's due date and returns the updated loan."
-        /></Action><Action Name="RenewAll" IsBound="true"><Parameter
-          Name="loans"
-          Type="Collection(Library.Circulation.Loan)"
-        /><ReturnType Type="Collection(Library.Circulation.Loan)" /></Action></Schema><Schema
-      Namespace="PublisherRegistry"
-      xmlns="http://docs.oasis-open.org/odata/ns/edm"
-    ><EntityType Name="Publisher"><Key><PropertyRef Name="Id" /></Key><Property
-          Name="Id"
-          Type="Edm.Int32"
-          Nullable="false"
-        ><Annotation Term="Org.OData.Core.V1.Computed" Bool="true" /></Property><Property
-          Name="Name"
-          Type="Edm.String"
-          Nullable="false"
-          MaxLength="100"
-        /><Property Name="Country" Type="Edm.String" MaxLength="60" /><Property
-          Name="Founded"
-          Type="Edm.Date"
-        /><NavigationProperty
-          Name="Books"
-          Type="Collection(Library.Catalog.Book)"
-          Partner="Publisher"
-        /></EntityType><EntityType Name="Branch"><Key><PropertyRef Name="Id" /></Key><Property
-          Name="Id"
-          Type="Edm.Int32"
-          Nullable="false"
-        ><Annotation Term="Org.OData.Core.V1.Computed" Bool="true" /></Property><Property
-          Name="City"
-          Type="Edm.String"
-          MaxLength="80"
-        /><Property Name="Country" Type="Edm.String" MaxLength="60" /></EntityType></Schema><Schema
-      Namespace="Library.Service"
-      xmlns="http://docs.oasis-open.org/odata/ns/edm"
-    ><EntityContainer Name="LibraryService"><EntitySet
-          Name="Media"
-          EntityType="Library.Catalog.Medium"
-        ><NavigationPropertyBinding Path="Copies" Target="Copies" /><NavigationPropertyBinding
-            Path="Library.Catalog.Book/Publisher"
-            Target="Publishers"
-          /><NavigationPropertyBinding
-            Path="Library.Catalog.CollectorsItem/StorageLocation"
-            Target="Branches"
-          /><Annotation
+        />
+      </Action>
+      <Action Name="RenewAll" IsBound="true">
+        <Parameter Name="loans" Type="Collection(Library.Circulation.Loan)" />
+        <ReturnType Type="Collection(Library.Circulation.Loan)" />
+      </Action>
+    </Schema>
+    <Schema Namespace="PublisherRegistry" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="Publisher">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
+        </Property>
+        <Property Name="Name" Type="Edm.String" Nullable="false" MaxLength="100" />
+        <Property Name="Country" Type="Edm.String" MaxLength="60" />
+        <Property Name="Founded" Type="Edm.Date" />
+        <NavigationProperty Name="Books" Type="Collection(Library.Catalog.Book)" Partner="Publisher" />
+      </EntityType>
+      <EntityType Name="Branch">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false">
+          <Annotation Term="Org.OData.Core.V1.Computed" Bool="true" />
+        </Property>
+        <Property Name="City" Type="Edm.String" MaxLength="80" />
+        <Property Name="Country" Type="Edm.String" MaxLength="60" />
+      </EntityType>
+    </Schema>
+    <Schema Namespace="Library.Service" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityContainer Name="LibraryService">
+        <EntitySet Name="Media" EntityType="Library.Catalog.Medium">
+          <NavigationPropertyBinding Path="Copies" Target="Copies" />
+          <NavigationPropertyBinding Path="Library.Catalog.Book/Publisher" Target="Publishers" />
+          <NavigationPropertyBinding Path="Library.Catalog.CollectorsItem/StorageLocation" Target="Branches" />
+          <Annotation
             Term="Org.OData.Core.V1.Description"
             String="Everything the library holds, across all media types."
-          /></EntitySet><EntitySet Name="Copies" EntityType="Library.Circulation.Copy"><NavigationPropertyBinding
-            Path="Location"
-            Target="Branches"
-          /><NavigationPropertyBinding Path="Medium" Target="Media" /><Annotation
-            Term="Org.OData.Core.V1.OptimisticConcurrency"
-          ><Collection><PropertyPath>Condition</PropertyPath></Collection></Annotation><Annotation
+          />
+        </EntitySet>
+        <EntitySet Name="Copies" EntityType="Library.Circulation.Copy">
+          <NavigationPropertyBinding Path="Location" Target="Branches" />
+          <NavigationPropertyBinding Path="Medium" Target="Media" />
+          <Annotation Term="Org.OData.Core.V1.OptimisticConcurrency">
+            <Collection>
+              <PropertyPath>Condition</PropertyPath>
+            </Collection>
+          </Annotation>
+          <Annotation
             Term="Org.OData.Core.V1.Description"
             String="The physical or licensed copies of a medium; what is borrowed."
-          /></EntitySet><EntitySet Name="Members" EntityType="Library.Circulation.Member"><NavigationPropertyBinding
-            Path="IdDocument"
-            Target="IdDocuments"
-          /><NavigationPropertyBinding Path="Loans" Target="Loans" /><NavigationPropertyBinding
-            Path="Reservations"
-            Target="Reservations"
-          /><Annotation Term="Org.OData.Core.V1.Description" String="Registered members." /></EntitySet><EntitySet
-          Name="Loans"
-          EntityType="Library.Circulation.Loan"
-        ><NavigationPropertyBinding Path="Copy" Target="Copies" /><NavigationPropertyBinding
-            Path="Member"
-            Target="Members"
-          /><Annotation
-            Term="Org.OData.Core.V1.Description"
-            String="Loans, open and returned alike."
-          /></EntitySet><EntitySet Name="Reservations" EntityType="Library.Circulation.Reservation" /><EntitySet
-          Name="IdDocuments"
-          EntityType="Library.Circulation.IdDocument"
-        /><EntitySet Name="Branches" EntityType="Library.Circulation.Branch" /><EntitySet
-          Name="Bookmobiles"
-          EntityType="Library.Circulation.Bookmobile"
-        ><Annotation
+          />
+        </EntitySet>
+        <EntitySet Name="Members" EntityType="Library.Circulation.Member">
+          <NavigationPropertyBinding Path="IdDocument" Target="IdDocuments" />
+          <NavigationPropertyBinding Path="Loans" Target="Loans" />
+          <NavigationPropertyBinding Path="Reservations" Target="Reservations" />
+          <Annotation Term="Org.OData.Core.V1.Description" String="Registered members." />
+        </EntitySet>
+        <EntitySet Name="Loans" EntityType="Library.Circulation.Loan">
+          <NavigationPropertyBinding Path="Copy" Target="Copies" />
+          <NavigationPropertyBinding Path="Member" Target="Members" />
+          <Annotation Term="Org.OData.Core.V1.Description" String="Loans, open and returned alike." />
+        </EntitySet>
+        <EntitySet Name="Reservations" EntityType="Library.Circulation.Reservation" />
+        <EntitySet Name="IdDocuments" EntityType="Library.Circulation.IdDocument" />
+        <EntitySet Name="Branches" EntityType="Library.Circulation.Branch" />
+        <EntitySet Name="Bookmobiles" EntityType="Library.Circulation.Bookmobile">
+          <Annotation
             Term="Org.OData.Core.V1.Description"
             String="Mobile branches, with their route and current position."
-          /></EntitySet><EntitySet Name="Publishers" EntityType="PublisherRegistry.Publisher"><NavigationPropertyBinding
-            Path="Books"
-            Target="Media"
-          /></EntitySet><EntitySet Name="PublisherBranches" EntityType="PublisherRegistry.Branch" /><Singleton
-          Name="MainBranch"
-          Type="Library.Circulation.Branch"
-        ><Annotation
+          />
+        </EntitySet>
+        <EntitySet Name="Publishers" EntityType="PublisherRegistry.Publisher">
+          <NavigationPropertyBinding Path="Books" Target="Media" />
+        </EntitySet>
+        <EntitySet Name="PublisherBranches" EntityType="PublisherRegistry.Branch" />
+        <Singleton Name="MainBranch" Type="Library.Circulation.Branch">
+          <Annotation
             Term="Org.OData.Core.V1.Description"
             String="The central branch - the one that is always there."
-          /></Singleton><FunctionImport
+          />
+        </Singleton>
+        <FunctionImport
           Name="TotalMediaCount"
           Function="Library.Circulation.TotalMediaCount"
           IncludeInServiceDocument="true"
-        /><FunctionImport
+        />
+        <FunctionImport
           Name="AllLanguages"
           Function="Library.Circulation.AllLanguages"
           IncludeInServiceDocument="true"
-        /><FunctionImport
+        />
+        <FunctionImport
           Name="LoanStatistics"
           Function="Library.Circulation.LoanStatistics"
           IncludeInServiceDocument="true"
-        /><FunctionImport
+        />
+        <FunctionImport
           Name="StatsPerBranch"
           Function="Library.Circulation.StatsPerBranch"
           IncludeInServiceDocument="true"
-        /><FunctionImport
+        />
+        <FunctionImport
           Name="MostReadMedium"
           Function="Library.Circulation.MostReadMedium"
           EntitySet="Media"
           IncludeInServiceDocument="true"
-        /><FunctionImport
+        />
+        <FunctionImport
           Name="NewReleases"
           Function="Library.Circulation.NewReleases"
           EntitySet="Media"
           IncludeInServiceDocument="true"
-        /><FunctionImport
+        />
+        <FunctionImport
           Name="Search"
           Function="Library.Circulation.Search"
           EntitySet="Media"
           IncludeInServiceDocument="true"
-        /><ActionImport Name="ClosureDay" Action="Library.Circulation.ClosureDay" /><ActionImport
-          Name="NextInventoryNumber"
-          Action="Library.Circulation.NextInventoryNumber"
-        /><ActionImport Name="CleanUpKeywords" Action="Library.Circulation.CleanUpKeywords" /><ActionImport
-          Name="YearEndClosing"
-          Action="Library.Circulation.YearEndClosing"
-        /><ActionImport Name="RunOverdueNotices" Action="Library.Circulation.RunOverdueNotices" /><ActionImport
+        />
+        <ActionImport Name="ClosureDay" Action="Library.Circulation.ClosureDay" />
+        <ActionImport Name="NextInventoryNumber" Action="Library.Circulation.NextInventoryNumber" />
+        <ActionImport Name="CleanUpKeywords" Action="Library.Circulation.CleanUpKeywords" />
+        <ActionImport Name="YearEndClosing" Action="Library.Circulation.YearEndClosing" />
+        <ActionImport Name="RunOverdueNotices" Action="Library.Circulation.RunOverdueNotices" />
+        <ActionImport
           Name="AcquireCollectorsItem"
           Action="Library.Circulation.AcquireCollectorsItem"
           EntitySet="Media"
-        /><ActionImport Name="RunStockCheck" Action="Library.Circulation.RunStockCheck" EntitySet="Media" /><Annotation
+        />
+        <ActionImport Name="RunStockCheck" Action="Library.Circulation.RunStockCheck" EntitySet="Media" />
+        <Annotation
           Term="Org.OData.Core.V1.Description"
           String="The odata2ts &quot;Library&quot; reference model, served by ASP.NET Core OData."
-        /><Annotation Term="Org.OData.Capabilities.V1.SupportedFormats"><Collection><String
-            >application/json</String></Collection></Annotation><Annotation
-          Term="Org.OData.Capabilities.V1.BatchSupported"
-          Bool="true"
-        /><Annotation Term="Org.OData.Capabilities.V1.KeyAsSegmentSupported" Bool="true" /><Annotation
-          Term="Org.OData.Capabilities.V1.QuerySegmentSupported"
-          Bool="true"
-        /><Annotation Term="Org.OData.Capabilities.V1.AsynchronousRequestsSupported" Bool="false" /><Annotation
-          Term="Org.OData.Capabilities.V1.CrossJoinSupported"
-          Bool="false"
-        /></EntityContainer></Schema></edmx:DataServices></edmx:Edmx>
+        />
+        <Annotation Term="Org.OData.Capabilities.V1.SupportedFormats">
+          <Collection>
+            <String>application/json</String>
+          </Collection>
+        </Annotation>
+        <Annotation Term="Org.OData.Capabilities.V1.BatchSupported" Bool="true" />
+        <Annotation Term="Org.OData.Capabilities.V1.KeyAsSegmentSupported" Bool="true" />
+        <Annotation Term="Org.OData.Capabilities.V1.QuerySegmentSupported" Bool="true" />
+        <Annotation Term="Org.OData.Capabilities.V1.AsynchronousRequestsSupported" Bool="false" />
+        <Annotation Term="Org.OData.Capabilities.V1.CrossJoinSupported" Bool="false" />
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/int-test/olingo-v2/resource/library-v2.xml
+++ b/int-test/olingo-v2/resource/library-v2.xml
@@ -1,1 +1,548 @@
-<?xml version="1.0" ?><edmx:Edmx xmlns:edmx="http://schemas.microsoft.com/ado/2007/06/edmx" Version="1.0"><edmx:DataServices m:DataServiceVersion="2.0" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"><Schema Namespace="Library.Catalog" xmlns="http://schemas.microsoft.com/ado/2008/09/edm"><EntityType Name="Medium" Abstract="true"><Key><PropertyRef Name="Id"></PropertyRef></Key><Property Name="Id" Type="Edm.Guid" Nullable="false" annotation:StoreGeneratedPattern="Identity" xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation" sap:creatable="false" xmlns:sap="http://www.sap.com/Protocols/SAPData" sap:updatable="false"></Property><Property Name="Title" Type="Edm.String" Nullable="false" MaxLength="200"></Property><Property Name="Language" Type="Edm.String" MaxLength="40"></Property><Property Name="PublicationDate" Type="Edm.DateTime"></Property><Property Name="PopularityScore" Type="Edm.Double" annotation:StoreGeneratedPattern="Computed" xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation" sap:creatable="false" xmlns:sap="http://www.sap.com/Protocols/SAPData" sap:updatable="false"></Property><NavigationProperty Name="Copies" Relationship="Library.Circulation.Medium_Copies" FromRole="Medium" ToRole="Copy"></NavigationProperty></EntityType><EntityType Name="PrintMedium" BaseType="Library.Catalog.Medium" Abstract="true"><Property Name="ISBN" Type="Edm.String" MaxLength="13"></Property></EntityType><EntityType Name="Book" BaseType="Library.Catalog.PrintMedium"><Property Name="PageCount" Type="Edm.Int16"></Property><Property Name="AgeRating" Type="Edm.Byte"></Property><NavigationProperty Name="Publisher" Relationship="Library.Catalog.Book_Publisher" FromRole="Book" ToRole="Publisher"></NavigationProperty></EntityType><EntityType Name="Magazine" BaseType="Library.Catalog.PrintMedium"><Property Name="IssueNumber" Type="Edm.Int32"></Property></EntityType><EntityType Name="TradeJournal" BaseType="Library.Catalog.Magazine"><Property Name="Field" Type="Edm.String"></Property></EntityType><EntityType Name="AudioMedium" BaseType="Library.Catalog.Medium" Abstract="true"><Property Name="Duration" Type="Edm.Time"></Property></EntityType><EntityType Name="Audiobook" BaseType="Library.Catalog.AudioMedium"><Property Name="Narrator" Type="Edm.String"></Property><NavigationProperty Name="Chapters" Relationship="Library.Catalog.Audiobook_Chapters" FromRole="Audiobook" ToRole="Chapter"></NavigationProperty></EntityType><EntityType Name="AudiobookChapter" m:HasStream="true"><Key><PropertyRef Name="Id"></PropertyRef></Key><Property Name="Id" Type="Edm.Int32" Nullable="false" annotation:StoreGeneratedPattern="Identity" xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation" sap:creatable="false" xmlns:sap="http://www.sap.com/Protocols/SAPData" sap:updatable="false"></Property><Property Name="Title" Type="Edm.String"></Property><NavigationProperty Name="Audiobook" Relationship="Library.Catalog.Audiobook_Chapters" FromRole="Chapter" ToRole="Audiobook"></NavigationProperty></EntityType><EntityType Name="DVD" BaseType="Library.Catalog.AudioMedium"><Property Name="RegionCode" Type="Edm.Byte"></Property></EntityType><EntityType Name="EBook" BaseType="Library.Catalog.Medium" m:HasStream="true"><Property Name="FileFormat" Type="Edm.String" MaxLength="20"></Property></EntityType><ComplexType Name="Address" Abstract="true"><Property Name="Street" Type="Edm.String" MaxLength="120"></Property><Property Name="City" Type="Edm.String" MaxLength="80"></Property></ComplexType><ComplexType Name="PostalAddress" BaseType="Library.Catalog.Address"><Property Name="PostalCode" Type="Edm.String" MaxLength="10"></Property><Property Name="Country" Type="Edm.String" MaxLength="60"></Property></ComplexType><ComplexType Name="ConditionReport"><Property Name="ConditionBefore" Type="Edm.Byte"></Property><Property Name="ConditionAfter" Type="Edm.Byte"></Property><Property Name="Remark" Type="Edm.String"></Property></ComplexType><ComplexType Name="MediumStats"><Property Name="TotalLoanCount" Type="Edm.Int64"></Property><Property Name="AverageLoanDuration" Type="Edm.Time"></Property></ComplexType><Association Name="Book_Publisher"><End Type="Library.Catalog.Book" Multiplicity="*" Role="Book"></End><End Type="PublisherRegistry.Publisher" Multiplicity="0..1" Role="Publisher"></End></Association><Association Name="Audiobook_Chapters"><End Type="Library.Catalog.Audiobook" Multiplicity="1" Role="Audiobook"></End><End Type="Library.Catalog.AudiobookChapter" Multiplicity="*" Role="Chapter"></End></Association></Schema><Schema Namespace="Library.Circulation" xmlns="http://schemas.microsoft.com/ado/2008/09/edm"><EntityType Name="Member"><Key><PropertyRef Name="Id"></PropertyRef></Key><Property Name="Id" Type="Edm.Int32" Nullable="false" annotation:StoreGeneratedPattern="Identity" xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation" sap:creatable="false" xmlns:sap="http://www.sap.com/Protocols/SAPData" sap:updatable="false"></Property><Property Name="Name" Type="Edm.String" Nullable="false" MaxLength="100"></Property><Property Name="DateOfBirth" Type="Edm.DateTime"></Property><Property Name="Address" Type="Library.Catalog.PostalAddress"></Property><Property Name="ActiveSince" Type="Edm.DateTimeOffset" Precision="7"></Property><Property Name="Balance" Type="Edm.Decimal" Precision="9" Scale="2"></Property><NavigationProperty Name="Loans" Relationship="Library.Circulation.Member_Loans" FromRole="Member" ToRole="Loan"></NavigationProperty><NavigationProperty Name="Reservations" Relationship="Library.Circulation.Member_Reservations" FromRole="Member" ToRole="Reservation"></NavigationProperty><NavigationProperty Name="IdDocument" Relationship="Library.Circulation.Member_IdDocument" FromRole="Member" ToRole="IdDocument"></NavigationProperty></EntityType><EntityType Name="Copy"><Key><PropertyRef Name="MediumId"></PropertyRef><PropertyRef Name="InventoryNumber"></PropertyRef></Key><Property Name="MediumId" Type="Edm.Guid" Nullable="false"></Property><Property Name="InventoryNumber" Type="Edm.Int32" Nullable="false"></Property><Property Name="Condition" Type="Edm.Byte" ConcurrencyMode="Fixed"></Property><Property Name="IsLoanable" Type="Edm.Boolean" Nullable="false" DefaultValue="true"></Property><Property Name="Status" Type="Edm.Byte"></Property><Property Name="AcquisitionDate" Type="Edm.DateTime"></Property><Property Name="WeightKg" Type="Edm.Single"></Property><Property Name="Location_" Type="Edm.String" MaxLength="10" Unicode="false"></Property><NavigationProperty Name="Medium" Relationship="Library.Circulation.Medium_Copies" FromRole="Copy" ToRole="Medium"></NavigationProperty><NavigationProperty Name="Location" Relationship="Library.Circulation.Copy_Location" FromRole="Copy" ToRole="Branch"></NavigationProperty></EntityType><EntityType Name="Loan"><Key><PropertyRef Name="Id"></PropertyRef></Key><Property Name="Id" Type="Edm.Guid" Nullable="false" annotation:StoreGeneratedPattern="Identity" xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation" sap:creatable="false" xmlns:sap="http://www.sap.com/Protocols/SAPData" sap:updatable="false"></Property><Property Name="LoanedAt" Type="Edm.DateTimeOffset" Nullable="false" Precision="7" sap:updatable="false" xmlns:sap="http://www.sap.com/Protocols/SAPData"></Property><Property Name="DueDate" Type="Edm.DateTime" Nullable="false"></Property><Property Name="ReturnedAt" Type="Edm.DateTimeOffset" Precision="7"></Property><Property Name="LateFee" Type="Edm.Decimal" Precision="5" Scale="2"></Property><NavigationProperty Name="Member" Relationship="Library.Circulation.Member_Loans" FromRole="Loan" ToRole="Member"></NavigationProperty><NavigationProperty Name="Copy" Relationship="Library.Circulation.Loan_Copy" FromRole="Loan" ToRole="Copy"></NavigationProperty></EntityType><EntityType Name="Reservation"><Key><PropertyRef Name="Id"></PropertyRef></Key><Property Name="Id" Type="Edm.Guid" Nullable="false" annotation:StoreGeneratedPattern="Identity" xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation" sap:creatable="false" xmlns:sap="http://www.sap.com/Protocols/SAPData" sap:updatable="false"></Property><Property Name="ReservedAt" Type="Edm.DateTimeOffset" Precision="7"></Property></EntityType><EntityType Name="IdDocument"><Key><PropertyRef Name="Id"></PropertyRef></Key><Property Name="Id" Type="Edm.Guid" Nullable="false" annotation:StoreGeneratedPattern="Identity" xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation" sap:creatable="false" xmlns:sap="http://www.sap.com/Protocols/SAPData" sap:updatable="false"></Property><Property Name="Scan" Type="Edm.Binary"></Property><Property Name="UploadedAt" Type="Edm.DateTimeOffset" Precision="7"></Property></EntityType><EntityType Name="Branch"><Key><PropertyRef Name="Id"></PropertyRef></Key><Property Name="Id" Type="Edm.Int32" Nullable="false"></Property><Property Name="Name" Type="Edm.String" Nullable="false" MaxLength="100"></Property><Property Name="Address" Type="Library.Catalog.PostalAddress"></Property><Property Name="LowestFloor" Type="Edm.SByte"></Property><Property Name="OpensAt" Type="Edm.Time"></Property><Property Name="ClosesAt" Type="Edm.Time"></Property><Property Name="Amenities" Type="Edm.Int32"></Property><Property Name="Population" Type="Edm.Int64"></Property></EntityType><ComplexType Name="OverdueNotice"><Property Name="Reason" Type="Edm.String"></Property><Property Name="Amount" Type="Edm.Decimal" Precision="5" Scale="2"></Property><Property Name="CreatedAt" Type="Edm.DateTimeOffset" Precision="7"></Property></ComplexType><ComplexType Name="LoanStats"><Property Name="TotalLoans" Type="Edm.Int64"></Property><Property Name="AverageLoanDuration" Type="Edm.Time"></Property></ComplexType><ComplexType Name="BranchStats"><Property Name="BranchId" Type="Edm.Int32"></Property><Property Name="LoanCount" Type="Edm.Int64"></Property></ComplexType><ComplexType Name="AnnualReport"><Property Name="Year" Type="Edm.Int32"></Property><Property Name="TotalLoans" Type="Edm.Int64"></Property><Property Name="TotalLateFees" Type="Edm.Decimal" Precision="12" Scale="2"></Property></ComplexType><Association Name="Medium_Copies"><End Type="Library.Catalog.Medium" Multiplicity="1" Role="Medium"></End><End Type="Library.Circulation.Copy" Multiplicity="*" Role="Copy"></End><ReferentialConstraint><Principal Role="Medium"><PropertyRef Name="Id"></PropertyRef></Principal><Dependent Role="Copy"><PropertyRef Name="MediumId"></PropertyRef></Dependent></ReferentialConstraint></Association><Association Name="Member_Loans"><End Type="Library.Circulation.Member" Multiplicity="1" Role="Member"><OnDelete Action="Cascade"></OnDelete></End><End Type="Library.Circulation.Loan" Multiplicity="*" Role="Loan"></End></Association><Association Name="Member_Reservations"><End Type="Library.Circulation.Member" Multiplicity="0..1" Role="Member"></End><End Type="Library.Circulation.Reservation" Multiplicity="*" Role="Reservation"></End></Association><Association Name="Member_IdDocument"><End Type="Library.Circulation.Member" Multiplicity="0..1" Role="Member"></End><End Type="Library.Circulation.IdDocument" Multiplicity="0..1" Role="IdDocument"></End></Association><Association Name="Copy_Location"><End Type="Library.Circulation.Copy" Multiplicity="*" Role="Copy"></End><End Type="Library.Circulation.Branch" Multiplicity="0..1" Role="Branch"></End></Association><Association Name="Loan_Copy"><End Type="Library.Circulation.Loan" Multiplicity="*" Role="Loan"></End><End Type="Library.Circulation.Copy" Multiplicity="1" Role="Copy"></End></Association></Schema><Schema Namespace="PublisherRegistry" xmlns="http://schemas.microsoft.com/ado/2008/09/edm"><EntityType Name="Publisher"><Key><PropertyRef Name="Id"></PropertyRef></Key><Property Name="Id" Type="Edm.Int32" Nullable="false" annotation:StoreGeneratedPattern="Identity" xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation" sap:creatable="false" xmlns:sap="http://www.sap.com/Protocols/SAPData" sap:updatable="false"></Property><Property Name="Name" Type="Edm.String" Nullable="false" MaxLength="100"></Property><Property Name="Country" Type="Edm.String" MaxLength="60"></Property><Property Name="Founded" Type="Edm.DateTime"></Property><NavigationProperty Name="Books" Relationship="Library.Catalog.Book_Publisher" FromRole="Publisher" ToRole="Book"></NavigationProperty></EntityType><EntityType Name="Branch"><Key><PropertyRef Name="Id"></PropertyRef></Key><Property Name="Id" Type="Edm.Int32" Nullable="false" annotation:StoreGeneratedPattern="Identity" xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation" sap:creatable="false" xmlns:sap="http://www.sap.com/Protocols/SAPData" sap:updatable="false"></Property><Property Name="City" Type="Edm.String" MaxLength="80"></Property><Property Name="Country" Type="Edm.String" MaxLength="60"></Property></EntityType></Schema><Schema Namespace="Library.Service" xmlns="http://schemas.microsoft.com/ado/2008/09/edm"><EntityContainer Name="LibraryService" m:IsDefaultEntityContainer="true"><EntitySet Name="Books" EntityType="Library.Catalog.Book"></EntitySet><EntitySet Name="Magazines" EntityType="Library.Catalog.Magazine"></EntitySet><EntitySet Name="TradeJournals" EntityType="Library.Catalog.TradeJournal"></EntitySet><EntitySet Name="Audiobooks" EntityType="Library.Catalog.Audiobook"></EntitySet><EntitySet Name="AudiobookChapters" EntityType="Library.Catalog.AudiobookChapter"></EntitySet><EntitySet Name="DVDs" EntityType="Library.Catalog.DVD"></EntitySet><EntitySet Name="EBooks" EntityType="Library.Catalog.EBook"></EntitySet><EntitySet Name="Copies" EntityType="Library.Circulation.Copy"></EntitySet><EntitySet Name="Members" EntityType="Library.Circulation.Member"></EntitySet><EntitySet Name="Loans" EntityType="Library.Circulation.Loan"></EntitySet><EntitySet Name="Reservations" EntityType="Library.Circulation.Reservation"></EntitySet><EntitySet Name="IdDocuments" EntityType="Library.Circulation.IdDocument"></EntitySet><EntitySet Name="Branches" EntityType="Library.Circulation.Branch"></EntitySet><EntitySet Name="Publishers" EntityType="PublisherRegistry.Publisher"></EntitySet><EntitySet Name="PublisherBranches" EntityType="PublisherRegistry.Branch"></EntitySet><AssociationSet Name="Medium_Copies_Books" Association="Library.Circulation.Medium_Copies"><End EntitySet="Books" Role="Medium"></End><End EntitySet="Copies" Role="Copy"></End></AssociationSet><AssociationSet Name="Medium_Copies_Magazines" Association="Library.Circulation.Medium_Copies"><End EntitySet="Magazines" Role="Medium"></End><End EntitySet="Copies" Role="Copy"></End></AssociationSet><AssociationSet Name="Medium_Copies_TradeJournals" Association="Library.Circulation.Medium_Copies"><End EntitySet="TradeJournals" Role="Medium"></End><End EntitySet="Copies" Role="Copy"></End></AssociationSet><AssociationSet Name="Medium_Copies_Audiobooks" Association="Library.Circulation.Medium_Copies"><End EntitySet="Audiobooks" Role="Medium"></End><End EntitySet="Copies" Role="Copy"></End></AssociationSet><AssociationSet Name="Medium_Copies_DVDs" Association="Library.Circulation.Medium_Copies"><End EntitySet="DVDs" Role="Medium"></End><End EntitySet="Copies" Role="Copy"></End></AssociationSet><AssociationSet Name="Medium_Copies_EBooks" Association="Library.Circulation.Medium_Copies"><End EntitySet="EBooks" Role="Medium"></End><End EntitySet="Copies" Role="Copy"></End></AssociationSet><AssociationSet Name="Book_Publisher" Association="Library.Catalog.Book_Publisher"><End EntitySet="Books" Role="Book"></End><End EntitySet="Publishers" Role="Publisher"></End></AssociationSet><AssociationSet Name="Audiobook_Chapters" Association="Library.Catalog.Audiobook_Chapters"><End EntitySet="Audiobooks" Role="Audiobook"></End><End EntitySet="AudiobookChapters" Role="Chapter"></End></AssociationSet><AssociationSet Name="Member_Loans" Association="Library.Circulation.Member_Loans"><End EntitySet="Members" Role="Member"></End><End EntitySet="Loans" Role="Loan"></End></AssociationSet><AssociationSet Name="Member_Reservations" Association="Library.Circulation.Member_Reservations"><End EntitySet="Members" Role="Member"></End><End EntitySet="Reservations" Role="Reservation"></End></AssociationSet><AssociationSet Name="Member_IdDocument" Association="Library.Circulation.Member_IdDocument"><End EntitySet="Members" Role="Member"></End><End EntitySet="IdDocuments" Role="IdDocument"></End></AssociationSet><AssociationSet Name="Copy_Location" Association="Library.Circulation.Copy_Location"><End EntitySet="Copies" Role="Copy"></End><End EntitySet="Branches" Role="Branch"></End></AssociationSet><AssociationSet Name="Loan_Copy" Association="Library.Circulation.Loan_Copy"><End EntitySet="Loans" Role="Loan"></End><End EntitySet="Copies" Role="Copy"></End></AssociationSet><FunctionImport Name="TotalMediaCount" ReturnType="Edm.Int64" m:HttpMethod="GET"></FunctionImport><FunctionImport Name="AllLanguages" ReturnType="Collection(Edm.String)" m:HttpMethod="GET"></FunctionImport><FunctionImport Name="LoanStatistics" ReturnType="Library.Circulation.LoanStats" m:HttpMethod="GET"><Parameter Name="From" Type="Edm.DateTime" Mode="In" Nullable="true"></Parameter><Parameter Name="To" Type="Edm.DateTime" Mode="In" Nullable="true"></Parameter></FunctionImport><FunctionImport Name="StatsPerBranch" ReturnType="Collection(Library.Circulation.BranchStats)" m:HttpMethod="GET"></FunctionImport><FunctionImport Name="MostReadMedium" ReturnType="Library.Catalog.Book" EntitySet="Books" m:HttpMethod="GET"></FunctionImport><FunctionImport Name="NewReleases" ReturnType="Collection(Library.Catalog.Book)" EntitySet="Books" m:HttpMethod="GET"></FunctionImport><FunctionImport Name="Search" ReturnType="Collection(Library.Catalog.Book)" EntitySet="Books" m:HttpMethod="GET"><Parameter Name="Term" Type="Edm.String" Mode="In" Nullable="false"></Parameter><Parameter Name="MaxResults" Type="Edm.Int32" Mode="In" Nullable="true"></Parameter></FunctionImport><FunctionImport Name="OutstandingBalance" ReturnType="Edm.Decimal" m:HttpMethod="GET"><Parameter Name="MemberId" Type="Edm.Int32" Mode="In" Nullable="false"></Parameter></FunctionImport><FunctionImport Name="NoticeHistory" ReturnType="Collection(Library.Circulation.OverdueNotice)" m:HttpMethod="GET"><Parameter Name="MemberId" Type="Edm.Int32" Mode="In" Nullable="false"></Parameter></FunctionImport><FunctionImport Name="LoanMetrics" ReturnType="Library.Catalog.MediumStats" m:HttpMethod="GET"><Parameter Name="MediumId" Type="Edm.Guid" Mode="In" Nullable="false"></Parameter></FunctionImport><FunctionImport Name="AvailableLanguages" ReturnType="Collection(Edm.String)" m:HttpMethod="GET"></FunctionImport><FunctionImport Name="AvailableCopy" ReturnType="Library.Circulation.Copy" EntitySet="Copies" m:HttpMethod="GET"><Parameter Name="MediumId" Type="Edm.Guid" Mode="In" Nullable="false"></Parameter></FunctionImport><FunctionImport Name="AvailableCopies" ReturnType="Collection(Library.Circulation.Copy)" EntitySet="Copies" m:HttpMethod="GET"><Parameter Name="MediumId" Type="Edm.Guid" Mode="In" Nullable="false"></Parameter></FunctionImport><FunctionImport Name="ClosureDay" m:HttpMethod="POST"><Parameter Name="Day" Type="Edm.DateTime" Mode="In" Nullable="false"></Parameter></FunctionImport><FunctionImport Name="NextInventoryNumber" ReturnType="Edm.Int32" m:HttpMethod="POST"></FunctionImport><FunctionImport Name="CleanUpKeywords" ReturnType="Collection(Edm.String)" m:HttpMethod="POST"></FunctionImport><FunctionImport Name="YearEndClosing" ReturnType="Library.Circulation.AnnualReport" m:HttpMethod="POST"><Parameter Name="Year" Type="Edm.Int32" Mode="In" Nullable="false"></Parameter></FunctionImport><FunctionImport Name="RunOverdueNotices" ReturnType="Collection(Library.Circulation.OverdueNotice)" m:HttpMethod="POST"></FunctionImport><FunctionImport Name="RunStockCheck" ReturnType="Collection(Library.Catalog.Book)" EntitySet="Books" m:HttpMethod="POST"></FunctionImport><FunctionImport Name="CheckOut" m:HttpMethod="POST"><Parameter Name="MediumId" Type="Edm.Guid" Mode="In" Nullable="false"></Parameter><Parameter Name="InventoryNumber" Type="Edm.Int32" Mode="In" Nullable="false"></Parameter><Parameter Name="MemberId" Type="Edm.Int32" Mode="In" Nullable="false"></Parameter></FunctionImport><FunctionImport Name="AssessCondition" ReturnType="Library.Catalog.ConditionReport" m:HttpMethod="POST"><Parameter Name="MediumId" Type="Edm.Guid" Mode="In" Nullable="false"></Parameter><Parameter Name="InventoryNumber" Type="Edm.Int32" Mode="In" Nullable="false"></Parameter><Parameter Name="NewCondition" Type="Edm.Byte" Mode="In" Nullable="false"></Parameter><Parameter Name="Remark" Type="Edm.String" Mode="In" Nullable="true"></Parameter></FunctionImport><FunctionImport Name="Reserve" ReturnType="Edm.Int32" m:HttpMethod="POST"><Parameter Name="MediumId" Type="Edm.Guid" Mode="In" Nullable="false"></Parameter><Parameter Name="MemberId" Type="Edm.Int32" Mode="In" Nullable="false"></Parameter></FunctionImport><FunctionImport Name="RunReminders" ReturnType="Collection(Library.Circulation.OverdueNotice)" m:HttpMethod="POST"><Parameter Name="MemberId" Type="Edm.Int32" Mode="In" Nullable="false"></Parameter></FunctionImport><FunctionImport Name="Renew" ReturnType="Library.Circulation.Loan" EntitySet="Loans" m:HttpMethod="POST"><Parameter Name="LoanId" Type="Edm.Guid" Mode="In" Nullable="false"></Parameter></FunctionImport><FunctionImport Name="RenewAll" ReturnType="Collection(Library.Circulation.Loan)" EntitySet="Loans" m:HttpMethod="POST"><Parameter Name="MemberId" Type="Edm.Int32" Mode="In" Nullable="false"></Parameter></FunctionImport><FunctionImport Name="BulkRenew" ReturnType="Collection(Edm.String)" m:HttpMethod="POST"></FunctionImport></EntityContainer></Schema></edmx:DataServices></edmx:Edmx>
+<?xml version="1.0" ?>
+<edmx:Edmx xmlns:edmx="http://schemas.microsoft.com/ado/2007/06/edmx" Version="1.0">
+  <edmx:DataServices
+    m:DataServiceVersion="2.0"
+    xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"
+  >
+    <Schema Namespace="Library.Catalog" xmlns="http://schemas.microsoft.com/ado/2008/09/edm">
+      <EntityType Name="Medium" Abstract="true">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property
+          Name="Id"
+          Type="Edm.Guid"
+          Nullable="false"
+          annotation:StoreGeneratedPattern="Identity"
+          xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation"
+          sap:creatable="false"
+          xmlns:sap="http://www.sap.com/Protocols/SAPData"
+          sap:updatable="false"
+        />
+        <Property Name="Title" Type="Edm.String" Nullable="false" MaxLength="200" />
+        <Property Name="Language" Type="Edm.String" MaxLength="40" />
+        <Property Name="PublicationDate" Type="Edm.DateTime" />
+        <Property
+          Name="PopularityScore"
+          Type="Edm.Double"
+          annotation:StoreGeneratedPattern="Computed"
+          xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation"
+          sap:creatable="false"
+          xmlns:sap="http://www.sap.com/Protocols/SAPData"
+          sap:updatable="false"
+        />
+        <NavigationProperty
+          Name="Copies"
+          Relationship="Library.Circulation.Medium_Copies"
+          FromRole="Medium"
+          ToRole="Copy"
+        />
+      </EntityType>
+      <EntityType Name="PrintMedium" BaseType="Library.Catalog.Medium" Abstract="true">
+        <Property Name="ISBN" Type="Edm.String" MaxLength="13" />
+      </EntityType>
+      <EntityType Name="Book" BaseType="Library.Catalog.PrintMedium">
+        <Property Name="PageCount" Type="Edm.Int16" />
+        <Property Name="AgeRating" Type="Edm.Byte" />
+        <NavigationProperty
+          Name="Publisher"
+          Relationship="Library.Catalog.Book_Publisher"
+          FromRole="Book"
+          ToRole="Publisher"
+        />
+      </EntityType>
+      <EntityType Name="Magazine" BaseType="Library.Catalog.PrintMedium">
+        <Property Name="IssueNumber" Type="Edm.Int32" />
+      </EntityType>
+      <EntityType Name="TradeJournal" BaseType="Library.Catalog.Magazine">
+        <Property Name="Field" Type="Edm.String" />
+      </EntityType>
+      <EntityType Name="AudioMedium" BaseType="Library.Catalog.Medium" Abstract="true">
+        <Property Name="Duration" Type="Edm.Time" />
+      </EntityType>
+      <EntityType Name="Audiobook" BaseType="Library.Catalog.AudioMedium">
+        <Property Name="Narrator" Type="Edm.String" />
+        <NavigationProperty
+          Name="Chapters"
+          Relationship="Library.Catalog.Audiobook_Chapters"
+          FromRole="Audiobook"
+          ToRole="Chapter"
+        />
+      </EntityType>
+      <EntityType Name="AudiobookChapter" m:HasStream="true">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property
+          Name="Id"
+          Type="Edm.Int32"
+          Nullable="false"
+          annotation:StoreGeneratedPattern="Identity"
+          xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation"
+          sap:creatable="false"
+          xmlns:sap="http://www.sap.com/Protocols/SAPData"
+          sap:updatable="false"
+        />
+        <Property Name="Title" Type="Edm.String" />
+        <NavigationProperty
+          Name="Audiobook"
+          Relationship="Library.Catalog.Audiobook_Chapters"
+          FromRole="Chapter"
+          ToRole="Audiobook"
+        />
+      </EntityType>
+      <EntityType Name="DVD" BaseType="Library.Catalog.AudioMedium">
+        <Property Name="RegionCode" Type="Edm.Byte" />
+      </EntityType>
+      <EntityType Name="EBook" BaseType="Library.Catalog.Medium" m:HasStream="true">
+        <Property Name="FileFormat" Type="Edm.String" MaxLength="20" />
+      </EntityType>
+      <ComplexType Name="Address" Abstract="true">
+        <Property Name="Street" Type="Edm.String" MaxLength="120" />
+        <Property Name="City" Type="Edm.String" MaxLength="80" />
+      </ComplexType>
+      <ComplexType Name="PostalAddress" BaseType="Library.Catalog.Address">
+        <Property Name="PostalCode" Type="Edm.String" MaxLength="10" />
+        <Property Name="Country" Type="Edm.String" MaxLength="60" />
+      </ComplexType>
+      <ComplexType Name="ConditionReport">
+        <Property Name="ConditionBefore" Type="Edm.Byte" />
+        <Property Name="ConditionAfter" Type="Edm.Byte" />
+        <Property Name="Remark" Type="Edm.String" />
+      </ComplexType>
+      <ComplexType Name="MediumStats">
+        <Property Name="TotalLoanCount" Type="Edm.Int64" />
+        <Property Name="AverageLoanDuration" Type="Edm.Time" />
+      </ComplexType>
+      <Association Name="Book_Publisher">
+        <End Type="Library.Catalog.Book" Multiplicity="*" Role="Book" />
+        <End Type="PublisherRegistry.Publisher" Multiplicity="0..1" Role="Publisher" />
+      </Association>
+      <Association Name="Audiobook_Chapters">
+        <End Type="Library.Catalog.Audiobook" Multiplicity="1" Role="Audiobook" />
+        <End Type="Library.Catalog.AudiobookChapter" Multiplicity="*" Role="Chapter" />
+      </Association>
+    </Schema>
+    <Schema Namespace="Library.Circulation" xmlns="http://schemas.microsoft.com/ado/2008/09/edm">
+      <EntityType Name="Member">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property
+          Name="Id"
+          Type="Edm.Int32"
+          Nullable="false"
+          annotation:StoreGeneratedPattern="Identity"
+          xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation"
+          sap:creatable="false"
+          xmlns:sap="http://www.sap.com/Protocols/SAPData"
+          sap:updatable="false"
+        />
+        <Property Name="Name" Type="Edm.String" Nullable="false" MaxLength="100" />
+        <Property Name="DateOfBirth" Type="Edm.DateTime" />
+        <Property Name="Address" Type="Library.Catalog.PostalAddress" />
+        <Property Name="ActiveSince" Type="Edm.DateTimeOffset" Precision="7" />
+        <Property Name="Balance" Type="Edm.Decimal" Precision="9" Scale="2" />
+        <NavigationProperty
+          Name="Loans"
+          Relationship="Library.Circulation.Member_Loans"
+          FromRole="Member"
+          ToRole="Loan"
+        />
+        <NavigationProperty
+          Name="Reservations"
+          Relationship="Library.Circulation.Member_Reservations"
+          FromRole="Member"
+          ToRole="Reservation"
+        />
+        <NavigationProperty
+          Name="IdDocument"
+          Relationship="Library.Circulation.Member_IdDocument"
+          FromRole="Member"
+          ToRole="IdDocument"
+        />
+      </EntityType>
+      <EntityType Name="Copy">
+        <Key>
+          <PropertyRef Name="MediumId" />
+          <PropertyRef Name="InventoryNumber" />
+        </Key>
+        <Property Name="MediumId" Type="Edm.Guid" Nullable="false" />
+        <Property Name="InventoryNumber" Type="Edm.Int32" Nullable="false" />
+        <Property Name="Condition" Type="Edm.Byte" ConcurrencyMode="Fixed" />
+        <Property Name="IsLoanable" Type="Edm.Boolean" Nullable="false" DefaultValue="true" />
+        <Property Name="Status" Type="Edm.Byte" />
+        <Property Name="AcquisitionDate" Type="Edm.DateTime" />
+        <Property Name="WeightKg" Type="Edm.Single" />
+        <Property Name="Location_" Type="Edm.String" MaxLength="10" Unicode="false" />
+        <NavigationProperty
+          Name="Medium"
+          Relationship="Library.Circulation.Medium_Copies"
+          FromRole="Copy"
+          ToRole="Medium"
+        />
+        <NavigationProperty
+          Name="Location"
+          Relationship="Library.Circulation.Copy_Location"
+          FromRole="Copy"
+          ToRole="Branch"
+        />
+      </EntityType>
+      <EntityType Name="Loan">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property
+          Name="Id"
+          Type="Edm.Guid"
+          Nullable="false"
+          annotation:StoreGeneratedPattern="Identity"
+          xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation"
+          sap:creatable="false"
+          xmlns:sap="http://www.sap.com/Protocols/SAPData"
+          sap:updatable="false"
+        />
+        <Property
+          Name="LoanedAt"
+          Type="Edm.DateTimeOffset"
+          Nullable="false"
+          Precision="7"
+          sap:updatable="false"
+          xmlns:sap="http://www.sap.com/Protocols/SAPData"
+        />
+        <Property Name="DueDate" Type="Edm.DateTime" Nullable="false" />
+        <Property Name="ReturnedAt" Type="Edm.DateTimeOffset" Precision="7" />
+        <Property Name="LateFee" Type="Edm.Decimal" Precision="5" Scale="2" />
+        <NavigationProperty
+          Name="Member"
+          Relationship="Library.Circulation.Member_Loans"
+          FromRole="Loan"
+          ToRole="Member"
+        />
+        <NavigationProperty Name="Copy" Relationship="Library.Circulation.Loan_Copy" FromRole="Loan" ToRole="Copy" />
+      </EntityType>
+      <EntityType Name="Reservation">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property
+          Name="Id"
+          Type="Edm.Guid"
+          Nullable="false"
+          annotation:StoreGeneratedPattern="Identity"
+          xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation"
+          sap:creatable="false"
+          xmlns:sap="http://www.sap.com/Protocols/SAPData"
+          sap:updatable="false"
+        />
+        <Property Name="ReservedAt" Type="Edm.DateTimeOffset" Precision="7" />
+      </EntityType>
+      <EntityType Name="IdDocument">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property
+          Name="Id"
+          Type="Edm.Guid"
+          Nullable="false"
+          annotation:StoreGeneratedPattern="Identity"
+          xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation"
+          sap:creatable="false"
+          xmlns:sap="http://www.sap.com/Protocols/SAPData"
+          sap:updatable="false"
+        />
+        <Property Name="Scan" Type="Edm.Binary" />
+        <Property Name="UploadedAt" Type="Edm.DateTimeOffset" Precision="7" />
+      </EntityType>
+      <EntityType Name="Branch">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false" />
+        <Property Name="Name" Type="Edm.String" Nullable="false" MaxLength="100" />
+        <Property Name="Address" Type="Library.Catalog.PostalAddress" />
+        <Property Name="LowestFloor" Type="Edm.SByte" />
+        <Property Name="OpensAt" Type="Edm.Time" />
+        <Property Name="ClosesAt" Type="Edm.Time" />
+        <Property Name="Amenities" Type="Edm.Int32" />
+        <Property Name="Population" Type="Edm.Int64" />
+      </EntityType>
+      <ComplexType Name="OverdueNotice">
+        <Property Name="Reason" Type="Edm.String" />
+        <Property Name="Amount" Type="Edm.Decimal" Precision="5" Scale="2" />
+        <Property Name="CreatedAt" Type="Edm.DateTimeOffset" Precision="7" />
+      </ComplexType>
+      <ComplexType Name="LoanStats">
+        <Property Name="TotalLoans" Type="Edm.Int64" />
+        <Property Name="AverageLoanDuration" Type="Edm.Time" />
+      </ComplexType>
+      <ComplexType Name="BranchStats">
+        <Property Name="BranchId" Type="Edm.Int32" />
+        <Property Name="LoanCount" Type="Edm.Int64" />
+      </ComplexType>
+      <ComplexType Name="AnnualReport">
+        <Property Name="Year" Type="Edm.Int32" />
+        <Property Name="TotalLoans" Type="Edm.Int64" />
+        <Property Name="TotalLateFees" Type="Edm.Decimal" Precision="12" Scale="2" />
+      </ComplexType>
+      <Association Name="Medium_Copies">
+        <End Type="Library.Catalog.Medium" Multiplicity="1" Role="Medium" />
+        <End Type="Library.Circulation.Copy" Multiplicity="*" Role="Copy" />
+        <ReferentialConstraint>
+          <Principal Role="Medium">
+            <PropertyRef Name="Id" />
+          </Principal>
+          <Dependent Role="Copy">
+            <PropertyRef Name="MediumId" />
+          </Dependent>
+        </ReferentialConstraint>
+      </Association>
+      <Association Name="Member_Loans">
+        <End Type="Library.Circulation.Member" Multiplicity="1" Role="Member">
+          <OnDelete Action="Cascade" />
+        </End>
+        <End Type="Library.Circulation.Loan" Multiplicity="*" Role="Loan" />
+      </Association>
+      <Association Name="Member_Reservations">
+        <End Type="Library.Circulation.Member" Multiplicity="0..1" Role="Member" />
+        <End Type="Library.Circulation.Reservation" Multiplicity="*" Role="Reservation" />
+      </Association>
+      <Association Name="Member_IdDocument">
+        <End Type="Library.Circulation.Member" Multiplicity="0..1" Role="Member" />
+        <End Type="Library.Circulation.IdDocument" Multiplicity="0..1" Role="IdDocument" />
+      </Association>
+      <Association Name="Copy_Location">
+        <End Type="Library.Circulation.Copy" Multiplicity="*" Role="Copy" />
+        <End Type="Library.Circulation.Branch" Multiplicity="0..1" Role="Branch" />
+      </Association>
+      <Association Name="Loan_Copy">
+        <End Type="Library.Circulation.Loan" Multiplicity="*" Role="Loan" />
+        <End Type="Library.Circulation.Copy" Multiplicity="1" Role="Copy" />
+      </Association>
+    </Schema>
+    <Schema Namespace="PublisherRegistry" xmlns="http://schemas.microsoft.com/ado/2008/09/edm">
+      <EntityType Name="Publisher">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property
+          Name="Id"
+          Type="Edm.Int32"
+          Nullable="false"
+          annotation:StoreGeneratedPattern="Identity"
+          xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation"
+          sap:creatable="false"
+          xmlns:sap="http://www.sap.com/Protocols/SAPData"
+          sap:updatable="false"
+        />
+        <Property Name="Name" Type="Edm.String" Nullable="false" MaxLength="100" />
+        <Property Name="Country" Type="Edm.String" MaxLength="60" />
+        <Property Name="Founded" Type="Edm.DateTime" />
+        <NavigationProperty
+          Name="Books"
+          Relationship="Library.Catalog.Book_Publisher"
+          FromRole="Publisher"
+          ToRole="Book"
+        />
+      </EntityType>
+      <EntityType Name="Branch">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property
+          Name="Id"
+          Type="Edm.Int32"
+          Nullable="false"
+          annotation:StoreGeneratedPattern="Identity"
+          xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation"
+          sap:creatable="false"
+          xmlns:sap="http://www.sap.com/Protocols/SAPData"
+          sap:updatable="false"
+        />
+        <Property Name="City" Type="Edm.String" MaxLength="80" />
+        <Property Name="Country" Type="Edm.String" MaxLength="60" />
+      </EntityType>
+    </Schema>
+    <Schema Namespace="Library.Service" xmlns="http://schemas.microsoft.com/ado/2008/09/edm">
+      <EntityContainer Name="LibraryService" m:IsDefaultEntityContainer="true">
+        <EntitySet Name="Books" EntityType="Library.Catalog.Book" />
+        <EntitySet Name="Magazines" EntityType="Library.Catalog.Magazine" />
+        <EntitySet Name="TradeJournals" EntityType="Library.Catalog.TradeJournal" />
+        <EntitySet Name="Audiobooks" EntityType="Library.Catalog.Audiobook" />
+        <EntitySet Name="AudiobookChapters" EntityType="Library.Catalog.AudiobookChapter" />
+        <EntitySet Name="DVDs" EntityType="Library.Catalog.DVD" />
+        <EntitySet Name="EBooks" EntityType="Library.Catalog.EBook" />
+        <EntitySet Name="Copies" EntityType="Library.Circulation.Copy" />
+        <EntitySet Name="Members" EntityType="Library.Circulation.Member" />
+        <EntitySet Name="Loans" EntityType="Library.Circulation.Loan" />
+        <EntitySet Name="Reservations" EntityType="Library.Circulation.Reservation" />
+        <EntitySet Name="IdDocuments" EntityType="Library.Circulation.IdDocument" />
+        <EntitySet Name="Branches" EntityType="Library.Circulation.Branch" />
+        <EntitySet Name="Publishers" EntityType="PublisherRegistry.Publisher" />
+        <EntitySet Name="PublisherBranches" EntityType="PublisherRegistry.Branch" />
+        <AssociationSet Name="Medium_Copies_Books" Association="Library.Circulation.Medium_Copies">
+          <End EntitySet="Books" Role="Medium" />
+          <End EntitySet="Copies" Role="Copy" />
+        </AssociationSet>
+        <AssociationSet Name="Medium_Copies_Magazines" Association="Library.Circulation.Medium_Copies">
+          <End EntitySet="Magazines" Role="Medium" />
+          <End EntitySet="Copies" Role="Copy" />
+        </AssociationSet>
+        <AssociationSet Name="Medium_Copies_TradeJournals" Association="Library.Circulation.Medium_Copies">
+          <End EntitySet="TradeJournals" Role="Medium" />
+          <End EntitySet="Copies" Role="Copy" />
+        </AssociationSet>
+        <AssociationSet Name="Medium_Copies_Audiobooks" Association="Library.Circulation.Medium_Copies">
+          <End EntitySet="Audiobooks" Role="Medium" />
+          <End EntitySet="Copies" Role="Copy" />
+        </AssociationSet>
+        <AssociationSet Name="Medium_Copies_DVDs" Association="Library.Circulation.Medium_Copies">
+          <End EntitySet="DVDs" Role="Medium" />
+          <End EntitySet="Copies" Role="Copy" />
+        </AssociationSet>
+        <AssociationSet Name="Medium_Copies_EBooks" Association="Library.Circulation.Medium_Copies">
+          <End EntitySet="EBooks" Role="Medium" />
+          <End EntitySet="Copies" Role="Copy" />
+        </AssociationSet>
+        <AssociationSet Name="Book_Publisher" Association="Library.Catalog.Book_Publisher">
+          <End EntitySet="Books" Role="Book" />
+          <End EntitySet="Publishers" Role="Publisher" />
+        </AssociationSet>
+        <AssociationSet Name="Audiobook_Chapters" Association="Library.Catalog.Audiobook_Chapters">
+          <End EntitySet="Audiobooks" Role="Audiobook" />
+          <End EntitySet="AudiobookChapters" Role="Chapter" />
+        </AssociationSet>
+        <AssociationSet Name="Member_Loans" Association="Library.Circulation.Member_Loans">
+          <End EntitySet="Members" Role="Member" />
+          <End EntitySet="Loans" Role="Loan" />
+        </AssociationSet>
+        <AssociationSet Name="Member_Reservations" Association="Library.Circulation.Member_Reservations">
+          <End EntitySet="Members" Role="Member" />
+          <End EntitySet="Reservations" Role="Reservation" />
+        </AssociationSet>
+        <AssociationSet Name="Member_IdDocument" Association="Library.Circulation.Member_IdDocument">
+          <End EntitySet="Members" Role="Member" />
+          <End EntitySet="IdDocuments" Role="IdDocument" />
+        </AssociationSet>
+        <AssociationSet Name="Copy_Location" Association="Library.Circulation.Copy_Location">
+          <End EntitySet="Copies" Role="Copy" />
+          <End EntitySet="Branches" Role="Branch" />
+        </AssociationSet>
+        <AssociationSet Name="Loan_Copy" Association="Library.Circulation.Loan_Copy">
+          <End EntitySet="Loans" Role="Loan" />
+          <End EntitySet="Copies" Role="Copy" />
+        </AssociationSet>
+        <FunctionImport Name="TotalMediaCount" ReturnType="Edm.Int64" m:HttpMethod="GET" />
+        <FunctionImport Name="AllLanguages" ReturnType="Collection(Edm.String)" m:HttpMethod="GET" />
+        <FunctionImport Name="LoanStatistics" ReturnType="Library.Circulation.LoanStats" m:HttpMethod="GET">
+          <Parameter Name="From" Type="Edm.DateTime" Mode="In" Nullable="true" />
+          <Parameter Name="To" Type="Edm.DateTime" Mode="In" Nullable="true" />
+        </FunctionImport>
+        <FunctionImport
+          Name="StatsPerBranch"
+          ReturnType="Collection(Library.Circulation.BranchStats)"
+          m:HttpMethod="GET"
+        />
+        <FunctionImport Name="MostReadMedium" ReturnType="Library.Catalog.Book" EntitySet="Books" m:HttpMethod="GET" />
+        <FunctionImport
+          Name="NewReleases"
+          ReturnType="Collection(Library.Catalog.Book)"
+          EntitySet="Books"
+          m:HttpMethod="GET"
+        />
+        <FunctionImport
+          Name="Search"
+          ReturnType="Collection(Library.Catalog.Book)"
+          EntitySet="Books"
+          m:HttpMethod="GET"
+        >
+          <Parameter Name="Term" Type="Edm.String" Mode="In" Nullable="false" />
+          <Parameter Name="MaxResults" Type="Edm.Int32" Mode="In" Nullable="true" />
+        </FunctionImport>
+        <FunctionImport Name="OutstandingBalance" ReturnType="Edm.Decimal" m:HttpMethod="GET">
+          <Parameter Name="MemberId" Type="Edm.Int32" Mode="In" Nullable="false" />
+        </FunctionImport>
+        <FunctionImport
+          Name="NoticeHistory"
+          ReturnType="Collection(Library.Circulation.OverdueNotice)"
+          m:HttpMethod="GET"
+        >
+          <Parameter Name="MemberId" Type="Edm.Int32" Mode="In" Nullable="false" />
+        </FunctionImport>
+        <FunctionImport Name="LoanMetrics" ReturnType="Library.Catalog.MediumStats" m:HttpMethod="GET">
+          <Parameter Name="MediumId" Type="Edm.Guid" Mode="In" Nullable="false" />
+        </FunctionImport>
+        <FunctionImport Name="AvailableLanguages" ReturnType="Collection(Edm.String)" m:HttpMethod="GET" />
+        <FunctionImport
+          Name="AvailableCopy"
+          ReturnType="Library.Circulation.Copy"
+          EntitySet="Copies"
+          m:HttpMethod="GET"
+        >
+          <Parameter Name="MediumId" Type="Edm.Guid" Mode="In" Nullable="false" />
+        </FunctionImport>
+        <FunctionImport
+          Name="AvailableCopies"
+          ReturnType="Collection(Library.Circulation.Copy)"
+          EntitySet="Copies"
+          m:HttpMethod="GET"
+        >
+          <Parameter Name="MediumId" Type="Edm.Guid" Mode="In" Nullable="false" />
+        </FunctionImport>
+        <FunctionImport Name="ClosureDay" m:HttpMethod="POST">
+          <Parameter Name="Day" Type="Edm.DateTime" Mode="In" Nullable="false" />
+        </FunctionImport>
+        <FunctionImport Name="NextInventoryNumber" ReturnType="Edm.Int32" m:HttpMethod="POST" />
+        <FunctionImport Name="CleanUpKeywords" ReturnType="Collection(Edm.String)" m:HttpMethod="POST" />
+        <FunctionImport Name="YearEndClosing" ReturnType="Library.Circulation.AnnualReport" m:HttpMethod="POST">
+          <Parameter Name="Year" Type="Edm.Int32" Mode="In" Nullable="false" />
+        </FunctionImport>
+        <FunctionImport
+          Name="RunOverdueNotices"
+          ReturnType="Collection(Library.Circulation.OverdueNotice)"
+          m:HttpMethod="POST"
+        />
+        <FunctionImport
+          Name="RunStockCheck"
+          ReturnType="Collection(Library.Catalog.Book)"
+          EntitySet="Books"
+          m:HttpMethod="POST"
+        />
+        <FunctionImport Name="CheckOut" m:HttpMethod="POST">
+          <Parameter Name="MediumId" Type="Edm.Guid" Mode="In" Nullable="false" />
+          <Parameter Name="InventoryNumber" Type="Edm.Int32" Mode="In" Nullable="false" />
+          <Parameter Name="MemberId" Type="Edm.Int32" Mode="In" Nullable="false" />
+        </FunctionImport>
+        <FunctionImport Name="AssessCondition" ReturnType="Library.Catalog.ConditionReport" m:HttpMethod="POST">
+          <Parameter Name="MediumId" Type="Edm.Guid" Mode="In" Nullable="false" />
+          <Parameter Name="InventoryNumber" Type="Edm.Int32" Mode="In" Nullable="false" />
+          <Parameter Name="NewCondition" Type="Edm.Byte" Mode="In" Nullable="false" />
+          <Parameter Name="Remark" Type="Edm.String" Mode="In" Nullable="true" />
+        </FunctionImport>
+        <FunctionImport Name="Reserve" ReturnType="Edm.Int32" m:HttpMethod="POST">
+          <Parameter Name="MediumId" Type="Edm.Guid" Mode="In" Nullable="false" />
+          <Parameter Name="MemberId" Type="Edm.Int32" Mode="In" Nullable="false" />
+        </FunctionImport>
+        <FunctionImport
+          Name="RunReminders"
+          ReturnType="Collection(Library.Circulation.OverdueNotice)"
+          m:HttpMethod="POST"
+        >
+          <Parameter Name="MemberId" Type="Edm.Int32" Mode="In" Nullable="false" />
+        </FunctionImport>
+        <FunctionImport Name="Renew" ReturnType="Library.Circulation.Loan" EntitySet="Loans" m:HttpMethod="POST">
+          <Parameter Name="LoanId" Type="Edm.Guid" Mode="In" Nullable="false" />
+        </FunctionImport>
+        <FunctionImport
+          Name="RenewAll"
+          ReturnType="Collection(Library.Circulation.Loan)"
+          EntitySet="Loans"
+          m:HttpMethod="POST"
+        >
+          <Parameter Name="MemberId" Type="Edm.Int32" Mode="In" Nullable="false" />
+        </FunctionImport>
+        <FunctionImport Name="BulkRenew" ReturnType="Collection(Edm.String)" m:HttpMethod="POST" />
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>


### PR DESCRIPTION
- `.prettierignore` no longer excludes `int-test/*/resource/` and `examples/*/resource/`, so the committed `$metadata` snapshots are formatted like the rest of the repo
- this is what makes the format step in `bump-test-server.yml` take effect at all: without it a fetched release asset lands as the single line the server emits, and the bump PR shows one replaced line instead of what the release changed about the model
- the reformatting is content-neutral - element structure, attributes and all text nodes are identical before and after