### PR TITLE
feat: support alternate keys & EntitySetService gets `byId` method

### DIFF
--- a/int-test/asp-net/test/LibraryTestConstants.ts
+++ b/int-test/asp-net/test/LibraryTestConstants.ts
@@ -26,6 +26,8 @@ export const LIBRARY_STRICT = new LibraryStrictService(ODATA_CLIENT, BASE_URL);
 
 /** "Der Prozess" - a book with fixed, well-known values. */
 export const BOOK_DER_PROZESS = "11111111-1111-1111-1111-111111111111";
+/** Its ISBN, declared as `Core.AlternateKeys` on `PrintMedium` - see feature/Annotations.test.ts. */
+export const BOOK_DER_PROZESS_ISBN = "9783518188002";
 export const AUDIOBOOK = "22222222-2222-2222-2222-222222222222";
 export const EBOOK = "33333333-3333-3333-3333-333333333333";
 export const UNKNOWN_ID = "00000000-0000-0000-0000-000000000000";

--- a/int-test/asp-net/test/feature/Annotations.test.ts
+++ b/int-test/asp-net/test/feature/Annotations.test.ts
@@ -1,11 +1,13 @@
+import { HttpResponseModel } from "@odata2ts/http-client-api";
+import { ODataModelResponseV4 } from "@odata2ts/odata-core";
 import { describe, expect, expectTypeOf, test } from "vitest";
 import type {
   EditableBook as StrictEditableBook,
   EditableMedium as StrictEditableMedium,
 } from "../../src-generated/library-strict/library-catalog/index.js";
-import type { EditableBook, EditableMedium } from "../../src-generated/library/library-catalog/index.js";
+import type { EditableBook, EditableMedium, PrintMedium } from "../../src-generated/library/library-catalog/index.js";
 import type { EditableBranch } from "../../src-generated/library/library-circulation/index.js";
-import { BOOK_DER_PROZESS, LIBRARY } from "../LibraryTestConstants.js";
+import { BASE_URL, BOOK_DER_PROZESS, BOOK_DER_PROZESS_ISBN, LIBRARY } from "../LibraryTestConstants.js";
 
 /**
  * Evaluation of the `Org.OData.Core.V1` terms against ASP.NET, the counterpart of the same file in
@@ -78,5 +80,40 @@ describe("ASP.NET Library: Core annotations", () => {
     // property is optional here. The strict client requires it - see feature/ImmutableProperties.test.ts,
     // which is the pairing that gives the two settings their meaning.
     expectTypeOf<EditableBranch["Id"]>().toEqualTypeOf<number | undefined>();
+  });
+
+  /**
+   * `Core.AlternateKeys` on `PrintMedium` (`ISBN`, `AppliesTo=EntityType`).
+   *
+   * `ISBN` is a property of the subtype `PrintMedium`, not of the entity set's declared type `Medium` -
+   * so, unlike the primary key, addressing by it needs the type-cast segment in the URL. That is exactly
+   * what {@link EntitySetServiceV4.byId} is for: cast the collection first
+   * (`asPrintMediumCollectionService()`), then key it - `byId` is the general accessor a subtype cast
+   * gets automatically, not something built one-off for this annotation.
+   */
+  test("Core.AlternateKeys lets ISBN address a PrintMedium, through the cast collection's byId", async () => {
+    const printMedium = LIBRARY.Media().asPrintMediumCollectionService().byId({ ISBN: BOOK_DER_PROZESS_ISBN });
+
+    expect(printMedium.getPath()).toBe(
+      `${BASE_URL}/Media/Library.Catalog.PrintMedium(ISBN='${BOOK_DER_PROZESS_ISBN}')`,
+    );
+
+    const result = await printMedium.query().execute();
+
+    expect(result.status).toBe(200);
+    expect(result.data.Title).toBe("Der Prozess");
+    expectTypeOf(result).toEqualTypeOf<HttpResponseModel<ODataModelResponseV4<PrintMedium>>>();
+  });
+
+  test("Core.AlternateKeys: the primary key still addresses the very same entity", async () => {
+    const byPrimaryKey = await LIBRARY.Media(BOOK_DER_PROZESS).query().execute();
+    const byAlternateKey = await LIBRARY.Media()
+      .asPrintMediumCollectionService()
+      .byId({ ISBN: BOOK_DER_PROZESS_ISBN })
+      .query()
+      .execute();
+
+    expect(byAlternateKey.data.Id).toBe(byPrimaryKey.data.Id);
+    expect(byAlternateKey.data.Title).toBe(byPrimaryKey.data.Title);
   });
 });

--- a/int-test/cap/test/LibraryTestConstants.ts
+++ b/int-test/cap/test/LibraryTestConstants.ts
@@ -19,6 +19,8 @@ export const LIBRARY_STRICT = new LibraryStrictService(ODATA_CLIENT, BASE_URL);
 
 /** "Der Prozess" - a book with fixed, well-known values. */
 export const BOOK_DER_PROZESS = "11111111-1111-1111-1111-111111111111";
+/** Its ISBN, declared as `Core.AlternateKeys` on `Books` - see feature/Annotations.test.ts. */
+export const BOOK_DER_PROZESS_ISBN = "9783150094440";
 export const UNKNOWN_ID = "00000000-0000-0000-0000-000000000000";
 
 /** Carriers of binary content: a named stream property (`Sample`) and CAP's take on a media entity. */

--- a/int-test/cap/test/feature/Annotations.test.ts
+++ b/int-test/cap/test/feature/Annotations.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, expectTypeOf, test } from "vitest";
 import type { EditableBooks as StrictEditableBooks } from "../../src-generated/library-strict/index.js";
-import type { EditableBooks } from "../../src-generated/library/index.js";
-import { LIBRARY } from "../LibraryTestConstants.js";
+import type { BooksId, EditableBooks } from "../../src-generated/library/index.js";
+import { expectODataError } from "../expectODataError.js";
+import { BASE_URL, BOOK_DER_PROZESS_ISBN, LIBRARY } from "../LibraryTestConstants.js";
 
 /**
  * Evaluation of the `Org.OData.Core.V1` terms which say how the server manages a property, against the
@@ -86,5 +87,24 @@ describe("CAP Library: Core annotations", () => {
     } finally {
       await LIBRARY.Books(Id).delete().execute();
     }
+  });
+
+  /**
+   * `Core.AlternateKeys` on `Books` (`ISBN`) - the client builds the URL the annotation promises
+   * (`Books(ISBN='...')`, no cast segment needed here since `Books` is the entity set's own declared
+   * type, not a subtype), but CAP does not actually resolve an entity by it: it always requires the
+   * real key, `Id`. Pinned here as a server limitation, the counterpart of `int-test/asp-net`'s
+   * `Annotations.test.ts`, where the very same annotation does work (there via a cast collection's
+   * `byId`, since ASP.NET's `ISBN` belongs to a subtype of the entity set's type).
+   */
+  test("Core.AlternateKeys is declared but not honoured - CAP still demands the real key", async () => {
+    const isbnKey: BooksId = { ISBN: BOOK_DER_PROZESS_ISBN };
+
+    expect(LIBRARY.Books(isbnKey).getPath()).toBe(`${BASE_URL}/Books(ISBN='${BOOK_DER_PROZESS_ISBN}')`);
+
+    await expectODataError(LIBRARY.Books(isbnKey).query().execute(), {
+      status: 400,
+      message: /Key "Id" is missing for entity "Library\.Service\.Books"/,
+    });
   });
 });

