### PR TITLE
feat(odata2ts): Evaluate OptionalParameter Annotation

### DIFF
--- a/packages/odata2ts/src/data-model/AnnotationResolver.ts
+++ b/packages/odata2ts/src/data-model/AnnotationResolver.ts
@@ -1,5 +1,6 @@
 import { withNamespace } from "./DataModel.js";
 import { Annotatable, Annotation, ComplexType, EntityType, Reference, Schema } from "./edmx/ODataEdmxModelBase.js";
+import { Operation, SchemaV4 } from "./edmx/ODataEdmxModelV4.js";
 
 /**
  * A navigation property, of either version: the base EDMX types don't know the element - V4 declares it
@@ -62,6 +63,20 @@ export class AnnotationResolver {
    */
   private readonly containerChildren = new Map<string, Annotatable>();
 
+  /**
+   * Every Function and Action overload by its fully qualified name, under the namespace of its schema
+   * as well as under its alias - an annotation may address it either way, just like a type. Several
+   * overloads may share one name, which is why each entry is an array; disambiguating one from another
+   * is {@link findOperationParameterTarget}'s job, using the parameter-type signature the target path
+   * carries.
+   *
+   * V4 only: `Function`/`Action` are declared on {@link SchemaV4}, absent from the base {@link Schema}
+   * this class is typed against, so every access here reads a V4-only field through a cast - the same
+   * idiom `DataModelDigestion` and `DataModelDigestionV4` already use for other V4-only elements. A V2/V3
+   * schema simply contributes nothing to this map.
+   */
+  private readonly operations = new Map<string, Array<Operation>>();
+
   constructor(
     private readonly schemas: Array<Schema<EntityType, ComplexType>>,
     references: Array<Reference> | undefined,
@@ -80,6 +95,14 @@ export class AnnotationResolver {
         this.targets.set(withNamespace(ns, model.$.Name), model);
         if (alias) {
           this.targets.set(withNamespace(alias, model.$.Name), model);
+        }
+      }
+
+      const schemaV4 = schema as SchemaV4;
+      for (const operation of [...(schemaV4.Function ?? []), ...(schemaV4.Action ?? [])]) {
+        this.pushOperation(withNamespace(ns, operation.$.Name), operation);
+        if (alias) {
+          this.pushOperation(withNamespace(alias, operation.$.Name), operation);
         }
       }
 
@@ -106,6 +129,15 @@ export class AnnotationResolver {
     return [...(container.EntitySet ?? []), ...(container.Singleton ?? [])];
   }
 
+  private pushOperation(fqName: string, operation: Operation): void {
+    const overloads = this.operations.get(fqName);
+    if (overloads) {
+      overloads.push(operation);
+    } else {
+      this.operations.set(fqName, [operation]);
+    }
+  }
+
   /**
    * Normalizes the annotations of all schemas in place.
    */
@@ -123,6 +155,15 @@ export class AnnotationResolver {
         }
       }
       this.qualifyTerms(schema);
