### PR TITLE
feat(odata-query-builder): snapshot the query state as structured cache-key params

### DIFF
--- a/packages/odata-query-builder/src/CacheKeyParams.ts
+++ b/packages/odata-query-builder/src/CacheKeyParams.ts
@@ -1,0 +1,117 @@
+import { FilterClause, QFilterExpression } from "@odata2ts/odata-query-objects";
+
+/**
+ * An expand entry once its navigation property is known: the property's own OData name and kind - the same
+ * `(name, kind)` shape a structured hop in the main key already uses, minus any key value (an expand target
+ * is never addressed by a specific key, and a freshly deep-inserted entity has none of its own yet) - plus,
+ * only when a nested `expanding()` builder ran for this property, that nested builder's own
+ * `getCacheKeyParams()` output.
+ *
+ * That 3rd slot is not the same thing as a hierarchical hop's `<key>?` in the main key format: an expand
+ * target is never addressed by an explicit key at all, so there is nothing that position could hold
+ * instead, and the two never coexist.
+ */
+export type ExpandHop = readonly [name: string, kind: "list" | "detail", nestedParams?: CacheKeyParams];
+
+/**
+ * The restrictions a query puts on a resource, as a cache key carries them: one flat object, always the
+ * last element of the key.
+ *
+ * Built from the query builder's own state rather than from the URL it produces - the structured values
+ * exist one call frame up, and recovering them from a string would mean re-implementing OData's grammar.
+ */
+/**
+ * A `type` alias rather than an `interface`, deliberately: an interface has no implicit index
+ * signature and is therefore not assignable to `Record<string, unknown>`, which is what
+ * `RequestCmdOptions.queryParams` takes. A type alias is.
+ */
+export type CacheKeyParams = {
+  /** Structured filter map - see {@link foldFilterClauses}. */
+  filter?: Record<string, unknown>;
+  /** Rendered paths, sorted: their order carries no meaning. */
+  select?: Array<string>;
+  /** Rendered paths (bare) or hop-shaped entries where the target's own type is known, sorted by path. */
+  expand?: Array<string | ExpandHop>;
+  /** Rendered clauses, in source order: their order does carry meaning. */
+  orderBy?: Array<string>;
+  top?: number;
+  skip?: number;
+  /** Present only when `$count` / `$inlinecount` was actually requested. */
+  count?: true;
+  search?: string;
+  /** Custom query options, nested so user-chosen names cannot collide with ours. */
+  custom?: Record<string, unknown>;
+  /** FQ type name of a subtype cast. */
+  cast?: string;
+  /** Singleton name. */
+  singleton?: string;
+  /** FQ operation name and its typed parameters. */
+  operation?: string;
+  params?: Record<string, unknown>;
+};
+
+/** `$` cannot occur in an OData identifier, so this can never collide with a property path. */
+const RAW_KEY = "$raw";
+
+/**
+ * Folds every filter expression into one AND-map: a path maps to what is asserted about it.
+ *
+ * A single `eq` collapses to the bare value - the common case, and the form a derived relation produces,
+ * which is what lets `/Media(5)/Copies` converge with a hand-written `$filter=MediumId eq 5`. Anything
+ * else becomes `{<operator>: value}`, and several clauses on one path become an array in source order.
+ * Whatever could not be decomposed at all is joined verbatim under `$raw`.
+ */
+export function foldFilterClauses(filters: ReadonlyArray<QFilterExpression>): Record<string, unknown> | undefined {
+  const byPath = new Map<string, Array<FilterClause>>();
+  const raw: Array<string> = [];
+
+  for (const filter of filters) {
+    for (const clause of filter.getClauses()) {
+      const existing = byPath.get(clause.path);
+      if (existing) {
+        existing.push(clause);
+      } else {
+        byPath.set(clause.path, [clause]);
+      }
+    }
+    raw.push(...filter.getRaw());
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [path, clauses] of byPath) {
+    result[path] =
+      clauses.length === 1 ? renderSingle(clauses[0]) : clauses.map((clause) => ({ [clause.operator]: clause.value }));
+  }
+  if (raw.length) {
+    result[RAW_KEY] = raw.join(" and ");
+  }
+
+  return Object.keys(result).length ? result : undefined;
+}
+
+function renderSingle(clause: FilterClause): unknown {
+  return clause.operator === "eq" ? clause.value : { [clause.operator]: clause.value };
+}
+
+/**
+ * Drops every empty entry, and the whole object where nothing is left. Key order inside it is irrelevant -
+ * a cache hashes it order-independently, which is precisely why the filter is a map.
+ */
+export function normalizeCacheKeyParams(params: CacheKeyParams): CacheKeyParams | undefined {
+  const result = Object.fromEntries(
+    Object.entries(params).filter(([, value]) => {
+      if (value === undefined || value === null) {
+        return false;
+      }
+      if (Array.isArray(value)) {
+        return value.length > 0;
+      }
+      if (typeof value === "object") {
+        return Object.keys(value).length > 0;
+      }
+      return true;
+    }),
+  );
+
+  return Object.keys(result).length ? result : undefined;
+}