--- a/packages/odata-query-objects/src/operation/QFunction.ts
+++ b/packages/odata-query-objects/src/operation/QFunction.ts
@@ -49,7 +49,7 @@ export abstract class QFunction<ParamModel, ResponseStructure = undefined> {
 
   public abstract getParams(): Array<QParamModel<any, any>> | Array<Array<QParamModel<any, any>>>;
 
-  private getParamSets(): Array<Array<QParamModel<any, any>>> {
+  protected getParamSets(): Array<Array<QParamModel<any, any>>> {
     const params = this.getParams();
     if (params.length) {
       const elemZero = params[0];

--- a/packages/odata-query-objects/src/operation/QId.ts
+++ b/packages/odata-query-objects/src/operation/QId.ts
@@ -4,11 +4,36 @@ import { QFunctionV4 } from "./QFunctionV4";
 /**
  * Represents a function to produce the id path of an entity, e.g. MyEntity(number=123,name='Test').
  * There's no difference between V2 and V4 here.
+ *
+ * {@link getParams} may return either a single, flat param set - the common case, one way to identify
+ * the entity - or several: an entity which also declares one or more `Core.AlternateKeys` gets one
+ * param set per alternate key, in addition to the primary one. {@link buildUrl}/{@link parseUrl}
+ * (inherited from {@link QFunction}) already resolve which of several param sets applies, the same way
+ * they do for overloaded function/action parameters.
  */
 export abstract class QId<ParamModel> extends QFunctionV4<ParamModel, void> {
   public constructor(name: string) {
     super(name);
   }
 
-  public abstract getParams(): Array<QParamModel<any, any>>;
+  public abstract getParams(): Array<QParamModel<any, any>> | Array<Array<QParamModel<any, any>>>;
+
+  /**
+   * The primary key's param set, regardless of how many alternate keys this id also declares.
+   *
+   * Codegen guarantees the primary key's param set is always first - callers needing "the" identifying
+   * set of params for this entity, rather than one it may alternatively be identified by, want this
+   * over {@link getParams}.
+   */
+  public getPrimaryParams(): Array<QParamModel<any, any>> {
+    return this.getParamSets()[0] ?? [];
+  }
+
+  /**
+   * The param set of every alternate key this id also declares (`Core.AlternateKeys`), in the order
+   * {@link buildUrl}/{@link parseUrl} try them in after the primary key - empty where there are none.
+   */
+  public getAlternateParams(): Array<Array<QParamModel<any, any>>> {
+    return this.getParamSets().slice(1);
+  }
 }

--- a/packages/odata-query-objects/test/fixture/operation/IdFunction.ts
+++ b/packages/odata-query-objects/test/fixture/operation/IdFunction.ts
@@ -49,3 +49,17 @@ export class ComplexBookIdFunction extends QId<ComplexBookIdModel> {
     return this.params;
   }
 }
+
+/**
+ * An id with one alternate key alongside the primary key - the shape `Core.AlternateKeys` codegen
+ * produces: one flat param set per key, primary first.
+ */
+export type BookIdWithAlternateKeyModel = string | { id: string } | { isbn: string };
+
+export class BookIdWithAlternateKeyFunction extends QId<BookIdWithAlternateKeyModel> {
+  private readonly params = [[new QGuidParam("id")], [new QStringParam("ISBN", "isbn")]];
+
+  public getParams() {
+    return this.params;
+  }
+}

--- a/packages/odata-query-objects/test/operation/QId.test.ts
+++ b/packages/odata-query-objects/test/operation/QId.test.ts
@@ -3,6 +3,7 @@ import {
   BookIdFunction,
   BookIdFunctionWithConversion,
   BookIdV2Function,
+  BookIdWithAlternateKeyFunction,
   ComplexBookIdFunction,
 } from "../fixture/operation/IdFunction";
 
@@ -83,5 +84,40 @@ describe("QId Tests", () => {
     expect(() => exampleFunction.parseUrl("EntityXy(tiger=xxx)")).toThrow(
       "not part of this function's method signature",
     );
+  });
+
+  describe("alternate keys", () => {
+    test("getPrimaryParams always returns the first param set", () => {
+      const exampleFunction = new BookIdWithAlternateKeyFunction("EntityXy");
+
+      expect(exampleFunction.getPrimaryParams()).toHaveLength(1);
+      expect(exampleFunction.getPrimaryParams()[0].getName()).toBe("id");
+    });
+
+    test("getAlternateParams returns every param set but the first", () => {
+      const exampleFunction = new BookIdWithAlternateKeyFunction("EntityXy");
+
+      const alternateParams = exampleFunction.getAlternateParams();
+      expect(alternateParams).toHaveLength(1);
+      expect(alternateParams[0]).toHaveLength(1);
+      expect(alternateParams[0][0].getName()).toBe("ISBN");
+      expect(alternateParams[0][0].getMappedName()).toBe("isbn");
+    });
+
+    test("buildUrl picks the primary key for a bare scalar value", () => {
+      const exampleFunction = new BookIdWithAlternateKeyFunction("EntityXy");
+      expect(exampleFunction.buildUrl("some-guid")).toBe("EntityXy(some-guid)");
+    });
+
+    test("buildUrl picks the matching alternate key by its object shape", () => {
+      const exampleFunction = new BookIdWithAlternateKeyFunction("EntityXy");
+      expect(exampleFunction.buildUrl({ isbn: "123" })).toBe("EntityXy(ISBN='123')");
+    });
+
+    test("parseUrl picks the matching param set by the wire names actually present", () => {
+      const exampleFunction = new BookIdWithAlternateKeyFunction("EntityXy");
+      expect(exampleFunction.parseUrl("EntityXy(id=abc)")).toMatchObject({ id: "abc" });
+      expect(exampleFunction.parseUrl("EntityXy(ISBN='123')")).toMatchObject({ isbn: "123" });
+    });
   });
 });

--- a/packages/odata-service/src/v2/EntitySetServiceV2.ts
+++ b/packages/odata-service/src/v2/EntitySetServiceV2.ts
@@ -28,6 +28,7 @@ export abstract class EntitySetServiceV2<
   EditableT,
   Q extends QueryObjectModel,
   EIdType,
+  ES = unknown,
   AsV4 extends boolean = false,
 > {
   protected readonly __base: ServiceStateHelperV2<Q, AsV4>;
@@ -50,11 +51,32 @@ export abstract class EntitySetServiceV2<
   }
 
   /**
+   * Build the entity-type service for a specific entity of this set - the concrete class differs per
+   * generated entity type, so each generated collection service supplies its own construction here.
+   */
+  protected abstract createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternalV2<AsV4> | undefined,
+  ): ES;
+
+  /**
+   * The entity-type service addressed by the given id.
+   */
+  public byId(id: EIdType): ES {
+    // basePath, not path: __idFunction already builds the key predicate under this set's own name -
+    // path would double that segment
+    const { client, basePath, options, isUrlNotEncoded } = this.__base;
+    return this.createEntityService(client, basePath, this.__idFunction.buildUrl(id, isUrlNotEncoded()), options);
+  }
+
+  /**
    * The key specification for the given entity type.
    * Supports composite keys.
    */
   public getKeySpec() {
-    return this.__idFunction.getParams();
+    return this.__idFunction.getPrimaryParams();
   }
 
   /**
@@ -99,7 +121,7 @@ export abstract class EntitySetServiceV2<
    * itself, which is what lets a collection read fill the store for entities nobody read singly.
    */
   private entityKeyOf(entry: any): string | undefined {
-    const params = this.__idFunction.getParams();
+    const params = this.__idFunction.getPrimaryParams();
     if (!params.length || params.some((p) => entry?.[p.getMappedName()] === undefined)) {
       return undefined;
     }

--- a/packages/odata-service/src/v4/EntitySetServiceV4.ts
+++ b/packages/odata-service/src/v4/EntitySetServiceV4.ts
@@ -24,6 +24,7 @@ export abstract class EntitySetServiceV4<
   EditableT,
   Q extends QueryObjectModel,
   EIdType,
+  ES = unknown,
   V extends ODataVersionV4 = "4.0",
 > {
   protected readonly __base: ServiceStateHelperV4<Q, V>;
@@ -58,11 +59,47 @@ export abstract class EntitySetServiceV4<
   }
 
   /**
-   * The key specification for the given entity type.
+   * Build the entity-type service for a specific entity of this set - the concrete class differs per
+   * generated entity type (e.g. `MediumService` vs. `PrintMediumService`), so each generated collection
+   * service supplies its own construction here.
+   */
+  protected abstract createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ): ES;
+
+  /**
+   * The entity-type service addressed by the given id - primary or, where declared, an alternate key.
+   *
+   * Works the same after a subtype cast (e.g. {@link asPrintMediumCollectionService}-style getters):
+   * the cast segment is already part of this service's path, so the id only ever needs to add the key
+   * predicate - which is what makes addressing by a subtype's own alternate key possible at all, since
+   * the entity set's own id type never carries a subtype's alternate key.
+   */
+  public byId(id: EIdType): ES {
+    // basePath, not path: __idFunction already builds the key predicate under this set's own name (or,
+    // after a subtype cast, the cast segment's name) - path would double that segment
+    const { client, basePath, options, isUrlNotEncoded } = this.__base;
+    return this.createEntityService(client, basePath, this.__idFunction.buildUrl(id, isUrlNotEncoded()), options);
+  }
+
+  /**
+   * The key specification for the given entity type, i.e. the primary key.
    * Supports composite keys.
    */
   public getKeySpec() {
-    return this.__idFunction.getParams();
+    return this.__idFunction.getPrimaryParams();
+  }
+
+  /**
+   * The key specification of every alternate key declared for this entity type
+   * (`Core.AlternateKeys`) - empty where none are declared. One entry per alternate key, in the same
+   * order {@link createKey}/{@link parseKey} try them in after the primary key.
+   */
+  public getAlternateKeySpecs() {
+    return this.__idFunction.getAlternateParams();
   }
 
   /**
@@ -99,7 +136,9 @@ export abstract class EntitySetServiceV4<
    * Built from the mapped, user-facing property names, so it only works on a converted response.
    */
   private entityKeyOf(entry: any): string | undefined {
-    const params = this.__idFunction.getParams();
+    // always the primary key: the entity's real identity for cache purposes, regardless of which key
+    // shape it was originally fetched by
+    const params = this.__idFunction.getPrimaryParams();
     if (!params.length || params.some((p) => entry?.[p.getMappedName()] === undefined)) {
       return undefined;
     }

--- a/packages/odata-service/test/fixture/v2/PersonModelV2Service.ts
+++ b/packages/odata-service/test/fixture/v2/PersonModelV2Service.ts
@@ -63,9 +63,19 @@ export class PersonModelV2CollectionService extends EntitySetServiceV2<
   PersonModel,
   EditablePersonModel,
   QPersonV2,
-  PersonId
+  PersonId,
+  PersonModelV2Service
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternalV2) {
     super(client, basePath, name, qPersonV2, new QPersonIdFunction(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternalV2 | undefined,
+  ) {
+    return new PersonModelV2Service(client, path, name, options);
   }
 }

--- a/packages/odata-service/test/fixture/v4/BaseTypeModel.ts
+++ b/packages/odata-service/test/fixture/v4/BaseTypeModel.ts
@@ -18,7 +18,7 @@ export interface PlanItemModel {
 
 export interface EditablePlanItemModel extends Pick<PlanItemModel, "id">, Partial<Pick<PlanItemModel, "name">> {}
 
-export type PlanItemIdModel = string | { id: number };
+export type PlanItemIdModel = number | { id: number };
 
 export interface EventModel extends PlanItemModel {
   "@odata.type"?: "#Tester.Event";

--- a/packages/odata-service/test/fixture/v4/BaseTypeModel.ts
+++ b/packages/odata-service/test/fixture/v4/BaseTypeModel.ts
@@ -107,10 +107,20 @@ export class PlanItemCollectionService<V extends ODataVersionV4 = "4.0"> extends
   EditablePlanItemModel,
   QPlanItem,
   PlanItemIdModel,
+  PlanItemService<V>,
   V
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, new QPlanItem(), new QPlanItemId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new PlanItemService<V>(client, path, name, options);
   }
 
   public asFlightCollectionService() {
@@ -142,10 +152,20 @@ export class FlightCollectionService<V extends ODataVersionV4 = "4.0"> extends E
   EditableFlightModel,
   QFlight,
   PlanItemIdModel,
+  FlightService<V>,
   V
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, new QFlight(), new QPlanItemId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new FlightService<V>(client, path, name, options!);
   }
 }
 
@@ -165,9 +185,19 @@ export class EventCollectionService<V extends ODataVersionV4 = "4.0"> extends En
   EditableEventModel,
   QEvent,
   PlanItemIdModel,
+  EventService<V>,
   V
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, new QEvent(), new QPlanItemId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new EventService<V>(client, path, name, options!);
   }
 }

--- a/packages/odata-service/test/fixture/v4/PersonModelService.ts
+++ b/packages/odata-service/test/fixture/v4/PersonModelService.ts
@@ -107,12 +107,22 @@ export class PersonModelCollectionService<V extends ODataVersionV4 = "4.0"> exte
   EditablePersonModel,
   QPersonV4,
   PersonId,
+  PersonModelService<V>,
   V
 > {
   private _qGetSomething = new QGetSomethingFunction();
 
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qPersonV4, new QPersonIdFunction(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new PersonModelService<V>(client, path, name, options);
   }
 
   /**

--- a/packages/odata-service/test/fixture/v4/TypingModelService.ts
+++ b/packages/odata-service/test/fixture/v4/TypingModelService.ts
@@ -9,6 +9,8 @@ import {
   QId,
   QNumberParam,
   QNumberPath,
+  QStringParam,
+  QStringPath,
   QueryObject,
 } from "@odata2ts/odata-query-objects";
 import { numberToStringConverter } from "@odata2ts/test-converters";
@@ -21,6 +23,7 @@ export interface TestModel {
   tags: Array<string>;
   other?: TestModel;
   others?: Array<TestModel>;
+  name?: string;
 }
 
 export type TestModelId = string | { id: string };
@@ -34,6 +37,7 @@ export class QTest extends QueryObject {
   public readonly tags = new QCollectionPath(this.withPrefix("tags"), () => QGuidCollection);
   public readonly other = new QEntityPath(this.withPrefix("other"), () => QTest);
   public readonly others = new QEntityCollectionPath(this.withPrefix("others"), () => QTest);
+  public readonly name = new QStringPath(this.withPrefix("NAME"));
 
   constructor(path?: string) {
     super(path);
@@ -64,9 +68,53 @@ export class TestCollectionService<V extends ODataVersionV4 = "4.0"> extends Ent
   EditableTestModel,
   QTest,
   TestModelId,
+  TestService<V>,
   V
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qTest, new QTestIdFunction(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new TestService<V>(client, path, name, options!);
+  }
+}
+
+/**
+ * An id with `name` as an alternate key alongside the primary `id` - the shape `Core.AlternateKeys`
+ * codegen produces: the primary key's param set always first.
+ */
+export type TestModelIdWithAlternateKey = string | { id: string } | { name: string };
+
+export class QTestIdWithAlternateKeyFunction extends QId<TestModelIdWithAlternateKey> {
+  getParams() {
+    return [[new QNumberParam("ID", "id", numberToStringConverter)], [new QStringParam("NAME", "name")]];
+  }
+}
+
+export class TestCollectionServiceWithAlternateKey<V extends ODataVersionV4 = "4.0"> extends EntitySetServiceV4<
+  TestModel,
+  EditableTestModel,
+  QTest,
+  TestModelIdWithAlternateKey,
+  TestService<V>,
+  V
+> {
+  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
+    super(client, basePath, name, qTest, new QTestIdWithAlternateKeyFunction(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new TestService<V>(client, path, name, options!);
   }
 }

--- a/packages/odata-service/test/v2/ConcurrencyServiceV2.test.ts
+++ b/packages/odata-service/test/v2/ConcurrencyServiceV2.test.ts
@@ -22,9 +22,25 @@ class PersonServiceAsV4 extends EntityTypeServiceV2<PersonModel, EditablePersonM
   }
 }
 
-class PersonCollectionAsV4 extends EntitySetServiceV2<PersonModel, EditablePersonModel, QPersonV2, PersonId, true> {
+class PersonCollectionAsV4 extends EntitySetServiceV2<
+  PersonModel,
+  EditablePersonModel,
+  QPersonV2,
+  PersonId,
+  PersonServiceAsV4,
+  true
+> {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternalV2<true>) {
     super(client, basePath, name, qPersonV2, new QPersonIdFunction(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternalV2<true> | undefined,
+  ) {
+    return new PersonServiceAsV4(client, path, name, options);
   }
 }
 

--- a/packages/odata-service/test/v4/ConcurrencyServiceV4.test.ts
+++ b/packages/odata-service/test/v4/ConcurrencyServiceV4.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test } from "vitest";
 import { DEFAULT_HEADERS, ODataConcurrencyError } from "../../src";
 import { PersonModelCollectionService, PersonModelService } from "../fixture/v4/PersonModelService";
+import { TestCollectionServiceWithAlternateKey } from "../fixture/v4/TypingModelService";
 import { MockClient } from "../mock/MockClient";
 
 const BASE_URL = "test";
@@ -188,6 +189,19 @@ describe("Optimistic concurrency in the V4 services", () => {
         .execute();
 
       expect(client.concurrency.store.get(`${COLLECTION_PATH}('russell')`)).toBe('W/"1"');
+    });
+
+    test("a row is keyed by the primary key alone, even where the entity also declares an alternate one", async () => {
+      // before entityKeyOf was fixed to always use the primary param set, this threw instead of storing
+      // anything: it read the 2D params array as if it were flat
+      client.setCollectionResponse([{ ID: 7, NAME: "russell", "@odata.etag": 'W/"1"' }]);
+
+      const withAlternateKey = new TestCollectionServiceWithAlternateKey(client, BASE_URL, "Tests", {
+        concurrencyControlled: true,
+      });
+      await withAlternateKey.query().execute();
+
+      expect(client.concurrency.store.get(`${BASE_URL}/Tests(7)`)).toBe('W/"1"');
     });
   });
 });

