### PR TITLE
fix(odata2ts): send If-Match for actions bound to a concurrency-controlled entity

### DIFF
--- a/int-test/asp-net/test/feature/OptimisticConcurrency.test.ts
+++ b/int-test/asp-net/test/feature/OptimisticConcurrency.test.ts
@@ -113,4 +113,22 @@ describe("ASP.NET Library: optimistic concurrency", () => {
 
     expect([200, 204]).toContain(result.status);
   });
+
+  test("AssessCondition, an action bound to the entity, carries the ETag the preceding read filled in", async () => {
+    // this call succeeds whether or not the client sends `If-Match`: ASP.NET's action controllers, unlike
+    // its PATCH/DELETE pipeline, never check the header (IMPLEMENTATION.md, "What the database gained"),
+    // so what actually proves the fix on this server is the client-side test below, which never reaches
+    // the network in the first place
+    const result = await LIBRARY.Copies(COPY).AssessCondition({ NewCondition: 5 }).execute();
+
+    expect(result.status).toBe(200);
+  });
+
+  test("without a prior read, the bound action is refused before a request is sent", async () => {
+    const untouched = new LibraryService(new FetchClient(), BASE_URL);
+
+    await expect(untouched.Copies(COPY).AssessCondition({ NewCondition: 5 }).execute()).rejects.toThrow(
+      ODataConcurrencyError,
+    );
+  });
 });

--- a/int-test/cap/test/feature/OptimisticConcurrency.test.ts
+++ b/int-test/cap/test/feature/OptimisticConcurrency.test.ts
@@ -104,4 +104,18 @@ describe("CAP Library: optimistic concurrency", () => {
 
     await expect(other.Copies(COPY).delete().execute()).rejects.toThrow(ODataConcurrencyError);
   });
+
+  test("AssessCondition, an action bound to the entity, carries the ETag the preceding read filled in", async () => {
+    const result = await LIBRARY.Copies(COPY).AssessCondition({ NewCondition: 5 }).execute();
+
+    expect(result.status).toBe(200);
+  });
+
+  test("without a prior read, the bound action is refused before a request is sent", async () => {
+    const untouched = new LibraryService(new FetchClient(), BASE_URL);
+
+    await expect(untouched.Copies(COPY).AssessCondition({ NewCondition: 5 }).execute()).rejects.toThrow(
+      ODataConcurrencyError,
+    );
+  });
 });

--- a/int-test/cap/test/v2/core/Operations.test.ts
+++ b/int-test/cap/test/v2/core/Operations.test.ts
@@ -134,11 +134,13 @@ describe("CAP Library V2: operations", () => {
     });
   });
 