--- a/packages/odata-query-builder/src/ODataQueryBuilder.ts
+++ b/packages/odata-query-builder/src/ODataQueryBuilder.ts
@@ -11,6 +11,7 @@ import {
   QueryObjectModel,
   searchTerm,
 } from "@odata2ts/odata-query-objects";
+import { CacheKeyParams, ExpandHop, foldFilterClauses, normalizeCacheKeyParams } from "./CacheKeyParams.js";
 import { ODataOperators } from "./ODataModel";
 import {
   ExpandingCollectionQueryBuilderV4,
@@ -48,6 +49,40 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
    * the complex hop, until they reach a context that can embed them (see `expanding()` / `buildNested()`).
    */
   private hoistedExpandsBucket: Array<string> | undefined;
+
+  /**
+   * Structured, per-property information `getCacheKeyParams()` needs to enrich an expand entry - kept
+   * entirely separate from `expands`/`hoistedExpandsBucket`, which hold whatever `build()` renders onto
+   * the wire (a bare path for `expand()`, a fully rendered sub-query string for `expanding()`) and must
+   * stay untouched by anything cache-key related.
+   *
+   * `path` is the rendered OData path (a nav/complex property's own odataName, read directly off its
+   * Q-object wrapper - never a type, never looked up in a generated table), used both as the hop's own
+   * identity and for sorting and `rawForm`-based reconciliation with `expands`/`hoistedExpandsBucket`.
+   * `kind` is only known where the caller passed an actual `keyof Q` naming a nav/complex property (never
+   * for `addExpands()`'s raw strings, and never for a `QSelectExpression` passed to `expand()`, neither of
+   * which resolve to a Q-object property this could read a kind off) - its absence is exactly what marks
+   * an entry as a bare, unenriched path rather than a hop.
+   *
+   * `rawForm` is exactly what this same call also pushed into `expands` - needed to tell a direct entry
+   * apart from a hoisted one reconciled back from `expands` after `build()` has folded
+   * `hoistedExpandsBucket` into it, without depending on whether that fold has happened yet.
+   */
+  private expandEntries:
+    | Array<{
+        path: string;
+        kind?: "list" | "detail";
+        rawForm: string;
+        nestedBuilder?: ODataQueryBuilder<any>;
+      }>
+    | undefined;
+
+  private getExpandEntries() {
+    if (!this.expandEntries) {
+      this.expandEntries = [];
+    }
+    return this.expandEntries;
+  }
 
   constructor(path: string, qEntity: Q, config?: ODataQueryBuilderConfig) {
     if (!qEntity || !path || !path.trim()) {
@@ -111,6 +146,9 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
     const filteredPaths = paths.filter((p): p is string => !!p);
     if (filteredPaths.length) {
       this.getExpands().push(...filteredPaths);
+      // a raw path string, not a `keyof Q` - there is no Q-object property to read a kind off, so an
+      // addExpands() entry can never be enriched, whatever string happens to be passed
+      this.getExpandEntries().push(...filteredPaths.map((path) => ({ path, rawForm: path })));
     }
   };
 
@@ -175,9 +213,30 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
   } */
 
   public expand(props: NullableParamList<keyof Q | QSelectExpression>) {
+    // filterSelectAndMapPath's own first step is this identical filter, so filteredProps lines up
+    // position-for-position with filteredPaths below - and, since expand() rejects flat/complex properties
+    // at the type level (the one case that would expand one prop into several leaf paths), each valid
+    // entry here resolves to exactly one path, keeping the two arrays the same length too
+    const filteredProps = props.filter((p): p is keyof Q | QSelectExpression => !!p);
     const filteredPaths = this.filterSelectAndMapPath(props);
     if (filteredPaths.length) {
       this.getExpands().push(...filteredPaths);
+      this.getExpandEntries().push(
+        ...filteredPaths.map((path, i) => {
+          const prop = filteredProps[i];
+          // "*" (a select()-only wildcard, occasionally passed here anyway despite the type system) names
+          // no real property of Q - guarded here rather than assumed away, since it resolves to `undefined`
+          // and has no `isCollectionType()` to read a kind off
+          const entityProp =
+            typeof prop === "string" ? this.getEntityProp<QEntityPathModel<Q>>(prop as keyof Q) : undefined;
+          const kind = entityProp
+            ? entityProp.isCollectionType()
+              ? ("list" as const)
+              : ("detail" as const)
+            : undefined;
+          return { path, rawForm: path, kind };
+        }),
+      );
     }
   }
 
@@ -228,6 +287,14 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
       this.getSelects().push(content);
     } else {
       this.getExpands().push(content);
+      // navigation only - a complex property has no entity set and cannot be written to independently,
+      // so there is nothing for touchesResource to reach through it; only the entity case is tracked here
+      this.getExpandEntries().push({
+        path,
+        rawForm: content,
+        kind: entityProp.isCollectionType() ? "list" : "detail",
+        nestedBuilder: nestedEngine,
+      });
     }
     if (hoistedExpands.length) {
       this.getHoistedExpandsBucket().push(...hoistedExpands.map((fragment) => `${path}/${fragment}`));
@@ -405,5 +472,69 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
     const hoistedExpands = [...(this.expands ?? []), ...(this.hoistedExpandsBucket ?? [])];
 
     return { content, hoistedExpands };
+  }
+
+  /**
+   * The restrictions this builder puts on the resource, as a cache key carries them.
+   *
+   * Read off this builder's own fields, never off the URL it builds: the values in `filter` are the
+   * OData-side ones the query objects recorded, which a rendered `$filter` string has already escaped and
+   * quoted beyond recovery.
+   *
+   * `hoistedExpandsBucket`/`expands` are reconciled by `rawForm`, not read as a bare union - see the
+   * `expandItems` computation below for why: `build()` folds `hoistedExpandsBucket` into `expands`, and a
+   * cache key asked for before or after that fold must answer identically.
+   *
+   * `groupBys` is deliberately ignored too: `$apply` reshapes the response into something that is not the
+   * resource any more, so keying it as that resource would be wrong.
+   */
+  public getCacheKeyParams(): CacheKeyParams | undefined {
+    const entries = this.expandEntries ?? [];
+
+    // expand()/expanding()/addExpands() are the only ways to populate `expands`, and every one of them
+    // also pushes onto expandEntries in the same call - so expandEntries alone is a complete, structured
+    // account of every *direct* expand target on this builder. `kind`'s presence is what marks a real hop:
+    // `path` is already the property's own odataName, read straight off its Q-object wrapper at the point
+    // expand()/expanding() was called - no generated table, no type, needed to enrich it further.
+    const expandItems: Array<{ sortKey: string; entry: string | ExpandHop }> = entries.map(
+      ({ path, kind, nestedBuilder }) => {
+        if (!kind) {
+          return { sortKey: path, entry: path };
+        }
+        const nestedParams = nestedBuilder ? nestedBuilder.getCacheKeyParams() : undefined;
+        const expandHop: ExpandHop = nestedParams ? [path, kind, nestedParams] : [path, kind];
+        return { sortKey: path, entry: expandHop };
+      },
+    );
+
+    // A fragment relayed from a complex-typed descendant (a navigation property reached *through* a
+    // complex property) is never pushed to expandEntries at all - navigation-only hop-shaping (already
+    // decided) does not reach through a complex hop, so it always stays a bare string. It lives in
+    // hoistedExpandsBucket before build() folds it into expands, and in expands afterwards - reconciled
+    // here by rawForm (not path, which a nested expanding()'s rendered content never matches) so the
+    // answer does not depend on whether getCacheKeyParams() is asked before or after a request's URL was
+    // built.
+    const accountedForRawForms = new Set(entries.map((e) => e.rawForm));
+    const hoisted = [...(this.expands ?? []), ...(this.hoistedExpandsBucket ?? [])].filter(
+      (raw) => !accountedForRawForms.has(raw),
+    );
+    for (const raw of hoisted) {
+      expandItems.push({ sortKey: raw, entry: raw });
+    }
+
+    expandItems.sort((a, b) => (a.sortKey < b.sortKey ? -1 : a.sortKey > b.sortKey ? 1 : 0));
+
+    return normalizeCacheKeyParams({
+      filter: this.filters?.length ? foldFilterClauses(this.filters) : undefined,
+      select: this.selects?.length ? [...this.selects].sort() : undefined,
+      expand: expandItems.length ? expandItems.map((i) => i.entry) : undefined,
+      orderBy: this.orderBys?.length ? this.orderBys.map((exp) => exp.toString()) : undefined,
+      top: this.itemsTop,
+      skip: this.itemsToSkip,
+      // `count(false)` still assigns itemsCount, so a bare truthiness check would report a count
+      // nobody asked for - and would key `?$count=false` differently from the same query without it
+      count: this.itemsCount && this.itemsCount[1] !== "false" ? true : undefined,
+      search: this.searchTerms?.length ? this.searchTerms.map((st) => st.toString()).join(" AND ") : undefined,
+    });
   }
 }