+    }
+
+    // each overload is indexed under both its namespace and its alias, so the same `Operation` object
+    // may appear twice in `this.operations` - qualify each one's parameters only once
+    const uniqueOperations = new Set<Operation>([...this.operations.values()].flat());
+    for (const operation of uniqueOperations) {
+      for (const param of operation.Parameter ?? []) {
+        this.qualifyTerms(param);
+      }
     }
 
     for (const schema of this.schemas) {
@@ -214,6 +255,12 @@ export class AnnotationResolver {
    * deeper path yields nothing and is therefore left alone.
    */
   private findTarget(target: string): Annotatable | undefined {
+    // a type or container-child name never carries parentheses, so this is unambiguously the signature
+    // form addressing a Function/Action parameter, e.g. `Ns.Search(Edm.String,Edm.Int32)/MaxResults`
+    if (target.includes("(")) {
+      return this.findOperationParameterTarget(target);
+    }
+
     const containerChild = this.containerChildren.get(target);
     if (containerChild) {
       return containerChild;
@@ -236,6 +283,32 @@ export class AnnotationResolver {
       model.Property?.find((p) => p.$.Name === propName) ??
       (model as WithNavigationProps).NavigationProperty?.find((p) => p.$.Name === propName)
     );
+  }
+
+  /**
+   * Resolves a target addressing a parameter of a Function/Action overload, e.g.
+   * `Ns.Search(Edm.String,Edm.Int32)/MaxResults`. The parenthesized, comma-separated parameter types -
+   * in declaration order, binding parameter included - disambiguate the overload, since several may
+   * share one name; there is no other resolvable path onto a parameter. Both sides of the comparison
+   * come from the same document, so the types are compared as literally written, without normalizing
+   * aliases or namespaces.
+   */
+  private findOperationParameterTarget(target: string): Annotatable | undefined {
+    const match = target.match(/^([^()]+)\(([^)]*)\)\/(.+)$/);
+    if (!match) {
+      return undefined;
+    }
+    const [, operationName, signature, paramName] = match;
+    const types = signature
+      .split(",")
+      .map((type) => type.trim())
+      .filter((type) => !!type);
+
+    const overload = this.operations.get(operationName)?.find((op) => {
+      const paramTypes = (op.Parameter ?? []).map((p) => p.$.Type.trim());
+      return paramTypes.length === types.length && paramTypes.every((type, i) => type === types[i]);
+    });
+    return overload?.Parameter?.find((p) => p.$.Name === paramName);
   }
 
   /**

--- a/packages/odata2ts/src/data-model/CoreAnnotations.ts
+++ b/packages/odata2ts/src/data-model/CoreAnnotations.ts
@@ -9,6 +9,7 @@ const IMMUTABLE = `${CORE}.Immutable`;
 const PERMISSIONS = `${CORE}.Permissions`;
 
 const OPTIMISTIC_CONCURRENCY = `${CORE}.OptimisticConcurrency`;
+const OPTIONAL_PARAMETER = `${CORE}.OptionalParameter`;
 
 const PERMISSION_READ = `${CORE}.Permission/Read`;
 const PERMISSION_WRITE = `${CORE}.Permission/Write`;
@@ -101,4 +102,15 @@ export function getManagedState(allAnnotations: Array<Annotation> | undefined): 
  */
 export function isOptimisticConcurrency(annotations: Array<Annotation> | undefined): boolean {
   return !!annotations?.some((a) => a.$.Term === OPTIMISTIC_CONCURRENCY);
+}
+
+/**
+ * Whether the service states that this operation parameter may be omitted from the call, regardless of
+ * what `Nullable` says: the two facets answer different questions - whether the parameter accepts
+ * `null` when supplied, and whether it may be left out at all. `Core.OptionalParameter` carries a
+ * `DefaultValue` in principle, but that is server-side substitution semantics with nothing for a client
+ * to mirror, so presence of the term is the whole statement, like {@link isOptimisticConcurrency}.
+ */
+export function isOptionalParameter(annotations: Array<Annotation> | undefined): boolean {
+  return !!annotations?.some((a) => a.$.Term === OPTIONAL_PARAMETER);
 }

--- a/packages/odata2ts/src/data-model/DataModelDigestion.ts
+++ b/packages/odata2ts/src/data-model/DataModelDigestion.ts
@@ -13,7 +13,7 @@ import {
 import { AllowedValuesEnumSynthesizer, SynthesizedEnum } from "./AllowedValuesEnumSynthesizer.js";
 import { AnnotationResolver } from "./AnnotationResolver.js";
 import { ComplexTypeUnflattener } from "./ComplexTypeUnflattener.js";
-import { getManagedState } from "./CoreAnnotations.js";
+import { getManagedState, isOptionalParameter } from "./CoreAnnotations.js";
 import { DataModel, NamespaceWithAlias, withNamespace } from "./DataModel.js";
 import {
   ComplexType as ComplexModelType,
@@ -818,6 +818,7 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
       // only set when it applies: a flag on every single property would be noise
       ...(odataDataType === ODataTypesV4.Stream ? { isStream: true } : undefined),
       ...(this.isContained(p) ? { contained: true } : undefined),
+      ...(isOptionalParameter(p.Annotation) ? { omittable: true } : undefined),
       managed: toManagedState(
         typeof entityPropConfig?.managed !== "undefined" ? entityPropConfig.managed : configProp?.managed,
       ),

--- a/packages/odata2ts/src/data-model/DataTypeModel.ts
+++ b/packages/odata2ts/src/data-model/DataTypeModel.ts
@@ -59,6 +59,13 @@ export interface PropertyModel {
    * containment - and never set for anything but a navigation property.
    */
   contained?: boolean;
+  /**
+   * `Core.OptionalParameter`: the client may omit this operation parameter from the call even though
+   * `required` (from `Nullable`) says otherwise - the server applies a default of its own. Independent
+   * of `required`: unlike `Nullable`, it says nothing about whether the parameter accepts `null` when
+   * it *is* supplied. V4 operation parameters only - the annotation's `AppliesTo` is `Parameter`.
+   */
+  omittable?: boolean;
 }
 
 export type ModelType = EntityType | ComplexType | EnumType;

--- a/packages/odata2ts/src/generator/ModelGenerator.ts
+++ b/packages/odata2ts/src/generator/ModelGenerator.ts
@@ -748,7 +748,7 @@ class ModelGenerator {
           return {
             name: p.name,
             type: this.getPropType(file.getImports(), p),
-            hasQuestionToken: !p.required,
+            hasQuestionToken: !p.required || !!p.omittable,
           };
         }),
       });
@@ -763,7 +763,7 @@ class ModelGenerator {
             writer.block(() => {
               pSet.forEach((param, index) => {
                 const paramType = this.getPropType(file.getImports(), param);
-                writer.write(`${param.name}${param.required ? "" : "?"}: ${paramType}`);
+                writer.write(`${param.name}${param.required && !param.omittable ? "" : "?"}: ${paramType}`);
                 if (index < pSet.length - 1) {
                   writer.write(",");
                 }

--- a/packages/odata2ts/test/data-model/AnnotationResolver.test.ts
+++ b/packages/odata2ts/test/data-model/AnnotationResolver.test.ts
@@ -1,12 +1,13 @@
 import { ODataTypesV4 } from "@odata2ts/odata-core";
 import { describe, expect, test } from "vitest";
 import { AnnotationResolver } from "../../src/data-model/AnnotationResolver.js";
-import { propertyPaths } from "./builder/ODataAnnotationBuilder.js";
+import { core, propertyPaths } from "./builder/ODataAnnotationBuilder.js";
 import { ODataModelBuilderV4 } from "./builder/v4/ODataModelBuilderV4.js";
 
 const SERVICE_NAME = "Tester";
 const CONTAINER = "ENTITY_CONTAINER";
 const CONCURRENCY = "Org.OData.Core.V1.OptimisticConcurrency";
+const OPTIONAL_PARAMETER = "Org.OData.Core.V1.OptionalParameter";
 
 /**
  * Runs the resolver over a built model and hands back the entity container, whose sets and singletons
@@ -109,5 +110,66 @@ describe("AnnotationResolver: entity container targets", () => {
     new AnnotationResolver(schemas as any, builder.getReferences()).resolve();
 
     expect(termsOf((schemas[0] as any).EntityType[0])).toStrictEqual([]);
+  });
+});
+
+describe("AnnotationResolver: operation parameter targets", () => {
+  function resolveFunctions(builder: ODataModelBuilderV4) {
+    const schemas = builder.getSchemas();
+    new AnnotationResolver(schemas as any, builder.getReferences()).resolve();
+    return (schemas[0] as any).Function;
+  }
+
+  test("inline on the parameter, with an alias the resolver expands", () => {
+    const builder = new ODataModelBuilderV4(SERVICE_NAME)
+      .enableAnnotations()
+      .addFunction("Search", ODataTypesV4.String, false, (b: any) =>
+        b
+          .addParam("term", ODataTypesV4.String, false)
+          .addParam("maxResults", ODataTypesV4.Int32, false)
+          .addParamAnnotations("maxResults", [core("OptionalParameter")]),
+      );
+
+    const functions = resolveFunctions(builder);
+    expect(termsOf(functions[0].Parameter[1])).toContain(OPTIONAL_PARAMETER);
+    expect(termsOf(functions[0].Parameter[0])).toStrictEqual([]);
+  });
+
+  test("externally, targeting a parameter by its operation's signature - how CAP states it", () => {
+    const builder = new ODataModelBuilderV4(SERVICE_NAME)
+      .enableAnnotations()
+      .addFunction("Search", ODataTypesV4.String, false, (b: any) =>
+        b.addParam("term", ODataTypesV4.String, false).addParam("maxResults", ODataTypesV4.Int32, false),
+      )
+      .addExternalAnnotations(`${SERVICE_NAME}.Search(Edm.String,Edm.Int32)/maxResults`, [core("OptionalParameter")]);
+
+    const functions = resolveFunctions(builder);
+    expect(termsOf(functions[0].Parameter[1])).toContain(OPTIONAL_PARAMETER);
+  });
+
+  test("the signature disambiguates between overloads sharing a name", () => {
+    const builder = new ODataModelBuilderV4(SERVICE_NAME)
+      .enableAnnotations()
+      .addFunction("Search", ODataTypesV4.String, false, (b: any) => b.addParam("term", ODataTypesV4.String, false))
+      .addFunction("Search", ODataTypesV4.String, false, (b: any) =>
+        b.addParam("term", ODataTypesV4.String, false).addParam("maxResults", ODataTypesV4.Int32, false),
+      )
+      .addExternalAnnotations(`${SERVICE_NAME}.Search(Edm.String,Edm.Int32)/maxResults`, [core("OptionalParameter")]);
+
+    const functions = resolveFunctions(builder);
+    // the one-parameter overload must be left alone ...
+    expect(termsOf(functions[0].Parameter[0])).toStrictEqual([]);
+    // ... only the two-parameter overload the signature actually names gets it
+    expect(termsOf(functions[1].Parameter[1])).toContain(OPTIONAL_PARAMETER);
+  });
+
+  test("a target naming an unknown parameter resolves to nothing and throws nothing", () => {
+    const builder = new ODataModelBuilderV4(SERVICE_NAME)
+      .enableAnnotations()
+      .addFunction("Search", ODataTypesV4.String, false, (b: any) => b.addParam("term", ODataTypesV4.String, false))
+      .addExternalAnnotations(`${SERVICE_NAME}.Search(Edm.String)/Nope`, [core("OptionalParameter")]);
+
+    expect(() => resolveFunctions(builder)).not.toThrow();
+    expect(termsOf(resolveFunctions(builder)[0].Parameter[0])).toStrictEqual([]);
   });
 });

--- a/packages/odata2ts/test/data-model/builder/v4/ODataOperationBuilderV4.ts
+++ b/packages/odata2ts/test/data-model/builder/v4/ODataOperationBuilderV4.ts
@@ -1,3 +1,4 @@
+import { Annotation } from "../../../../src/data-model/edmx/ODataEdmxModelBase.js";
 import { Operation } from "../../../../src/data-model/edmx/ODataEdmxModelV4.js";
 import { createProperty } from "../ODataBuilderHelper.js";
 
@@ -38,6 +39,14 @@ export class ODataOperationBuilderV4 {
 
     const prop = createProperty(name, type, nullable, maxLength, precision);
     this.operation.Parameter.push(prop);
+    return this;
+  }
+
+  public addParamAnnotations(paramName: string, annotations: Array<Annotation>) {
+    const param = this.operation.Parameter?.find((p) => p.$.Name === paramName);
+    if (param) {
+      param.Annotation = [...(param.Annotation ?? []), ...annotations];
+    }
     return this;
   }
 }

--- a/packages/odata2ts/test/data-model/v4/ActionDigestion.test.ts
+++ b/packages/odata2ts/test/data-model/v4/ActionDigestion.test.ts
@@ -4,6 +4,7 @@ import { digest } from "../../../src/data-model/DataModelDigestionV4.js";
 import { DataTypes, OperationType, OperationTypes } from "../../../src/data-model/DataTypeModel.js";
 import { NamingHelper } from "../../../src/data-model/NamingHelper.js";
 import { getTestConfig } from "../../test.config.js";
+import { core } from "../builder/ODataAnnotationBuilder.js";
 import { ODataModelBuilderV4 } from "../builder/v4/ODataModelBuilderV4.js";
 
 describe("Action Digestion Test", () => {
@@ -21,7 +22,7 @@ describe("Action Digestion Test", () => {
   }
 
   function doDigest() {
-    return digest(odataBuilder.getSchemas(), CONFIG, NAMING_HELPER);
+    return digest(odataBuilder.getSchemas(), CONFIG, NAMING_HELPER, odataBuilder.getReferences());
   }
 
   beforeEach(() => {
@@ -92,6 +93,48 @@ describe("Action Digestion Test", () => {
           required: false,
           isCollection: false,
         },
+      },
+    ]);
+  });
+
+  test("Action: Core.OptionalParameter, inline on the parameter", async () => {
+    odataBuilder.enableAnnotations().addAction("Search", ODataTypesV4.String, false, (builder) => {
+      builder
+        .addParam("term", ODataTypesV4.String, false)
+        .addParam("maxResults", ODataTypesV4.Int32, false)
+        .addParamAnnotations("maxResults", [core("OptionalParameter")]);
+    });
+
+    const result = await doDigest();
+
+    expect(result.getUnboundOperationTypes()).toMatchObject([
+      {
+        odataName: "Search",
+        parameters: [
+          { name: "term", required: true },
+          { name: "maxResults", required: true, omittable: true },
+        ],
+      },
+    ]);
+  });
+
+  test("Action: Core.OptionalParameter, external via operation-signature target", async () => {
+    odataBuilder
+      .enableAnnotations()
+      .addAction("Search", ODataTypesV4.String, false, (builder) => {
+        builder.addParam("term", ODataTypesV4.String, false).addParam("maxResults", ODataTypesV4.Int32, false);
+      })
+      .addExternalAnnotations(`${withNs("Search")}(Edm.String,Edm.Int32)/maxResults`, [core("OptionalParameter")]);
+
+    const result = await doDigest();
+
+    expect(result.getUnboundOperationTypes()).toMatchObject([
+      {
+        odataName: "Search",
+        parameters: [
+          { name: "term", required: true },
+          { name: "maxResults", required: true, omittable: true },
+        ],
       },
     ]);
   });

--- a/packages/odata2ts/test/data-model/v4/FunctionDigestion.test.ts
+++ b/packages/odata2ts/test/data-model/v4/FunctionDigestion.test.ts
@@ -8,6 +8,7 @@ import { DigestionOptions } from "../../../src/FactoryFunctionModel.js";
 import { TypeModel } from "../../../src/index.js";
 import { TestOptions, TestSettings } from "../../generator/TestTypes.js";
 import { getTestConfig } from "../../test.config.js";
+import { core } from "../builder/ODataAnnotationBuilder.js";
 import { ODataModelBuilderV4 } from "../builder/v4/ODataModelBuilderV4.js";
 
 describe("Function Digestion Test", () => {
@@ -27,7 +28,7 @@ describe("Function Digestion Test", () => {
 
   function doDigest() {
     const opts = digestionOptions ? (deepmerge(CONFIG, digestionOptions) as TestSettings) : CONFIG;
-    return digest(odataBuilder.getSchemas(), opts, new NamingHelper(opts, NAMESPACE));
+    return digest(odataBuilder.getSchemas(), opts, new NamingHelper(opts, NAMESPACE), odataBuilder.getReferences());
   }
 
   beforeEach(() => {
@@ -113,6 +114,59 @@ describe("Function Digestion Test", () => {
           required: false,
           isCollection: false,
         },
+      },
+    ]);
+  });
+
+  test("Function: no Core.OptionalParameter means omittable stays unset", async () => {
+    odataBuilder.addFunction("GetBestFriend", ODataTypesV4.String, false, (builder) => {
+      builder.addParam("test", ODataTypesV4.String, false);
+    });
+
+    const result = await doDigest();
+
+    const [op] = result.getUnboundOperationTypes();
+    expect(op.parameters[0].omittable).toBeUndefined();
+  });
+
+  test("Function: Core.OptionalParameter, inline on the parameter", async () => {
+    odataBuilder.enableAnnotations().addFunction("Search", ODataTypesV4.String, false, (builder) => {
+      builder
+        .addParam("term", ODataTypesV4.String, false)
+        .addParam("maxResults", ODataTypesV4.Int32, false)
+        .addParamAnnotations("maxResults", [core("OptionalParameter")]);
+    });
+
+    const result = await doDigest();
+
+    expect(result.getUnboundOperationTypes()).toMatchObject([
+      {
+        odataName: "Search",
+        parameters: [
+          { name: "term", required: true },
+          { name: "maxResults", required: true, omittable: true },
+        ],
+      },
+    ]);
+  });
+
+  test("Function: Core.OptionalParameter, external via operation-signature target", async () => {
+    odataBuilder
+      .enableAnnotations()
+      .addFunction("Search", ODataTypesV4.String, false, (builder) => {
+        builder.addParam("term", ODataTypesV4.String, false).addParam("maxResults", ODataTypesV4.Int32, false);
+      })
+      .addExternalAnnotations(`${withNs("Search")}(Edm.String,Edm.Int32)/maxResults`, [core("OptionalParameter")]);
+
+    const result = await doDigest();
+
+    expect(result.getUnboundOperationTypes()).toMatchObject([
+      {
+        odataName: "Search",
+        parameters: [
+          { name: "term", required: true },
+          { name: "maxResults", required: true, omittable: true },
+        ],
       },
     ]);
   });

--- a/packages/odata2ts/test/fixture/generator/model/operation-optional-param.ts
+++ b/packages/odata2ts/test/fixture/generator/model/operation-optional-param.ts
@@ -1,0 +1,5 @@
+export interface OptionalParamOperationParams {
+  test: string;
+  optTest?: string | null;
+  omittableTest?: string;
+}

--- a/packages/odata2ts/test/generator/v4/ModelGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/ModelGenerator.test.ts
@@ -80,6 +80,22 @@ describe("Model Generator Tests V4", () => {
     await generateAndCompare("operation-min.ts");
   });
 
+  test(`${TEST_SUITE_NAME}: Core.OptionalParameter param model`, async () => {
+    // given a function with a required param, a nullable param, and a non-nullable-but-omittable one
+    odataBuilder.addFunction("OptionalParamOperation", ODataTypesV4.String, false, (builder) =>
+      builder
+        .addParam("test", ODataTypesV4.String, false)
+        .addParam("optTest", ODataTypesV4.String, true)
+        .addParam("omittableTest", ODataTypesV4.String, false)
+        .addParamAnnotations("omittableTest", [core("OptionalParameter", { fullyQualified: true })]),
+    );
+
+    // when generating model
+    // then match fixture text: omittableTest gets "?" but, unlike optTest, no "| null" - it rejects an
+    // explicit null, it may just be left out of the call entirely
+    await generateAndCompare("operation-optional-param.ts");
+  });
+
   test(`${TEST_SUITE_NAME}: max function param model`, async () => {
     // given a function
     odataBuilder.addFunction("maxOperation", ODataTypesV4.String, false, (builder) =>


### PR DESCRIPTION
Operation parameters which are `Nullable=false` and also have the core annotation OptionalParameter will be optional, but not nullable.