### PR TITLE
feat(odata-query-objects): cache-key foundations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,4 +65,9 @@ out/
 .project
 .settings/
 
+CLAUDE.md
+AGENTS.md
+.claude/
+.agents/
+CONTEXT.md
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -17,3 +17,5 @@ CHANGELOG.md
 # Generated clients: the generator formats them itself (option `prettier`), and they are gitignored -
 # checking them would only make the result depend on whether a build has run.
 src-generated
+
+.superpowers

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,4 +4,7 @@ enableGlobalCache: true
 
 nodeLinker: node-modules
 
+npmPreapprovedPackages:
+  - "@odata2ts/*"
+
 yarnPath: .yarn/releases/yarn-4.18.0.cjs

--- a/packages/odata-query-objects/package.json
+++ b/packages/odata-query-objects/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@odata2ts/converter-api": "^0.3.0",
-    "@odata2ts/http-client-api": "^0.6.8",
+    "@odata2ts/http-client-api": "^0.7.1",
     "@odata2ts/odata-core": "^0.7.1",
     "tslib": "^2.8.1"
   },

--- a/packages/odata-query-objects/src/QFilterExpression.ts
+++ b/packages/odata-query-objects/src/QFilterExpression.ts
@@ -1,20 +1,66 @@
+/**
+ * One decomposable comparison of a filter: a property path, an operator and the value asserted about it.
+ *
+ * The value is the OData-side one - after the property's converter, before URL rendering - so it is always
+ * a JSON-serialisable primitive. That is what lets a cache key be hashed at all: a caller-side value may be
+ * a `bigint`, which `JSON.stringify` refuses.
+ */
+export interface FilterClause {
+  readonly path: string;
+  readonly operator: string;
+  readonly value: unknown;
+}
+
 export class QFilterExpression {
-  constructor(private expression?: string) {}
+  /**
+   * The string form and a structured description of the very same filter, kept side by side.
+   *
+   * `clauses` holds what could be decomposed into path/operator/value; `raw` holds every fragment that
+   * could not - an `or`, a negation, a grouping, a string function, a lambda operator, a
+   * property-to-property comparison. A filter is fully described by the two together, and a cache key
+   * built from them converges with a differently written but equivalent query exactly as far as `clauses`
+   * reaches.
+   *
+   * An expression constructed from a string alone is raw by default: whoever built it did not say what it
+   * asserts, so nothing may be assumed about it.
+   */
+  constructor(
+    private expression?: string,
+    private clauses: ReadonlyArray<FilterClause> = [],
+    private raw: ReadonlyArray<string> = expression?.trim() && !clauses.length ? [expression] : [],
+  ) {}
 
   public toString(): string {
     return this.expression?.trim() || "";
   }
 
+  public getClauses(): ReadonlyArray<FilterClause> {
+    return this.clauses;
+  }
+
+  public getRaw(): ReadonlyArray<string> {
+    return this.raw;
+  }
+
+  /**
+   * Collapses this expression into a single raw fragment: the structure of what it asserts is gone the
+   * moment it is grouped, negated or or-ed, since the map a cache key uses is an AND-map of independent
+   * assertions.
+   */
+  private collapse(expression: string): QFilterExpression {
+    return new QFilterExpression(expression, [], [expression]);
+  }
+
   public group(): QFilterExpression {
     if (this.expression?.trim()) {
-      return new QFilterExpression(`(${this.expression})`);
+      return this.collapse(`(${this.expression})`);
     }
     return this;
   }
 
   public not(): QFilterExpression {
     if (this.expression?.trim()) {
-      return new QFilterExpression(`not ${this.expression}`);
+      return this.collapse(`not ${this.expression}`);
     }
     return this;
   }
@@ -23,7 +69,15 @@ export class QFilterExpression {
     if (expression?.toString()) {
       if (this.expression) {
         const newExpr = `${this.expression} ${isOrOperation ? "or" : "and"} ${expression.toString()}`;
-        return new QFilterExpression(newExpr);
+        // an `and` is what the structured map already means, so both sides survive it; an `or` is not
+        // expressible in it at all and takes the whole expression down to raw
+        return isOrOperation
+          ? this.collapse(newExpr)
+          : new QFilterExpression(
+              newExpr,
+              [...this.clauses, ...expression.getClauses()],
+              [...this.raw, ...expression.getRaw()],
+            );
       } else {
         return expression;
       }

--- a/packages/odata-query-objects/src/index.ts
+++ b/packages/odata-query-objects/src/index.ts
@@ -1,7 +1,7 @@
 export * from "./odata/ODataModel";
 export * from "./QueryObjectModel";
 export { QSelectExpression } from "./QSelectExpression";
-export { QFilterExpression } from "./QFilterExpression";
+export { QFilterExpression, type FilterClause } from "./QFilterExpression";
 export { QOrderByExpression } from "./QOrderByExpression";
 export { QSearchTerm, searchTerm } from "./QSearchTerm";
 export { QueryObject, ENUMERABLE_PROP_DEFINITION } from "./QueryObject";

--- a/packages/odata-query-objects/src/operation/QFunction.ts
+++ b/packages/odata-query-objects/src/operation/QFunction.ts
@@ -6,7 +6,7 @@ type FilteredParamModel = [string, string];
 const REGEXP_PARAMS = /.*\(([^)]+)\)/;
 const REGEXP_V2_PARAMS = /.*\?(.+)/;
 
-const SINGLE_VALUE_TYPES = ["string", "number", "boolean"];
+export const SINGLE_VALUE_TYPES = ["string", "number", "boolean"];
 
 function compileUrlParams(params: FunctionParams | undefined, notEncoded: boolean = false) {
   if (!params || !Object.keys(params).length) {
@@ -166,13 +166,16 @@ export abstract class QFunction<ParamModel, ResponseStructure = undefined> {
     }, {} as ParamModel);
   }
 
-  private findSingleParam() {
+  protected findSingleParam() {
     const result = this.getParamSets().find((pSet) => pSet.length === 1);
 
     return result ? result[0] : undefined;
   }
 
-  private findBestMatchingParamSet(paramKeys: Array<string>, findByMappedName: boolean): Array<QParamModel<any, any>> {
+  protected findBestMatchingParamSet(
+    paramKeys: Array<string>,
+    findByMappedName: boolean,
+  ): Array<QParamModel<any, any>> {
     const paramSets = this.getParamSets();
     if (!paramKeys.length || !paramSets.length) {
       return [];

--- a/packages/odata-query-objects/src/operation/QId.ts
+++ b/packages/odata-query-objects/src/operation/QId.ts
@@ -1,4 +1,5 @@
 import { QParamModel } from "../param/QParamModel";
+import { SINGLE_VALUE_TYPES } from "./QFunction";
 import { QFunctionV4 } from "./QFunctionV4";
 
 /**
@@ -35,5 +36,52 @@ export abstract class QId<ParamModel> extends QFunctionV4<ParamModel, void> {
    */
   public getAlternateParams(): Array<Array<QParamModel<any, any>>> {
     return this.getParamSets().slice(1);
+  }
+
+  /**
+   * The param set this id's value would resolve to in {@link buildUrl}/{@link parseUrl} - the same
+   * matching, reused rather than duplicated, so a cache key is always built from the very param set the
+   * URL was built from.
+   */
+  public getParamsFor(id: unknown): Array<QParamModel<any, any>> {
+    // the same resolution buildUrl performs, so a cache key is built from the very param set the URL was
+    if (SINGLE_VALUE_TYPES.includes(typeof id)) {
+      const single = this.findSingleParam();
+      return single ? [single] : [];
+    }
+    return this.findBestMatchingParamSet(Object.keys(id as object), true);
+  }
+
+  /**
+   * This entity's own canonical id - entity-set name plus key predicate - always via the *primary* key,
+   * regardless of which key shape `entity` was actually fetched or addressed by: two routes to the same
+   * entity must produce the very same canonical id, or nothing that compares them by it would ever match.
+   *
+   * Accepts three shapes, so callers never have to know which one they hold:
+   * - a bare value (`5`) - passed straight to {@link buildUrl}, the single-primary-key case
+   * - an already key-only object, mapped-name keyed (`{id: 5}`, `{mediumId: 5, inventoryNumber: 7}`) - a
+   *   single-property one still collapses to the bare form, so `{id: 5}` and `5` produce identical ids
+   * - a full entity representation with unrelated fields alongside the key (`{id: 5, title: "...", ...}`)
+   *   - only the primary key's own mapped-name fields are read out of it, everything else is ignored
+   *
+   * `undefined` where the primary key cannot be built at all: no primary key declared, or - the entity
+   * case - one of its properties is missing from `entity`.
+   */
+  public buildCanonicalId(entity: unknown): string | undefined {
+    if (entity === null || typeof entity !== "object") {
+      return this.getPrimaryParams().length ? this.buildUrl(entity as ParamModel) : undefined;
+    }
+
+    const params = this.getPrimaryParams();
+    const row = entity as Record<string, unknown>;
+    if (!params.length || params.some((p) => row[p.getMappedName()] === undefined)) {
+      return undefined;
+    }
+
+    const id =
+      params.length === 1
+        ? row[params[0].getMappedName()]
+        : Object.fromEntries(params.map((p) => [p.getMappedName(), row[p.getMappedName()]]));
+    return this.buildUrl(id as ParamModel);
   }
 }

--- a/packages/odata-query-objects/src/param/UrlParamHelper.ts
+++ b/packages/odata-query-objects/src/param/UrlParamHelper.ts
@@ -151,6 +151,13 @@ export function isPathValue(value: QPathModel | any): value is QPathModel {
   return typeof value === "object" && typeof value?.getPath === "function";
 }
 
+/**
+ * Marks a comparison whose right-hand side is another property rather than a literal
+ * (`Title eq Subtitle`). There is no value to put in a structured filter map, so such an expression is
+ * raw. A dedicated sentinel rather than `undefined`, since `null` and `undefined` are legitimate values.
+ */
+export const PATH_VALUE: unique symbol = Symbol("pathValue");
+
 export function buildOperatorExpression(
   path: string,
   operator: StandardFilterOperators | NumberFilterOperators,
@@ -170,6 +177,10 @@ export function buildQFilterOperation(
   path: string,
   operator: StandardFilterOperators | NumberFilterOperators,
   value: string,
+  typedValue: unknown = PATH_VALUE,
 ) {
-  return new QFilterExpression(buildOperatorExpression(path, operator, value));
+  const expression = buildOperatorExpression(path, operator, value);
+  return typedValue === PATH_VALUE
+    ? new QFilterExpression(expression)
+    : new QFilterExpression(expression, [{ path, operator, value: typedValue }]);
 }

--- a/packages/odata-query-objects/src/path/QBinding.ts
+++ b/packages/odata-query-objects/src/path/QBinding.ts
@@ -40,6 +40,24 @@ export class QBinding<Id> {
   }
 
   /**
+   * The name of the entity set this binding's target belongs to - the same name {@link format} already
+   * builds every URL from, exposed on its own for a caller after the resource's identity rather than a URL.
+   */
+  public getEntitySetName(): string {
+    return this.idFunctionFn().getName();
+  }
+
+  /**
+   * The target's own canonical id - entity-set name plus key predicate, e.g. `Copies(3)` or
+   * `Copies(Id=1,Category='books')` - built from the very same id function {@link format} uses, but without
+   * the notation-specific wrapping a binding property value needs. See {@link QId.buildCanonicalId} for the
+   * shapes `entity` may take.
+   */
+  public buildCanonicalId(entity: unknown): string | undefined {
+    return this.idFunctionFn().buildCanonicalId(entity);
+  }
+
+  /**
    * The property name the binding goes by, which is the navigation property itself in every version but
    * 4.0 - meaning that in those versions a binding and a deep insert share one property.
    */

--- a/packages/odata-query-objects/src/path/QModelBasePath.ts
+++ b/packages/odata-query-objects/src/path/QModelBasePath.ts
@@ -34,6 +34,11 @@ export class QModelBasePath<Q extends QueryObject> implements QEntityPathModel<Q
     return new (this.qEntityFn())(withPrefix ? this.path : undefined, this.separator);
   }
 
+  /** The factory behind {@link getEntity}, for a caller that wants to construct instances itself rather than take the one instance `getEntity` returns - a graph walk recursing property by property, say. */
+  public getEntityFn() {
+    return this.qEntityFn;
+  }
+
   public isCollectionType() {
     return false;
   }

--- a/packages/odata-query-objects/src/path/QModelCollectionBasePath.ts
+++ b/packages/odata-query-objects/src/path/QModelCollectionBasePath.ts
@@ -32,6 +32,11 @@ export class QModelCollectionBasePath<Q extends QueryObject> implements QEntityP
     return new (this.qEntityFn())(withPrefix ? this.path : undefined);
   }
 
+  /** The factory behind {@link getEntity}, for a caller that wants to construct instances itself rather than take the one instance `getEntity` returns - a graph walk recursing property by property, say. */
+  public getEntityFn() {
+    return this.qEntityFn;
+  }
+
   public isCollectionType() {
     return true;
   }

--- a/packages/odata-query-objects/src/path/base/BaseFunctions.ts
+++ b/packages/odata-query-objects/src/path/base/BaseFunctions.ts
@@ -1,9 +1,14 @@
 import { StandardFilterOperators } from "../../odata/ODataModel";
-import { buildQFilterOperation } from "../../param/UrlParamHelper";
+import { buildQFilterOperation, PATH_VALUE } from "../../param/UrlParamHelper";
 import { QFilterExpression } from "../../QFilterExpression";
 import { QOrderByExpression } from "../../QOrderByExpression";
 
 export type MapValue<T> = (value: T) => string;
+/**
+ * The OData-side value of what the caller passed - after the property's converter, before URL rendering.
+ * Returns {@link PATH_VALUE} where the "value" is another property path and nothing can be asserted.
+ */
+export type TypedValue<T> = (value: T) => unknown;
 
 export function orderAscending(path: string) {
   /**
@@ -27,73 +32,81 @@ export function filterIsNull(path: string) {
   /**
    * Base filter function: property must be null.
    */
-  return () => new QFilterExpression(`${path} eq null`);
+  return () =>
+    new QFilterExpression(`${path} eq null`, [{ path, operator: StandardFilterOperators.EQUALS, value: null }]);
 }
 
 export function filterIsNotNull(path: string) {
   /**
    * Base filter function: property must not be null.
    */
-  return () => new QFilterExpression(`${path} ne null`);
+  return () =>
+    new QFilterExpression(`${path} ne null`, [{ path, operator: StandardFilterOperators.NOT_EQUALS, value: null }]);
 }
 
-export function filterEquals<T>(path: string, mapValue: MapValue<T>) {
+export function filterEquals<T>(path: string, mapValue: MapValue<T>, typedValue?: TypedValue<T>) {
   /**
    * Base filter function: property must equal the given value.
    */
   return (value: T | null) => {
     const result = value === null ? "null" : mapValue(value);
-    return buildQFilterOperation(path, StandardFilterOperators.EQUALS, result);
+    const typed = value === null ? null : typedValue ? typedValue(value) : PATH_VALUE;
+    return buildQFilterOperation(path, StandardFilterOperators.EQUALS, result, typed);
   };
 }
 
-export function filterNotEquals<T>(path: string, mapValue: MapValue<T>) {
+export function filterNotEquals<T>(path: string, mapValue: MapValue<T>, typedValue?: TypedValue<T>) {
   /**
    * Base filter function: property must not equal the given value.
    */
   return (value: T | null) => {
     const result = value === null ? "null" : mapValue(value);
-    return buildQFilterOperation(path, StandardFilterOperators.NOT_EQUALS, result);
+    const typed = value === null ? null : typedValue ? typedValue(value) : PATH_VALUE;
+    return buildQFilterOperation(path, StandardFilterOperators.NOT_EQUALS, result, typed);
   };
 }
 
-export function filterLowerThan<T>(path: string, mapValue: MapValue<T>) {
+export function filterLowerThan<T>(path: string, mapValue: MapValue<T>, typedValue?: TypedValue<T>) {
   /**
    * Base filter function: property must be lower than the given value.
    */
   return (value: T) => {
-    return buildQFilterOperation(path, StandardFilterOperators.LOWER_THAN, mapValue(value));
+    const typed = typedValue ? typedValue(value) : PATH_VALUE;
+    return buildQFilterOperation(path, StandardFilterOperators.LOWER_THAN, mapValue(value), typed);
   };
 }
 
-export function filterLowerEquals<T>(path: string, mapValue: MapValue<T>) {
+export function filterLowerEquals<T>(path: string, mapValue: MapValue<T>, typedValue?: TypedValue<T>) {
   /**
    * Base filter function: property must be lower than or equal to the given value.
    */
   return (value: T) => {
-    return buildQFilterOperation(path, StandardFilterOperators.LOWER_EQUALS, mapValue(value));
+    const typed = typedValue ? typedValue(value) : PATH_VALUE;
+    return buildQFilterOperation(path, StandardFilterOperators.LOWER_EQUALS, mapValue(value), typed);
   };
 }
 
-export function filterGreaterThan<T>(path: string, mapValue: MapValue<T>) {
+export function filterGreaterThan<T>(path: string, mapValue: MapValue<T>, typedValue?: TypedValue<T>) {
   /**
    * Base filter function: property must be greater than the given value.
    */
   return (value: T) => {
-    return buildQFilterOperation(path, StandardFilterOperators.GREATER_THAN, mapValue(value));
+    const typed = typedValue ? typedValue(value) : PATH_VALUE;
+    return buildQFilterOperation(path, StandardFilterOperators.GREATER_THAN, mapValue(value), typed);
   };
 }
 
-export function filterGreaterEquals<T>(path: string, mapValue: MapValue<T>) {
+export function filterGreaterEquals<T>(path: string, mapValue: MapValue<T>, typedValue?: TypedValue<T>) {
   /**
    * Base filter function: property must be greater than or equal to the given value.
    */
   return (value: T) => {
-    return buildQFilterOperation(path, StandardFilterOperators.GREATER_EQUALS, mapValue(value));
+    const typed = typedValue ? typedValue(value) : PATH_VALUE;
+    return buildQFilterOperation(path, StandardFilterOperators.GREATER_EQUALS, mapValue(value), typed);
   };
 }
 
-export function filterHas<T>(path: string, mapValue: MapValue<T>) {
+export function filterHas<T>(path: string, mapValue: MapValue<T>, typedValue?: TypedValue<T>) {
   /**
    * Base filter function (V4): the flag enum property must contain the given member.
    *
@@ -102,7 +115,8 @@ export function filterHas<T>(path: string, mapValue: MapValue<T>) {
    * caller did not ask for.
    */
   return (value: T) => {
-    return buildQFilterOperation(path, StandardFilterOperators.HAS, mapValue(value));
+    const typed = typedValue ? typedValue(value) : PATH_VALUE;
+    return buildQFilterOperation(path, StandardFilterOperators.HAS, mapValue(value), typed);
   };
 }
 

--- a/packages/odata-query-objects/src/path/base/QBasePath.ts
+++ b/packages/odata-query-objects/src/path/base/QBasePath.ts
@@ -1,6 +1,6 @@
 import { ValueConverter } from "@odata2ts/converter-api";
 import { getIdentityConverter } from "../../IdentityConverter";
-import { isPathValue, URL_CONVERSION_OPTIONS } from "../../param/UrlParamHelper";
+import { isPathValue, PATH_VALUE, URL_CONVERSION_OPTIONS } from "../../param/UrlParamHelper";
 import { UrlExpressionValueModel } from "../../param/UrlParamModel";
 import { QValuePathModel } from "../QPathModel";
 import {
@@ -51,6 +51,18 @@ export abstract class QBasePath<ValueType extends UrlExpressionValueModel, Conve
   };
 
   /**
+   * The OData-side value of what the caller passed: the property's converter applied, but not the URL
+   * rendering on top of it. This is what a cache key carries - always a JSON-serialisable primitive,
+   * unlike the caller's own value, which may be a `bigint` and therefore unhashable.
+   */
+  protected convertInputTyped = (value: InputModel<this["converter"]>): unknown => {
+    if (isPathValue(value)) {
+      return PATH_VALUE;
+    }
+    return this.converter.convertTo(value, URL_CONVERSION_OPTIONS);
+  };
+
+  /**
    * Get the path to this property.
    *
    * @returns this property path
@@ -66,18 +78,38 @@ export abstract class QBasePath<ValueType extends UrlExpressionValueModel, Conve
 
   public isNull = filterIsNull(this.path);
   public isNotNull = filterIsNotNull(this.path);
-  public equals = filterEquals<InputModel<this["converter"]>>(this.path, this.convertInput);
+  public equals = filterEquals<InputModel<this["converter"]>>(this.path, this.convertInput, this.convertInputTyped);
   public eq = this.equals;
-  public notEquals = filterNotEquals<InputModel<this["converter"]>>(this.path, this.convertInput);
+  public notEquals = filterNotEquals<InputModel<this["converter"]>>(
+    this.path,
+    this.convertInput,
+    this.convertInputTyped,
+  );
   public ne = this.notEquals;
 
-  public lowerThan = filterLowerThan<InputModel<this["converter"]>>(this.path, this.convertInput);
+  public lowerThan = filterLowerThan<InputModel<this["converter"]>>(
+    this.path,
+    this.convertInput,
+    this.convertInputTyped,
+  );
   public lt = this.lowerThan;
-  public lowerEquals = filterLowerEquals<InputModel<this["converter"]>>(this.path, this.convertInput);
+  public lowerEquals = filterLowerEquals<InputModel<this["converter"]>>(
+    this.path,
+    this.convertInput,
+    this.convertInputTyped,
+  );
   public le = this.lowerEquals;
-  public greaterThan = filterGreaterThan<InputModel<this["converter"]>>(this.path, this.convertInput);
+  public greaterThan = filterGreaterThan<InputModel<this["converter"]>>(
+    this.path,
+    this.convertInput,
+    this.convertInputTyped,
+  );
   public gt = this.greaterThan;
-  public greaterEquals = filterGreaterEquals<InputModel<this["converter"]>>(this.path, this.convertInput);
+  public greaterEquals = filterGreaterEquals<InputModel<this["converter"]>>(
+    this.path,
+    this.convertInput,
+    this.convertInputTyped,
+  );
   public ge = this.greaterEquals;
   public in = this.options.nativeIn
     ? filterIn<InputModel<this["converter"]>>(this.path, this.convertInput)

--- a/packages/odata-query-objects/src/path/enum/BaseEnumPath.ts
+++ b/packages/odata-query-objects/src/path/enum/BaseEnumPath.ts
@@ -23,6 +23,14 @@ export abstract class BaseEnumPath<EnumMemberType> implements QPathModel {
   protected abstract mapValue(value: EnumMemberType): string;
 
   /**
+   * The OData-side value of the given enum member: the converting half of {@link mapValue}, without the
+   * quoting or literal rendering on top. Always a string - an enum member is an identity, not a
+   * quantity, so a numeric enum's symbolic name is represented the same way as a string enum's, keeping
+   * the clause stable and JSON-serialisable across both.
+   */
+  protected abstract typedValue(value: EnumMemberType): string;
+
+  /**
    * Returns the path of this property.
    */
   public getPath(): string {
@@ -38,22 +46,34 @@ export abstract class BaseEnumPath<EnumMemberType> implements QPathModel {
   public isNull = filterIsNull(this.path);
   public isNotNull = filterIsNotNull(this.path);
 
-  public equals = filterEquals<EnumMemberType>(this.path, this.mapValue.bind(this));
+  public equals = filterEquals<EnumMemberType>(this.path, this.mapValue.bind(this), this.typedValue.bind(this));
   public eq = this.equals;
 
-  public notEquals = filterNotEquals<EnumMemberType>(this.path, this.mapValue.bind(this));
+  public notEquals = filterNotEquals<EnumMemberType>(this.path, this.mapValue.bind(this), this.typedValue.bind(this));
   public ne = this.notEquals;
 
-  public lowerThan = filterLowerThan<EnumMemberType>(this.path, this.mapValue.bind(this));
+  public lowerThan = filterLowerThan<EnumMemberType>(this.path, this.mapValue.bind(this), this.typedValue.bind(this));
   public lt = this.lowerThan;
 
-  public lowerEquals = filterLowerEquals<EnumMemberType>(this.path, this.mapValue.bind(this));
+  public lowerEquals = filterLowerEquals<EnumMemberType>(
+    this.path,
+    this.mapValue.bind(this),
+    this.typedValue.bind(this),
+  );
   public le = this.lowerEquals;
 
-  public greaterThan = filterGreaterThan<EnumMemberType>(this.path, this.mapValue.bind(this));
+  public greaterThan = filterGreaterThan<EnumMemberType>(
+    this.path,
+    this.mapValue.bind(this),
+    this.typedValue.bind(this),
+  );
   public gt = this.greaterThan;
 
-  public greaterEquals = filterGreaterEquals<EnumMemberType>(this.path, this.mapValue.bind(this));
+  public greaterEquals = filterGreaterEquals<EnumMemberType>(
+    this.path,
+    this.mapValue.bind(this),
+    this.typedValue.bind(this),
+  );
   public ge = this.greaterEquals;
 
   public in = filterInEmulated<EnumMemberType>(this.path, this.mapValue.bind(this));

--- a/packages/odata-query-objects/src/path/enum/QEnumPath.ts
+++ b/packages/odata-query-objects/src/path/enum/QEnumPath.ts
@@ -38,4 +38,11 @@ export class QEnumPath<EnumType extends StringEnumSource, WireType = string> ext
     const wireValue = this.converter.convertTo(value, URL_CONVERSION_OPTIONS);
     return typeof wireValue === "string" ? formatWithQuotes(wireValue) : formatLiteral(wireValue as any);
   }
+
+  protected typedValue(value: StringEnumSourceMember<EnumType>): string {
+    if (!this.converter) {
+      return value as string;
+    }
+    return String(this.converter.convertTo(value, URL_CONVERSION_OPTIONS));
+  }
 }

--- a/packages/odata-query-objects/src/path/enum/QFlagsEnumPath.ts
+++ b/packages/odata-query-objects/src/path/enum/QFlagsEnumPath.ts
@@ -11,5 +11,9 @@ import { QEnumPath } from "./QEnumPath";
  * where the service would evaluate it as bit arithmetic over values that are not bits.
  */
 export class QFlagsEnumPath<EnumType extends StringEnumSource> extends QEnumPath<EnumType> {
-  public has = filterHas<StringEnumSourceMember<EnumType>>(this.path, this.mapValue.bind(this));
+  public has = filterHas<StringEnumSourceMember<EnumType>>(
+    this.path,
+    this.mapValue.bind(this),
+    this.typedValue.bind(this),
+  );
 }

--- a/packages/odata-query-objects/src/path/enum/QNumericEnumPath.ts
+++ b/packages/odata-query-objects/src/path/enum/QNumericEnumPath.ts
@@ -23,4 +23,8 @@ export class QNumericEnumPath<EnumType extends NumericEnumLike> extends BaseEnum
   protected mapValue(value: NumericEnumMember<EnumType>): string {
     return formatWithQuotes(this.converter.convertTo(value)!);
   }
+
+  protected typedValue(value: NumericEnumMember<EnumType>): string {
+    return this.converter.convertTo(value)!;
+  }
 }

--- a/packages/odata-query-objects/src/path/enum/QNumericFlagsEnumPath.ts
+++ b/packages/odata-query-objects/src/path/enum/QNumericFlagsEnumPath.ts
@@ -10,5 +10,5 @@ import { QNumericEnumPath } from "./QNumericEnumPath";
  * its flags variant just as the string one does.
  */
 export class QNumericFlagsEnumPath<EnumType extends NumericEnumLike> extends QNumericEnumPath<EnumType> {
-  public has = filterHas<NumericEnumMember<EnumType>>(this.path, this.mapValue.bind(this));
+  public has = filterHas<NumericEnumMember<EnumType>>(this.path, this.mapValue.bind(this), this.typedValue.bind(this));
 }

--- a/packages/odata-query-objects/test/QBinding.test.ts
+++ b/packages/odata-query-objects/test/QBinding.test.ts
@@ -110,4 +110,21 @@ describe("QBinding: binding by key", () => {
   test("4.0 is the notation by default", () => {
     expect(new QBinding(() => new QAuthorId("Authors")).getNotation()).toBe("4.0");
   });
+
+  test("getEntitySetName returns the target entity set's own name", () => {
+    expect(new QBinding(() => new QAuthorId("Authors")).getEntitySetName()).toBe("Authors");
+  });
+
+  test("buildCanonicalId builds the entity set's own canonical URL segment, single key", () => {
+    expect(new QBinding(() => new QAuthorId("Authors")).buildCanonicalId(3)).toBe("Authors(3)");
+  });
+
+  test("buildCanonicalId delegates to QId.buildCanonicalId - a single-key object collapses to the same bare form", () => {
+    const qId = new QBinding(() => new QAuthorId("Authors"));
+    expect(qId.buildCanonicalId({ id: 3 })).toBe("Authors(3)");
+  });
+
+  test("buildCanonicalId is unaffected by the binding notation - it never wraps like format does", () => {
+    expect(new QBinding(() => new QAuthorId("Authors"), "4.01").buildCanonicalId(3)).toBe("Authors(3)");
+  });
 });

--- a/packages/odata-query-objects/test/QFilterExpression.test.ts
+++ b/packages/odata-query-objects/test/QFilterExpression.test.ts
@@ -113,3 +113,77 @@ describe("QFilterExpression test", () => {
     );
   });
 });
+
+describe("QFilterExpression: structured description", () => {
+  const eqFive = new QFilterExpression("MediumId eq 5", [{ path: "MediumId", operator: "eq", value: 5 }]);
+  const gtTwo = new QFilterExpression("Year gt 2000", [{ path: "Year", operator: "gt", value: 2000 }]);
+
+  test("a bare expression with no clauses is raw", () => {
+    const expression = new QFilterExpression("A eq 1 or B eq 2");
+    expect(expression.getClauses()).toEqual([]);
+    expect(expression.getRaw()).toEqual(["A eq 1 or B eq 2"]);
+  });
+
+  test("an expression built with clauses is not raw", () => {
+    expect(eqFive.getClauses()).toEqual([{ path: "MediumId", operator: "eq", value: 5 }]);
+    expect(eqFive.getRaw()).toEqual([]);
+  });
+
+  test("an empty expression carries nothing", () => {
+    const expression = new QFilterExpression();
+    expect(expression.getClauses()).toEqual([]);
+    expect(expression.getRaw()).toEqual([]);
+  });
+
+  test("whitespace-only expression carries nothing", () => {
+    const expression = new QFilterExpression("   ");
+    expect(expression.getClauses()).toEqual([]);
+    expect(expression.getRaw()).toEqual([]);
+    expect(expression.toString()).toBe("");
+  });
+
+  test("and() merges clauses and raw from both sides", () => {
+    const merged = eqFive.and(gtTwo).and(new QFilterExpression("contains(Title,'ai')"));
+    expect(merged.getClauses()).toEqual([
+      { path: "MediumId", operator: "eq", value: 5 },
+      { path: "Year", operator: "gt", value: 2000 },
+    ]);
+    expect(merged.getRaw()).toEqual(["contains(Title,'ai')"]);
+    expect(merged.toString()).toBe("MediumId eq 5 and Year gt 2000 and contains(Title,'ai')");
+  });
+
+  test("and() with an empty expression changes nothing", () => {
+    expect(eqFive.and(new QFilterExpression()).getClauses()).toEqual(eqFive.getClauses());
+    expect(eqFive.and(null).getClauses()).toEqual(eqFive.getClauses());
+  });
+
+  test("and() onto an empty expression adopts the other side unchanged", () => {
+    const merged = new QFilterExpression().and(eqFive);
+    expect(merged.getClauses()).toEqual(eqFive.getClauses());
+    expect(merged.getRaw()).toEqual([]);
+  });
+
+  test("or() collapses everything into one raw fragment", () => {
+    const merged = eqFive.or(gtTwo);
+    expect(merged.getClauses()).toEqual([]);
+    expect(merged.getRaw()).toEqual(["MediumId eq 5 or Year gt 2000"]);
+  });
+
+  test("not() collapses into one raw fragment", () => {
+    const negated = eqFive.not();
+    expect(negated.getClauses()).toEqual([]);
+    expect(negated.getRaw()).toEqual(["not MediumId eq 5"]);
+  });
+
+  test("group() collapses into one raw fragment", () => {
+    const grouped = eqFive.and(gtTwo).group();
+    expect(grouped.getClauses()).toEqual([]);
+    expect(grouped.getRaw()).toEqual(["(MediumId eq 5 and Year gt 2000)"]);
+  });
+
+  test("not() and group() leave an empty expression alone", () => {
+    const empty = new QFilterExpression();
+    expect(empty.not().getRaw()).toEqual([]);
+    expect(empty.group().getRaw()).toEqual([]);
+  });
+});

--- a/packages/odata-query-objects/test/operation/QId.test.ts
+++ b/packages/odata-query-objects/test/operation/QId.test.ts
@@ -86,6 +86,43 @@ describe("QId Tests", () => {
     );
   });
 
+  describe("buildCanonicalId", () => {
+    test("a bare value builds the same canonical id as buildUrl would", () => {
+      const exampleFunction = new BookIdFunction("EntityXy");
+      expect(exampleFunction.buildCanonicalId("123")).toBe("EntityXy(123)");
+    });
+
+    test("a clean single-key object collapses to the very same bare form - consistency is the point", () => {
+      const exampleFunction = new BookIdFunction("EntityXy");
+      expect(exampleFunction.buildCanonicalId({ isbn: "123" })).toBe(exampleFunction.buildCanonicalId("123"));
+      expect(exampleFunction.buildCanonicalId({ isbn: "123" })).toBe("EntityXy(123)");
+    });
+
+    test("a full entity representation with unrelated fields still resolves - only the key is read out of it", () => {
+      const exampleFunction = new BookIdFunction("EntityXy");
+      expect(exampleFunction.buildCanonicalId({ isbn: "123", title: "The Trial" })).toBe("EntityXy(123)");
+    });
+
+    test("a composite key builds the same as buildUrl, key by key", () => {
+      const exampleFunction = new ComplexBookIdFunction("EntityXy");
+      expect(exampleFunction.buildCanonicalId({ title: "test", author: "xxx" })).toBe(
+        "EntityXy(title='test',author='xxx')",
+      );
+    });
+
+    test("a composite key survives unrelated fields alongside it too", () => {
+      const exampleFunction = new ComplexBookIdFunction("EntityXy");
+      expect(exampleFunction.buildCanonicalId({ title: "test", author: "xxx", extra: true })).toBe(
+        "EntityXy(title='test',author='xxx')",
+      );
+    });
+
+    test("a missing key property resolves to undefined - never a partial or wrong id", () => {
+      const exampleFunction = new ComplexBookIdFunction("EntityXy");
+      expect(exampleFunction.buildCanonicalId({ title: "test" })).toBeUndefined();
+    });
+  });
+
   describe("alternate keys", () => {
     test("getPrimaryParams always returns the first param set", () => {
       const exampleFunction = new BookIdWithAlternateKeyFunction("EntityXy");

--- a/packages/odata-query-objects/test/path/FilterClauses.test.ts
+++ b/packages/odata-query-objects/test/path/FilterClauses.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "vitest";
+import {
+  QCollectionPath,
+  QDateTimeOffsetPath,
+  QEnumPath,
+  QFlagsEnumPath,
+  QGuidPath,
+  QNumberPath,
+  QNumericEnumPath,
+  QNumericFlagsEnumPath,
+  QStringCollection,
+  QStringPath,
+  QStringV2Path,
+} from "../../src";
+
+describe("filter clauses", () => {
+  const id = new QNumberPath("MediumId");
+  const title = new QStringPath("Title");
+
+  test("every comparison operator records one clause with the typed value", () => {
+    expect(id.eq(5).getClauses()).toEqual([{ path: "MediumId", operator: "eq", value: 5 }]);
+    expect(id.ne(5).getClauses()).toEqual([{ path: "MediumId", operator: "ne", value: 5 }]);
+    expect(id.lt(5).getClauses()).toEqual([{ path: "MediumId", operator: "lt", value: 5 }]);
+    expect(id.le(5).getClauses()).toEqual([{ path: "MediumId", operator: "le", value: 5 }]);
+    expect(id.gt(5).getClauses()).toEqual([{ path: "MediumId", operator: "gt", value: 5 }]);
+    expect(id.ge(5).getClauses()).toEqual([{ path: "MediumId", operator: "ge", value: 5 }]);
+  });
+
+  test("a string value is the bare string, not the quoted URL literal", () => {
+    expect(title.eq("ai").getClauses()).toEqual([{ path: "Title", operator: "eq", value: "ai" }]);
+    expect(title.eq("ai").toString()).toBe("Title eq 'ai'");
+  });
+
+  test("isNull and isNotNull record a clause with value null", () => {
+    expect(title.isNull().getClauses()).toEqual([{ path: "Title", operator: "eq", value: null }]);
+    expect(title.isNotNull().getClauses()).toEqual([{ path: "Title", operator: "ne", value: null }]);
+  });
+
+  test("an explicit null value records a clause", () => {
+    expect(title.eq(null).getClauses()).toEqual([{ path: "Title", operator: "eq", value: null }]);
+  });
+
+  test("a value converter is applied: the clause holds the OData-side value", () => {
+    const converter = {
+      id: "test",
+      from: "Edm.String",
+      to: "number",
+      convertFrom: (v: string | null | undefined) => (v == null ? v : Number(v)),
+      convertTo: (v: number | null | undefined) => (v == null ? v : String(v)),
+    };
+    const converted = new QNumberPath("Big", converter as any);
+    expect(converted.eq(9 as any).getClauses()).toEqual([{ path: "Big", operator: "eq", value: "9" }]);
+  });
+
+  test("a property-to-property comparison is raw, with no clause", () => {
+    const other = new QStringPath("Subtitle");
+    const expression = title.eq(other);
+    expect(expression.getClauses()).toEqual([]);
+    expect(expression.getRaw()).toEqual(["Title eq Subtitle"]);
+  });
+
+  test("string functions are raw only", () => {
+    const expression = title.contains("ai");
+    expect(expression.getClauses()).toEqual([]);
+    expect(expression.getRaw()).toEqual(["contains(Title,'ai')"]);
+  });
+
+  test("the emulated in operator is raw only", () => {
+    const expression = id.in(1, 2);
+    expect(expression.getClauses()).toEqual([]);
+    expect(expression.getRaw()).toEqual(["(MediumId eq 1 or MediumId eq 2)"]);
+  });
+
+  test("the native in operator is raw only", () => {
+    const nativeIn = new QNumberPath("MediumId", undefined, { nativeIn: true });
+    const expression = nativeIn.in(1, 2);
+    expect(expression.getClauses()).toEqual([]);
+    expect(expression.getRaw()).toEqual(["MediumId in (1,2)"]);
+  });
+
+  test("a guid keeps its bare string form", () => {
+    const guid = new QGuidPath("Id");
+    expect(guid.eq("5f2c").getClauses()).toEqual([{ path: "Id", operator: "eq", value: "5f2c" }]);
+  });
+
+  test("a date offset keeps its ISO string, not a V2 type prefix", () => {
+    const at = new QDateTimeOffsetPath("LoanedAt");
+    expect(at.eq("2026-01-01T00:00:00Z").getClauses()).toEqual([
+      { path: "LoanedAt", operator: "eq", value: "2026-01-01T00:00:00Z" },
+    ]);
+  });
+
+  enum FeatureEnum {
+    Feature1 = "Feature1",
+    Feature2 = "Feature2",
+  }
+  enum NumericFeatureEnum {
+    Feature1,
+    Feature2,
+  }
+
+  test("a string enum comparison records the bare symbolic name, while toString() still quotes it", () => {
+    const feature = new QEnumPath("Feature", FeatureEnum);
+    const expression = feature.eq(FeatureEnum.Feature1);
+    expect(expression.getClauses()).toEqual([{ path: "Feature", operator: "eq", value: "Feature1" }]);
+    expect(expression.toString()).toBe("Feature eq 'Feature1'");
+  });
+
+  test("a numeric enum comparison records the symbolic name as a string, not the number", () => {
+    const feature = new QNumericEnumPath("Feature", NumericFeatureEnum);
+    const expression = feature.eq(NumericFeatureEnum.Feature1);
+    expect(expression.getClauses()).toEqual([{ path: "Feature", operator: "eq", value: "Feature1" }]);
+  });
+
+  test("a string enum with a wire-value converter records that value as a string", () => {
+    const converter = {
+      id: "test",
+      from: "Edm.Byte",
+      to: "FeatureEnum",
+      convertFrom: (v: number | null | undefined) => (v == null ? v : FeatureEnum.Feature1),
+      convertTo: (v: FeatureEnum | null | undefined) => (v == null ? v : 0),
+    };
+    const feature = new QEnumPath<typeof FeatureEnum, number>("Feature", FeatureEnum, converter);
+    const expression = feature.eq(FeatureEnum.Feature1);
+    expect(expression.getClauses()).toEqual([{ path: "Feature", operator: "eq", value: "0" }]);
+  });
+
+  test("has() on both flags variants records a clause", () => {
+    const stringFlags = new QFlagsEnumPath("Feature", FeatureEnum);
+    expect(stringFlags.has(FeatureEnum.Feature2).getClauses()).toEqual([
+      { path: "Feature", operator: "has", value: "Feature2" },
+    ]);
+
+    const numericFlags = new QNumericFlagsEnumPath("Feature", NumericFeatureEnum);
+    expect(numericFlags.has(NumericFeatureEnum.Feature2).getClauses()).toEqual([
+      { path: "Feature", operator: "has", value: "Feature2" },
+    ]);
+  });
+
+  test("in() on an enum path still records nothing", () => {
+    const feature = new QEnumPath("Feature", FeatureEnum);
+    expect(feature.in(FeatureEnum.Feature1, FeatureEnum.Feature2).getClauses()).toEqual([]);
+  });
+
+  test("isNull() on an enum path still records value null", () => {
+    const feature = new QEnumPath("Feature", FeatureEnum);
+    expect(feature.isNull().getClauses()).toEqual([{ path: "Feature", operator: "eq", value: null }]);
+  });
+});
+
+describe("expressions that cannot be decomposed", () => {
+  test("a lambda operator over a collection is raw only", () => {
+    const keywords = new QCollectionPath("Keywords", () => QStringCollection);
+    const expression = keywords.any((q) => q.it.eq("ai"));
+    expect(expression.getClauses()).toEqual([]);
+    expect(expression.getRaw()).toHaveLength(1);
+    expect(expression.getRaw()[0]).toBe(expression.toString());
+  });
+
+  test("an empty lambda is raw only", () => {
+    const keywords = new QCollectionPath("Keywords", () => QStringCollection);
+    const expression = keywords.any();
+    expect(expression.getClauses()).toEqual([]);
+    expect(expression.getRaw()).toEqual(["Keywords/any()"]);
+  });
+
+  test("a V2 string function is raw only", () => {
+    const title = new QStringV2Path("Title");
+    const expression = title.startsWith("a");
+    expect(expression.getClauses()).toEqual([]);
+    expect(expression.getRaw()).toHaveLength(1);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -477,6 +477,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@odata2ts/http-client-api@npm:^0.7.1":
+  version: 0.7.1
+  resolution: "@odata2ts/http-client-api@npm:0.7.1"
+  dependencies:
+    tslib: "npm:^2.8.1"
+  checksum: 10/c9d53b75410beb93f70445e1ce91c56c1622dcb11c938df30cfbb49d83761f1ad59b79cffcf5501a40a2a92c342a61351befe562af0d9f848af8d2620002e28d
+  languageName: node
+  linkType: hard
+
 "@odata2ts/http-client-axios@npm:^0.14.0":
   version: 0.14.0
   resolution: "@odata2ts/http-client-axios@npm:0.14.0"
@@ -645,7 +654,7 @@ __metadata:
   resolution: "@odata2ts/odata-query-objects@workspace:packages/odata-query-objects"
   dependencies:
     "@odata2ts/converter-api": "npm:^0.3.0"
-    "@odata2ts/http-client-api": "npm:^0.6.8"
+    "@odata2ts/http-client-api": "npm:^0.7.1"
     "@odata2ts/odata-core": "npm:^0.7.1"
     "@vitest/coverage-istanbul": "npm:^4.1.10"
     madge: "npm:^8.0.0"


### PR DESCRIPTION
## Summary
First of a 5-PR stack splitting the long-running `feat/cache-keys` (#526) into one PR per package, in dependency order:

1. **odata-query-objects** (this PR) → 2. odata-query-builder → 3. odata-service → 4. odata2ts (generator) → 5. int-test/examples

This layer covers everything the cache-key feature needs from `odata-query-objects`, with no dependency on any later layer:

- `QFilterExpression`/`BaseFunctions`/enum paths: every decomposable filter clause now also records its own structured `(field, operator, OData-side value)` form alongside the rendered `$filter` string, so a cache key can hold a typed value instead of re-parsing OData syntax back out of a URL.
- `QId.buildCanonicalId(entity)`: an entity's own canonical id - entity-set name plus key predicate, always via the primary key - accepting a bare value, a key-only object, or a full entity row alike. `QBinding` delegates to it.
- `QModelBasePath`/`QModelCollectionBasePath.getEntityFn()` and `QBinding.getEntitySetName()`: expose a navigation property's own Q-object factory and target entity-set name, so a cache key's hop can read them directly rather than needing a generated lookup table.
- Workspace tooling: `.yarnrc.yml` preapproves `@odata2ts/*` packages (a later PR in this stack bumps `http-client-api`), `.gitignore`/`.prettierignore` keep local agent tooling out of the repo and out of formatting.
- `CONTEXT.md` + `docs/adr/0001-remove-nav-hops-table.md`: the domain glossary and ADR the whole redesign was reviewed against.

## Test plan
- [x] `yarn workspace @odata2ts/odata-query-objects test` — 846/846 passing, standalone against current `main`
- [x] `yarn prettier --check`