--- a/packages/odata-query-builder/src/ODataQueryBuilderModel.ts
+++ b/packages/odata-query-builder/src/ODataQueryBuilderModel.ts
@@ -10,6 +10,7 @@ import {
   QSelectExpression,
   QueryObjectModel,
 } from "@odata2ts/odata-query-objects";
+import { CacheKeyParams } from "./CacheKeyParams.js";
 
 /**
  * Extracts the wrapped entity from QEntityPath, QEntityCollectionPath, QComplexPath, QComplexCollectionPath
@@ -320,6 +321,13 @@ export interface CollectionQueryBuilderV2<Q extends QueryObjectModel>
    * Creates a new builder with the identical state (deep copy).
    */
   clone: () => CollectionQueryBuilderV2<Q>;
+
+  /**
+   * The restrictions this builder puts on the resource, as a cache key carries them - see
+   * {@link CacheKeyParams}. Not one of the ordinary query operations, so it lives here rather than in
+   * {@link ODataQueryBuilderModel}, which several unrelated expanding/nested builder shapes also draw from.
+   */
+  getCacheKeyParams: () => CacheKeyParams | undefined;
 }
 
 /**
@@ -335,6 +343,9 @@ export interface ModelQueryBuilderV2<Q extends QueryObjectModel>
    * Creates a new builder with the identical state (deep copy).
    */
   clone: () => ModelQueryBuilderV2<Q>;