-  test("an operation on an ETag-carrying entity demands a precondition odata2ts cannot send", async () => {
+  test("an operation on an ETag-carrying entity demands a precondition V2 has no way to send", async () => {
     // `Copy.Condition` carries `@odata.etag`, so every write against a copy - this action included - needs
-    // `If-Match`. odata2ts sends none, in either version, so the operation stays unreachable over V4 as
-    // well. See core/CrudOperations.test.ts for what V2 does differently: it declares the token in the
-    // metadata, where V4 leaves the annotation empty.
+    // `If-Match`. Over V4 odata2ts sends it for an action bound to the entity (odata2ts#514); V2 has no
+    // notion of a bound operation at all - every operation is a container-level import - so there is no
+    // entity whose ETag store it could consult, and the call stays unreachable here regardless. See
+    // core/CrudOperations.test.ts for what V2 does differently for plain writes: it declares the token in
+    // the metadata, where V4 leaves the annotation empty.
     await expectODataError(
       LIBRARY_V2.Copies_CheckOut({ MediumId: BOOK_DER_PROZESS, InventoryNumber: 1001, MemberId: 1 }).execute(),
       { status: 428, message: /Precondition Required/ },

--- a/packages/odata2ts/src/generator/ServiceGenerator.ts
+++ b/packages/odata2ts/src/generator/ServiceGenerator.ts
@@ -287,7 +287,7 @@ class ServiceGenerator {
       }
 
       result.properties.push(this.generateQOperationProp(op));
-      result.methods.push(this.generateMethod(name, op, importContainer, "", this.getMainVersionArg()));
+      result.methods.push(this.generateMethod(name, op, importContainer, "", this.getMainVersionArg(), false));
     });
 
     return result;
@@ -424,7 +424,7 @@ class ServiceGenerator {
     const { properties, methods }: PropsAndOps = deepmerge(
       deepmerge(
         this.generateServiceProperties(importContainer, model.serviceName, props),
-        this.generateServiceOperations(importContainer, model, operations),
+        this.generateServiceOperations(importContainer, model, operations, true),
       ),
       this.generateCastOperations(importContainer, model, false),
     );
@@ -518,13 +518,21 @@ class ServiceGenerator {
     importContainer: ImportContainer,
     model: ComplexType,
     operations: Array<OperationType>,
+    isEntityBound: boolean,
   ): PropsAndOps {
     const result: PropsAndOps = { properties: [], methods: [] };
 
     operations.forEach((operation) => {
       result.properties.push(this.generateQOperationProp(operation));
       result.methods.push(
-        this.generateMethod(operation.name, operation, importContainer, model.fqName, this.getServiceVersionArg()),
+        this.generateMethod(
+          operation.name,
+          operation,
+          importContainer,
+          model.fqName,
+          this.getServiceVersionArg(),
+          isEntityBound,
+        ),
       );
     });
 
@@ -756,7 +764,7 @@ class ServiceGenerator {
     const collectionOperations = this.dataModel.getEntitySetOperations(model.fqName);
 
     const { properties, methods } = deepmerge(
-      this.generateServiceOperations(importContainer, model, collectionOperations),
+      this.generateServiceOperations(importContainer, model, collectionOperations, false),
       this.generateCastOperations(importContainer, model, true),
     );
 
@@ -845,9 +853,15 @@ class ServiceGenerator {
     importContainer: ImportContainer,
     baseFqName: string,
     versionArg: string,
+    isEntityBound = false,
   ): OptionalKind<MethodDeclarationStructure> {
     const isFunc = operation.type === OperationTypes.Function;
     const returnType = operation.returnType;
+    // OData V4.01 Part 1, §8.3.1: an action bound to a resource carries `If-Match` for that resource,
+    // just like patch, update and delete do (see ServiceStateHelperV4/V2#getConcurrencyOptions). A
+    // function reads rather than writes, and a collection-bound or unbound operation addresses no
+    // single resource, so neither carries the precondition.
+    const withConcurrency = !isFunc && isEntityBound;
     const hasParams = operation.parameters.length > 0 || operation.overrides?.length;
     const isParamsOptional = !![operation.parameters, ...(operation.overrides ?? [])].find((pSet) => pSet.length === 0);
     const isComposable =
@@ -891,6 +905,7 @@ class ServiceGenerator {
       `headers: getDefaultHeaders()` +
       (!isFunc && hasParams ? `, mainRequestConverter: ${qOpProp}.getRequestConverter()` : "") +
       (returnType ? `, mainResponseConverter: ${qOpProp}.getResponseConverter()` : "") +
+      (withConcurrency ? `, concurrency: getConcurrencyOptions()` : "") +
       `}`;
     const requestCmdStmt = isComposable
       ? `return new ${requestCmd}<${responseService}${versionArg}, ${responseStructure}<${rtType}>>(` +
@@ -918,7 +933,7 @@ class ServiceGenerator {
         `  ${qOpProp} = new ${qOperationName}()`,
         "}",
 
-        `const { addFullPath, client, getDefaultHeaders${isFunc ? `, isUrlNotEncoded${isComposable ? ", options" : ""}` : ""} } = this.__base;`,
+        `const { addFullPath, client, getDefaultHeaders${isFunc ? `, isUrlNotEncoded${isComposable ? ", options" : ""}` : ""}${withConcurrency ? ", getConcurrencyOptions" : ""} } = this.__base;`,
         `const url = addFullPath(${qOpProp}.buildUrl(${!isFunc ? "" : hasParams ? "params, isUrlNotEncoded()" : "isUrlNotEncoded()"}));`,
         ``,
         requestCmdStmt,

--- a/packages/odata2ts/test/fixture/generator/service/v4/action-rt-enum.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v4/action-rt-enum.ts
@@ -46,11 +46,12 @@ export class BookService<V extends ODataVersionV4 = "4.0"> extends EntityTypeSer
       this._bookQLike = new Book_QLike();
     }
 
-    const { addFullPath, client, getDefaultHeaders } = this.__base;
+    const { addFullPath, client, getDefaultHeaders, getConcurrencyOptions } = this.__base;
     const url = addFullPath(this._bookQLike.buildUrl());
 
     return new UrlRequestCmd<undefined>(client, ODataHttpMethods.Post, url, undefined, {
       headers: getDefaultHeaders(),
+      concurrency: getConcurrencyOptions(),
     });
   }
 
@@ -59,7 +60,7 @@ export class BookService<V extends ODataVersionV4 = "4.0"> extends EntityTypeSer
       this._bookQRate = new Book_QRate();
     }
 
-    const { addFullPath, client, getDefaultHeaders } = this.__base;
+    const { addFullPath, client, getDefaultHeaders, getConcurrencyOptions } = this.__base;
     const url = addFullPath(this._bookQRate.buildUrl());
 
     return new UrlRequestCmd<ODataModelResponseV4<Rating>, Book_RateParams>(
@@ -71,6 +72,7 @@ export class BookService<V extends ODataVersionV4 = "4.0"> extends EntityTypeSer
         headers: getDefaultHeaders(),
         mainRequestConverter: this._bookQRate.getRequestConverter(),
         mainResponseConverter: this._bookQRate.getResponseConverter(),
+        concurrency: getConcurrencyOptions(),
       },
     );
   }

--- a/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
@@ -129,6 +129,48 @@ describe("Service Generator Tests V4", () => {
 
       expect(generatedText()).not.toContain("concurrencyControlled");
     });
+
+    test("an action bound to the entity carries the entity's concurrency options", async () => {
+      addCopy(true);
+      odataBuilder.addAction("checkOut", undefined, true, (builder) =>
+        builder.addParam("copy", withNs("Copy")).addParam("memberId", ODataTypesV4.Int32),
+      );
+
+      await doGenerate();
+
+      expect(generatedText()).toContain("concurrency: getConcurrencyOptions()");
+    });
+
+    test("an action bound to the collection carries no concurrency options - it addresses no single entity", async () => {
+      addCopy(true);
+      odataBuilder.addAction("bulkAssess", undefined, true, (builder) =>
+        builder.addParam("copies", `Collection(${withNs("Copy")})`),
+      );
+
+      await doGenerate();
+
+      expect(generatedText()).not.toContain("getConcurrencyOptions");
+    });
+
+    test("an unbound action carries no concurrency options - it addresses no resource", async () => {
+      addCopy(true);
+      odataBuilder.addAction("ping", undefined, false);
+
+      await doGenerate();
+
+      expect(generatedText()).not.toContain("getConcurrencyOptions");
+    });
+
+    test("a function bound to the entity carries no concurrency options - it is a read", async () => {
+      addCopy(true);
+      odataBuilder.addFunction("currentCondition", ODataTypesV4.Byte, true, (builder) =>
+        builder.addParam("copy", withNs("Copy")),
+      );
+
+      await doGenerate();
+
+      expect(generatedText()).not.toContain("getConcurrencyOptions");
+    });
   });
 
   test("Service Generator: Min Case", async () => {


### PR DESCRIPTION
## Summary
- `patch`, `update`, `delete` and `query` already send `If-Match` for a concurrency-controlled entity (#482); an **action bound to such an entity** did not, so invoking one was answered with `428 Precondition Required` (OData V4.01 Part 1, §8.3.1 requires the precondition for an action bound to a resource, same as for a data modification request).
- `generateMethod` in `ServiceGenerator.ts` now knows whether the operation it emits is bound to a single entity (vs. a collection, vs. unbound), threaded down from `generateServiceOperations`. For an **action** (never a function - it reads) bound to an entity, it now destructures `getConcurrencyOptions` off `this.__base` and adds `concurrency: getConcurrencyOptions()` to the request command's options, exactly like the hand-written `patch`/`update`/`delete`/`query` methods already do. No runtime changes needed: `RequestCmd.applyConcurrency`/`updateConcurrency` already handle `options.concurrency` generically.
- Collection-bound and unbound operations address no single resource and stay unchanged.

Fixes #514

## Test plan
- [x] Unit tests in `packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts` ("Optimistic concurrency" describe block): an entity-bound action carries `concurrency: getConcurrencyOptions()`; a collection-bound action, an unbound action, and an entity-bound function do not. Verified RED before the generator change, GREEN after.
- [x] Updated fixture `action-rt-enum.ts` for the two entity-bound actions it exercises.
- [x] Integration tests added to `int-test/asp-net` and `int-test/cap`'s `OptimisticConcurrency.test.ts`, calling `Copies(id).AssessCondition(...)` (already bound to the concurrency-controlled `Copy` entity on both reference servers). Verified RED (428 from CAP; ASP.NET's action controllers don't enforce `If-Match` server-side, so the client-side "refused before a request is sent" case is what proves the fix there - documented in a comment) and GREEN against the real dockerized servers.
- [x] Updated a stale comment in `int-test/cap/test/v2/core/Operations.test.ts` that had described this as a V4 gap too; it's V2-only now (V2 has no bound-operation concept at all, so it stays unreachable there regardless).
- [x] Full `odata2ts` unit suite, both int-test suites (`int-test:asp-net`, `int-test:cap`), and `test-compile` all pass.
