### PR TITLE
fix(odata-service): evict the stale ETag when a write is answered with 412

### DIFF
--- a/int-test/asp-net/test/feature/OptimisticConcurrency.test.ts
+++ b/int-test/asp-net/test/feature/OptimisticConcurrency.test.ts
@@ -82,6 +82,33 @@ describe("ASP.NET Library: optimistic concurrency", () => {
     expect(isConcurrencyRequired(error)).toBe(false);
   });
 
+  test("a real 412 forgets the ETag it disproved, so the next write is refused instead of failing again", async () => {
+    // two clients of their own, so the ETag store under test is not the one the rest of the suite shares
+    const mine = new LibraryService(new FetchClient(), BASE_URL);
+    const someoneElse = new LibraryService(new FetchClient(), BASE_URL);
+
+    // I read the copy, which fills my store with the ETag current at that moment
+    expect((await mine.Copies(COPY).query().execute()).status).toBe(200);
+
+    // somebody else changes it behind my back, so my ETag is now stale
+    const theirWrite = await someoneElse.Copies(COPY).patch({ Condition: 4 }).ignoreETag().execute();
+    expect([200, 204]).toContain(theirWrite.status);
+
+    // my write carries the stale ETag and the server refuses it
+    const conflict = await expectODataError(mine.Copies(COPY).patch({ Condition: 5 }).execute(), {
+      status: 412,
+      message: /.*/,
+    });
+    expect(isConcurrencyConflict(conflict)).toBe(true);
+
+    // and now the point: the disproved ETag is gone, so the retry never reaches the server
+    await expect(mine.Copies(COPY).patch({ Condition: 5 }).execute()).rejects.toThrow(ODataConcurrencyError);
+
+    // reading again is what makes writing possible once more
+    expect((await mine.Copies(COPY).query().execute()).status).toBe(200);
+    expect([200, 204]).toContain((await mine.Copies(COPY).patch({ Condition: 5 }).execute()).status);
+  });
+
   test("ignoreETag writes past whatever is current", async () => {
     const result = await LIBRARY.Copies(COPY).patch({ Condition: 6 }).ignoreETag().execute();
 

--- a/int-test/cap/test/feature/OptimisticConcurrency.test.ts
+++ b/int-test/cap/test/feature/OptimisticConcurrency.test.ts
@@ -61,6 +61,33 @@ describe("CAP Library: optimistic concurrency", () => {
     expect(isConcurrencyRequired(error)).toBe(false);
   });
 
+  test("a real 412 forgets the ETag it disproved, so the next write is refused instead of failing again", async () => {
+    // two clients of their own, so the ETag store under test is not the one the rest of the suite shares
+    const mine = new LibraryService(new FetchClient(), BASE_URL);
+    const someoneElse = new LibraryService(new FetchClient(), BASE_URL);
+
+    // I read the copy, which fills my store with the ETag current at that moment
+    expect((await mine.Copies(COPY).query().execute()).status).toBe(200);
+
+    // somebody else changes it behind my back, so my ETag is now stale
+    const theirWrite = await someoneElse.Copies(COPY).patch({ Condition: 4 }).ignoreETag().execute();
+    expect([200, 204]).toContain(theirWrite.status);
+
+    // my write carries the stale ETag and the server refuses it
+    const conflict = await expectODataError(mine.Copies(COPY).patch({ Condition: 5 }).execute(), {
+      status: 412,
+      message: /.*/,
+    });
+    expect(isConcurrencyConflict(conflict)).toBe(true);
+
+    // and now the point: the disproved ETag is gone, so the retry never reaches the server
+    await expect(mine.Copies(COPY).patch({ Condition: 5 }).execute()).rejects.toThrow(ODataConcurrencyError);
+
+    // reading again is what makes writing possible once more
+    expect((await mine.Copies(COPY).query().execute()).status).toBe(200);
+    expect([200, 204]).toContain((await mine.Copies(COPY).patch({ Condition: 5 }).execute()).status);
+  });
+
   test("ignoreETag writes past whatever is current", async () => {
     const result = await LIBRARY.Copies(COPY).patch({ Condition: 6 }).ignoreETag().execute();
 

--- a/packages/odata-service/src/request/RequestCmd.ts
+++ b/packages/odata-service/src/request/RequestCmd.ts
@@ -1,7 +1,7 @@
 import { HttpResponseModel, ODataHttpClient, ODataHttpMethods, ODataRequestConfig } from "@odata2ts/http-client-api";
 import { MainResponseConverter } from "@odata2ts/odata-query-objects";
 import { getHeaderETag } from "../ETagExtraction";
-import { ODataConcurrencyError } from "../ODataConcurrencyError";
+import { isConcurrencyConflict, ODataConcurrencyError } from "../ODataConcurrencyError";
 import { MainRequestConverter, RequestConverter } from "./converter/RequestConverter";
 import { RequestConverterChain } from "./converter/RequestConverterChain";
 import { ResponseConverter } from "./converter/ResponseConverter";
@@ -189,7 +189,13 @@ export abstract class RequestCmd<
     const request = this.applyConcurrency(this.getInfoConverted());
 
     // execute the request
-    const response = await this.sendRequest(request, requestConfig);
+    let response: HttpResponseModel<any>;
+    try {
+      response = await this.sendRequest(request, requestConfig);
+    } catch (error) {
+      this.evictOnConflict(error);
+      throw error;
+    }
 
     // apply response converters
     const converted = this.convertResponse(response);
@@ -226,6 +232,27 @@ export abstract class RequestCmd<
     }
 
     return new RequestInfo(request.method, request.url, { ...request.headers, "If-Match": etag }, request.data);
+  }
+
+  /**
+   * Forgets an ETag the service has just disproved.
+   *
+   * A `412` is the one answer that says something about the stored ETag itself: the resource has moved on,
+   * so the token is stale for good. Keeping it would send the very same `If-Match` on the next write and
+   * earn the very same `412` - silently, forever, until something happens to re-read the resource. After
+   * eviction that next write instead hits the pre-send {@link ODataConcurrencyError} ("nothing known, read
+   * it first"), which names the resource and says what to do about it.
+   *
+   * No other status evicts: a `404`, a `500` or a broken connection say nothing about whether the token
+   * was still current, and throwing it away would turn a passing write into a needless error.
+   *
+   * The error itself travels on untouched - resolving a conflict is the application's business.
+   */
+  private evictOnConflict(error: unknown): void {
+    const { concurrency } = this.options;
+    if (concurrency && isConcurrencyConflict(error)) {
+      this.client.concurrency?.evict(concurrency.key);
+    }
   }
 
   /**

--- a/packages/odata-service/test/mock/MockClient.ts
+++ b/packages/odata-service/test/mock/MockClient.ts
@@ -55,6 +55,11 @@ export class MockClient implements ODataHttpClient<MockRequestConfig> {
   public responseStatus = 200;
   /** The headers the next response carries, e.g. `{ etag: 'W/"7"' }`. */
   public responseHeaders: Record<string, string> = {};
+  /**
+   * Makes the next request fail the way every real client does: a non-2xx answer is not returned, it is
+   * thrown as an error carrying the status. Set to a status to arm it, `undefined` to respond normally.
+   */
+  public failWithStatus?: number;
 
   public readonly concurrency = new MockConcurrencyHandler();
 
@@ -274,6 +279,11 @@ export class MockClient implements ODataHttpClient<MockRequestConfig> {
 
   private respond() {
     this.requestCount++;
+    if (this.failWithStatus !== undefined) {
+      const error = new Error(`Mock failure with status ${this.failWithStatus}`) as Error & { status: number };
+      error.status = this.failWithStatus;
+      return Promise.reject(error);
+    }
     const result = Promise.resolve({
       status: this.responseStatus,
       statusText: "OK",

--- a/packages/odata-service/test/request/ConcurrencyRequestCmd.test.ts
+++ b/packages/odata-service/test/request/ConcurrencyRequestCmd.test.ts
@@ -47,6 +47,7 @@ describe("RequestCmd: optimistic concurrency", () => {
     client.responseStatus = 200;
     client.responseHeaders = {};
     client.requestCount = 0;
+    client.failWithStatus = undefined;
   });
 
   describe("sending If-Match", () => {
@@ -210,6 +211,94 @@ describe("RequestCmd: optimistic concurrency", () => {
       await cmd(ODataHttpMethods.Patch, controlled(false)).execute();
 
       expect(client.concurrency.store.has(KEY)).toBe(false);
+    });
+  });
+
+  describe("keeping the store in step after a failed write", () => {
+    test("a 412 evicts the ETag it has just disproved", async () => {
+      client.concurrency.set(KEY, 'W/"1"');
+      client.failWithStatus = 412;
+
+      await expect(cmd(ODataHttpMethods.Patch, controlled()).execute()).rejects.toThrow();
+
+      expect(client.concurrency.store.has(KEY)).toBe(false);
+    });
+
+    test("the original error still travels on unchanged", async () => {
+      client.concurrency.set(KEY, 'W/"1"');
+      client.failWithStatus = 412;
+
+      const error = await cmd(ODataHttpMethods.Patch, controlled())
+        .execute()
+        .then(
+          () => undefined,
+          (e: any) => e,
+        );
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error.status).toBe(412);
+      expect(error).not.toBeInstanceOf(ODataConcurrencyError);
+      expect(error.message).toBe("Mock failure with status 412");
+    });
+
+    test("the write after a 412 is refused before a request is sent", async () => {
+      // the point of evicting: what follows is the actionable "read it first", not another silent 412
+      client.concurrency.set(KEY, 'W/"1"');
+      client.failWithStatus = 412;
+      await expect(cmd(ODataHttpMethods.Patch, controlled()).execute()).rejects.toThrow();
+
+      client.failWithStatus = undefined;
+      client.requestCount = 0;
+
+      await expect(cmd(ODataHttpMethods.Patch, controlled()).execute()).rejects.toThrow(ODataConcurrencyError);
+      expect(client.requestCount).toBe(0);
+    });
+
+    test("a 404 leaves the store alone - it says nothing about the ETag", async () => {
+      client.concurrency.set(KEY, 'W/"1"');
+      client.failWithStatus = 404;
+
+      await expect(cmd(ODataHttpMethods.Patch, controlled()).execute()).rejects.toThrow();
+
+      expect(client.concurrency.store.get(KEY)).toBe('W/"1"');
+    });
+
+    test("a 500 leaves the store alone as well", async () => {
+      client.concurrency.set(KEY, 'W/"1"');
+      client.failWithStatus = 500;
+
+      await expect(cmd(ODataHttpMethods.Patch, controlled()).execute()).rejects.toThrow();
+
+      expect(client.concurrency.store.get(KEY)).toBe('W/"1"');
+    });
+
+    test("a 412 on a delete evicts too", async () => {
+      client.concurrency.set(KEY, 'W/"1"');
+      client.failWithStatus = 412;
+
+      await expect(cmd(ODataHttpMethods.Delete, controlled()).execute()).rejects.toThrow();
+
+      expect(client.concurrency.store.has(KEY)).toBe(false);
+    });
+
+    test("a 412 on a command without concurrency options evicts nothing", async () => {
+      client.concurrency.set(KEY, 'W/"1"');
+      client.failWithStatus = 412;
+
+      await expect(cmd(ODataHttpMethods.Patch).execute()).rejects.toThrow();
+
+      expect(client.concurrency.store.get(KEY)).toBe('W/"1"');
+    });
+
+    test("a 412 against a client without a store is simply rethrown", async () => {
+      const bare = new MockClient(false);
+      delete (bare as unknown as { concurrency?: unknown }).concurrency;
+      client = bare;
+      client.failWithStatus = 412;
+
+      await expect(cmd(ODataHttpMethods.Patch, controlled(false)).execute()).rejects.toThrow(
+        "Mock failure with status 412",
+      );
     });
   });
 


### PR DESCRIPTION
## The bug

`RequestCmd.execute()` did:

```ts
const response = await this.sendRequest(request, requestConfig);
const converted = this.convertResponse(response);
this.updateConcurrency(response);
```

Every HTTP client throws on a non-2xx answer (`FetchClient.executeRequest`: `if (!response.ok) throw new FetchClientError(...)`), so `updateConcurrency` was only ever reached on success.

The consequence is a dead end for optimistic concurrency: a **412 Precondition Failed** leaves the ETag it has just disproved sitting in the `ConcurrencyHandler` store. The next write to that resource sends the very same `If-Match` and gets the very same 412 — silently, and permanently, until something happens to re-read the resource. There was no test covering the failure path at all.

## The fix

`execute()` now catches the failure from `sendRequest`, evicts the key for a concurrency conflict, and rethrows the original error unchanged:

- **succeeded** → update the store as before, unchanged behaviour
- **412** → evict `options.concurrency.key` from `client.concurrency`, then rethrow
- **any other failure** → store untouched, rethrow

The status is read through the existing `isConcurrencyConflict` guard in `ODataConcurrencyError.ts` rather than compared by hand. Neither the thrown error type nor its message changes, and no client package is touched.

## Why only 412 evicts

A 412 is the one answer that says something about the *stored token*: the resource has moved on, so the ETag is stale for good. Everything else — a 404, a 500, a broken connection — says nothing about whether the token was still current, and discarding it there would turn a write that would have passed into a needless error.

After eviction the next write to a concurrency-controlled resource hits the existing pre-send `ODataConcurrencyError` ("no ETag is known … read the resource first"), which names the resource and says what to do about it. An actionable error, instead of an endless silent 412 loop.

## Tests

**Unit** — `packages/odata-service/test/request/ConcurrencyRequestCmd.test.ts`, new `describe("keeping the store in step after a failed write")`:

- a 412 evicts the ETag it has just disproved
- the original error travels on unchanged (still the client's error, status 412, message intact, not an `ODataConcurrencyError`)
- the write after a 412 is refused before a request is sent — the point of evicting
- a 404 and a 500 each leave the store alone
- a 412 on a delete evicts too; a 412 on a command without concurrency options evicts nothing; a 412 against a client without a store is simply rethrown

`test/mock/MockClient.ts` gained one field, `failWithStatus`, so a test can make the mock reject with a status the way a real client does. Existing tests are unchanged and still pass.

**Integration** — a test of the same shape added to both suites that cover optimistic concurrency, `int-test/cap/test/feature/OptimisticConcurrency.test.ts` and `int-test/asp-net/test/feature/OptimisticConcurrency.test.ts`. It provokes a genuine conflict against the real server: read the copy on a client of its own, let a second client patch it behind that client's back, then write with the now-stale ETag. The 412 is pinned with `expectODataError({ status: 412, … })`, and the write that follows is asserted to fail with `ODataConcurrencyError` — before any request is sent — rather than with another 412. Reading again restores the ability to write.

No generation configuration was changed; both tests fit the existing clients. `int-test/olingo-v2` has no optimistic-concurrency suite to extend.

Both int-tests were verified to fail against the unfixed `odata-service` and pass with it.

## Verification

- `yarn workspace @odata2ts/odata-service test` — 29 files, 347 tests, all pass
- `yarn workspace @odata2ts/odata-service run compile` — clean
- `yarn int-test:cap` — 28 files, 201 pass / 2 skipped
- `yarn int-test:asp-net` — 20 files, 133 pass
- `yarn int-test:olingo-v2` — 16 files, 124 pass
- `yarn check-format` — clean
- `test-compile` for both int-test packages — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)