+
+  /** See {@link CollectionQueryBuilderV2.getCacheKeyParams}. */
+  getCacheKeyParams: () => CacheKeyParams | undefined;
 }
 
 export interface ExpandingQueryBuilderV2<Q extends QueryObjectModel>
@@ -361,6 +372,9 @@ export interface CollectionQueryBuilderV4<Q extends QueryObjectModel> extends Pi
    * Creates a new builder with the identical state (deep copy).
    */
   clone: () => CollectionQueryBuilderV4<Q>;
+
+  /** See {@link CollectionQueryBuilderV2.getCacheKeyParams}. */
+  getCacheKeyParams: () => CacheKeyParams | undefined;
 }
 
 /**
@@ -375,6 +389,9 @@ export interface ModelQueryBuilderV4<Q extends QueryObjectModel> extends Pick<
    * Creates a new builder with the identical state (deep copy).
    */
   clone: () => ModelQueryBuilderV4<Q>;
+
+  /** See {@link CollectionQueryBuilderV2.getCacheKeyParams}. */
+  getCacheKeyParams: () => CacheKeyParams | undefined;
 }
 
 export interface ExpandingCollectionQueryBuilderV4<Q extends QueryObjectModel> extends Pick<

--- a/packages/odata-query-builder/src/index.ts
+++ b/packages/odata-query-builder/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./CacheKeyParams";
 export * from "./ODataQueryBuilderModel";
 
 export { createQueryBuilderV2 } from "./v2/ODataQueryBuilderV2";

