### PR TITLE
fix(odata2ts): resolve the prettier config for the metadata file, not its directory

### DIFF
--- a/packages/odata2ts/src/download/storeMetadata.ts
+++ b/packages/odata2ts/src/download/storeMetadata.ts
@@ -15,7 +15,9 @@ export async function storeMetadata(filePath: string, metadataXml: string, prett
 
   let prettified = metadataXml;
   if (prettify) {
-    const prettierConfig = await resolveConfig(outDir);
+    // the file rather than its directory: prettier matches `overrides` against the path it is given,
+    // and the options for XML - xmlWhitespaceSensitivity above all - only ever live in such an override
+    const prettierConfig = await resolveConfig(filePath);
     prettified = await format(
       metadataXml,
       // @ts-ignore: xmlWhitespaceSensitivity is an option of the plugin

--- a/packages/odata2ts/test/download/storeMetadata.test.ts
+++ b/packages/odata2ts/test/download/storeMetadata.test.ts
@@ -51,4 +51,12 @@ describe("StoreMetadata Test", () => {
     expect(resolveConfig).toHaveBeenCalled();
     expect(format).toHaveBeenCalledWith(DEFAULT_INPUT, { parser: "xml", plugins: ["@prettier/plugin-xml"] });
   });
+
+  test("resolve the config for the file, not its directory", async () => {
+    await storeMetadata(DEFAULT_SOURCE, DEFAULT_INPUT, true);
+
+    // prettier matches `overrides` against the path it is given, so a directory silently drops every
+    // override the user wrote for `*.xml` - which is where options like xmlWhitespaceSensitivity live
+    expect(resolveConfig).toHaveBeenCalledWith(DEFAULT_SOURCE);
+  });
 });


### PR DESCRIPTION
- `storeMetadata` resolved the prettier config for the target *directory*; prettier matches `overrides` against the path it is handed, so every option declared for `*.xml` was dropped
- in this repo that is `xmlWhitespaceSensitivity: "ignore"`, which is why a downloaded snapshot did not look like the same file after `prettier --write`
- the added test pins the argument, since the mocked prettier cannot show the effect itself