--- a/packages/odata-service/test/v4/EntitySetServiceV4.test.ts
+++ b/packages/odata-service/test/v4/EntitySetServiceV4.test.ts
@@ -7,11 +7,12 @@ import { EditablePersonModel, Feature, PersonModel } from "../fixture/PersonMode
 import {
   EditableFlightModel,
   FlightModel,
+  FlightService,
   PlanItemCollectionService,
   PlanItemModel,
 } from "../fixture/v4/BaseTypeModel";
-import { PersonModelCollectionService } from "../fixture/v4/PersonModelService";
-import { TestCollectionService } from "../fixture/v4/TypingModelService";
+import { PersonModelCollectionService, PersonModelService } from "../fixture/v4/PersonModelService";
+import { TestCollectionService, TestCollectionServiceWithAlternateKey } from "../fixture/v4/TypingModelService";
 import { MockClient } from "../mock/MockClient";
 
 describe("V4 EntitySetService Test", () => {
@@ -124,6 +125,21 @@ describe("V4 EntitySetService Test", () => {
     expectTypeOf(await cmd.execute()).toEqualTypeOf<HttpResponseModel<ODataModelResponseV4<FlightModel>>>();
   });
 
+  /**
+   * The scenario `byId` exists for: a key that only a subtype's own property identifies (e.g. an
+   * alternate key declared on that subtype alone) needs the cast segment in the URL - unlike `create`,
+   * which can address the base collection directly, a key predicate belonging to the subtype cannot be
+   * built without it.
+   */
+  test("entitySet: byId after a subtype cast keys through the cast segment", () => {
+    const serviceToTest = new PlanItemCollectionService(odataClient, BASE_URL, NAME).asFlightCollectionService();
+
+    const entityService = serviceToTest.byId(123);
+
+    expectTypeOf(entityService).toEqualTypeOf<FlightService>();
+    expect(entityService.getPath()).toBe(`${EXPECTED_PATH}/Tester.Flight(123)`);
+  });
+
   test("entitySet: create subtype from base type", async () => {
     const serviceToTest = new PlanItemCollectionService(odataClient, BASE_URL, NAME);
     // control information belongs to the payload, not to the model
@@ -225,5 +241,49 @@ describe("V4 EntitySetService Test", () => {
 
     expect(toTest.parseKey(`${NAME}(123)`)).toBe("123");
     expect(toTest.parseKey(`${NAME}(ID=456)`)).toStrictEqual({ id: "456" });
+  });
+
+  test("byId builds the entity-type service addressed by the given key", () => {
+    const entityService = testService.byId("tester");
+
+    expectTypeOf(entityService).toEqualTypeOf<PersonModelService>();
+    expect(entityService.getPath()).toBe(`${EXPECTED_PATH}('tester')`);
+  });
+
+  describe("alternate keys", () => {
+    let toTest: TestCollectionServiceWithAlternateKey;
+
+    beforeEach(() => {
+      toTest = new TestCollectionServiceWithAlternateKey(odataClient, "", NAME);
+    });
+
+    test("getKeySpec returns the primary key's param spec only", () => {
+      const spec = toTest.getKeySpec();
+      expect(spec).toHaveLength(1);
+      expect(spec[0].getName()).toBe("ID");
+    });
+
+    test("getAlternateKeySpecs returns every alternate key's param spec", () => {
+      const specs = toTest.getAlternateKeySpecs();
+      expect(specs).toHaveLength(1);
+      expect(specs[0]).toHaveLength(1);
+      expect(specs[0][0].getName()).toBe("NAME");
+    });
+
+    test("createKey builds the primary or the alternate key's URL depending on the shape given", () => {
+      expect(toTest.createKey("7")).toBe(`${NAME}(7)`);
+      expect(toTest.createKey({ id: "7" })).toBe(`${NAME}(ID=7)`);
+      expect(toTest.createKey({ name: "russell" })).toBe(`${NAME}(NAME='russell')`);
+    });
+
+    test("parseKey resolves either shape from the URL", () => {
+      expect(toTest.parseKey(`${NAME}(ID=7)`)).toStrictEqual({ id: "7" });
+      expect(toTest.parseKey(`${NAME}(NAME='russell')`)).toStrictEqual({ name: "russell" });
+    });
+
+    test("byId builds the entity-type service for the alternate key just as well as for the primary one", () => {
+      expect(toTest.byId("7").getPath()).toBe(`${NAME}(7)`);
+      expect(toTest.byId({ name: "russell" }).getPath()).toBe(`${NAME}(NAME='russell')`);
+    });
   });
 });

--- a/packages/odata2ts/src/OptionModel.ts
+++ b/packages/odata2ts/src/OptionModel.ts
@@ -196,6 +196,15 @@ export interface AnnotationOptions {
    * demands one answers `428 Precondition Required`.
    */
   disableOptimisticConcurrency?: boolean;
+  /**
+   * Stop deriving additional identification options from `Core.AlternateKeys`. Off by default: a
+   * declared alternate key widens the generated `*Id` type with another option, and the generated
+   * service accepts it wherever the primary key is accepted today.
+   *
+   * Turn it on where the annotation is wrong, unwanted, or the service does not actually support
+   * addressing by it.
+   */
+  disableAlternateKeys?: boolean;
 }
 
 /**

--- a/packages/odata2ts/src/data-model/CoreAnnotations.ts
+++ b/packages/odata2ts/src/data-model/CoreAnnotations.ts
@@ -10,6 +10,7 @@ const PERMISSIONS = `${CORE}.Permissions`;
 
 const OPTIMISTIC_CONCURRENCY = `${CORE}.OptimisticConcurrency`;
 const OPTIONAL_PARAMETER = `${CORE}.OptionalParameter`;
+const ALTERNATE_KEYS = `${CORE}.AlternateKeys`;
 
 const PERMISSION_READ = `${CORE}.Permission/Read`;
 const PERMISSION_WRITE = `${CORE}.Permission/Write`;
@@ -113,4 +114,57 @@ export function isOptimisticConcurrency(annotations: Array<Annotation> | undefin
  */
 export function isOptionalParameter(annotations: Array<Annotation> | undefined): boolean {
   return !!annotations?.some((a) => a.$.Term === OPTIONAL_PARAMETER);
+}
+
+/**
+ * One property of one alternate key, as `Core.PropertyRef` states it: the entity's own property name
+ * (`Name`, declared `Edm.PropertyPath` - only a direct property is supported, not a nested one), and
+ * the name to use in the URL instead of it, if the service states one (`Alias`).
+ */
+export interface AlternateKeyRef {
+  name: string;
+  alias?: string;
+}
+
+/**
+ * The alternate keys a service declares for an entity via `Core.AlternateKeys`
+ * (`Collection(Core.AlternateKey)`): one entry per alternate key, itself one or more
+ * {@link AlternateKeyRef} for a composite one.
+ *
+ * Unlike {@link getManagedState} or {@link isOptimisticConcurrency} this term is neither a scalar
+ * constant nor a bare tag - it is a `Collection(Record)` nested two levels deep
+ * (`AlternateKey.Key` is itself `Collection(PropertyRef)`), so it gets its own structural walk rather
+ * than reusing {@link isConstant}/{@link getConstantValue}.
+ */
+export function getAlternateKeys(
+  annotations: Array<Annotation> | undefined,
+): Array<Array<AlternateKeyRef>> | undefined {
+  const annotation = annotations?.find((a) => a.$.Term === ALTERNATE_KEYS);
+  const alternateKeyRecords = annotation?.Collection?.[0]?.Record;
+  if (!alternateKeyRecords?.length) {
+    return undefined;
+  }
+
+  return alternateKeyRecords.map((record) => {
+    const keyPropertyValue = record.PropertyValue?.find((pv) => pv.$.Property === "Key");
+    const propertyRefRecords = keyPropertyValue?.Collection?.[0]?.Record ?? [];
+
+    return propertyRefRecords.map((propertyRef) => {
+      const nameValue = propertyRef.PropertyValue?.find((pv) => pv.$.Property === "Name");
+      const aliasValue = propertyRef.PropertyValue?.find((pv) => pv.$.Property === "Alias");
+      const name = nameValue?.$.PropertyPath ?? nameValue?.$.String;
+
+      if (!name) {
+        throw new Error(`${ALTERNATE_KEYS}: a PropertyRef without a Name/PropertyPath was found!`);
+      }
+      if (name.includes("/")) {
+        throw new Error(
+          `${ALTERNATE_KEYS}: nested property path "${name}" is not supported - only a direct property` +
+            ` of the entity type may form an alternate key.`,
+        );
+      }
+
+      return { name, alias: aliasValue?.$.String };
+    });
+  });
 }

--- a/packages/odata2ts/src/data-model/DataModelDigestion.ts
+++ b/packages/odata2ts/src/data-model/DataModelDigestion.ts
@@ -13,7 +13,7 @@ import {
 import { AllowedValuesEnumSynthesizer, SynthesizedEnum } from "./AllowedValuesEnumSynthesizer.js";
 import { AnnotationResolver } from "./AnnotationResolver.js";
 import { ComplexTypeUnflattener } from "./ComplexTypeUnflattener.js";
-import { getManagedState, isOptionalParameter } from "./CoreAnnotations.js";
+import { AlternateKeyRef, getAlternateKeys, getManagedState, isOptionalParameter } from "./CoreAnnotations.js";
 import { DataModel, NamespaceWithAlias, withNamespace } from "./DataModel.js";
 import {
   ComplexType as ComplexModelType,
@@ -112,6 +112,16 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
    * because {@link postProcessModel} clones the inherited ones.
    */
   private annotatedManagedStates = new Map<string, ManagedState>();
+
+  /**
+   * The alternate keys stated on an entity type, by its fully qualified name, as raw name/alias pairs -
+   * not yet resolved to {@link PropertyModel}s. `Core.AlternateKeys` may also apply to an `EntitySet` or
+   * `NavigationProperty`, but only the `EntityType` target is read: the generated `Q*Id` is one artifact
+   * shared by every access path (the entity set, every navigation property, every subtype cast), so only
+   * a statement that itself applies to the type - not to one particular way of reaching it - can be
+   * represented there. See {@link resolveAlternateKeys}.
+   */
+  private alternateKeyRefs = new Map<string, Array<Array<AlternateKeyRef>>>();
 
   /**
    * The enums declared `IsFlags="true"`, by fully qualified name and by alias. Their members are bits and
@@ -221,6 +231,67 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
     return this.dataModel;
   }
 
+  /**
+   * Resolves every entity type's raw {@link alternateKeyRefs} against its own properties, now that
+   * inheritance has been resolved.
+   */
+  private resolveAlternateKeys() {
+    const entityTypes = this.dataModel.getEntityTypes();
+
+    // phase 1: a type with alternate keys of its own must generate its own id - never fold them into an
+    // ancestor's, which every other subtype sharing that ancestor's id would then appear to support too
+    // (e.g. Medium's other subtypes have no ISBN, even though PrintMedium/Book do)
+    entityTypes.forEach((et) => {
+      const refs = this.alternateKeyRefs.get(et.fqName);
+      if (!refs) {
+        return;
+      }
+
+      const props = [...et.baseProps, ...et.props];
+      et.alternateKeys = refs.map((altKey) =>
+        altKey.map(({ name, alias }) => {
+          const property = props.find((p) => p.odataName === name);
+          if (!property) {
+            throw new Error(
+              `Core.AlternateKeys: property [${name}] not found among the properties of entity type [${et.fqName}]!`,
+            );
+          }
+          return { property, alias };
+        }),
+      );
+
+      if (!et.generateId) {
+        et.generateId = true;
+        et.id = {
+          fqName: et.fqName,
+          modelName: this.namingHelper.getIdModelName(et.name),
+          qName: this.namingHelper.getQIdFunctionName(et.name),
+        };
+      }
+    });
+
+    // phase 2: a type that still shares another type's id (no key, no alternate key of its own) has to
+    // point at the *nearest* id-generating ancestor - which phase 1 may just have moved closer, e.g. Book
+    // (no key, no alternate key of its own) now shares PrintMedium's id instead of skipping past it to
+    // Medium's
+    entityTypes.forEach((et) => {
+      if (et.generateId) {
+        return;
+      }
+      let owner = et;
+      while (!owner.generateId && owner.baseClasses.length) {
+        const parent = this.dataModel.getEntityType(owner.baseClasses[0]);
+        if (!parent) {
+          break;
+        }
+        owner = parent;
+      }
+      if (owner !== et && owner.generateId) {
+        et.id = { fqName: owner.fqName, modelName: owner.id.modelName, qName: owner.id.qName };
+      }
+    });
+  }
+
   private digestEntityTypesAndOperations() {
     // reshaping happens on the EDMX itself, before anything is digested: from here on the model looks like
     // one the service stated in that shape to begin with
@@ -251,6 +322,7 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
 
     this.postProcessModel();
     this.deriveManagedState();
+    this.resolveAlternateKeys();
 
     this.schemas.forEach((schema) => {
       this.analyzeModelUsage(schema.EntityContainer?.length ? schema.EntityContainer[0] : undefined);
@@ -404,6 +476,15 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
         }
       }
 
+      // Core.AlternateKeys is a V4/Core-vocabulary concept - V2 is left untouched by this, even where
+      // a service (CAP does) states the term on V2 metadata too
+      if (this.version === ODataVersion.V4 && !this.options.annotations?.disableAlternateKeys) {
+        const alternateKeyRefs = getAlternateKeys(model.Annotation);
+        if (alternateKeyRefs) {
+          this.alternateKeyRefs.set(fqName, alternateKeyRefs);
+        }
+      }
+
       this.dataModel.addEntityType(namespace[0], baseModel.odataName, {
         ...baseModel,
         id: {
@@ -414,6 +495,8 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
         generateId: !!keyNames.length,
         keyNames: keyNames, // postprocess required to include key specs from base classes
         keys: [], // postprocess required to include props from base classes
+        // postprocess required as well: resolveAlternateKeys resolves the raw refs read below into this
+        alternateKeys: [],
         getKeyUnion: () => keyNames.join(" | "),
         subtypes: new Set(),
         // postprocess required as well: the media entity marker is inherited from base types

--- a/packages/odata2ts/src/data-model/DataTypeModel.ts
+++ b/packages/odata2ts/src/data-model/DataTypeModel.ts
@@ -70,6 +70,19 @@ export interface PropertyModel {
 
 export type ModelType = EntityType | ComplexType | EnumType;
 
+/**
+ * One property of one alternate key, resolved against the entity's own properties - see
+ * {@link CoreAnnotations.AlternateKeyRef}, which this is resolved from.
+ *
+ * Kept separate from {@link PropertyModel} rather than folded into it: the alias belongs to the
+ * annotation stating the alternate key, not to the property itself, which in principle could appear in
+ * more than one alternate key under different aliases.
+ */
+export interface AlternateKeyPropertyRef {
+  property: PropertyModel;
+  alias?: string;
+}
+
 export interface EntityType extends ComplexType {
   id: {
     // fully qualified name of entity to which this id belongs (might have been inherited)
@@ -82,6 +95,13 @@ export interface EntityType extends ComplexType {
   generateId: boolean;
   keyNames: Array<string>;
   keys: Array<PropertyModel>;
+  /**
+   * The alternate keys declared via `Core.AlternateKeys`, one entry per alternate key - empty where
+   * none are declared, or where `annotations.disableAlternateKeys` is set. Widens the generated `*Id`
+   * type with one more option per entry, and the generated service accepts any of them wherever the
+   * primary key (`keys`) is accepted.
+   */
+  alternateKeys: Array<Array<AlternateKeyPropertyRef>>;
   getKeyUnion(): string;
   /**
    * Media entity (`HasStream="true"`): the entity's own representation is binary content, reachable by

--- a/packages/odata2ts/src/data-model/edmx/ODataEdmxModelBase.ts
+++ b/packages/odata2ts/src/data-model/edmx/ODataEdmxModelBase.ts
@@ -74,7 +74,11 @@ export interface AnnotationRecord extends Annotatable {
 
 /**
  * One property of a record. The value sits in an attribute named after its type; as everywhere else in
- * the parsed EDMX it arrives as a string, whatever that type says.
+ * the parsed EDMX it arrives as a string, whatever that type says - `PropertyPath` is the exception,
+ * used by `Core.AlternateKeys`' `PropertyRef.Name` (declared `Edm.PropertyPath`).
+ *
+ * A property may also carry its value as a nested `Collection` rather than an attribute -
+ * `Core.AlternateKey.Key` (`Collection(Core.PropertyRef)`) is the one we read that way.
  */
 export interface PropertyValue {
   $: {
@@ -83,7 +87,9 @@ export interface PropertyValue {
     String?: string;
     Int?: string;
     EnumMember?: string;
+    PropertyPath?: string;
   };
+  Collection?: Array<Collection>;
 }
 
 /**

--- a/packages/odata2ts/src/generator/ModelGenerator.ts
+++ b/packages/odata2ts/src/generator/ModelGenerator.ts
@@ -392,17 +392,33 @@ class ModelGenerator {
   }
 
   private generateIdModel(file: FileHandler, model: EntityType) {
-    const singleType = model.keys.length === 1 ? `${model.keys[0].type} | ` : "";
-    const keyTypes = model.keys
-      .map((keyProp) => `${keyProp.name}: ${this.getPropType(file.getImports(), keyProp)}`)
-      .join(",");
-    const type = `${singleType}{${keyTypes}}`;
+    const alternateKeyTypes = model.alternateKeys.map((altKey) =>
+      this.getIdKeyType(
+        file,
+        altKey.map((ref) => ref.property),
+      ),
+    );
+    const type = [this.getIdKeyType(file, model.keys), ...alternateKeyTypes].join(" | ");
 
     file.getFile().addTypeAlias({
       name: model.id.modelName,
       isExported: true,
       type,
     });
+  }
+
+  /**
+   * The type for one key or alternate key: the bare scalar type where it is a single property, plus -
+   * always - the object type over all its properties. The object's field names are always the
+   * properties' own TS names, never an alternate key's `alias`: the alias is a URL-addressing detail,
+   * not a payload/field rename.
+   */
+  private getIdKeyType(file: FileHandler, keyProps: Array<PropertyModel>): string {
+    const singleType = keyProps.length === 1 ? `${keyProps[0].type} | ` : "";
+    const keyTypes = keyProps
+      .map((keyProp) => `${keyProp.name}: ${this.getPropType(file.getImports(), keyProp)}`)
+      .join(",");
+    return `${singleType}{${keyTypes}}`;
   }
 
   private generateEditableModel(file: FileHandler, model: ComplexType) {

--- a/packages/odata2ts/src/generator/QueryObjectGenerator.ts
+++ b/packages/odata2ts/src/generator/QueryObjectGenerator.ts
@@ -397,6 +397,13 @@ class QueryObjectGenerator {
     const qFunc = importContainer.addQObject(QueryObjectImports.QId);
     const idModelName = importContainer.addGeneratedModel(model.fqName, model.id.modelName);
 
+    // an alternate key's wire name is its alias where stated - achieved by feeding getParamInitString
+    // a property clone with `odataName` swapped for the alias; the mapped name it derives from that
+    // (`odataName !== name`) then still resolves to the property's own, unaltered TS name
+    const alternateKeyOverloads = model.alternateKeys.map((altKey) =>
+      altKey.map(({ property, alias }) => (alias ? { ...property, odataName: alias } : property)),
+    );
+
     file.getFile().addClass({
       name: model.id.qName,
       isExported: true,
@@ -406,7 +413,11 @@ class QueryObjectGenerator {
           name: "params",
           scope: Scope.Private,
           isReadonly: true,
-          initializer: this.getParamInitString(importContainer, model.keys),
+          initializer: this.getParamInitString(
+            importContainer,
+            model.keys,
+            alternateKeyOverloads.length ? alternateKeyOverloads : undefined,
+          ),
         },
       ],
       methods: [

--- a/packages/odata2ts/src/generator/ServiceGenerator.ts
+++ b/packages/odata2ts/src/generator/ServiceGenerator.ts
@@ -301,7 +301,6 @@ class ServiceGenerator {
     versionArg: string,
   ): OptionalKind<MethodDeclarationStructure> {
     const idName = imports.addGeneratedModel(entityType.id.fqName, entityType.id.modelName);
-    const idFunctionName = imports.addGeneratedQObject(entityType.id.fqName, entityType.id.qName);
     const serviceName = imports.addGeneratedService(entityType.fqName, entityType.serviceName);
     const collectionName = imports.addGeneratedService(entityType.fqName, entityType.serviceCollectionName);
 
@@ -332,14 +331,13 @@ class ServiceGenerator {
       ],
       statements: [
         `const fieldName = "${odataPropName}";`,
-        `const { client, path, options, isUrlNotEncoded } = this.__base;`,
-        'return typeof id === "undefined" || id === null',
+        `const { client, path, options } = this.__base;`,
         // the version argument is only spelled out on the constructor call for v2ResponseAsV4: without it,
         // "new Type(...)" infers AsV4's default (false), which mismatches the declared return type above
         // wherever it isn't itself the abstract AsV4 - concretely, on every getter of the main service,
         // which pins the literal true rather than passing an abstract type parameter along
-        `? new ${collectionName}${this.isV2AsV4() ? versionArg : ""}(client, path, fieldName, options)`,
-        `: new ${serviceName}${this.isV2AsV4() ? versionArg : ""}(client, path, new ${idFunctionName}(fieldName).buildUrl(id, isUrlNotEncoded()), options);`,
+        `const collection = new ${collectionName}${this.isV2AsV4() ? versionArg : ""}(client, path, fieldName, options);`,
+        'return typeof id === "undefined" || id === null ? collection : collection.byId(id);',
       ],
     };
   }
@@ -752,6 +750,8 @@ class ServiceGenerator {
     const paramsModelName = importContainer.addGeneratedModel(model.id.fqName, model.id.modelName);
     const qIdFunctionName = importContainer.addGeneratedQObject(model.id.fqName, model.id.qName);
     const serviceOptions = this.getServiceOptionsType(importContainer);
+    const entityServiceName = importContainer.addGeneratedService(model.fqName, model.serviceName);
+    const httpClient = importContainer.addClientApi(ClientApiImports.ODataHttpClient);
 
     const collectionOperations = this.dataModel.getEntitySetOperations(model.fqName);
 
@@ -766,11 +766,11 @@ class ServiceGenerator {
       typeParameters: this.getServiceTypeParams(importContainer),
       extends:
         entitySetServiceType +
-        `<${model.modelName}, ${editableModelName}, ${model.qName}, ${paramsModelName}${this.getServiceVersionArgSuffix()}>`,
+        `<${model.modelName}, ${editableModelName}, ${model.qName}, ${paramsModelName}, ${entityServiceName}${this.getServiceVersionArg()}${this.getServiceVersionArgSuffix()}>`,
       ctors: [
         {
           parameters: [
-            { name: "client", type: importContainer.addClientApi(ClientApiImports.ODataHttpClient) },
+            { name: "client", type: httpClient },
             { name: "basePath", type: "string" },
             { name: "name", type: "string" },
             {
@@ -785,7 +785,20 @@ class ServiceGenerator {
         },
       ],
       properties,
-      methods,
+      methods: [
+        ...methods,
+        {
+          scope: Scope.Protected,
+          name: "createEntityService",
+          parameters: [
+            { name: "client", type: httpClient },
+            { name: "path", type: "string" },
+            { name: "name", type: "string" },
+            { name: "options", type: `${serviceOptions}${this.getServiceVersionArg()} | undefined` },
+          ],
+          statements: [`return new ${entityServiceName}${this.getServiceVersionArg()}(client, path, name, options);`],
+        },
+      ],
     });
   }
 

--- a/packages/odata2ts/test/data-model/builder/ODataAnnotationBuilder.ts
+++ b/packages/odata2ts/test/data-model/builder/ODataAnnotationBuilder.ts
@@ -149,6 +149,54 @@ export function allowedValues(values: Array<AllowedValue>, options: AnnotationOp
 }
 
 /**
+ * One `Core.PropertyRef` of an alternate key: the entity's own property name, and optionally the name
+ * to use for it in the URL instead (`Alias`).
+ */
+export interface AlternateKeyPropertyRef {
+  name: string;
+  alias?: string;
+}
+
+/**
+ * `Core.AlternateKeys`, in the shape both ASP.NET and CAP emit it: a collection of `Core.AlternateKey`
+ * records, each naming its own properties via a nested `Key` collection of `Core.PropertyRef` records.
+ * One entry in `keys` is one alternate key; an entry with more than one ref is a composite one.
+ */
+export function alternateKeys(
+  keys: Array<Array<AlternateKeyPropertyRef>>,
+  options: AnnotationOptions = {},
+): Annotation {
+  const prefix = options.fullyQualified ? VOCABULARIES.core.namespace : VOCABULARIES.core.alias;
+
+  return {
+    ...annotation("core", "AlternateKeys", options),
+    Collection: [
+      {
+        Record: keys.map((refs) => ({
+          $: { Type: `${prefix}.AlternateKey` },
+          PropertyValue: [
+            {
+              $: { Property: "Key" },
+              Collection: [
+                {
+                  Record: refs.map(({ name, alias }) => ({
+                    $: { Type: `${prefix}.PropertyRef` },
+                    PropertyValue: [
+                      { $: { Property: "Name", PropertyPath: name } },
+                      ...(alias ? [{ $: { Property: "Alias", String: alias } }] : []),
+                    ],
+                  })),
+                },
+              ],
+            },
+          ],
+        })),
+      },
+    ],
+  };
+}
+
+/**
  * `Core.Permissions`, whose value is a flags enum: several members may be granted at once.
  */
 export function corePermissions(members: Array<string>, options?: AnnotationOptions): Annotation {

--- a/packages/odata2ts/test/data-model/v2/EntitySetDigestion.test.ts
+++ b/packages/odata2ts/test/data-model/v2/EntitySetDigestion.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, test } from "vitest";
 import { digest } from "../../../src/data-model/DataModelDigestionV2.js";
 import { NamingHelper } from "../../../src/data-model/NamingHelper.js";
 import { getTestConfig } from "../../test.config.js";
+import { alternateKeys } from "../builder/ODataAnnotationBuilder.js";
 import { ODataModelBuilderV2 } from "../builder/v2/ODataModelBuilderV2.js";
 
 describe("EntitySet Digestion Test", () => {
@@ -144,5 +145,21 @@ describe("EntitySet Digestion Test", () => {
     const result = await doDigest();
 
     expect(result.getEntityContainer().entitySets[withEc("Products")]).toMatchObject({ navPropBinding: [] });
+  });
+
+  test("Core.AlternateKeys is a V4 concept - a V2 service stating it anyway is ignored", async () => {
+    // CAP does state this term on V2 metadata too, but it is odata2ts' own decision to read it for V4 only
+    odataBuilder
+      .enableAnnotations()
+      .addEntityType("Product", undefined, (builder) => {
+        builder.addKeyProp("id", ODataTypesV2.String);
+        builder.addProp("isbn", ODataTypesV2.String);
+        builder.addTypeAnnotations([alternateKeys([[{ name: "isbn" }]])]);
+      })
+      .addEntitySet("Products", withNs("Product"));
+
+    const result = await doDigest();
+
+    expect(result.getEntityType(withNs("Product"))!.alternateKeys).toEqual([]);
   });
 });

--- a/packages/odata2ts/test/data-model/v4/DataModelDigestion.test.ts
+++ b/packages/odata2ts/test/data-model/v4/DataModelDigestion.test.ts
@@ -1,9 +1,66 @@
-import { describe } from "vitest";
+import { describe, expect, test } from "vitest";
 import { digest } from "../../../src/data-model/DataModelDigestionV4.js";
 import { ODataVersion } from "../../../src/data-model/DataTypeModel.js";
+import { NamingHelper } from "../../../src/data-model/NamingHelper.js";
+import { getTestConfig } from "../../test.config.js";
+import { alternateKeys } from "../builder/ODataAnnotationBuilder.js";
 import { ODataModelBuilderV4 } from "../builder/v4/ODataModelBuilderV4.js";
 import { createDataModelTests } from "../DataModelDigestionTests.js";
 
 describe("DataModelDigestion Test", () => {
   createDataModelTests(ODataVersion.V4, ODataModelBuilderV4, digest);
+
+  test("Alternate keys: a subtype without a key of its own generates its own id rather than polluting the ancestor's", async () => {
+    // PrintMedium inherits its key from Medium and would otherwise never generate an id of its own - but
+    // its alternate key must not be folded into Medium's shared id, since Medium's *other* subtypes (not
+    // modelled here, but real ones like Magazine/EBook) have no ISBN at all. Book, in turn, has neither a
+    // key nor an alternate key of its own, and must redirect past PrintMedium's now-own id rather than
+    // skip straight to Medium's.
+    const SERVICE_NAME = "AlternateKeyInheritanceTest";
+    const withNs = (name: string) => `${SERVICE_NAME}.${name}`;
+
+    const odataBuilder = new ODataModelBuilderV4(SERVICE_NAME);
+    odataBuilder
+      .enableAnnotations()
+      .addEntityType("Medium", undefined, (builder) => {
+        builder.addKeyProp("Id", "Edm.String");
+      })
+      .addEntityType("PrintMedium", { baseType: withNs("Medium") }, (builder) => {
+        builder.addProp("ISBN", "Edm.String");
+        builder.addTypeAnnotations([alternateKeys([[{ name: "ISBN" }]], { fullyQualified: true })]);
+      })
+      .addEntityType("Book", { baseType: withNs("PrintMedium") }, (builder) => {
+        builder.addProp("PageCount", "Edm.Int32");
+      });
+
+    const config = getTestConfig();
+    const namingHelper = new NamingHelper(config, SERVICE_NAME);
+    const result = await digest(odataBuilder.getSchemas(), config, namingHelper, odataBuilder.getReferences());
+
+    const medium = result.getEntityType(withNs("Medium"))!;
+    const printMedium = result.getEntityType(withNs("PrintMedium"))!;
+    const book = result.getEntityType(withNs("Book"))!;
+
+    // Medium is untouched: still the plain key, no alternate keys leaked in from its subtype
+    expect(medium.generateId).toBe(true);
+    expect(medium.id.fqName).toBe(withNs("Medium"));
+    expect(medium.alternateKeys).toEqual([]);
+
+    // PrintMedium now generates its own id, carrying both its inherited primary key and its own
+    // alternate key
+    expect(printMedium.generateId).toBe(true);
+    expect(printMedium.id.fqName).toBe(withNs("PrintMedium"));
+    expect(printMedium.id.modelName).toBe("PrintMediumId");
+    expect(printMedium.id.qName).toBe("QPrintMediumId");
+    expect(printMedium.keys.map((k) => k.odataName)).toEqual(["Id"]);
+    expect(printMedium.alternateKeys).toHaveLength(1);
+    expect(printMedium.alternateKeys[0].map((r) => r.property.odataName)).toEqual(["ISBN"]);
+
+    // Book has neither a key nor an alternate key of its own, and now shares PrintMedium's id rather
+    // than Medium's
+    expect(book.generateId).toBe(false);
+    expect(book.id.fqName).toBe(withNs("PrintMedium"));
+    expect(book.id.modelName).toBe("PrintMediumId");
+    expect(book.alternateKeys).toEqual([]);
+  });
 });

--- a/packages/odata2ts/test/data-model/v4/EntitySetDigestion.test.ts
+++ b/packages/odata2ts/test/data-model/v4/EntitySetDigestion.test.ts
@@ -1,9 +1,10 @@
 import { ODataTypesV4 } from "@odata2ts/odata-core";
 import { beforeEach, describe, expect, test } from "vitest";
 import { digest } from "../../../src/data-model/DataModelDigestionV4.js";
+import { Annotation } from "../../../src/data-model/edmx/ODataEdmxModelBase.js";
 import { NamingHelper } from "../../../src/data-model/NamingHelper.js";
 import { getTestConfig } from "../../test.config.js";
-import { propertyPaths } from "../builder/ODataAnnotationBuilder.js";
+import { alternateKeys, propertyPaths } from "../builder/ODataAnnotationBuilder.js";
 import { ODataModelBuilderV4 } from "../builder/v4/ODataModelBuilderV4.js";
 
 describe("EntitySet Digestion Test", () => {
@@ -156,6 +157,114 @@ describe("EntitySet Digestion Test", () => {
 
       expect(result.getEntityContainer().entitySets[withEc("Products")].concurrencyControlled).toBe(false);
       expect(result.getEntityType(withNs("Product"))!.concurrencyControlled).toBe(false);
+    });
+  });
+
+  describe("Alternate keys", () => {
+    function addProduct(entityTypeAnnotations?: Array<Annotation>) {
+      return odataBuilder.enableAnnotations().addEntityType("Product", undefined, (builder) => {
+        builder.addKeyProp("id", ODataTypesV4.String);
+        builder.addProp("isbn", ODataTypesV4.String);
+        builder.addProp("title", ODataTypesV4.String);
+        builder.addProp("author", ODataTypesV4.String);
+        if (entityTypeAnnotations) {
+          builder.addTypeAnnotations(entityTypeAnnotations);
+        }
+      });
+    }
+
+    async function productType() {
+      return (await doDigest()).getEntityType(withNs("Product"))!;
+    }
+
+    test("no annotation means no alternate keys", async () => {
+      addProduct().addEntitySet("Products", withNs("Product"));
+
+      expect((await productType()).alternateKeys).toEqual([]);
+    });
+
+    test("single-property alternate key from the entity type", async () => {
+      addProduct([alternateKeys([[{ name: "isbn" }]])]).addEntitySet("Products", withNs("Product"));
+
+      const result = await productType();
+      expect(result.alternateKeys).toHaveLength(1);
+      expect(result.alternateKeys[0]).toHaveLength(1);
+      expect(result.alternateKeys[0][0].property.odataName).toBe("isbn");
+      expect(result.alternateKeys[0][0].alias).toBeUndefined();
+    });
+
+    test("alias is carried through", async () => {
+      addProduct([alternateKeys([[{ name: "isbn", alias: "ISBN" }]])]).addEntitySet("Products", withNs("Product"));
+
+      const result = await productType();
+      expect(result.alternateKeys[0][0].alias).toBe("ISBN");
+    });
+
+    test("composite alternate key", async () => {
+      addProduct([alternateKeys([[{ name: "title" }, { name: "author" }]])]).addEntitySet(
+        "Products",
+        withNs("Product"),
+      );
+
+      const result = await productType();
+      expect(result.alternateKeys[0].map((ref) => ref.property.odataName)).toEqual(["title", "author"]);
+    });
+
+    test("multiple alternate keys", async () => {
+      addProduct([alternateKeys([[{ name: "isbn" }], [{ name: "title" }, { name: "author" }]])]).addEntitySet(
+        "Products",
+        withNs("Product"),
+      );
+
+      const result = await productType();
+      expect(result.alternateKeys).toHaveLength(2);
+      expect(result.alternateKeys[0].map((r) => r.property.odataName)).toEqual(["isbn"]);
+      expect(result.alternateKeys[1].map((r) => r.property.odataName)).toEqual(["title", "author"]);
+    });
+
+    test("an entity-set-only annotation is ignored - only the EntityType target is read", async () => {
+      // Core.AlternateKeys' AppliesTo also lists EntitySet and NavigationProperty, but odata2ts
+      // generates one Q*Id shared by every access path (the entity set, every navigation property,
+      // every subtype cast) - only a statement that applies to the type itself can be represented there
+      addProduct().addEntitySet(
+        "Products",
+        withNs("Product"),
+        [],
+        [alternateKeys([[{ name: "title" }, { name: "author" }]])],
+      );
+
+      const result = await productType();
+      expect(result.alternateKeys).toEqual([]);
+    });
+
+    test("the entity type's own annotation applies regardless of what the entity set additionally states", async () => {
+      addProduct([alternateKeys([[{ name: "isbn" }]])]).addEntitySet(
+        "Products",
+        withNs("Product"),
+        [],
+        [alternateKeys([[{ name: "title" }, { name: "author" }]])],
+      );
+
+      const result = await productType();
+      expect(result.alternateKeys).toHaveLength(1);
+      expect(result.alternateKeys[0].map((r) => r.property.odataName)).toEqual(["isbn"]);
+    });
+
+    test("the switch turns the evaluation off", async () => {
+      addProduct([alternateKeys([[{ name: "isbn" }]])]).addEntitySet("Products", withNs("Product"));
+
+      const config = { ...CONFIG, annotations: { disableAlternateKeys: true } };
+      const result = await digest(odataBuilder.getSchemas(), config, NAMING_HELPER, odataBuilder.getReferences());
+
+      expect(result.getEntityType(withNs("Product"))!.alternateKeys).toEqual([]);
+    });
+
+    test("an unresolvable property name throws", async () => {
+      addProduct([alternateKeys([[{ name: "doesNotExist" }]])]).addEntitySet("Products", withNs("Product"));
+
+      await expect(() => doDigest()).rejects.toThrow(
+        "Core.AlternateKeys: property [doesNotExist] not found among the properties of entity type [EntitySetTest.Product]!",
+      );
     });
   });
 });

--- a/packages/odata2ts/test/data-model/v4/SingletonDigestion.test.ts
+++ b/packages/odata2ts/test/data-model/v4/SingletonDigestion.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, test } from "vitest";
 import { digest } from "../../../src/data-model/DataModelDigestionV4.js";
 import { NamingHelper } from "../../../src/data-model/NamingHelper.js";
 import { getTestConfig } from "../../test.config.js";
-import { propertyPaths } from "../builder/ODataAnnotationBuilder.js";
+import { alternateKeys, propertyPaths } from "../builder/ODataAnnotationBuilder.js";
 import { ODataModelBuilderV4 } from "../builder/v4/ODataModelBuilderV4.js";
 
 describe("Singleton Digestion Test", () => {
@@ -118,5 +118,24 @@ describe("Singleton Digestion Test", () => {
 
       expect((await doDigest()).getEntityType(withNs("User"))!.concurrencyControlled).toBe(true);
     });
+  });
+
+  test("Alternate keys: a singleton's own annotation is ignored - only the EntityType target is read", async () => {
+    // Core.AlternateKeys' AppliesTo doesn't even list Singleton (only EntityType, EntitySet,
+    // NavigationProperty) - and regardless, odata2ts generates one Q*Id shared by every access path, so
+    // only a statement that applies to the type itself can be represented there
+    odataBuilder
+      .enableAnnotations()
+      .addEntityType("User", undefined, (builder) => {
+        builder.addKeyProp("id", ODataTypesV4.String);
+        builder.addProp("email", ODataTypesV4.String);
+        builder.addTypeAnnotations([alternateKeys([[{ name: "email", alias: "Email" }]])]);
+      })
+      .addSingleton("Me", withNs("User"), [], [alternateKeys([[{ name: "id" }]])]);
+
+    const result = (await doDigest()).getEntityType(withNs("User"))!;
+
+    expect(result.alternateKeys).toHaveLength(1);
+    expect(result.alternateKeys[0].map((r) => r.property.odataName)).toEqual(["email"]);
   });
 });

--- a/packages/odata2ts/test/fixture/generator/model/entity-alternate-key-composite.ts
+++ b/packages/odata2ts/test/fixture/generator/model/entity-alternate-key-composite.ts
@@ -1,0 +1,8 @@
+export interface Book {
+  id: string;
+  isbn: string;
+  title: string;
+  author: string;
+}
+
+export type BookId = string | { id: string } | string | { isbn: string } | { title: string; author: string };

--- a/packages/odata2ts/test/fixture/generator/model/entity-alternate-key.ts
+++ b/packages/odata2ts/test/fixture/generator/model/entity-alternate-key.ts
@@ -1,0 +1,6 @@
+export interface Book {
+  id: string;
+  isbn: string;
+}
+
+export type BookId = string | { id: string } | string | { isbn: string };

--- a/packages/odata2ts/test/fixture/generator/qobject/entity-alternate-key.ts
+++ b/packages/odata2ts/test/fixture/generator/qobject/entity-alternate-key.ts
@@ -1,0 +1,18 @@
+import { QGuidParam, QGuidPath, QId, QStringParam, QStringPath, QueryObject } from "@odata2ts/odata-query-objects";
+// @ts-ignore
+import type { BookId } from "./TesterModel.js";
+
+export class QBook extends QueryObject {
+  public readonly id = new QGuidPath(this.withPrefix("id"));
+  public readonly isbn = new QStringPath(this.withPrefix("isbn"));
+}
+
+export const qBook = new QBook();
+
+export class QBookId extends QId<BookId> {
+  private readonly params = [[new QGuidParam("id")], [new QStringParam("ISBN", "isbn")]];
+
+  getParams() {
+    return this.params;
+  }
+}

--- a/packages/odata2ts/test/fixture/generator/service/v2/abstract-and-open-types.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/abstract-and-open-types.ts
@@ -30,30 +30,18 @@ export class TesterService extends ODataService {
   public fromAbstract(id: ExtendedFromAbstractId): ExtendedFromAbstractService;
   public fromAbstract(id?: ExtendedFromAbstractId | undefined) {
     const fieldName = "FromAbstract";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new ExtendedFromAbstractCollectionService(client, path, fieldName, options)
-      : new ExtendedFromAbstractService(
-          client,
-          path,
-          new QExtendedFromAbstractId(fieldName).buildUrl(id, isUrlNotEncoded()),
-          options,
-        );
+    const { client, path, options } = this.__base;
+    const collection = new ExtendedFromAbstractCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 
   public fromOpen(): ExtendedFromOpenCollectionService;
   public fromOpen(id: ExtendedFromOpenId): ExtendedFromOpenService;
   public fromOpen(id?: ExtendedFromOpenId | undefined) {
     const fieldName = "FromOpen";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new ExtendedFromOpenCollectionService(client, path, fieldName, options)
-      : new ExtendedFromOpenService(
-          client,
-          path,
-          new QExtendedFromOpenId(fieldName).buildUrl(id, isUrlNotEncoded()),
-          options,
-        );
+    const { client, path, options } = this.__base;
+    const collection = new ExtendedFromOpenCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 }
 
@@ -87,10 +75,20 @@ export class ExtendedFromAbstractCollectionService extends EntitySetServiceV2<
   ExtendedFromAbstract,
   EditableExtendedFromAbstract,
   QExtendedFromAbstract,
-  ExtendedFromAbstractId
+  ExtendedFromAbstractId,
+  ExtendedFromAbstractService
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qExtendedFromAbstract, new QExtendedFromAbstractId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptions | undefined,
+  ) {
+    return new ExtendedFromAbstractService(client, path, name, options);
   }
 }
 
@@ -108,9 +106,19 @@ export class ExtendedFromOpenCollectionService extends EntitySetServiceV2<
   ExtendedFromOpen,
   EditableExtendedFromOpen,
   QExtendedFromOpen,
-  ExtendedFromOpenId
+  ExtendedFromOpenId,
+  ExtendedFromOpenService
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qExtendedFromOpen, new QExtendedFromOpenId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptions | undefined,
+  ) {
+    return new ExtendedFromOpenService(client, path, name, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v2/complex-type-v2-response-as-v4.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/complex-type-v2-response-as-v4.ts
@@ -23,10 +23,9 @@ export class TesterService extends ODataService {
   public books(id: BookId): BookService<true>;
   public books(id?: BookId | undefined) {
     const fieldName = "Books";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new BookCollectionService<true>(client, path, fieldName, options)
-      : new BookService<true>(client, path, new QBookId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new BookCollectionService<true>(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 }
 
@@ -52,10 +51,20 @@ export class BookCollectionService<AsV4 extends boolean = false> extends EntityS
   EditableBook,
   QBook,
   BookId,
+  BookService<AsV4>,
   AsV4
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternalV2<AsV4>) {
     super(client, basePath, name, qBook, new QBookId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternalV2<AsV4> | undefined,
+  ) {
+    return new BookService<AsV4>(client, path, name, options);
   }
 }
 

--- a/packages/odata2ts/test/fixture/generator/service/v2/complex-type.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/complex-type.ts
@@ -19,10 +19,9 @@ export class TesterService extends ODataService {
   public books(id: BookId): BookService;
   public books(id?: BookId | undefined) {
     const fieldName = "Books";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new BookCollectionService(client, path, fieldName, options)
-      : new BookService(client, path, new QBookId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new BookCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 }
 
@@ -53,9 +52,18 @@ export class BookService extends EntityTypeServiceV2<Book, EditableBook, QBook> 
   }
 }
 
-export class BookCollectionService extends EntitySetServiceV2<Book, EditableBook, QBook, BookId> {
+export class BookCollectionService extends EntitySetServiceV2<Book, EditableBook, QBook, BookId, BookService> {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qBook, new QBookId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptions | undefined,
+  ) {
+    return new BookService(client, path, name, options);
   }
 }
 

--- a/packages/odata2ts/test/fixture/generator/service/v2/entity-hierarchy.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/entity-hierarchy.ts
@@ -21,10 +21,9 @@ export class TesterService extends ODataService {
   public tests(id: ChildId): ChildService;
   public tests(id?: ChildId | undefined) {
     const fieldName = "tests";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new ChildCollectionService(client, path, fieldName, options)
-      : new ChildService(client, path, new QChildId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new ChildCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 }
 
@@ -38,10 +37,20 @@ export class GrandParentCollectionService extends EntitySetServiceV2<
   GrandParent,
   EditableGrandParent,
   QGrandParent,
-  GrandParentId
+  GrandParentId,
+  GrandParentService
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qGrandParent, new QGrandParentId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptions | undefined,
+  ) {
+    return new GrandParentService(client, path, name, options);
   }
 }
 
@@ -51,9 +60,24 @@ export class ParentService extends EntityTypeServiceV2<Parent, EditableParent, Q
   }
 }
 
-export class ParentCollectionService extends EntitySetServiceV2<Parent, EditableParent, QParent, GrandParentId> {
+export class ParentCollectionService extends EntitySetServiceV2<
+  Parent,
+  EditableParent,
+  QParent,
+  GrandParentId,
+  ParentService
+> {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qParent, new QGrandParentId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptions | undefined,
+  ) {
+    return new ParentService(client, path, name, options);
   }
 }
 
@@ -63,8 +87,17 @@ export class ChildService extends EntityTypeServiceV2<Child, EditableChild, QChi
   }
 }
 
-export class ChildCollectionService extends EntitySetServiceV2<Child, EditableChild, QChild, ChildId> {
+export class ChildCollectionService extends EntitySetServiceV2<Child, EditableChild, QChild, ChildId, ChildService> {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qChild, new QChildId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptions | undefined,
+  ) {
+    return new ChildService(client, path, name, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v2/entity-relationships.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/entity-relationships.ts
@@ -18,10 +18,9 @@ export class TesterService extends ODataService {
   public books(id: BookId): BookService;
   public books(id?: BookId | undefined) {
     const fieldName = "books";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new BookCollectionService(client, path, fieldName, options)
-      : new BookService(client, path, new QBookId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new BookCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 }
 
@@ -52,9 +51,24 @@ export class AuthorService extends EntityTypeServiceV2<Author, EditableAuthor, Q
   }
 }
 
-export class AuthorCollectionService extends EntitySetServiceV2<Author, EditableAuthor, QAuthor, AuthorId> {
+export class AuthorCollectionService extends EntitySetServiceV2<
+  Author,
+  EditableAuthor,
+  QAuthor,
+  AuthorId,
+  AuthorService
+> {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qAuthor, new QAuthorId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptions | undefined,
+  ) {
+    return new AuthorService(client, path, name, options);
   }
 }
 
@@ -88,15 +102,23 @@ export class BookService extends EntityTypeServiceV2<Book, EditableBook, QBook> 
   public relatedAuthors(id: AuthorId): AuthorService;
   public relatedAuthors(id?: AuthorId | undefined) {
     const fieldName = "relatedAuthors";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new AuthorCollectionService(client, path, fieldName, options)
-      : new AuthorService(client, path, new QAuthorId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new AuthorCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 }
 
-export class BookCollectionService extends EntitySetServiceV2<Book, EditableBook, QBook, BookId> {
+export class BookCollectionService extends EntitySetServiceV2<Book, EditableBook, QBook, BookId, BookService> {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qBook, new QBookId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptions | undefined,
+  ) {
+    return new BookService(client, path, name, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v2/enum-numeric-type.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/enum-numeric-type.ts
@@ -22,10 +22,9 @@ export class TesterService extends ODataService {
   public books(id: BookId): BookService;
   public books(id?: BookId | undefined) {
     const fieldName = "books";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new BookCollectionService(client, path, fieldName, options)
-      : new BookService(client, path, new QBookId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new BookCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 }
 
@@ -52,8 +51,17 @@ export class BookService extends EntityTypeServiceV2<Book, EditableBook, QBook> 
   }
 }
 
-export class BookCollectionService extends EntitySetServiceV2<Book, EditableBook, QBook, BookId> {
+export class BookCollectionService extends EntitySetServiceV2<Book, EditableBook, QBook, BookId, BookService> {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qBook, new QBookId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptions | undefined,
+  ) {
+    return new BookService(client, path, name, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v2/enum-type.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/enum-type.ts
@@ -22,10 +22,9 @@ export class TesterService extends ODataService {
   public books(id: BookId): BookService;
   public books(id?: BookId | undefined) {
     const fieldName = "books";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new BookCollectionService(client, path, fieldName, options)
-      : new BookService(client, path, new QBookId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new BookCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 }
 
@@ -46,8 +45,17 @@ export class BookService extends EntityTypeServiceV2<Book, EditableBook, QBook> 
   }
 }
 
-export class BookCollectionService extends EntitySetServiceV2<Book, EditableBook, QBook, BookId> {
+export class BookCollectionService extends EntitySetServiceV2<Book, EditableBook, QBook, BookId, BookService> {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qBook, new QBookId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptions | undefined,
+  ) {
+    return new BookService(client, path, name, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v2/function-import-special-params.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/function-import-special-params.ts
@@ -22,10 +22,9 @@ export class TesterService extends ODataService {
   public tests(id: TestEntityId): TestEntityService;
   public tests(id?: TestEntityId | undefined) {
     const fieldName = "tests";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new TestEntityCollectionService(client, path, fieldName, options)
-      : new TestEntityService(client, path, new QTestEntityId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new TestEntityCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 
   public bestBook(params: BestBookParams) {
@@ -53,9 +52,19 @@ export class TestEntityCollectionService extends EntitySetServiceV2<
   TestEntity,
   EditableTestEntity,
   QTestEntity,
-  TestEntityId
+  TestEntityId,
+  TestEntityService
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qTestEntity, new QTestEntityId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptions | undefined,
+  ) {
+    return new TestEntityService(client, path, name, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v2/function-import.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/function-import.ts
@@ -30,10 +30,9 @@ export class TesterService extends ODataService {
   public tests(id: TestEntityId): TestEntityService;
   public tests(id?: TestEntityId | undefined) {
     const fieldName = "tests";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new TestEntityCollectionService(client, path, fieldName, options)
-      : new TestEntityService(client, path, new QTestEntityId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new TestEntityCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 
   public mostPop() {
@@ -89,9 +88,19 @@ export class TestEntityCollectionService extends EntitySetServiceV2<
   TestEntity,
   EditableTestEntity,
   QTestEntity,
-  TestEntityId
+  TestEntityId,
+  TestEntityService
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qTestEntity, new QTestEntityId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptions | undefined,
+  ) {
+    return new TestEntityService(client, path, name, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v2/media-entity.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/media-entity.ts
@@ -12,10 +12,9 @@ export class TesterService extends ODataService {
   public eBooks(id: EBookId): EBookService;
   public eBooks(id?: EBookId | undefined) {
     const fieldName = "EBooks";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new EBookCollectionService(client, path, fieldName, options)
-      : new EBookService(client, path, new QEBookId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new EBookCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 }
 
@@ -25,8 +24,17 @@ export class EBookService extends MediaEntityServiceV2<EBook, EditableEBook, QEB
   }
 }
 
-export class EBookCollectionService extends EntitySetServiceV2<EBook, EditableEBook, QEBook, EBookId> {
+export class EBookCollectionService extends EntitySetServiceV2<EBook, EditableEBook, QEBook, EBookId, EBookService> {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qEBook, new QEBookId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptions | undefined,
+  ) {
+    return new EBookService(client, path, name, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v2/one-entityset-v2-response-as-v4.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/one-entityset-v2-response-as-v4.ts
@@ -23,15 +23,9 @@ export class TesterService extends ODataService {
   public ents(id: TestEntityId): TestEntityService<true>;
   public ents(id?: TestEntityId | undefined) {
     const fieldName = "Ents";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new TestEntityCollectionService<true>(client, path, fieldName, options)
-      : new TestEntityService<true>(
-          client,
-          path,
-          new QTestEntityId(fieldName).buildUrl(id, isUrlNotEncoded()),
-          options,
-        );
+    const { client, path, options } = this.__base;
+    const collection = new TestEntityCollectionService<true>(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 }
 
@@ -72,9 +66,19 @@ export class TestEntityCollectionService<AsV4 extends boolean = false> extends E
   EditableTestEntity,
   QTestEntity,
   TestEntityId,
+  TestEntityService<AsV4>,
   AsV4
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternalV2<AsV4>) {
     super(client, basePath, name, qTestEntity, new QTestEntityId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternalV2<AsV4> | undefined,
+  ) {
+    return new TestEntityService<AsV4>(client, path, name, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v2/one-entityset.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/one-entityset.ts
@@ -18,10 +18,9 @@ export class TesterService extends ODataService {
   public ents(id: TestEntityId): TestEntityService;
   public ents(id?: TestEntityId | undefined) {
     const fieldName = "Ents";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new TestEntityCollectionService(client, path, fieldName, options)
-      : new TestEntityService(client, path, new QTestEntityId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new TestEntityCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 }
 
@@ -137,9 +136,19 @@ export class TestEntityCollectionService extends EntitySetServiceV2<
   TestEntity,
   EditableTestEntity,
   QTestEntity,
-  TestEntityId
+  TestEntityId,
+  TestEntityService
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
     super(client, basePath, name, qTestEntity, new QTestEntityId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptions | undefined,
+  ) {
+    return new TestEntityService(client, path, name, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/abstract-and-open-types.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/abstract-and-open-types.ts
@@ -36,30 +36,18 @@ export class TesterService extends ODataService {
   public fromAbstract(id: ExtendedFromAbstractId): ExtendedFromAbstractService;
   public fromAbstract(id?: ExtendedFromAbstractId | undefined) {
     const fieldName = "FromAbstract";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new ExtendedFromAbstractCollectionService(client, path, fieldName, options)
-      : new ExtendedFromAbstractService(
-          client,
-          path,
-          new QExtendedFromAbstractId(fieldName).buildUrl(id, isUrlNotEncoded()),
-          options,
-        );
+    const { client, path, options } = this.__base;
+    const collection = new ExtendedFromAbstractCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 
   public fromOpen(): ExtendedFromOpenCollectionService;
   public fromOpen(id: ExtendedFromOpenId): ExtendedFromOpenService;
   public fromOpen(id?: ExtendedFromOpenId | undefined) {
     const fieldName = "FromOpen";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new ExtendedFromOpenCollectionService(client, path, fieldName, options)
-      : new ExtendedFromOpenService(
-          client,
-          path,
-          new QExtendedFromOpenId(fieldName).buildUrl(id, isUrlNotEncoded()),
-          options,
-        );
+    const { client, path, options } = this.__base;
+    const collection = new ExtendedFromOpenCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 }
 
@@ -121,10 +109,20 @@ export class ExtendedFromAbstractCollectionService<V extends ODataVersionV4 = "4
   EditableExtendedFromAbstract,
   QExtendedFromAbstract,
   ExtendedFromAbstractId,
+  ExtendedFromAbstractService<V>,
   V
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qExtendedFromAbstract, new QExtendedFromAbstractId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new ExtendedFromAbstractService<V>(client, path, name, options);
   }
 }
 
@@ -144,9 +142,19 @@ export class ExtendedFromOpenCollectionService<V extends ODataVersionV4 = "4.0">
   EditableExtendedFromOpen,
   QExtendedFromOpen,
   ExtendedFromOpenId,
+  ExtendedFromOpenService<V>,
   V
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qExtendedFromOpen, new QExtendedFromOpenId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new ExtendedFromOpenService<V>(client, path, name, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/abstract-with-inheritance.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/abstract-with-inheritance.ts
@@ -24,10 +24,9 @@ export class TesterService extends ODataService {
   public testing(id: AbstractEntityId): TestEntityService;
   public testing(id?: AbstractEntityId | undefined) {
     const fieldName = "Testing";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new TestEntityCollectionService(client, path, fieldName, options)
-      : new TestEntityService(client, path, new QAbstractEntityId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new TestEntityCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 }
 
@@ -52,6 +51,7 @@ export class AbstractEntityCollectionService<V extends ODataVersionV4 = "4.0"> e
   EditableAbstractEntity,
   QAbstractEntity,
   AbstractEntityId,
+  AbstractEntityService<V>,
   V
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
@@ -61,6 +61,15 @@ export class AbstractEntityCollectionService<V extends ODataVersionV4 = "4.0"> e
   public asTestEntityCollectionService() {
     const { client, path, options } = this.__base;
     return new TestEntityCollectionService(client, path, "Tester.TestEntity", { ...options, subtype: true });
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new AbstractEntityService<V>(client, path, name, options);
   }
 }
 
@@ -80,9 +89,19 @@ export class TestEntityCollectionService<V extends ODataVersionV4 = "4.0"> exten
   EditableTestEntity,
   QTestEntity,
   AbstractEntityId,
+  TestEntityService<V>,
   V
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qTestEntity, new QAbstractEntityId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new TestEntityService<V>(client, path, name, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/action-bound-unbound.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/action-bound-unbound.ts
@@ -23,10 +23,9 @@ export class TesterService extends ODataService {
   public tests(id: TestEntityId): TestEntityService;
   public tests(id?: TestEntityId | undefined) {
     const fieldName = "tests";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new TestEntityCollectionService(client, path, fieldName, options)
-      : new TestEntityService(client, path, new QTestEntityId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new TestEntityCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 
   public keepAlive() {
@@ -74,9 +73,19 @@ export class TestEntityCollectionService<V extends ODataVersionV4 = "4.0"> exten
   EditableTestEntity,
   QTestEntity,
   TestEntityId,
+  TestEntityService<V>,
   V
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qTestEntity, new QTestEntityId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new TestEntityService<V>(client, path, name, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/action-rt-enum.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/action-rt-enum.ts
@@ -27,10 +27,9 @@ export class TesterService extends ODataService {
   public books(id: BookId): BookService;
   public books(id?: BookId | undefined) {
     const fieldName = "books";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new BookCollectionService(client, path, fieldName, options)
-      : new BookService(client, path, new QBookId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new BookCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 }
 
@@ -82,6 +81,7 @@ export class BookCollectionService<V extends ODataVersionV4 = "4.0"> extends Ent
   EditableBook,
   QBook,
   BookId,
+  BookService<V>,
   V
 > {
   private _bookCollectionQRatings?: BookCollection_QRatings;
@@ -109,5 +109,14 @@ export class BookCollectionService<V extends ODataVersionV4 = "4.0"> extends Ent
         mainResponseConverter: this._bookCollectionQRatings.getResponseConverter(),
       },
     );
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new BookService<V>(client, path, name, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/action-rt-primitive.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/action-rt-primitive.ts
@@ -24,10 +24,9 @@ export class TesterService extends ODataService {
   public tests(id: TestEntityId): TestEntityService;
   public tests(id?: TestEntityId | undefined) {
     const fieldName = "tests";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new TestEntityCollectionService(client, path, fieldName, options)
-      : new TestEntityService(client, path, new QTestEntityId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new TestEntityCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 
   public pingString() {
@@ -89,9 +88,19 @@ export class TestEntityCollectionService<V extends ODataVersionV4 = "4.0"> exten
   EditableTestEntity,
   QTestEntity,
   TestEntityId,
+  TestEntityService<V>,
   V
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qTestEntity, new QTestEntityId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new TestEntityService<V>(client, path, name, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/big-number-return-types.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/big-number-return-types.ts
@@ -29,10 +29,9 @@ export class TesterService extends ODataService {
   public tests(id: TestEntityId): TestEntityService;
   public tests(id?: TestEntityId | undefined) {
     const fieldName = "tests";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new TestEntityCollectionService(client, path, fieldName, options)
-      : new TestEntityService(client, path, new QTestEntityId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new TestEntityCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 
   public pingBigNumber() {
@@ -94,9 +93,19 @@ export class TestEntityCollectionService<V extends ODataVersionV4 = "4.0"> exten
   EditableTestEntity,
   QTestEntity,
   TestEntityId,
+  TestEntityService<V>,
   V
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qTestEntity, new QTestEntityId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new TestEntityService<V>(client, path, name, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/big-numbers.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/big-numbers.ts
@@ -27,10 +27,9 @@ export class TesterService extends ODataService {
   public ents(id: TestEntityId): TestEntityService;
   public ents(id?: TestEntityId | undefined) {
     const fieldName = "Ents";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new TestEntityCollectionService(client, path, fieldName, options)
-      : new TestEntityService(client, path, new QTestEntityId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new TestEntityCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 }
 
@@ -72,9 +71,19 @@ export class TestEntityCollectionService<V extends ODataVersionV4 = "4.0"> exten
   EditableTestEntity,
   QTestEntity,
   TestEntityId,
+  TestEntityService<V>,
   V
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qTestEntity, new QTestEntityId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new TestEntityService<V>(client, path, name, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/complex-type.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/complex-type.ts
@@ -19,10 +19,9 @@ export class TesterService extends ODataService {
   public books(id: BookId): BookService;
   public books(id?: BookId | undefined) {
     const fieldName = "Books";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new BookCollectionService(client, path, fieldName, options)
-      : new BookService(client, path, new QBookId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new BookCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 }
 
@@ -58,10 +57,20 @@ export class BookCollectionService<V extends ODataVersionV4 = "4.0"> extends Ent
   EditableBook,
   QBook,
   BookId,
+  BookService<V>,
   V
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qBook, new QBookId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new BookService<V>(client, path, name, options);
   }
 }
 

--- a/packages/odata2ts/test/fixture/generator/service/v4/entity-relationships.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/entity-relationships.ts
@@ -19,10 +19,9 @@ export class TesterService extends ODataService {
   public books(id: BookId): BookService;
   public books(id?: BookId | undefined) {
     const fieldName = "books";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new BookCollectionService(client, path, fieldName, options)
-      : new BookService(client, path, new QBookId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new BookCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 }
 
@@ -63,10 +62,20 @@ export class AuthorCollectionService<V extends ODataVersionV4 = "4.0"> extends E
   EditableAuthor,
   QAuthor,
   AuthorId,
+  AuthorService<V>,
   V
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qAuthor, new QAuthorId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new AuthorService<V>(client, path, name, options);
   }
 }
 
@@ -100,10 +109,9 @@ export class BookService<V extends ODataVersionV4 = "4.0"> extends EntityTypeSer
   public relatedAuthors(id: AuthorId): AuthorService<V>;
   public relatedAuthors(id?: AuthorId | undefined) {
     const fieldName = "RelatedAuthors";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new AuthorCollectionService(client, path, fieldName, options)
-      : new AuthorService(client, path, new QAuthorId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new AuthorCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 }
 
@@ -112,9 +120,19 @@ export class BookCollectionService<V extends ODataVersionV4 = "4.0"> extends Ent
   EditableBook,
   QBook,
   BookId,
+  BookService<V>,
   V
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qBook, new QBookId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new BookService<V>(client, path, name, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/enum-numeric-type.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/enum-numeric-type.ts
@@ -24,10 +24,9 @@ export class TesterService extends ODataService {
   public books(id: BookId): BookService;
   public books(id?: BookId | undefined) {
     const fieldName = "books";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new BookCollectionService(client, path, fieldName, options)
-      : new BookService(client, path, new QBookId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new BookCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 }
 
@@ -64,9 +63,19 @@ export class BookCollectionService<V extends ODataVersionV4 = "4.0"> extends Ent
   EditableBook,
   QBook,
   BookId,
+  BookService<V>,
   V
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qBook, new QBookId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new BookService<V>(client, path, name, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/enum-type.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/enum-type.ts
@@ -24,10 +24,9 @@ export class TesterService extends ODataService {
   public books(id: BookId): BookService;
   public books(id?: BookId | undefined) {
     const fieldName = "books";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new BookCollectionService(client, path, fieldName, options)
-      : new BookService(client, path, new QBookId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new BookCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 }
 
@@ -58,9 +57,19 @@ export class BookCollectionService<V extends ODataVersionV4 = "4.0"> extends Ent
   EditableBook,
   QBook,
   BookId,
+  BookService<V>,
   V
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qBook, new QBookId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new BookService<V>(client, path, name, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/function-bound-unbound.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/function-bound-unbound.ts
@@ -22,10 +22,9 @@ export class TesterService extends ODataService {
   public tests(id: TestEntityId): TestEntityService;
   public tests(id?: TestEntityId | undefined) {
     const fieldName = "tests";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new TestEntityCollectionService(client, path, fieldName, options)
-      : new TestEntityService(client, path, new QTestEntityId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new TestEntityCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 
   public mostPop() {
@@ -73,9 +72,19 @@ export class TestEntityCollectionService<V extends ODataVersionV4 = "4.0"> exten
   EditableTestEntity,
   QTestEntity,
   TestEntityId,
+  TestEntityService<V>,
   V
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qTestEntity, new QTestEntityId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new TestEntityService<V>(client, path, name, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/function-composable.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/function-composable.ts
@@ -23,10 +23,9 @@ export class TesterService extends ODataService {
   public books(id: BookId): BookService;
   public books(id?: BookId | undefined) {
     const fieldName = "Books";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new BookCollectionService(client, path, fieldName, options)
-      : new BookService(client, path, new QBookId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new BookCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 
   public bestBook() {
@@ -100,10 +99,20 @@ export class BookCollectionService<V extends ODataVersionV4 = "4.0"> extends Ent
   EditableBook,
   QBook,
   BookId,
+  BookService<V>,
   V
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qBook, new QBookId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new BookService<V>(client, path, name, options);
   }
 }
 

--- a/packages/odata2ts/test/fixture/generator/service/v4/function-rt-complex.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/function-rt-complex.ts
@@ -19,10 +19,9 @@ export class TesterService extends ODataService {
   public books(id: BookId): BookService;
   public books(id?: BookId | undefined) {
     const fieldName = "books";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new BookCollectionService(client, path, fieldName, options)
-      : new BookService(client, path, new QBookId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new BookCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 }
 
@@ -53,6 +52,7 @@ export class BookCollectionService<V extends ODataVersionV4 = "4.0"> extends Ent
   EditableBook,
   QBook,
   BookId,
+  BookService<V>,
   V
 > {
   private _bookCollectionQFilterReviews?: BookCollection_QFilterReviews;
@@ -73,5 +73,14 @@ export class BookCollectionService<V extends ODataVersionV4 = "4.0"> extends Ent
       headers: getDefaultHeaders(),
       mainResponseConverter: this._bookCollectionQFilterReviews.getResponseConverter(),
     });
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new BookService<V>(client, path, name, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/media-entity.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/media-entity.ts
@@ -18,10 +18,9 @@ export class TesterService extends ODataService {
   public eBooks(id: EBookId): EBookService;
   public eBooks(id?: EBookId | undefined) {
     const fieldName = "EBooks";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new EBookCollectionService(client, path, fieldName, options)
-      : new EBookService(client, path, new QEBookId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new EBookCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 }
 
@@ -41,9 +40,19 @@ export class EBookCollectionService<V extends ODataVersionV4 = "4.0"> extends En
   EditableEBook,
   QEBook,
   EBookId,
+  EBookService<V>,
   V
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qEBook, new QEBookId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new EBookService<V>(client, path, name, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/naming.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/naming.ts
@@ -18,10 +18,9 @@ export class tester extends ODataService {
   public NAVIGATE_TO_LIST(id: TEST_ENTITY_ID): TEST_ENTITY_SRV;
   public NAVIGATE_TO_LIST(id?: TEST_ENTITY_ID | undefined) {
     const fieldName = "list";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new TEST_ENTITY_COLLECTION_SRV(client, path, fieldName, options)
-      : new TEST_ENTITY_SRV(client, path, new Q_TEST_ENTITY_ID(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new TEST_ENTITY_COLLECTION_SRV(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 }
 
@@ -41,9 +40,19 @@ export class TEST_ENTITY_COLLECTION_SRV<V extends ODataVersionV4 = "4.0"> extend
   EDITABLE_TEST_ENTITY,
   Q_TEST_ENTITY,
   TEST_ENTITY_ID,
+  TEST_ENTITY_SRV<V>,
   V
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, q_TEST_ENTITY, new Q_TEST_ENTITY_ID(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new TEST_ENTITY_SRV<V>(client, path, name, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/one-entityset.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/one-entityset.ts
@@ -19,10 +19,9 @@ export class TesterService extends ODataService {
   public ents(id: TestEntityId): TestEntityService;
   public ents(id?: TestEntityId | undefined) {
     const fieldName = "Ents";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new TestEntityCollectionService(client, path, fieldName, options)
-      : new TestEntityService(client, path, new QTestEntityId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new TestEntityCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 }
 
@@ -83,9 +82,19 @@ export class TestEntityCollectionService<V extends ODataVersionV4 = "4.0"> exten
   EditableTestEntity,
   QTestEntity,
   TestEntityId,
+  TestEntityService<V>,
   V
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qTestEntity, new QTestEntityId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new TestEntityService<V>(client, path, name, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/singleton.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/singleton.ts
@@ -42,9 +42,19 @@ export class TestEntityCollectionService<V extends ODataVersionV4 = "4.0"> exten
   EditableTestEntity,
   QTestEntity,
   TestEntityId,
+  TestEntityService<V>,
   V
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qTestEntity, new QTestEntityId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new TestEntityService<V>(client, path, name, options);
   }
 }

--- a/packages/odata2ts/test/fixture/generator/service/v4/stream-property.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/stream-property.ts
@@ -19,10 +19,9 @@ export class TesterService extends ODataService {
   public audiobooks(id: AudiobookId): AudiobookService;
   public audiobooks(id?: AudiobookId | undefined) {
     const fieldName = "Audiobooks";
-    const { client, path, options, isUrlNotEncoded } = this.__base;
-    return typeof id === "undefined" || id === null
-      ? new AudiobookCollectionService(client, path, fieldName, options)
-      : new AudiobookService(client, path, new QAudiobookId(fieldName).buildUrl(id, isUrlNotEncoded()), options);
+    const { client, path, options } = this.__base;
+    const collection = new AudiobookCollectionService(client, path, fieldName, options);
+    return typeof id === "undefined" || id === null ? collection : collection.byId(id);
   }
 }
 
@@ -53,9 +52,19 @@ export class AudiobookCollectionService<V extends ODataVersionV4 = "4.0"> extend
   EditableAudiobook,
   QAudiobook,
   AudiobookId,
+  AudiobookService<V>,
   V
 > {
   constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
     super(client, basePath, name, qAudiobook, new QAudiobookId(name), options);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<V> | undefined,
+  ) {
+    return new AudiobookService<V>(client, path, name, options);
   }
 }

--- a/packages/odata2ts/test/generator/v4/ModelGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/ModelGenerator.test.ts
@@ -11,7 +11,12 @@ import {
   Modes,
 } from "../../../src/index.js";
 import { createProjectManager } from "../../../src/project/ProjectManager.js";
-import { allowedValues, core, corePermissions } from "../../data-model/builder/ODataAnnotationBuilder.js";
+import {
+  allowedValues,
+  alternateKeys,
+  core,
+  corePermissions,
+} from "../../data-model/builder/ODataAnnotationBuilder.js";
 import { ODataModelBuilderV4 } from "../../data-model/builder/v4/ODataModelBuilderV4.js";
 import {
   createHelper,
@@ -237,6 +242,34 @@ describe("Model Generator Tests V4", () => {
       skipEditableModels: false,
       skipIdModels: false,
     });
+  });
+
+  test(`${TEST_SUITE_NAME}: single alternate key widens the id model`, async () => {
+    odataBuilder.enableAnnotations().addEntityType(ENTITY_NAME, undefined, (builder) =>
+      builder
+        .addKeyProp("id", ODataTypesV4.String)
+        .addProp("isbn", ODataTypesV4.String, false)
+        .addTypeAnnotations([alternateKeys([[{ name: "isbn" }]], { fullyQualified: true })]),
+    );
+
+    await generateAndCompare("entity-alternate-key.ts", { skipIdModels: false });
+  });
+
+  test(`${TEST_SUITE_NAME}: composite and aliased alternate keys widen the id model`, async () => {
+    odataBuilder.enableAnnotations().addEntityType(ENTITY_NAME, undefined, (builder) =>
+      builder
+        .addKeyProp("id", ODataTypesV4.String)
+        .addProp("isbn", ODataTypesV4.String, false)
+        .addProp("title", ODataTypesV4.String, false)
+        .addProp("author", ODataTypesV4.String, false)
+        .addTypeAnnotations([
+          alternateKeys([[{ name: "isbn", alias: "ISBN" }], [{ name: "title" }, { name: "author" }]], {
+            fullyQualified: true,
+          }),
+        ]),
+    );
+
+    await generateAndCompare("entity-alternate-key-composite.ts", { skipIdModels: false });
   });
 
   test(`${TEST_SUITE_NAME}: composite key defaults to createOnly`, async () => {

--- a/packages/odata2ts/test/generator/v4/QueryObjectGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/QueryObjectGenerator.test.ts
@@ -4,7 +4,7 @@ import { digest } from "../../../src/data-model/DataModelDigestionV4.js";
 import { generateQueryObjects } from "../../../src/generator/index.js";
 import { EmitModes, EnumSynthesis } from "../../../src/index.js";
 import { createProjectManager } from "../../../src/project/ProjectManager.js";
-import { allowedValues } from "../../data-model/builder/ODataAnnotationBuilder.js";
+import { allowedValues, alternateKeys } from "../../data-model/builder/ODataAnnotationBuilder.js";
 import { ODataModelBuilderV4 } from "../../data-model/builder/v4/ODataModelBuilderV4.js";
 import {
   createHelper,
@@ -48,6 +48,17 @@ describe("Query Object Generator Tests V4", () => {
 
   beforeEach(() => {
     odataBuilder = new ODataModelBuilderV4(SERVICE_NAME);
+  });
+
+  test(`${TEST_SUITE_NAME}: an aliased alternate key adds an overloaded param set to QId`, async () => {
+    odataBuilder.enableAnnotations().addEntityType(ENTITY_NAME, undefined, (builder) =>
+      builder
+        .addKeyProp("id", ODataTypesV4.Guid)
+        .addProp("isbn", ODataTypesV4.String, false)
+        .addTypeAnnotations([alternateKeys([[{ name: "isbn", alias: "ISBN" }]], { fullyQualified: true })]),
+    );
+
+    await generateAndCompare("entity-alternate-key.ts", { skipIdModels: false });
   });
 
   test(`${TEST_SUITE_NAME}: flags enum offers has, the collection of it does not`, async () => {

--- a/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
@@ -647,7 +647,7 @@ describe("Service Generator Tests V4", () => {
     expect(serviceText).toContain("extends EntityTypeServiceV4<TestEntity, UpdatableTestEntity, QTestEntity, V>");
     // while the collection service, which is where creation happens, keeps the EditableModel
     expect(serviceText).toContain(
-      "extends EntitySetServiceV4<TestEntity, EditableTestEntity, QTestEntity, TestEntityId, V>",
+      "extends EntitySetServiceV4<TestEntity, EditableTestEntity, QTestEntity, TestEntityId, TestEntityService<V>, V>",
     );
 
     // `strictOmit` drops the key from the update model instead of relaxing it - a different model, the


### PR DESCRIPTION
Unfortunately 2 features developed in one go:
1. Support for alternate keys which are provided via annotations
2. dedicated `byId` method on EntitySetServices

While 2. was only required for special cases of 1., it is hereby rolled out as common convenience function.  Navigation paths like `service.people(keys)` can now also be build via `service.people().byId(keys)`. Seems convenient as I know of two incidents where people found the former version rather unintuitive. It's the only way to force a type cast to a sub type (`service.people().asVipCustomer().byId(alternateKey)`) with an own id specificaiton (the special case: only the sub type is annotated with alternate keys).

Feature 1 reads the core annotation for alternate keys applying to EntityTypes (one entity might define multiple alternate keys) and widens the ID specification for that entity because of it: `type BookId = string | { id: string } | { isbn: string }` (isbn being the alternate key here). The spec also allows to annotate EntitySet and NavigationProperty with alternate keys, which has not been implemented.