--- a/packages/odata-query-builder/src/v2/ODataQueryBuilderV2.ts
+++ b/packages/odata-query-builder/src/v2/ODataQueryBuilderV2.ts
@@ -129,4 +129,8 @@ class ODataQueryBuilderV2<Q extends QueryObjectModel> implements ODataQueryBuild
   public build() {
     return this.builder.build();
   }
+
+  public getCacheKeyParams() {
+    return this.builder.getCacheKeyParams();
+  }
 }

--- a/packages/odata-query-builder/src/v4/ODataQueryBuilderV4.ts
+++ b/packages/odata-query-builder/src/v4/ODataQueryBuilderV4.ts
@@ -120,4 +120,8 @@ class ODataQueryBuilderV4<Q extends QueryObjectModel> implements ODataQueryBuild
   public build() {
     return this.builder.build();
   }
+
+  public getCacheKeyParams() {
+    return this.builder.getCacheKeyParams();
+  }
 }

--- a/packages/odata-query-builder/test/CacheKeyParams.test.ts
+++ b/packages/odata-query-builder/test/CacheKeyParams.test.ts
@@ -1,0 +1,186 @@
+import { QFilterExpression, QStringPath } from "@odata2ts/odata-query-objects";
+import { beforeEach, describe, expect, test } from "vitest";
+import { createExpandingQueryBuilderV4 } from "../src";
+import { ODataQueryBuilder } from "../src/ODataQueryBuilder";
+import { QPerson, qPerson } from "./fixture/types/QSimplePersonModel";
+
+describe("CacheKeyParams", () => {
+  let builder: ODataQueryBuilder<QPerson>;
+
+  beforeEach(() => {
+    builder = new ODataQueryBuilder("Persons", qPerson);
+  });
+
+  test("an untouched builder contributes nothing", () => {
+    expect(builder.getCacheKeyParams()).toBeUndefined();
+  });
+
+  test("select and expand are sorted, their order carries no meaning", () => {
+    // addSelects/addExpands take raw path strings, not tied to the fixture's own properties.
+    builder.addSelects("UserName", "Age", "Name");
+    builder.addExpands("Friends", "BestFriend");
+    expect(builder.getCacheKeyParams()).toEqual({
+      select: ["Age", "Name", "UserName"],
+      expand: ["BestFriend", "Friends"],
+    });
+  });
+
+  test("orderBy keeps source order, which does carry meaning", () => {
+    builder.orderBy([qPerson.age.desc(), qPerson.name.asc()]);
+    expect(builder.getCacheKeyParams()).toEqual({ orderBy: ["age desc", "name asc"] });
+  });
+
+  test("top, skip and count come through as they are", () => {
+    builder.top(10);
+    builder.skip(20);
+    builder.count();
+    expect(builder.getCacheKeyParams()).toEqual({ top: 10, skip: 20, count: true });
+  });
+
+  test("count(false) contributes nothing", () => {
+    builder.count(false);
+    expect(builder.getCacheKeyParams()).toBeUndefined();
+  });
+
+  test("countV2 counts as count", () => {
+    builder.countV2();
+    expect(builder.getCacheKeyParams()).toEqual({ count: true });
+  });
+
+  test("search is the rendered term", () => {
+    builder.search(["ai"]);
+    expect(builder.getCacheKeyParams()).toEqual({ search: "ai" });
+  });
+
+  test("several filter calls fold into one map", () => {
+    builder.filter([qPerson.age.gt(18)]);
+    builder.filter([qPerson.name.eq("russell")]);
+    expect(builder.getCacheKeyParams()).toEqual({ filter: { age: { gt: 18 }, name: "russell" } });
+  });
+
+  test("a single eq clause collapses to the bare value", () => {
+    builder.filter([qPerson.name.eq("russell")]);
+    expect(builder.getCacheKeyParams()).toEqual({ filter: { name: "russell" } });
+  });
+
+  test("a non-eq operator becomes an object", () => {
+    builder.filter([qPerson.age.ne(3)]);
+    expect(builder.getCacheKeyParams()).toEqual({ filter: { age: { ne: 3 } } });
+  });
+
+  test("several clauses on one path become an array in source order", () => {
+    builder.filter([qPerson.age.gt(2000).and(qPerson.age.lt(2020))]);
+    expect(builder.getCacheKeyParams()).toEqual({ filter: { age: [{ gt: 2000 }, { lt: 2020 }] } });
+  });
+
+  test("two eq clauses on one path also become an array", () => {
+    builder.filter([qPerson.age.eq(1).and(qPerson.age.eq(2))]);
+    expect(builder.getCacheKeyParams()).toEqual({ filter: { age: [{ eq: 1 }, { eq: 2 }] } });
+  });
+
+  test("raw fragments are joined with ' and ' in source order under $raw", () => {
+    builder.filter([new QFilterExpression("(A eq 1 or B eq 2)")]);
+    builder.filter([new QFilterExpression("contains(Name,'x')")]);
+    expect(builder.getCacheKeyParams()).toEqual({
+      filter: { $raw: "(A eq 1 or B eq 2) and contains(Name,'x')" },
+    });
+  });
+
+  test("clauses and raw live in one map side by side", () => {
+    builder.filter([qPerson.name.eq("russell").and(new QFilterExpression("(A eq 1 or B eq 2)"))]);
+    expect(builder.getCacheKeyParams()).toEqual({
+      filter: { name: "russell", $raw: "(A eq 1 or B eq 2)" },
+    });
+  });
+
+  test("the clause path is the OData name, not a mapped TypeScript name", () => {
+    // the whole convergence claim rests on this: a derived relation produces OData names, so a
+    // hand-written filter has to produce the same spelling or the two key separately
+    builder.filter([new QStringPath("User_Name").eq("russell")]);
+    expect(builder.getCacheKeyParams()).toEqual({ filter: { User_Name: "russell" } });
+  });
+
+  test("an empty filter expression contributes nothing", () => {
+    builder.filter([new QFilterExpression()]);
+    expect(builder.getCacheKeyParams()).toBeUndefined();
+  });
+
+  test("expanding() still renders exactly the same $expand content as before - tracking the structured entry alongside it changes nothing observable", () => {
+    builder.expanding(createExpandingQueryBuilderV4, "friends", (nested: any) => {
+      nested.filter(qPerson.friends.getEntity().name.equals("x"));
+    });
+    expect(builder.build()).toBe("Persons?%24expand=friends(%24filter%3Dname%20eq%20'x')");
+  });
+
+  test("a nav property reached through a complex property stays a bare, hoisted string - identically whether asked before or after build()", () => {
+    builder.expanding(createExpandingQueryBuilderV4, "address", (nested: any) => {
+      nested.expanding("responsible", () => {});
+    });
+    const before = builder.getCacheKeyParams();
+    builder.build();
+    const after = builder.getCacheKeyParams();
+
+    expect(before).toEqual({ select: ["Address"], expand: ["Address/responsible"] });
+    expect(after).toEqual(before);
+  });
+
+  describe("getCacheKeyParams: expand enrichment", () => {
+    test("expand() enriches with the property's own name and kind, read directly off the Q-object - no table, no type", () => {
+      builder.expand(["friends"]);
+      expect(builder.getCacheKeyParams()).toEqual({ expand: [["friends", "list"]] });
+    });
+
+    test("a to-one navigation property enriches with kind 'detail'", () => {
+      builder.expand(["bestFriend"]);
+      expect(builder.getCacheKeyParams()).toEqual({ expand: [["bestFriend", "detail"]] });
+    });
+
+    test("addExpands() never enriches - it takes a raw path string, never a Q-object property, so there is no kind to read", () => {
+      // "friends" happens to be both the property name and the rendered path in this fixture, but
+      // addExpands() has no way to know that - it stays bare regardless of a coincidental string match
+      builder.addExpands("friends");
+      expect(builder.getCacheKeyParams()).toEqual({ expand: ["friends"] });
+    });
+
+    test("a bare (unenriched) path stays a string, mixed with hop entries", () => {
+      builder.expand(["friends"]);
+      builder.addExpands("address");
+      expect(builder.getCacheKeyParams()).toEqual({
+        expand: ["address", ["friends", "list"]],
+      });
+    });
+
+    test("sorting mixes bare paths and hop entries by path, order carries no meaning", () => {
+      builder.expand(["friends", "bestFriend"]);
+      expect(builder.getCacheKeyParams()).toEqual({
+        expand: [
+          ["bestFriend", "detail"],
+          ["friends", "list"],
+        ],
+      });
+    });
+
+    test("a nested expanding() carries its own nested params as the hop's 3rd element", () => {
+      builder.expanding(createExpandingQueryBuilderV4, "friends", (nested: any, qFriend: any) => {
+        nested.filter(qFriend.name.equals("x"));
+      });
+      expect(builder.getCacheKeyParams()).toEqual({
+        expand: [["friends", "list", { filter: { name: "x" } }]],
+      });
+    });
+
+    test("a nested expanding() with nothing to report contributes no 3rd element", () => {
+      builder.expanding(createExpandingQueryBuilderV4, "friends", () => {});
+      expect(builder.getCacheKeyParams()).toEqual({ expand: [["friends", "list"]] });
+    });
+
+    test("a nested expanding() resolves its own further nested expands the same way - no shared table needed at any depth", () => {
+      builder.expanding(createExpandingQueryBuilderV4, "friends", (nested: any) => {
+        nested.expanding("bestFriend", () => {});
+      });
+      expect(builder.getCacheKeyParams()).toEqual({
+        expand: [["friends", "list", { expand: [["bestFriend", "detail"]] }]],
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Second of a 5-PR stack splitting `feat/cache-keys` (#526) into one PR per package. Stacked on #528 (odata-query-objects) — merge that one first.

- `CacheKeyParams.ts`: the params-object shape a built query snapshots into - `select`/`filter`/`orderby`/`top`/`skip`/`count`/`search` plus a `cast`, and an `ExpandHop = (name, kind, nestedParams?)` for every `$expand`'d relation, recursing into `expanding()`'s own nested params.
- `ODataQueryBuilder.getCacheKeyParams()`: reads the filter clauses' structured OData-side values (from odata-query-objects), a nav property's own entity-set name and collection-ness directly off the Q-object passed into `expand()`/`expanding()` - no generated lookup table needed for either.
- V2/V4 builder facades expose `getCacheKeyParams()` alongside the query they already build.

## Test plan
- [x] `yarn workspace @odata2ts/odata-query-builder test` — 173/173 passing, on top of #528
- [x] `yarn prettier --check`