### PR TITLE
feat(odata2ts): generate name-rooted cache keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,4 +65,9 @@ out/
 .project
 .settings/
 
+CLAUDE.md
+AGENTS.md
+.claude/
+.agents/
+
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -17,3 +17,7 @@ CHANGELOG.md
 # Generated clients: the generator formats them itself (option `prettier`), and they are gitignored -
 # checking them would only make the result depend on whether a build has run.
 src-generated
+
+# Agent scratch: git-ignored working files (briefs, reports, review packages). Formatting them
+# would rewrite generated reports and makes check-format fail on content nobody ships.
+.superpowers

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,4 +4,7 @@ enableGlobalCache: true
 
 nodeLinker: node-modules
 
+npmPreapprovedPackages:
+  - "@odata2ts/*"
+
 yarnPath: .yarn/releases/yarn-4.18.0.cjs

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,94 @@
+# odata2ts (generator + runtime)
+
+Generates a typed TypeScript client from an OData v4 (and v2) service's metadata (CSDL). This context
+covers the cache-key/invalidation feature: giving generated `RequestCmd`s a stable, collision-free identity
+so a consuming cache library (e.g. TanStack Query) can be told what to invalidate after a write.
+
+## Language
+
+**Resource**:
+The thing an OData URL addresses, per spec — identified by a chain of container- or property-scoped
+_names_ terminated by a key, never by type. Two different resources (e.g. two entity sets) can share a
+type; sharing a type does not make them the same resource.
+_Avoid_: using "type" as a stand-in for resource identity — this was the bug the identity redesign fixes.
+
+**Entity set**:
+The named, top-level collection a non-contained entity actually lives in (e.g. `Authors`, `Editors`) — the
+anchor for a resource's canonical identity. Distinct from the entity's _type_, which only describes its
+shape and may be shared across multiple entity sets.
+_Avoid_: conflating with "entity type" — see [[Resource]].
+
+**Canonical URL**:
+The one spec-defined address for a resource: entity-set name + key predicate for a non-contained entity
+(no cast segment, ever — OData v4.01 Part 2 §4.3.1), or the parent's canonical URL + containment nav
+property's own name + [key] for a contained one (§4.3.2). Always name-anchored, never type-anchored.
+
+**Cache key**:
+The value `RequestCmd.cacheKey` produces for a read: a flat, ordered tuple identifying the exact route
+taken to reach a response, used as a cache library's query key. Distinct from a resource's canonical
+identity — a cache key describes _how the client got there_ (route), not necessarily the resource's one
+true address.
+_Avoid_: "identity" alone — ambiguous between cache key (route-shaped) and canonical id (resource-shaped).
+
+**Root / hop**:
+The first element of a cache key (root) and each subsequent chained segment (hop), reached via navigation
+or containment. As of the identity redesign, root and hop share one uniform local shape: `(name, kind,
+key?)` — `name` is the entity set's own name at the root, or the navigation/containment property's own
+OData name at a hop.
+
+**Kind marker**:
+The `"list"` / `"detail"` tag carried at the root and every hop. Not part of identity — a deliberate,
+TanStack-Query-community-style granularity control (`todoKeys.lists()` vs `todoKeys.detail(id)`), kept even
+though the identity redesign removed type from the key.
+
+**`invalidates`**:
+The array `RequestCmd` produces for a _write_, listing cache keys (or `touchesResource`-style patterns) that
+became stale as a result of that write.
+
+**`touchesResource`**:
+A pattern-matching helper: does a given cache key fall under a given (partial) key prefix/pattern? Used to
+express "invalidate every list under this resource" without enumerating every concrete key.
+
+**Canonical id**:
+A runtime-only string identifying one specific resource observed in an actual server response — the join
+key `ResourceIdentityHandler` uses to relate cache keys (route-shaped) that happen to point at the same
+resource (identity-shaped). Serialized identically to `ConcurrencyHandler`'s existing ETag key: the
+resource's own canonical-URL segment, `entitySetName + QFunction.buildUrl(key)` (e.g. `Copies(3)`,
+`Copies(Id=1,Category='books')`) — deliberately the same encoding already proven for ETags, not a new
+format.
+
+**Seeding**:
+Pre-populating a cache (or, here, `ResourceIdentityHandler`'s route↔canonical-resource map) with a value it
+has not itself fetched or observed — TkDodo's term (cited by the official TanStack Query docs' "Seeding the
+Query Cache"), the same source as [[Kind marker]]'s list/detail convention.
+_Avoid_: "cold start" — implies a temporary state that warms up with ordinary usage. The real shape is
+structural, not temporal: a route pair that's never read together in the same client instance stays
+unmapped indefinitely, however long the app runs, unless it's seeded.
+
+`ResourceIdentityHandler` supports **hydration-style** seeding only: `dehydrate()`/`hydrate()` bulk-transfer
+the exact `(canonicalId, hierarchicalKey)` pairs `record()`/`resolve()` already traffic in — e.g. across an
+SSR→client boundary, or persisted across sessions — no new data shape, mirroring TanStack's own
+`dehydrate`/`hydrate`. It deliberately does _not_ support **static** seeding (populating a mapping before
+_any_ read has ever happened, anywhere): a canonical id needs a real key value, and reaching a resource's
+_other_ routes without ever having observed them needs the referential-constraint reasoning
+[[Convergence]] deliberately dropped — reintroducing it here would just be that mechanism through a side
+door.
+
+**`ResourceIdentityHandler`**:
+A runtime store (client-held, like `ConcurrencyHandler`) recording which cache keys were observed to resolve
+to which canonical id — one entry per entity actually present in a response, at every level (the directly
+addressed resource and every `$expand`'d entity, however deep), not just the top. Recording is gated by a
+**static, generator/Q-object-forwarded** signal (each hop's own entity-set name, present only for
+non-contained navigation — `@odata.context` was tried and rejected, see [[Convergence]]), never by response
+inspection. Lets a write on one route invalidate a cache key reached via a _different_ route to the same
+resource — replacing the old generation-time "type flattening" / re-rooting prediction with a
+runtime-observed mapping.
+
+**Convergence**:
+The general problem this whole feature keeps returning to: two different routes (a navigated hop vs a
+direct query) reaching the same resource should produce cache keys (or at least an invalidation path) that
+recognize each other. Previously attempted at generation time via `ReferentialConstraint`/`Partner` grading
+(removed); now attempted at runtime via [[ResourceIdentityHandler]]. `@odata.context`/`@odata.id` were also
+tried and rejected as the runtime signal (unreliable across servers, and `@odata.context` can't reach
+`$expand`'d entities at all) in favor of a static entity-set-name signal the generator/Q-objects forward
+directly.

--- a/docs/adr/0001-remove-nav-hops-table.md
+++ b/docs/adr/0001-remove-nav-hops-table.md
@@ -1,0 +1,11 @@
+# Remove the generated `NavHopsTable`
+
+`NavHopsTable` (`NavHopsGenerator.ts`, emitted as `CacheKeyNavHops.ts` per package) existed to give
+`$expand`/`deepEdit` cache-key encoding a target entity type's fully-qualified name for each hop, since the
+Q-object passed into `expand()`/`expanding()` doesn't carry its own type's FQN. The [names-not-types
+identity redesign](/docs/superpowers/specs/2026-09-04-cache-key-identity-redesign.md) drops type from cache
+keys entirely, so that FQN — the one thing the table supplied that the Q-object itself doesn't already
+expose via `.getPath()`/`.isCollectionType()` — is no longer needed by anything. We remove the table, its
+generator, and `ProjectManager.createNavHopsFile` rather than keep emitting dead per-package output;
+`getCacheKeyParams()`'s recursion switches from table lookup to reading the nested Q-object (via
+`getEntity()`) directly.

--- a/packages/odata-query-builder/src/CacheKeyParams.ts
+++ b/packages/odata-query-builder/src/CacheKeyParams.ts
@@ -1,0 +1,117 @@
+import { FilterClause, QFilterExpression } from "@odata2ts/odata-query-objects";
+
+/**
+ * An expand entry once its navigation property is known: the property's own OData name and kind - the same
+ * `(name, kind)` shape a structured hop in the main key already uses, minus any key value (an expand target
+ * is never addressed by a specific key, and a freshly deep-inserted entity has none of its own yet) - plus,
+ * only when a nested `expanding()` builder ran for this property, that nested builder's own
+ * `getCacheKeyParams()` output.
+ *
+ * That 3rd slot is not the same thing as a hierarchical hop's `<key>?` in the main key format: an expand
+ * target is never addressed by an explicit key at all, so there is nothing that position could hold
+ * instead, and the two never coexist.
+ */
+export type ExpandHop = readonly [name: string, kind: "list" | "detail", nestedParams?: CacheKeyParams];
+
+/**
+ * The restrictions a query puts on a resource, as a cache key carries them: one flat object, always the
+ * last element of the key.
+ *
+ * Built from the query builder's own state rather than from the URL it produces - the structured values
+ * exist one call frame up, and recovering them from a string would mean re-implementing OData's grammar.
+ */
+/**
+ * A `type` alias rather than an `interface`, deliberately: an interface has no implicit index
+ * signature and is therefore not assignable to `Record<string, unknown>`, which is what
+ * `RequestCmdOptions.queryParams` takes. A type alias is.
+ */
+export type CacheKeyParams = {
+  /** Structured filter map - see {@link foldFilterClauses}. */
+  filter?: Record<string, unknown>;
+  /** Rendered paths, sorted: their order carries no meaning. */
+  select?: Array<string>;
+  /** Rendered paths (bare) or hop-shaped entries where the target's own type is known, sorted by path. */
+  expand?: Array<string | ExpandHop>;
+  /** Rendered clauses, in source order: their order does carry meaning. */
+  orderBy?: Array<string>;
+  top?: number;
+  skip?: number;
+  /** Present only when `$count` / `$inlinecount` was actually requested. */
+  count?: true;
+  search?: string;
+  /** Custom query options, nested so user-chosen names cannot collide with ours. */
+  custom?: Record<string, unknown>;
+  /** FQ type name of a subtype cast. */
+  cast?: string;
+  /** Singleton name. */
+  singleton?: string;
+  /** FQ operation name and its typed parameters. */
+  operation?: string;
+  params?: Record<string, unknown>;
+};
+
+/** `$` cannot occur in an OData identifier, so this can never collide with a property path. */
+const RAW_KEY = "$raw";
+
+/**
+ * Folds every filter expression into one AND-map: a path maps to what is asserted about it.
+ *
+ * A single `eq` collapses to the bare value - the common case, and the form a derived relation produces,
+ * which is what lets `/Media(5)/Copies` converge with a hand-written `$filter=MediumId eq 5`. Anything
+ * else becomes `{<operator>: value}`, and several clauses on one path become an array in source order.
+ * Whatever could not be decomposed at all is joined verbatim under `$raw`.
+ */
+export function foldFilterClauses(filters: ReadonlyArray<QFilterExpression>): Record<string, unknown> | undefined {
+  const byPath = new Map<string, Array<FilterClause>>();
+  const raw: Array<string> = [];
+
+  for (const filter of filters) {
+    for (const clause of filter.getClauses()) {
+      const existing = byPath.get(clause.path);
+      if (existing) {
+        existing.push(clause);
+      } else {
+        byPath.set(clause.path, [clause]);
+      }
+    }
+    raw.push(...filter.getRaw());
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [path, clauses] of byPath) {
+    result[path] =
+      clauses.length === 1 ? renderSingle(clauses[0]) : clauses.map((clause) => ({ [clause.operator]: clause.value }));
+  }
+  if (raw.length) {
+    result[RAW_KEY] = raw.join(" and ");
+  }
+
+  return Object.keys(result).length ? result : undefined;
+}
+
+function renderSingle(clause: FilterClause): unknown {
+  return clause.operator === "eq" ? clause.value : { [clause.operator]: clause.value };
+}
+
+/**
+ * Drops every empty entry, and the whole object where nothing is left. Key order inside it is irrelevant -
+ * a cache hashes it order-independently, which is precisely why the filter is a map.
+ */
+export function normalizeCacheKeyParams(params: CacheKeyParams): CacheKeyParams | undefined {
+  const result = Object.fromEntries(
+    Object.entries(params).filter(([, value]) => {
+      if (value === undefined || value === null) {
+        return false;
+      }
+      if (Array.isArray(value)) {
+        return value.length > 0;
+      }
+      if (typeof value === "object") {
+        return Object.keys(value).length > 0;
+      }
+      return true;
+    }),
+  );
+
+  return Object.keys(result).length ? result : undefined;
+}

--- a/packages/odata-query-builder/src/ODataQueryBuilder.ts
+++ b/packages/odata-query-builder/src/ODataQueryBuilder.ts
@@ -11,6 +11,7 @@ import {
   QueryObjectModel,
   searchTerm,
 } from "@odata2ts/odata-query-objects";
+import { CacheKeyParams, ExpandHop, foldFilterClauses, normalizeCacheKeyParams } from "./CacheKeyParams.js";
 import { ODataOperators } from "./ODataModel";
 import {
   ExpandingCollectionQueryBuilderV4,
@@ -48,6 +49,40 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
    * the complex hop, until they reach a context that can embed them (see `expanding()` / `buildNested()`).
    */
   private hoistedExpandsBucket: Array<string> | undefined;
+
+  /**
+   * Structured, per-property information `getCacheKeyParams()` needs to enrich an expand entry - kept
+   * entirely separate from `expands`/`hoistedExpandsBucket`, which hold whatever `build()` renders onto
+   * the wire (a bare path for `expand()`, a fully rendered sub-query string for `expanding()`) and must
+   * stay untouched by anything cache-key related.
+   *
+   * `path` is the rendered OData path (a nav/complex property's own odataName, read directly off its
+   * Q-object wrapper - never a type, never looked up in a generated table), used both as the hop's own
+   * identity and for sorting and `rawForm`-based reconciliation with `expands`/`hoistedExpandsBucket`.
+   * `kind` is only known where the caller passed an actual `keyof Q` naming a nav/complex property (never
+   * for `addExpands()`'s raw strings, and never for a `QSelectExpression` passed to `expand()`, neither of
+   * which resolve to a Q-object property this could read a kind off) - its absence is exactly what marks
+   * an entry as a bare, unenriched path rather than a hop.
+   *
+   * `rawForm` is exactly what this same call also pushed into `expands` - needed to tell a direct entry
+   * apart from a hoisted one reconciled back from `expands` after `build()` has folded
+   * `hoistedExpandsBucket` into it, without depending on whether that fold has happened yet.
+   */
+  private expandEntries:
+    | Array<{
+        path: string;
+        kind?: "list" | "detail";
+        rawForm: string;
+        nestedBuilder?: ODataQueryBuilder<any>;
+      }>
+    | undefined;
+
+  private getExpandEntries() {
+    if (!this.expandEntries) {
+      this.expandEntries = [];
+    }
+    return this.expandEntries;
+  }
 
   constructor(path: string, qEntity: Q, config?: ODataQueryBuilderConfig) {
     if (!qEntity || !path || !path.trim()) {
@@ -111,6 +146,9 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
     const filteredPaths = paths.filter((p): p is string => !!p);
     if (filteredPaths.length) {
       this.getExpands().push(...filteredPaths);
+      // a raw path string, not a `keyof Q` - there is no Q-object property to read a kind off, so an
+      // addExpands() entry can never be enriched, whatever string happens to be passed
+      this.getExpandEntries().push(...filteredPaths.map((path) => ({ path, rawForm: path })));
     }
   };
 
@@ -175,9 +213,30 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
   } */
 
   public expand(props: NullableParamList<keyof Q | QSelectExpression>) {
+    // filterSelectAndMapPath's own first step is this identical filter, so filteredProps lines up
+    // position-for-position with filteredPaths below - and, since expand() rejects flat/complex properties
+    // at the type level (the one case that would expand one prop into several leaf paths), each valid
+    // entry here resolves to exactly one path, keeping the two arrays the same length too
+    const filteredProps = props.filter((p): p is keyof Q | QSelectExpression => !!p);
     const filteredPaths = this.filterSelectAndMapPath(props);
     if (filteredPaths.length) {
       this.getExpands().push(...filteredPaths);
+      this.getExpandEntries().push(
+        ...filteredPaths.map((path, i) => {
+          const prop = filteredProps[i];
+          // "*" (a select()-only wildcard, occasionally passed here anyway despite the type system) names
+          // no real property of Q - guarded here rather than assumed away, since it resolves to `undefined`
+          // and has no `isCollectionType()` to read a kind off
+          const entityProp =
+            typeof prop === "string" ? this.getEntityProp<QEntityPathModel<Q>>(prop as keyof Q) : undefined;
+          const kind = entityProp
+            ? entityProp.isCollectionType()
+              ? ("list" as const)
+              : ("detail" as const)
+            : undefined;
+          return { path, rawForm: path, kind };
+        }),
+      );
     }
   }
 
@@ -228,6 +287,14 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
       this.getSelects().push(content);
     } else {
       this.getExpands().push(content);
+      // navigation only - a complex property has no entity set and cannot be written to independently,
+      // so there is nothing for touchesResource to reach through it; only the entity case is tracked here
+      this.getExpandEntries().push({
+        path,
+        rawForm: content,
+        kind: entityProp.isCollectionType() ? "list" : "detail",
+        nestedBuilder: nestedEngine,
+      });
     }
     if (hoistedExpands.length) {
       this.getHoistedExpandsBucket().push(...hoistedExpands.map((fragment) => `${path}/${fragment}`));
@@ -405,5 +472,69 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
     const hoistedExpands = [...(this.expands ?? []), ...(this.hoistedExpandsBucket ?? [])];
 
     return { content, hoistedExpands };
+  }
+
+  /**
+   * The restrictions this builder puts on the resource, as a cache key carries them.
+   *
+   * Read off this builder's own fields, never off the URL it builds: the values in `filter` are the
+   * OData-side ones the query objects recorded, which a rendered `$filter` string has already escaped and
+   * quoted beyond recovery.
+   *
+   * `hoistedExpandsBucket`/`expands` are reconciled by `rawForm`, not read as a bare union - see the
+   * `expandItems` computation below for why: `build()` folds `hoistedExpandsBucket` into `expands`, and a
+   * cache key asked for before or after that fold must answer identically.
+   *
+   * `groupBys` is deliberately ignored too: `$apply` reshapes the response into something that is not the
+   * resource any more, so keying it as that resource would be wrong.
+   */
+  public getCacheKeyParams(): CacheKeyParams | undefined {
+    const entries = this.expandEntries ?? [];
+
+    // expand()/expanding()/addExpands() are the only ways to populate `expands`, and every one of them
+    // also pushes onto expandEntries in the same call - so expandEntries alone is a complete, structured
+    // account of every *direct* expand target on this builder. `kind`'s presence is what marks a real hop:
+    // `path` is already the property's own odataName, read straight off its Q-object wrapper at the point
+    // expand()/expanding() was called - no generated table, no type, needed to enrich it further.
+    const expandItems: Array<{ sortKey: string; entry: string | ExpandHop }> = entries.map(
+      ({ path, kind, nestedBuilder }) => {
+        if (!kind) {
+          return { sortKey: path, entry: path };
+        }
+        const nestedParams = nestedBuilder ? nestedBuilder.getCacheKeyParams() : undefined;
+        const expandHop: ExpandHop = nestedParams ? [path, kind, nestedParams] : [path, kind];
+        return { sortKey: path, entry: expandHop };
+      },
+    );
+
+    // A fragment relayed from a complex-typed descendant (a navigation property reached *through* a
+    // complex property) is never pushed to expandEntries at all - navigation-only hop-shaping (already
+    // decided) does not reach through a complex hop, so it always stays a bare string. It lives in
+    // hoistedExpandsBucket before build() folds it into expands, and in expands afterwards - reconciled
+    // here by rawForm (not path, which a nested expanding()'s rendered content never matches) so the
+    // answer does not depend on whether getCacheKeyParams() is asked before or after a request's URL was
+    // built.
+    const accountedForRawForms = new Set(entries.map((e) => e.rawForm));
+    const hoisted = [...(this.expands ?? []), ...(this.hoistedExpandsBucket ?? [])].filter(
+      (raw) => !accountedForRawForms.has(raw),
+    );
+    for (const raw of hoisted) {
+      expandItems.push({ sortKey: raw, entry: raw });
+    }
+
+    expandItems.sort((a, b) => (a.sortKey < b.sortKey ? -1 : a.sortKey > b.sortKey ? 1 : 0));
+
+    return normalizeCacheKeyParams({
+      filter: this.filters?.length ? foldFilterClauses(this.filters) : undefined,
+      select: this.selects?.length ? [...this.selects].sort() : undefined,
+      expand: expandItems.length ? expandItems.map((i) => i.entry) : undefined,
+      orderBy: this.orderBys?.length ? this.orderBys.map((exp) => exp.toString()) : undefined,
+      top: this.itemsTop,
+      skip: this.itemsToSkip,
+      // `count(false)` still assigns itemsCount, so a bare truthiness check would report a count
+      // nobody asked for - and would key `?$count=false` differently from the same query without it
+      count: this.itemsCount && this.itemsCount[1] !== "false" ? true : undefined,
+      search: this.searchTerms?.length ? this.searchTerms.map((st) => st.toString()).join(" AND ") : undefined,
+    });
   }
 }

--- a/packages/odata-query-builder/src/ODataQueryBuilderModel.ts
+++ b/packages/odata-query-builder/src/ODataQueryBuilderModel.ts
@@ -10,6 +10,7 @@ import {
   QSelectExpression,
   QueryObjectModel,
 } from "@odata2ts/odata-query-objects";
+import { CacheKeyParams } from "./CacheKeyParams.js";
 
 /**
  * Extracts the wrapped entity from QEntityPath, QEntityCollectionPath, QComplexPath, QComplexCollectionPath
@@ -320,6 +321,13 @@ export interface CollectionQueryBuilderV2<Q extends QueryObjectModel>
    * Creates a new builder with the identical state (deep copy).
    */
   clone: () => CollectionQueryBuilderV2<Q>;
+
+  /**
+   * The restrictions this builder puts on the resource, as a cache key carries them - see
+   * {@link CacheKeyParams}. Not one of the ordinary query operations, so it lives here rather than in
+   * {@link ODataQueryBuilderModel}, which several unrelated expanding/nested builder shapes also draw from.
+   */
+  getCacheKeyParams: () => CacheKeyParams | undefined;
 }
 
 /**
@@ -335,6 +343,9 @@ export interface ModelQueryBuilderV2<Q extends QueryObjectModel>
    * Creates a new builder with the identical state (deep copy).
    */
   clone: () => ModelQueryBuilderV2<Q>;
+
+  /** See {@link CollectionQueryBuilderV2.getCacheKeyParams}. */
+  getCacheKeyParams: () => CacheKeyParams | undefined;
 }
 
 export interface ExpandingQueryBuilderV2<Q extends QueryObjectModel>
@@ -361,6 +372,9 @@ export interface CollectionQueryBuilderV4<Q extends QueryObjectModel> extends Pi
    * Creates a new builder with the identical state (deep copy).
    */
   clone: () => CollectionQueryBuilderV4<Q>;
+
+  /** See {@link CollectionQueryBuilderV2.getCacheKeyParams}. */
+  getCacheKeyParams: () => CacheKeyParams | undefined;
 }
 
 /**
@@ -375,6 +389,9 @@ export interface ModelQueryBuilderV4<Q extends QueryObjectModel> extends Pick<
    * Creates a new builder with the identical state (deep copy).
    */
   clone: () => ModelQueryBuilderV4<Q>;
+
+  /** See {@link CollectionQueryBuilderV2.getCacheKeyParams}. */
+  getCacheKeyParams: () => CacheKeyParams | undefined;
 }
 
 export interface ExpandingCollectionQueryBuilderV4<Q extends QueryObjectModel> extends Pick<

--- a/packages/odata-query-builder/src/index.ts
+++ b/packages/odata-query-builder/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./CacheKeyParams";
 export * from "./ODataQueryBuilderModel";
 
 export { createQueryBuilderV2 } from "./v2/ODataQueryBuilderV2";

--- a/packages/odata-query-builder/src/v2/ODataQueryBuilderV2.ts
+++ b/packages/odata-query-builder/src/v2/ODataQueryBuilderV2.ts
@@ -129,4 +129,8 @@ class ODataQueryBuilderV2<Q extends QueryObjectModel> implements ODataQueryBuild
   public build() {
     return this.builder.build();
   }
+
+  public getCacheKeyParams() {
+    return this.builder.getCacheKeyParams();
+  }
 }

--- a/packages/odata-query-builder/src/v4/ODataQueryBuilderV4.ts
+++ b/packages/odata-query-builder/src/v4/ODataQueryBuilderV4.ts
@@ -120,4 +120,8 @@ class ODataQueryBuilderV4<Q extends QueryObjectModel> implements ODataQueryBuild
   public build() {
     return this.builder.build();
   }
+
+  public getCacheKeyParams() {
+    return this.builder.getCacheKeyParams();
+  }
 }

--- a/packages/odata-query-builder/test/CacheKeyParams.test.ts
+++ b/packages/odata-query-builder/test/CacheKeyParams.test.ts
@@ -1,0 +1,186 @@
+import { QFilterExpression, QStringPath } from "@odata2ts/odata-query-objects";
+import { beforeEach, describe, expect, test } from "vitest";
+import { createExpandingQueryBuilderV4 } from "../src";
+import { ODataQueryBuilder } from "../src/ODataQueryBuilder";
+import { QPerson, qPerson } from "./fixture/types/QSimplePersonModel";
+
+describe("CacheKeyParams", () => {
+  let builder: ODataQueryBuilder<QPerson>;
+
+  beforeEach(() => {
+    builder = new ODataQueryBuilder("Persons", qPerson);
+  });
+
+  test("an untouched builder contributes nothing", () => {
+    expect(builder.getCacheKeyParams()).toBeUndefined();
+  });
+
+  test("select and expand are sorted, their order carries no meaning", () => {
+    // addSelects/addExpands take raw path strings, not tied to the fixture's own properties.
+    builder.addSelects("UserName", "Age", "Name");
+    builder.addExpands("Friends", "BestFriend");
+    expect(builder.getCacheKeyParams()).toEqual({
+      select: ["Age", "Name", "UserName"],
+      expand: ["BestFriend", "Friends"],
+    });
+  });
+
+  test("orderBy keeps source order, which does carry meaning", () => {
+    builder.orderBy([qPerson.age.desc(), qPerson.name.asc()]);
+    expect(builder.getCacheKeyParams()).toEqual({ orderBy: ["age desc", "name asc"] });
+  });
+
+  test("top, skip and count come through as they are", () => {
+    builder.top(10);
+    builder.skip(20);
+    builder.count();
+    expect(builder.getCacheKeyParams()).toEqual({ top: 10, skip: 20, count: true });
+  });
+
+  test("count(false) contributes nothing", () => {
+    builder.count(false);
+    expect(builder.getCacheKeyParams()).toBeUndefined();
+  });
+
+  test("countV2 counts as count", () => {
+    builder.countV2();
+    expect(builder.getCacheKeyParams()).toEqual({ count: true });
+  });
+
+  test("search is the rendered term", () => {
+    builder.search(["ai"]);
+    expect(builder.getCacheKeyParams()).toEqual({ search: "ai" });
+  });
+
+  test("several filter calls fold into one map", () => {
+    builder.filter([qPerson.age.gt(18)]);
+    builder.filter([qPerson.name.eq("russell")]);
+    expect(builder.getCacheKeyParams()).toEqual({ filter: { age: { gt: 18 }, name: "russell" } });
+  });
+
+  test("a single eq clause collapses to the bare value", () => {
+    builder.filter([qPerson.name.eq("russell")]);
+    expect(builder.getCacheKeyParams()).toEqual({ filter: { name: "russell" } });
+  });
+
+  test("a non-eq operator becomes an object", () => {
+    builder.filter([qPerson.age.ne(3)]);
+    expect(builder.getCacheKeyParams()).toEqual({ filter: { age: { ne: 3 } } });
+  });
+
+  test("several clauses on one path become an array in source order", () => {
+    builder.filter([qPerson.age.gt(2000).and(qPerson.age.lt(2020))]);
+    expect(builder.getCacheKeyParams()).toEqual({ filter: { age: [{ gt: 2000 }, { lt: 2020 }] } });
+  });
+
+  test("two eq clauses on one path also become an array", () => {
+    builder.filter([qPerson.age.eq(1).and(qPerson.age.eq(2))]);
+    expect(builder.getCacheKeyParams()).toEqual({ filter: { age: [{ eq: 1 }, { eq: 2 }] } });
+  });
+
+  test("raw fragments are joined with ' and ' in source order under $raw", () => {
+    builder.filter([new QFilterExpression("(A eq 1 or B eq 2)")]);
+    builder.filter([new QFilterExpression("contains(Name,'x')")]);
+    expect(builder.getCacheKeyParams()).toEqual({
+      filter: { $raw: "(A eq 1 or B eq 2) and contains(Name,'x')" },
+    });
+  });
+
+  test("clauses and raw live in one map side by side", () => {
+    builder.filter([qPerson.name.eq("russell").and(new QFilterExpression("(A eq 1 or B eq 2)"))]);
+    expect(builder.getCacheKeyParams()).toEqual({
+      filter: { name: "russell", $raw: "(A eq 1 or B eq 2)" },
+    });
+  });
+
+  test("the clause path is the OData name, not a mapped TypeScript name", () => {
+    // the whole convergence claim rests on this: a derived relation produces OData names, so a
+    // hand-written filter has to produce the same spelling or the two key separately
+    builder.filter([new QStringPath("User_Name").eq("russell")]);
+    expect(builder.getCacheKeyParams()).toEqual({ filter: { User_Name: "russell" } });
+  });
+
+  test("an empty filter expression contributes nothing", () => {
+    builder.filter([new QFilterExpression()]);
+    expect(builder.getCacheKeyParams()).toBeUndefined();
+  });
+
+  test("expanding() still renders exactly the same $expand content as before - tracking the structured entry alongside it changes nothing observable", () => {
+    builder.expanding(createExpandingQueryBuilderV4, "friends", (nested: any) => {
+      nested.filter(qPerson.friends.getEntity().name.equals("x"));
+    });
+    expect(builder.build()).toBe("Persons?%24expand=friends(%24filter%3Dname%20eq%20'x')");
+  });
+
+  test("a nav property reached through a complex property stays a bare, hoisted string - identically whether asked before or after build()", () => {
+    builder.expanding(createExpandingQueryBuilderV4, "address", (nested: any) => {
+      nested.expanding("responsible", () => {});
+    });
+    const before = builder.getCacheKeyParams();
+    builder.build();
+    const after = builder.getCacheKeyParams();
+
+    expect(before).toEqual({ select: ["Address"], expand: ["Address/responsible"] });
+    expect(after).toEqual(before);
+  });
+
+  describe("getCacheKeyParams: expand enrichment", () => {
+    test("expand() enriches with the property's own name and kind, read directly off the Q-object - no table, no type", () => {
+      builder.expand(["friends"]);
+      expect(builder.getCacheKeyParams()).toEqual({ expand: [["friends", "list"]] });
+    });
+
+    test("a to-one navigation property enriches with kind 'detail'", () => {
+      builder.expand(["bestFriend"]);
+      expect(builder.getCacheKeyParams()).toEqual({ expand: [["bestFriend", "detail"]] });
+    });
+
+    test("addExpands() never enriches - it takes a raw path string, never a Q-object property, so there is no kind to read", () => {
+      // "friends" happens to be both the property name and the rendered path in this fixture, but
+      // addExpands() has no way to know that - it stays bare regardless of a coincidental string match
+      builder.addExpands("friends");
+      expect(builder.getCacheKeyParams()).toEqual({ expand: ["friends"] });
+    });
+
+    test("a bare (unenriched) path stays a string, mixed with hop entries", () => {
+      builder.expand(["friends"]);
+      builder.addExpands("address");
+      expect(builder.getCacheKeyParams()).toEqual({
+        expand: ["address", ["friends", "list"]],
+      });
+    });
+
+    test("sorting mixes bare paths and hop entries by path, order carries no meaning", () => {
+      builder.expand(["friends", "bestFriend"]);
+      expect(builder.getCacheKeyParams()).toEqual({
+        expand: [
+          ["bestFriend", "detail"],
+          ["friends", "list"],
+        ],
+      });
+    });
+
+    test("a nested expanding() carries its own nested params as the hop's 3rd element", () => {
+      builder.expanding(createExpandingQueryBuilderV4, "friends", (nested: any, qFriend: any) => {
+        nested.filter(qFriend.name.equals("x"));
+      });
+      expect(builder.getCacheKeyParams()).toEqual({
+        expand: [["friends", "list", { filter: { name: "x" } }]],
+      });
+    });
+
+    test("a nested expanding() with nothing to report contributes no 3rd element", () => {
+      builder.expanding(createExpandingQueryBuilderV4, "friends", () => {});
+      expect(builder.getCacheKeyParams()).toEqual({ expand: [["friends", "list"]] });
+    });
+
+    test("a nested expanding() resolves its own further nested expands the same way - no shared table needed at any depth", () => {
+      builder.expanding(createExpandingQueryBuilderV4, "friends", (nested: any) => {
+        nested.expanding("bestFriend", () => {});
+      });
+      expect(builder.getCacheKeyParams()).toEqual({
+        expand: [["friends", "list", { expand: [["bestFriend", "detail"]] }]],
+      });
+    });
+  });
+});

--- a/packages/odata-query-objects/package.json
+++ b/packages/odata-query-objects/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@odata2ts/converter-api": "^0.3.0",
-    "@odata2ts/http-client-api": "^0.6.8",
+    "@odata2ts/http-client-api": "^0.7.1",
     "@odata2ts/odata-core": "^0.7.1",
     "tslib": "^2.8.1"
   },

--- a/packages/odata-query-objects/src/QFilterExpression.ts
+++ b/packages/odata-query-objects/src/QFilterExpression.ts
@@ -1,20 +1,66 @@
+/**
+ * One decomposable comparison of a filter: a property path, an operator and the value asserted about it.
+ *
+ * The value is the OData-side one - after the property's converter, before URL rendering - so it is always
+ * a JSON-serialisable primitive. That is what lets a cache key be hashed at all: a caller-side value may be
+ * a `bigint`, which `JSON.stringify` refuses.
+ */
+export interface FilterClause {
+  readonly path: string;
+  readonly operator: string;
+  readonly value: unknown;
+}
+
 export class QFilterExpression {
-  constructor(private expression?: string) {}
+  /**
+   * The string form and a structured description of the very same filter, kept side by side.
+   *
+   * `clauses` holds what could be decomposed into path/operator/value; `raw` holds every fragment that
+   * could not - an `or`, a negation, a grouping, a string function, a lambda operator, a
+   * property-to-property comparison. A filter is fully described by the two together, and a cache key
+   * built from them converges with a differently written but equivalent query exactly as far as `clauses`
+   * reaches.
+   *
+   * An expression constructed from a string alone is raw by default: whoever built it did not say what it
+   * asserts, so nothing may be assumed about it.
+   */
+  constructor(
+    private expression?: string,
+    private clauses: ReadonlyArray<FilterClause> = [],
+    private raw: ReadonlyArray<string> = expression?.trim() && !clauses.length ? [expression] : [],
+  ) {}
 
   public toString(): string {
     return this.expression?.trim() || "";
   }
 
+  public getClauses(): ReadonlyArray<FilterClause> {
+    return this.clauses;
+  }
+
+  public getRaw(): ReadonlyArray<string> {
+    return this.raw;
+  }
+
+  /**
+   * Collapses this expression into a single raw fragment: the structure of what it asserts is gone the
+   * moment it is grouped, negated or or-ed, since the map a cache key uses is an AND-map of independent
+   * assertions.
+   */
+  private collapse(expression: string): QFilterExpression {
+    return new QFilterExpression(expression, [], [expression]);
+  }
+
   public group(): QFilterExpression {
     if (this.expression?.trim()) {
-      return new QFilterExpression(`(${this.expression})`);
+      return this.collapse(`(${this.expression})`);
     }
     return this;
   }
 
   public not(): QFilterExpression {
     if (this.expression?.trim()) {
-      return new QFilterExpression(`not ${this.expression}`);
+      return this.collapse(`not ${this.expression}`);
     }
     return this;
   }
@@ -23,7 +69,15 @@ export class QFilterExpression {
     if (expression?.toString()) {
       if (this.expression) {
         const newExpr = `${this.expression} ${isOrOperation ? "or" : "and"} ${expression.toString()}`;
-        return new QFilterExpression(newExpr);
+        // an `and` is what the structured map already means, so both sides survive it; an `or` is not
+        // expressible in it at all and takes the whole expression down to raw
+        return isOrOperation
+          ? this.collapse(newExpr)
+          : new QFilterExpression(
+              newExpr,
+              [...this.clauses, ...expression.getClauses()],
+              [...this.raw, ...expression.getRaw()],
+            );
       } else {
         return expression;
       }

--- a/packages/odata-query-objects/src/index.ts
+++ b/packages/odata-query-objects/src/index.ts
@@ -1,7 +1,7 @@
 export * from "./odata/ODataModel";
 export * from "./QueryObjectModel";
 export { QSelectExpression } from "./QSelectExpression";
-export { QFilterExpression } from "./QFilterExpression";
+export { QFilterExpression, type FilterClause } from "./QFilterExpression";
 export { QOrderByExpression } from "./QOrderByExpression";
 export { QSearchTerm, searchTerm } from "./QSearchTerm";
 export { QueryObject, ENUMERABLE_PROP_DEFINITION } from "./QueryObject";

--- a/packages/odata-query-objects/src/operation/QFunction.ts
+++ b/packages/odata-query-objects/src/operation/QFunction.ts
@@ -6,7 +6,7 @@ type FilteredParamModel = [string, string];
 const REGEXP_PARAMS = /.*\(([^)]+)\)/;
 const REGEXP_V2_PARAMS = /.*\?(.+)/;
 
-const SINGLE_VALUE_TYPES = ["string", "number", "boolean"];
+export const SINGLE_VALUE_TYPES = ["string", "number", "boolean"];
 
 function compileUrlParams(params: FunctionParams | undefined, notEncoded: boolean = false) {
   if (!params || !Object.keys(params).length) {
@@ -166,13 +166,16 @@ export abstract class QFunction<ParamModel, ResponseStructure = undefined> {
     }, {} as ParamModel);
   }
 
-  private findSingleParam() {
+  protected findSingleParam() {
     const result = this.getParamSets().find((pSet) => pSet.length === 1);
 
     return result ? result[0] : undefined;
   }
 
-  private findBestMatchingParamSet(paramKeys: Array<string>, findByMappedName: boolean): Array<QParamModel<any, any>> {
+  protected findBestMatchingParamSet(
+    paramKeys: Array<string>,
+    findByMappedName: boolean,
+  ): Array<QParamModel<any, any>> {
     const paramSets = this.getParamSets();
     if (!paramKeys.length || !paramSets.length) {
       return [];

--- a/packages/odata-query-objects/src/operation/QId.ts
+++ b/packages/odata-query-objects/src/operation/QId.ts
@@ -1,4 +1,5 @@
 import { QParamModel } from "../param/QParamModel";
+import { SINGLE_VALUE_TYPES } from "./QFunction";
 import { QFunctionV4 } from "./QFunctionV4";
 
 /**
@@ -35,5 +36,52 @@ export abstract class QId<ParamModel> extends QFunctionV4<ParamModel, void> {
    */
   public getAlternateParams(): Array<Array<QParamModel<any, any>>> {
     return this.getParamSets().slice(1);
+  }
+
+  /**
+   * The param set this id's value would resolve to in {@link buildUrl}/{@link parseUrl} - the same
+   * matching, reused rather than duplicated, so a cache key is always built from the very param set the
+   * URL was built from.
+   */
+  public getParamsFor(id: unknown): Array<QParamModel<any, any>> {
+    // the same resolution buildUrl performs, so a cache key is built from the very param set the URL was
+    if (SINGLE_VALUE_TYPES.includes(typeof id)) {
+      const single = this.findSingleParam();
+      return single ? [single] : [];
+    }
+    return this.findBestMatchingParamSet(Object.keys(id as object), true);
+  }
+
+  /**
+   * This entity's own canonical id - entity-set name plus key predicate - always via the *primary* key,
+   * regardless of which key shape `entity` was actually fetched or addressed by: two routes to the same
+   * entity must produce the very same canonical id, or nothing that compares them by it would ever match.
+   *
+   * Accepts three shapes, so callers never have to know which one they hold:
+   * - a bare value (`5`) - passed straight to {@link buildUrl}, the single-primary-key case
+   * - an already key-only object, mapped-name keyed (`{id: 5}`, `{mediumId: 5, inventoryNumber: 7}`) - a
+   *   single-property one still collapses to the bare form, so `{id: 5}` and `5` produce identical ids
+   * - a full entity representation with unrelated fields alongside the key (`{id: 5, title: "...", ...}`)
+   *   - only the primary key's own mapped-name fields are read out of it, everything else is ignored
+   *
+   * `undefined` where the primary key cannot be built at all: no primary key declared, or - the entity
+   * case - one of its properties is missing from `entity`.
+   */
+  public buildCanonicalId(entity: unknown): string | undefined {
+    if (entity === null || typeof entity !== "object") {
+      return this.getPrimaryParams().length ? this.buildUrl(entity as ParamModel) : undefined;
+    }
+
+    const params = this.getPrimaryParams();
+    const row = entity as Record<string, unknown>;
+    if (!params.length || params.some((p) => row[p.getMappedName()] === undefined)) {
+      return undefined;
+    }
+
+    const id =
+      params.length === 1
+        ? row[params[0].getMappedName()]
+        : Object.fromEntries(params.map((p) => [p.getMappedName(), row[p.getMappedName()]]));
+    return this.buildUrl(id as ParamModel);
   }
 }

--- a/packages/odata-query-objects/src/param/UrlParamHelper.ts
+++ b/packages/odata-query-objects/src/param/UrlParamHelper.ts
@@ -151,6 +151,13 @@ export function isPathValue(value: QPathModel | any): value is QPathModel {
   return typeof value === "object" && typeof value?.getPath === "function";
 }
 
+/**
+ * Marks a comparison whose right-hand side is another property rather than a literal
+ * (`Title eq Subtitle`). There is no value to put in a structured filter map, so such an expression is
+ * raw. A dedicated sentinel rather than `undefined`, since `null` and `undefined` are legitimate values.
+ */
+export const PATH_VALUE: unique symbol = Symbol("pathValue");
+
 export function buildOperatorExpression(
   path: string,
   operator: StandardFilterOperators | NumberFilterOperators,
@@ -170,6 +177,10 @@ export function buildQFilterOperation(
   path: string,
   operator: StandardFilterOperators | NumberFilterOperators,
   value: string,
+  typedValue: unknown = PATH_VALUE,
 ) {
-  return new QFilterExpression(buildOperatorExpression(path, operator, value));
+  const expression = buildOperatorExpression(path, operator, value);
+  return typedValue === PATH_VALUE
+    ? new QFilterExpression(expression)
+    : new QFilterExpression(expression, [{ path, operator, value: typedValue }]);
 }

--- a/packages/odata-query-objects/src/path/QBinding.ts
+++ b/packages/odata-query-objects/src/path/QBinding.ts
@@ -40,6 +40,24 @@ export class QBinding<Id> {
   }
 
   /**
+   * The name of the entity set this binding's target belongs to - the same name {@link format} already
+   * builds every URL from, exposed on its own for a caller after the resource's identity rather than a URL.
+   */
+  public getEntitySetName(): string {
+    return this.idFunctionFn().getName();
+  }
+
+  /**
+   * The target's own canonical id - entity-set name plus key predicate, e.g. `Copies(3)` or
+   * `Copies(Id=1,Category='books')` - built from the very same id function {@link format} uses, but without
+   * the notation-specific wrapping a binding property value needs. See {@link QId.buildCanonicalId} for the
+   * shapes `entity` may take.
+   */
+  public buildCanonicalId(entity: unknown): string | undefined {
+    return this.idFunctionFn().buildCanonicalId(entity);
+  }
+
+  /**
    * The property name the binding goes by, which is the navigation property itself in every version but
    * 4.0 - meaning that in those versions a binding and a deep insert share one property.
    */

--- a/packages/odata-query-objects/src/path/QModelBasePath.ts
+++ b/packages/odata-query-objects/src/path/QModelBasePath.ts
@@ -34,6 +34,11 @@ export class QModelBasePath<Q extends QueryObject> implements QEntityPathModel<Q
     return new (this.qEntityFn())(withPrefix ? this.path : undefined, this.separator);
   }
 
+  /** The factory behind {@link getEntity}, for a caller that wants to construct instances itself rather than take the one instance `getEntity` returns - a graph walk recursing property by property, say. */
+  public getEntityFn() {
+    return this.qEntityFn;
+  }
+
   public isCollectionType() {
     return false;
   }

--- a/packages/odata-query-objects/src/path/QModelCollectionBasePath.ts
+++ b/packages/odata-query-objects/src/path/QModelCollectionBasePath.ts
@@ -32,6 +32,11 @@ export class QModelCollectionBasePath<Q extends QueryObject> implements QEntityP
     return new (this.qEntityFn())(withPrefix ? this.path : undefined);
   }
 
+  /** The factory behind {@link getEntity}, for a caller that wants to construct instances itself rather than take the one instance `getEntity` returns - a graph walk recursing property by property, say. */
+  public getEntityFn() {
+    return this.qEntityFn;
+  }
+
   public isCollectionType() {
     return true;
   }

--- a/packages/odata-query-objects/src/path/base/BaseFunctions.ts
+++ b/packages/odata-query-objects/src/path/base/BaseFunctions.ts
@@ -1,9 +1,14 @@
 import { StandardFilterOperators } from "../../odata/ODataModel";
-import { buildQFilterOperation } from "../../param/UrlParamHelper";
+import { buildQFilterOperation, PATH_VALUE } from "../../param/UrlParamHelper";
 import { QFilterExpression } from "../../QFilterExpression";
 import { QOrderByExpression } from "../../QOrderByExpression";
 
 export type MapValue<T> = (value: T) => string;
+/**
+ * The OData-side value of what the caller passed - after the property's converter, before URL rendering.
+ * Returns {@link PATH_VALUE} where the "value" is another property path and nothing can be asserted.
+ */
+export type TypedValue<T> = (value: T) => unknown;
 
 export function orderAscending(path: string) {
   /**
@@ -27,73 +32,81 @@ export function filterIsNull(path: string) {
   /**
    * Base filter function: property must be null.
    */
-  return () => new QFilterExpression(`${path} eq null`);
+  return () =>
+    new QFilterExpression(`${path} eq null`, [{ path, operator: StandardFilterOperators.EQUALS, value: null }]);
 }
 
 export function filterIsNotNull(path: string) {
   /**
    * Base filter function: property must not be null.
    */
-  return () => new QFilterExpression(`${path} ne null`);
+  return () =>
+    new QFilterExpression(`${path} ne null`, [{ path, operator: StandardFilterOperators.NOT_EQUALS, value: null }]);
 }
 
-export function filterEquals<T>(path: string, mapValue: MapValue<T>) {
+export function filterEquals<T>(path: string, mapValue: MapValue<T>, typedValue?: TypedValue<T>) {
   /**
    * Base filter function: property must equal the given value.
    */
   return (value: T | null) => {
     const result = value === null ? "null" : mapValue(value);
-    return buildQFilterOperation(path, StandardFilterOperators.EQUALS, result);
+    const typed = value === null ? null : typedValue ? typedValue(value) : PATH_VALUE;
+    return buildQFilterOperation(path, StandardFilterOperators.EQUALS, result, typed);
   };
 }
 
-export function filterNotEquals<T>(path: string, mapValue: MapValue<T>) {
+export function filterNotEquals<T>(path: string, mapValue: MapValue<T>, typedValue?: TypedValue<T>) {
   /**
    * Base filter function: property must not equal the given value.
    */
   return (value: T | null) => {
     const result = value === null ? "null" : mapValue(value);
-    return buildQFilterOperation(path, StandardFilterOperators.NOT_EQUALS, result);
+    const typed = value === null ? null : typedValue ? typedValue(value) : PATH_VALUE;
+    return buildQFilterOperation(path, StandardFilterOperators.NOT_EQUALS, result, typed);
   };
 }
 
-export function filterLowerThan<T>(path: string, mapValue: MapValue<T>) {
+export function filterLowerThan<T>(path: string, mapValue: MapValue<T>, typedValue?: TypedValue<T>) {
   /**
    * Base filter function: property must be lower than the given value.
    */
   return (value: T) => {
-    return buildQFilterOperation(path, StandardFilterOperators.LOWER_THAN, mapValue(value));
+    const typed = typedValue ? typedValue(value) : PATH_VALUE;
+    return buildQFilterOperation(path, StandardFilterOperators.LOWER_THAN, mapValue(value), typed);
   };
 }
 
-export function filterLowerEquals<T>(path: string, mapValue: MapValue<T>) {
+export function filterLowerEquals<T>(path: string, mapValue: MapValue<T>, typedValue?: TypedValue<T>) {
   /**
    * Base filter function: property must be lower than or equal to the given value.
    */
   return (value: T) => {
-    return buildQFilterOperation(path, StandardFilterOperators.LOWER_EQUALS, mapValue(value));
+    const typed = typedValue ? typedValue(value) : PATH_VALUE;
+    return buildQFilterOperation(path, StandardFilterOperators.LOWER_EQUALS, mapValue(value), typed);
   };
 }
 
-export function filterGreaterThan<T>(path: string, mapValue: MapValue<T>) {
+export function filterGreaterThan<T>(path: string, mapValue: MapValue<T>, typedValue?: TypedValue<T>) {
   /**
    * Base filter function: property must be greater than the given value.
    */
   return (value: T) => {
-    return buildQFilterOperation(path, StandardFilterOperators.GREATER_THAN, mapValue(value));
+    const typed = typedValue ? typedValue(value) : PATH_VALUE;
+    return buildQFilterOperation(path, StandardFilterOperators.GREATER_THAN, mapValue(value), typed);
   };
 }
 
-export function filterGreaterEquals<T>(path: string, mapValue: MapValue<T>) {
+export function filterGreaterEquals<T>(path: string, mapValue: MapValue<T>, typedValue?: TypedValue<T>) {
   /**
    * Base filter function: property must be greater than or equal to the given value.
    */
   return (value: T) => {
-    return buildQFilterOperation(path, StandardFilterOperators.GREATER_EQUALS, mapValue(value));
+    const typed = typedValue ? typedValue(value) : PATH_VALUE;
+    return buildQFilterOperation(path, StandardFilterOperators.GREATER_EQUALS, mapValue(value), typed);
   };
 }
 
-export function filterHas<T>(path: string, mapValue: MapValue<T>) {
+export function filterHas<T>(path: string, mapValue: MapValue<T>, typedValue?: TypedValue<T>) {
   /**
    * Base filter function (V4): the flag enum property must contain the given member.
    *
@@ -102,7 +115,8 @@ export function filterHas<T>(path: string, mapValue: MapValue<T>) {
    * caller did not ask for.
    */
   return (value: T) => {
-    return buildQFilterOperation(path, StandardFilterOperators.HAS, mapValue(value));
+    const typed = typedValue ? typedValue(value) : PATH_VALUE;
+    return buildQFilterOperation(path, StandardFilterOperators.HAS, mapValue(value), typed);
   };
 }
 

--- a/packages/odata-query-objects/src/path/base/QBasePath.ts
+++ b/packages/odata-query-objects/src/path/base/QBasePath.ts
@@ -1,6 +1,6 @@
 import { ValueConverter } from "@odata2ts/converter-api";
 import { getIdentityConverter } from "../../IdentityConverter";
-import { isPathValue, URL_CONVERSION_OPTIONS } from "../../param/UrlParamHelper";
+import { isPathValue, PATH_VALUE, URL_CONVERSION_OPTIONS } from "../../param/UrlParamHelper";
 import { UrlExpressionValueModel } from "../../param/UrlParamModel";
 import { QValuePathModel } from "../QPathModel";
 import {
@@ -51,6 +51,18 @@ export abstract class QBasePath<ValueType extends UrlExpressionValueModel, Conve
   };
 
   /**
+   * The OData-side value of what the caller passed: the property's converter applied, but not the URL
+   * rendering on top of it. This is what a cache key carries - always a JSON-serialisable primitive,
+   * unlike the caller's own value, which may be a `bigint` and therefore unhashable.
+   */
+  protected convertInputTyped = (value: InputModel<this["converter"]>): unknown => {
+    if (isPathValue(value)) {
+      return PATH_VALUE;
+    }
+    return this.converter.convertTo(value, URL_CONVERSION_OPTIONS);
+  };
+
+  /**
    * Get the path to this property.
    *
    * @returns this property path
@@ -66,18 +78,38 @@ export abstract class QBasePath<ValueType extends UrlExpressionValueModel, Conve
 
   public isNull = filterIsNull(this.path);
   public isNotNull = filterIsNotNull(this.path);
-  public equals = filterEquals<InputModel<this["converter"]>>(this.path, this.convertInput);
+  public equals = filterEquals<InputModel<this["converter"]>>(this.path, this.convertInput, this.convertInputTyped);
   public eq = this.equals;
-  public notEquals = filterNotEquals<InputModel<this["converter"]>>(this.path, this.convertInput);
+  public notEquals = filterNotEquals<InputModel<this["converter"]>>(
+    this.path,
+    this.convertInput,
+    this.convertInputTyped,
+  );
   public ne = this.notEquals;
 
-  public lowerThan = filterLowerThan<InputModel<this["converter"]>>(this.path, this.convertInput);
+  public lowerThan = filterLowerThan<InputModel<this["converter"]>>(
+    this.path,
+    this.convertInput,
+    this.convertInputTyped,
+  );
   public lt = this.lowerThan;
-  public lowerEquals = filterLowerEquals<InputModel<this["converter"]>>(this.path, this.convertInput);
+  public lowerEquals = filterLowerEquals<InputModel<this["converter"]>>(
+    this.path,
+    this.convertInput,
+    this.convertInputTyped,
+  );
   public le = this.lowerEquals;
-  public greaterThan = filterGreaterThan<InputModel<this["converter"]>>(this.path, this.convertInput);
+  public greaterThan = filterGreaterThan<InputModel<this["converter"]>>(
+    this.path,
+    this.convertInput,
+    this.convertInputTyped,
+  );
   public gt = this.greaterThan;
-  public greaterEquals = filterGreaterEquals<InputModel<this["converter"]>>(this.path, this.convertInput);
+  public greaterEquals = filterGreaterEquals<InputModel<this["converter"]>>(
+    this.path,
+    this.convertInput,
+    this.convertInputTyped,
+  );
   public ge = this.greaterEquals;
   public in = this.options.nativeIn
     ? filterIn<InputModel<this["converter"]>>(this.path, this.convertInput)

--- a/packages/odata-query-objects/src/path/enum/BaseEnumPath.ts
+++ b/packages/odata-query-objects/src/path/enum/BaseEnumPath.ts
@@ -23,6 +23,14 @@ export abstract class BaseEnumPath<EnumMemberType> implements QPathModel {
   protected abstract mapValue(value: EnumMemberType): string;
 
   /**
+   * The OData-side value of the given enum member: the converting half of {@link mapValue}, without the
+   * quoting or literal rendering on top. Always a string - an enum member is an identity, not a
+   * quantity, so a numeric enum's symbolic name is represented the same way as a string enum's, keeping
+   * the clause stable and JSON-serialisable across both.
+   */
+  protected abstract typedValue(value: EnumMemberType): string;
+
+  /**
    * Returns the path of this property.
    */
   public getPath(): string {
@@ -38,22 +46,34 @@ export abstract class BaseEnumPath<EnumMemberType> implements QPathModel {
   public isNull = filterIsNull(this.path);
   public isNotNull = filterIsNotNull(this.path);
 
-  public equals = filterEquals<EnumMemberType>(this.path, this.mapValue.bind(this));
+  public equals = filterEquals<EnumMemberType>(this.path, this.mapValue.bind(this), this.typedValue.bind(this));
   public eq = this.equals;
 
-  public notEquals = filterNotEquals<EnumMemberType>(this.path, this.mapValue.bind(this));
+  public notEquals = filterNotEquals<EnumMemberType>(this.path, this.mapValue.bind(this), this.typedValue.bind(this));
   public ne = this.notEquals;
 
-  public lowerThan = filterLowerThan<EnumMemberType>(this.path, this.mapValue.bind(this));
+  public lowerThan = filterLowerThan<EnumMemberType>(this.path, this.mapValue.bind(this), this.typedValue.bind(this));
   public lt = this.lowerThan;
 
-  public lowerEquals = filterLowerEquals<EnumMemberType>(this.path, this.mapValue.bind(this));
+  public lowerEquals = filterLowerEquals<EnumMemberType>(
+    this.path,
+    this.mapValue.bind(this),
+    this.typedValue.bind(this),
+  );
   public le = this.lowerEquals;
 
-  public greaterThan = filterGreaterThan<EnumMemberType>(this.path, this.mapValue.bind(this));
+  public greaterThan = filterGreaterThan<EnumMemberType>(
+    this.path,
+    this.mapValue.bind(this),
+    this.typedValue.bind(this),
+  );
   public gt = this.greaterThan;
 
-  public greaterEquals = filterGreaterEquals<EnumMemberType>(this.path, this.mapValue.bind(this));
+  public greaterEquals = filterGreaterEquals<EnumMemberType>(
+    this.path,
+    this.mapValue.bind(this),
+    this.typedValue.bind(this),
+  );
   public ge = this.greaterEquals;
 
   public in = filterInEmulated<EnumMemberType>(this.path, this.mapValue.bind(this));

--- a/packages/odata-query-objects/src/path/enum/QEnumPath.ts
+++ b/packages/odata-query-objects/src/path/enum/QEnumPath.ts
@@ -38,4 +38,11 @@ export class QEnumPath<EnumType extends StringEnumSource, WireType = string> ext
     const wireValue = this.converter.convertTo(value, URL_CONVERSION_OPTIONS);
     return typeof wireValue === "string" ? formatWithQuotes(wireValue) : formatLiteral(wireValue as any);
   }
+
+  protected typedValue(value: StringEnumSourceMember<EnumType>): string {
+    if (!this.converter) {
+      return value as string;
+    }
+    return String(this.converter.convertTo(value, URL_CONVERSION_OPTIONS));
+  }
 }

--- a/packages/odata-query-objects/src/path/enum/QFlagsEnumPath.ts
+++ b/packages/odata-query-objects/src/path/enum/QFlagsEnumPath.ts
@@ -11,5 +11,9 @@ import { QEnumPath } from "./QEnumPath";
  * where the service would evaluate it as bit arithmetic over values that are not bits.
  */
 export class QFlagsEnumPath<EnumType extends StringEnumSource> extends QEnumPath<EnumType> {
-  public has = filterHas<StringEnumSourceMember<EnumType>>(this.path, this.mapValue.bind(this));
+  public has = filterHas<StringEnumSourceMember<EnumType>>(
+    this.path,
+    this.mapValue.bind(this),
+    this.typedValue.bind(this),
+  );
 }

--- a/packages/odata-query-objects/src/path/enum/QNumericEnumPath.ts
+++ b/packages/odata-query-objects/src/path/enum/QNumericEnumPath.ts
@@ -23,4 +23,8 @@ export class QNumericEnumPath<EnumType extends NumericEnumLike> extends BaseEnum
   protected mapValue(value: NumericEnumMember<EnumType>): string {
     return formatWithQuotes(this.converter.convertTo(value)!);
   }
+
+  protected typedValue(value: NumericEnumMember<EnumType>): string {
+    return this.converter.convertTo(value)!;
+  }
 }

--- a/packages/odata-query-objects/src/path/enum/QNumericFlagsEnumPath.ts
+++ b/packages/odata-query-objects/src/path/enum/QNumericFlagsEnumPath.ts
@@ -10,5 +10,5 @@ import { QNumericEnumPath } from "./QNumericEnumPath";
  * its flags variant just as the string one does.
  */
 export class QNumericFlagsEnumPath<EnumType extends NumericEnumLike> extends QNumericEnumPath<EnumType> {
-  public has = filterHas<NumericEnumMember<EnumType>>(this.path, this.mapValue.bind(this));
+  public has = filterHas<NumericEnumMember<EnumType>>(this.path, this.mapValue.bind(this), this.typedValue.bind(this));
 }

--- a/packages/odata-query-objects/test/QBinding.test.ts
+++ b/packages/odata-query-objects/test/QBinding.test.ts
@@ -110,4 +110,21 @@ describe("QBinding: binding by key", () => {
   test("4.0 is the notation by default", () => {
     expect(new QBinding(() => new QAuthorId("Authors")).getNotation()).toBe("4.0");
   });
+
+  test("getEntitySetName returns the target entity set's own name", () => {
+    expect(new QBinding(() => new QAuthorId("Authors")).getEntitySetName()).toBe("Authors");
+  });
+
+  test("buildCanonicalId builds the entity set's own canonical URL segment, single key", () => {
+    expect(new QBinding(() => new QAuthorId("Authors")).buildCanonicalId(3)).toBe("Authors(3)");
+  });
+
+  test("buildCanonicalId delegates to QId.buildCanonicalId - a single-key object collapses to the same bare form", () => {
+    const qId = new QBinding(() => new QAuthorId("Authors"));
+    expect(qId.buildCanonicalId({ id: 3 })).toBe("Authors(3)");
+  });
+
+  test("buildCanonicalId is unaffected by the binding notation - it never wraps like format does", () => {
+    expect(new QBinding(() => new QAuthorId("Authors"), "4.01").buildCanonicalId(3)).toBe("Authors(3)");
+  });
 });

--- a/packages/odata-query-objects/test/QFilterExpression.test.ts
+++ b/packages/odata-query-objects/test/QFilterExpression.test.ts
@@ -113,3 +113,77 @@ describe("QFilterExpression test", () => {
     );
   });
 });
+
+describe("QFilterExpression: structured description", () => {
+  const eqFive = new QFilterExpression("MediumId eq 5", [{ path: "MediumId", operator: "eq", value: 5 }]);
+  const gtTwo = new QFilterExpression("Year gt 2000", [{ path: "Year", operator: "gt", value: 2000 }]);
+
+  test("a bare expression with no clauses is raw", () => {
+    const expression = new QFilterExpression("A eq 1 or B eq 2");
+    expect(expression.getClauses()).toEqual([]);
+    expect(expression.getRaw()).toEqual(["A eq 1 or B eq 2"]);
+  });
+
+  test("an expression built with clauses is not raw", () => {
+    expect(eqFive.getClauses()).toEqual([{ path: "MediumId", operator: "eq", value: 5 }]);
+    expect(eqFive.getRaw()).toEqual([]);
+  });
+
+  test("an empty expression carries nothing", () => {
+    const expression = new QFilterExpression();
+    expect(expression.getClauses()).toEqual([]);
+    expect(expression.getRaw()).toEqual([]);
+  });
+
+  test("whitespace-only expression carries nothing", () => {
+    const expression = new QFilterExpression("   ");
+    expect(expression.getClauses()).toEqual([]);
+    expect(expression.getRaw()).toEqual([]);
+    expect(expression.toString()).toBe("");
+  });
+
+  test("and() merges clauses and raw from both sides", () => {
+    const merged = eqFive.and(gtTwo).and(new QFilterExpression("contains(Title,'ai')"));
+    expect(merged.getClauses()).toEqual([
+      { path: "MediumId", operator: "eq", value: 5 },
+      { path: "Year", operator: "gt", value: 2000 },
+    ]);
+    expect(merged.getRaw()).toEqual(["contains(Title,'ai')"]);
+    expect(merged.toString()).toBe("MediumId eq 5 and Year gt 2000 and contains(Title,'ai')");
+  });
+
+  test("and() with an empty expression changes nothing", () => {
+    expect(eqFive.and(new QFilterExpression()).getClauses()).toEqual(eqFive.getClauses());
+    expect(eqFive.and(null).getClauses()).toEqual(eqFive.getClauses());
+  });
+
+  test("and() onto an empty expression adopts the other side unchanged", () => {
+    const merged = new QFilterExpression().and(eqFive);
+    expect(merged.getClauses()).toEqual(eqFive.getClauses());
+    expect(merged.getRaw()).toEqual([]);
+  });
+
+  test("or() collapses everything into one raw fragment", () => {
+    const merged = eqFive.or(gtTwo);
+    expect(merged.getClauses()).toEqual([]);
+    expect(merged.getRaw()).toEqual(["MediumId eq 5 or Year gt 2000"]);
+  });
+
+  test("not() collapses into one raw fragment", () => {
+    const negated = eqFive.not();
+    expect(negated.getClauses()).toEqual([]);
+    expect(negated.getRaw()).toEqual(["not MediumId eq 5"]);
+  });
+
+  test("group() collapses into one raw fragment", () => {
+    const grouped = eqFive.and(gtTwo).group();
+    expect(grouped.getClauses()).toEqual([]);
+    expect(grouped.getRaw()).toEqual(["(MediumId eq 5 and Year gt 2000)"]);
+  });
+
+  test("not() and group() leave an empty expression alone", () => {
+    const empty = new QFilterExpression();
+    expect(empty.not().getRaw()).toEqual([]);
+    expect(empty.group().getRaw()).toEqual([]);
+  });
+});

--- a/packages/odata-query-objects/test/operation/QId.test.ts
+++ b/packages/odata-query-objects/test/operation/QId.test.ts
@@ -86,6 +86,43 @@ describe("QId Tests", () => {
     );
   });
 
+  describe("buildCanonicalId", () => {
+    test("a bare value builds the same canonical id as buildUrl would", () => {
+      const exampleFunction = new BookIdFunction("EntityXy");
+      expect(exampleFunction.buildCanonicalId("123")).toBe("EntityXy(123)");
+    });
+
+    test("a clean single-key object collapses to the very same bare form - consistency is the point", () => {
+      const exampleFunction = new BookIdFunction("EntityXy");
+      expect(exampleFunction.buildCanonicalId({ isbn: "123" })).toBe(exampleFunction.buildCanonicalId("123"));
+      expect(exampleFunction.buildCanonicalId({ isbn: "123" })).toBe("EntityXy(123)");
+    });
+
+    test("a full entity representation with unrelated fields still resolves - only the key is read out of it", () => {
+      const exampleFunction = new BookIdFunction("EntityXy");
+      expect(exampleFunction.buildCanonicalId({ isbn: "123", title: "The Trial" })).toBe("EntityXy(123)");
+    });
+
+    test("a composite key builds the same as buildUrl, key by key", () => {
+      const exampleFunction = new ComplexBookIdFunction("EntityXy");
+      expect(exampleFunction.buildCanonicalId({ title: "test", author: "xxx" })).toBe(
+        "EntityXy(title='test',author='xxx')",
+      );
+    });
+
+    test("a composite key survives unrelated fields alongside it too", () => {
+      const exampleFunction = new ComplexBookIdFunction("EntityXy");
+      expect(exampleFunction.buildCanonicalId({ title: "test", author: "xxx", extra: true })).toBe(
+        "EntityXy(title='test',author='xxx')",
+      );
+    });
+
+    test("a missing key property resolves to undefined - never a partial or wrong id", () => {
+      const exampleFunction = new ComplexBookIdFunction("EntityXy");
+      expect(exampleFunction.buildCanonicalId({ title: "test" })).toBeUndefined();
+    });
+  });
+
   describe("alternate keys", () => {
     test("getPrimaryParams always returns the first param set", () => {
       const exampleFunction = new BookIdWithAlternateKeyFunction("EntityXy");

--- a/packages/odata-query-objects/test/path/FilterClauses.test.ts
+++ b/packages/odata-query-objects/test/path/FilterClauses.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "vitest";
+import {
+  QCollectionPath,
+  QDateTimeOffsetPath,
+  QEnumPath,
+  QFlagsEnumPath,
+  QGuidPath,
+  QNumberPath,
+  QNumericEnumPath,
+  QNumericFlagsEnumPath,
+  QStringCollection,
+  QStringPath,
+  QStringV2Path,
+} from "../../src";
+
+describe("filter clauses", () => {
+  const id = new QNumberPath("MediumId");
+  const title = new QStringPath("Title");
+
+  test("every comparison operator records one clause with the typed value", () => {
+    expect(id.eq(5).getClauses()).toEqual([{ path: "MediumId", operator: "eq", value: 5 }]);
+    expect(id.ne(5).getClauses()).toEqual([{ path: "MediumId", operator: "ne", value: 5 }]);
+    expect(id.lt(5).getClauses()).toEqual([{ path: "MediumId", operator: "lt", value: 5 }]);
+    expect(id.le(5).getClauses()).toEqual([{ path: "MediumId", operator: "le", value: 5 }]);
+    expect(id.gt(5).getClauses()).toEqual([{ path: "MediumId", operator: "gt", value: 5 }]);
+    expect(id.ge(5).getClauses()).toEqual([{ path: "MediumId", operator: "ge", value: 5 }]);
+  });
+
+  test("a string value is the bare string, not the quoted URL literal", () => {
+    expect(title.eq("ai").getClauses()).toEqual([{ path: "Title", operator: "eq", value: "ai" }]);
+    expect(title.eq("ai").toString()).toBe("Title eq 'ai'");
+  });
+
+  test("isNull and isNotNull record a clause with value null", () => {
+    expect(title.isNull().getClauses()).toEqual([{ path: "Title", operator: "eq", value: null }]);
+    expect(title.isNotNull().getClauses()).toEqual([{ path: "Title", operator: "ne", value: null }]);
+  });
+
+  test("an explicit null value records a clause", () => {
+    expect(title.eq(null).getClauses()).toEqual([{ path: "Title", operator: "eq", value: null }]);
+  });
+
+  test("a value converter is applied: the clause holds the OData-side value", () => {
+    const converter = {
+      id: "test",
+      from: "Edm.String",
+      to: "number",
+      convertFrom: (v: string | null | undefined) => (v == null ? v : Number(v)),
+      convertTo: (v: number | null | undefined) => (v == null ? v : String(v)),
+    };
+    const converted = new QNumberPath("Big", converter as any);
+    expect(converted.eq(9 as any).getClauses()).toEqual([{ path: "Big", operator: "eq", value: "9" }]);
+  });
+
+  test("a property-to-property comparison is raw, with no clause", () => {
+    const other = new QStringPath("Subtitle");
+    const expression = title.eq(other);
+    expect(expression.getClauses()).toEqual([]);
+    expect(expression.getRaw()).toEqual(["Title eq Subtitle"]);
+  });
+
+  test("string functions are raw only", () => {
+    const expression = title.contains("ai");
+    expect(expression.getClauses()).toEqual([]);
+    expect(expression.getRaw()).toEqual(["contains(Title,'ai')"]);
+  });
+
+  test("the emulated in operator is raw only", () => {
+    const expression = id.in(1, 2);
+    expect(expression.getClauses()).toEqual([]);
+    expect(expression.getRaw()).toEqual(["(MediumId eq 1 or MediumId eq 2)"]);
+  });
+
+  test("the native in operator is raw only", () => {
+    const nativeIn = new QNumberPath("MediumId", undefined, { nativeIn: true });
+    const expression = nativeIn.in(1, 2);
+    expect(expression.getClauses()).toEqual([]);
+    expect(expression.getRaw()).toEqual(["MediumId in (1,2)"]);
+  });
+
+  test("a guid keeps its bare string form", () => {
+    const guid = new QGuidPath("Id");
+    expect(guid.eq("5f2c").getClauses()).toEqual([{ path: "Id", operator: "eq", value: "5f2c" }]);
+  });
+
+  test("a date offset keeps its ISO string, not a V2 type prefix", () => {
+    const at = new QDateTimeOffsetPath("LoanedAt");
+    expect(at.eq("2026-01-01T00:00:00Z").getClauses()).toEqual([
+      { path: "LoanedAt", operator: "eq", value: "2026-01-01T00:00:00Z" },
+    ]);
+  });
+
+  enum FeatureEnum {
+    Feature1 = "Feature1",
+    Feature2 = "Feature2",
+  }
+  enum NumericFeatureEnum {
+    Feature1,
+    Feature2,
+  }
+
+  test("a string enum comparison records the bare symbolic name, while toString() still quotes it", () => {
+    const feature = new QEnumPath("Feature", FeatureEnum);
+    const expression = feature.eq(FeatureEnum.Feature1);
+    expect(expression.getClauses()).toEqual([{ path: "Feature", operator: "eq", value: "Feature1" }]);
+    expect(expression.toString()).toBe("Feature eq 'Feature1'");
+  });
+
+  test("a numeric enum comparison records the symbolic name as a string, not the number", () => {
+    const feature = new QNumericEnumPath("Feature", NumericFeatureEnum);
+    const expression = feature.eq(NumericFeatureEnum.Feature1);
+    expect(expression.getClauses()).toEqual([{ path: "Feature", operator: "eq", value: "Feature1" }]);
+  });
+
+  test("a string enum with a wire-value converter records that value as a string", () => {
+    const converter = {
+      id: "test",
+      from: "Edm.Byte",
+      to: "FeatureEnum",
+      convertFrom: (v: number | null | undefined) => (v == null ? v : FeatureEnum.Feature1),
+      convertTo: (v: FeatureEnum | null | undefined) => (v == null ? v : 0),
+    };
+    const feature = new QEnumPath<typeof FeatureEnum, number>("Feature", FeatureEnum, converter);
+    const expression = feature.eq(FeatureEnum.Feature1);
+    expect(expression.getClauses()).toEqual([{ path: "Feature", operator: "eq", value: "0" }]);
+  });
+
+  test("has() on both flags variants records a clause", () => {
+    const stringFlags = new QFlagsEnumPath("Feature", FeatureEnum);
+    expect(stringFlags.has(FeatureEnum.Feature2).getClauses()).toEqual([
+      { path: "Feature", operator: "has", value: "Feature2" },
+    ]);
+
+    const numericFlags = new QNumericFlagsEnumPath("Feature", NumericFeatureEnum);
+    expect(numericFlags.has(NumericFeatureEnum.Feature2).getClauses()).toEqual([
+      { path: "Feature", operator: "has", value: "Feature2" },
+    ]);
+  });
+
+  test("in() on an enum path still records nothing", () => {
+    const feature = new QEnumPath("Feature", FeatureEnum);
+    expect(feature.in(FeatureEnum.Feature1, FeatureEnum.Feature2).getClauses()).toEqual([]);
+  });
+
+  test("isNull() on an enum path still records value null", () => {
+    const feature = new QEnumPath("Feature", FeatureEnum);
+    expect(feature.isNull().getClauses()).toEqual([{ path: "Feature", operator: "eq", value: null }]);
+  });
+});
+
+describe("expressions that cannot be decomposed", () => {
+  test("a lambda operator over a collection is raw only", () => {
+    const keywords = new QCollectionPath("Keywords", () => QStringCollection);
+    const expression = keywords.any((q) => q.it.eq("ai"));
+    expect(expression.getClauses()).toEqual([]);
+    expect(expression.getRaw()).toHaveLength(1);
+    expect(expression.getRaw()[0]).toBe(expression.toString());
+  });
+
+  test("an empty lambda is raw only", () => {
+    const keywords = new QCollectionPath("Keywords", () => QStringCollection);
+    const expression = keywords.any();
+    expect(expression.getClauses()).toEqual([]);
+    expect(expression.getRaw()).toEqual(["Keywords/any()"]);
+  });
+
+  test("a V2 string function is raw only", () => {
+    const title = new QStringV2Path("Title");
+    const expression = title.startsWith("a");
+    expect(expression.getClauses()).toEqual([]);
+    expect(expression.getRaw()).toHaveLength(1);
+  });
+});

--- a/packages/odata-service/package.json
+++ b/packages/odata-service/package.json
@@ -35,7 +35,7 @@
     "test-compile": "tsc -p tsconfig.compile.json"
   },
   "dependencies": {
-    "@odata2ts/http-client-api": "^0.6.8",
+    "@odata2ts/http-client-api": "^0.7.1",
     "@odata2ts/odata-query-builder": "^0.19.3",
     "@odata2ts/odata-query-objects": "^0.31.0",
     "tslib": "^2.8.1"

--- a/packages/odata-service/src/ServiceStateHelper.ts
+++ b/packages/odata-service/src/ServiceStateHelper.ts
@@ -1,5 +1,6 @@
 import { ODataHttpClient } from "@odata2ts/http-client-api";
 import { ODataVersionV4 } from "@odata2ts/odata-core";
+import { CacheKeyState } from "./cacheKey/index.js";
 import { ODataServiceOptionsInternal } from "./ODataServiceOptions";
 import { BIG_NUMBERS_HEADERS, DEFAULT_HEADERS, getODataVersionHeaders } from "./RequestHeaders.js";
 
@@ -11,6 +12,13 @@ export class ServiceStateHelper<V extends ODataVersionV4 = "4.0"> {
     public basePath: string,
     public name?: string,
     public options: ODataServiceOptionsInternal<V> = {},
+    /**
+     * What resource this service addresses, in the form a cache key is built from.
+     *
+     * Stored verbatim; nothing is computed from it here, and it is never derived from `name` or `path`:
+     * `name` for a `byId`-created service is the rendered key predicate, which must not appear in a key.
+     */
+    public readonly cacheKeyState?: CacheKeyState,
   ) {
     this.path = basePath && name ? basePath + "/" + name : basePath ? basePath : name || "";
   }

--- a/packages/odata-service/src/StreamServiceBase.ts
+++ b/packages/odata-service/src/StreamServiceBase.ts
@@ -1,5 +1,6 @@
 import { ODataHttpClient, ODataHttpMethods } from "@odata2ts/http-client-api";
 import { ODataVersionV4 } from "@odata2ts/odata-core";
+import { CacheKeyState } from "./cacheKey/index.js";
 import { ODataServiceOptionsInternal } from "./ODataServiceOptions";
 import {
   BlobGetRequestCmd,
@@ -28,12 +29,17 @@ export abstract class StreamServiceBase<V extends ODataVersionV4 = "4.0"> {
     basePath: string,
     name: string,
     options?: ODataServiceOptionsInternal<V>,
+    cacheKeyState?: CacheKeyState,
   ) {
-    this.__base = new ServiceStateHelper(client, basePath, name, options);
+    this.__base = new ServiceStateHelper(client, basePath, name, options, cacheKeyState);
   }
 
   public getPath() {
     return this.__base.path;
+  }
+
+  public getCacheKeyState() {
+    return this.__base.cacheKeyState;
   }
 
   /**
@@ -43,9 +49,9 @@ export abstract class StreamServiceBase<V extends ODataVersionV4 = "4.0"> {
    * distinction a client needs to decide whether to upload, and it must not be confused with 404.
    */
   public getBlob() {
-    const { client, path } = this.__base;
+    const { client, path, cacheKeyState } = this.__base;
 
-    return new BlobGetRequestCmd(client, path);
+    return new BlobGetRequestCmd(client, path, { cacheKeyState });
   }
 
   /**
@@ -59,9 +65,11 @@ export abstract class StreamServiceBase<V extends ODataVersionV4 = "4.0"> {
    * @param mimeType overrides the blob's own type
    */
   public updateBlob(data: Blob, mimeType?: string) {
-    const { client, path } = this.__base;
+    const { client, path, cacheKeyState } = this.__base;
 
-    return new BlobUpdateRequestCmd(client, path, data, mimeType || data.type || DEFAULT_MIME_TYPE);
+    return new BlobUpdateRequestCmd(client, path, data, mimeType || data.type || DEFAULT_MIME_TYPE, {
+      cacheKeyState,
+    });
   }
 
   /**
@@ -73,9 +81,9 @@ export abstract class StreamServiceBase<V extends ODataVersionV4 = "4.0"> {
    * An entity which exists but has no content yet answers 204, so `data` is `undefined`.
    */
   public getStream() {
-    const { client, path } = this.__base;
+    const { client, path, cacheKeyState } = this.__base;
 
-    return new StreamGetRequestCmd(client, path);
+    return new StreamGetRequestCmd(client, path, { cacheKeyState });
   }
 
   /**
@@ -91,9 +99,9 @@ export abstract class StreamServiceBase<V extends ODataVersionV4 = "4.0"> {
    * @param mimeType the content's MIME type
    */
   public updateStream(data: ReadableStream, mimeType?: string) {
-    const { client, path } = this.__base;
+    const { client, path, cacheKeyState } = this.__base;
 
-    return new StreamUpdateRequestCmd(client, path, data, mimeType || DEFAULT_MIME_TYPE);
+    return new StreamUpdateRequestCmd(client, path, data, mimeType || DEFAULT_MIME_TYPE, { cacheKeyState });
   }
 
   /**
@@ -103,8 +111,8 @@ export abstract class StreamServiceBase<V extends ODataVersionV4 = "4.0"> {
    * refuse `DELETE` with 405, in which case the content can only be replaced, not removed.
    */
   public deleteBlob() {
-    const { client, path } = this.__base;
+    const { client, path, cacheKeyState } = this.__base;
 
-    return new UrlRequestCmd<undefined>(client, ODataHttpMethods.Delete, path);
+    return new UrlRequestCmd<undefined>(client, ODataHttpMethods.Delete, path, undefined, { cacheKeyState });
   }
 }

--- a/packages/odata-service/src/cacheKey/BuildCacheKey.ts
+++ b/packages/odata-service/src/cacheKey/BuildCacheKey.ts
@@ -1,0 +1,100 @@
+import { CacheKeyState } from "./CacheKeyState";
+import { sameElement } from "./KeyElementEquality";
+
+/**
+ * The key a resource is stored under: the root type, a hop per traversal step, then at most one params
+ * object.
+ *
+ * The state's own restrictions and the query's are merged here rather than at either end, so that key and
+ * invalidation set share one normalization and cannot drift apart. A derived relation is applied **last**
+ * and replaces any entry for the same path: `/Media(5)/Copies` filtered on `MediumId eq 9` yields
+ * `{filter: {MediumId: 5}}`, the same key as the unfiltered call. That query is nonsense - the navigation
+ * path already pins `MediumId` to 5 - and the rule stays simple at its expense.
+ */
+export function buildCacheKey(
+  state: CacheKeyState,
+  queryParams?: Readonly<Record<string, unknown>>,
+): ReadonlyArray<unknown> {
+  const params = mergeParams(queryParams, state.params);
+  return params ? [state.name, ...state.steps, params] : [state.name, ...state.steps];
+}
+
+function mergeParams(
+  queryParams: Readonly<Record<string, unknown>> | undefined,
+  ownParams: Readonly<Record<string, unknown>> | undefined,
+): Record<string, unknown> | undefined {
+  const merged: Record<string, unknown> = { ...queryParams };
+
+  for (const [name, value] of Object.entries(ownParams ?? {})) {
+    if (name === "filter" && isRecord(value) && isRecord(merged.filter)) {
+      // the derived relation wins per path, the query's other assertions survive next to it
+      merged.filter = { ...merged.filter, ...value };
+    } else {
+      merged[name] = value;
+    }
+  }
+
+  return Object.keys(merged).length ? merged : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * The keys a write makes stale.
+ *
+ * Five rules: the addressed resource's own key without its params object (a write invalidates the
+ * resource however it was filtered, sorted or paged), the resource's own entity set as a bare list key
+ * where it belongs to one, the key of every ancestor hop - which is what catches a parent that was
+ * fetched with `$expand` - a bare list-key entry per entity set the write's own payload deep-inserted
+ * into (`state.params.deepEdit`, populated by `buildDeepEditHops` at the write's own call site), and
+ * whatever hierarchical keys `crossRouteKeys` names - a route to this same resource the write's own route
+ * never took, resolved via `ResourceIdentityHandler` from what an earlier response actually observed (see
+ * `resolveCrossRouteInvalidates`; empty, never computed here, for a client with no such store). Entries
+ * another entry is a prefix of are dropped; what is left is coarsest first.
+ *
+ * Rule 2 is skipped where the resource has no entity set of its own - a contained entity, a complex value,
+ * a singleton: nothing is ever registered under such a key. `deepEdit` hops read straight off
+ * `state.params`, unlike every other params entry: they are not a restriction on the addressed resource
+ * the way `filter`/`cast` are, so there is nothing to drop them for - they name additional, unrelated
+ * entity sets this same write also touched, each with no key of its own yet since the entity is freshly
+ * created.
+ *
+ * Deliberately does **not** enumerate the resource's children on its own: the ancestor entry covers them
+ * by prefix for a hierarchical route, and `crossRouteKeys` is what reaches a route this write never took.
+ */
+export function buildInvalidates(
+  state: CacheKeyState,
+  crossRouteKeys: ReadonlyArray<ReadonlyArray<unknown>> = [],
+): ReadonlyArray<ReadonlyArray<unknown>> {
+  const deepEditHops = (state.params?.deepEdit as ReadonlyArray<string> | undefined) ?? [];
+
+  // ancestors in route order (coarsest first), then the resource itself, then its entity set, then
+  // whatever it deep-inserted into, then whatever another route to this same resource already has cached
+  const candidates: Array<ReadonlyArray<unknown>> = [
+    ...(state.ancestors ?? []),
+    [state.name, ...state.steps],
+    ...(state.entitySetName ? [[state.entitySetName, "list"]] : []),
+    ...deepEditHops.map((entitySetName) => [entitySetName, "list"]),
+    ...crossRouteKeys,
+  ];
+
+  // an entry another entry properly prefixes is redundant - invalidating the prefix reaches it
+  // anyway. A POST to a collection whose own key equals its bare entity-set entry, which
+  // the same pass deduplicates.
+  return candidates.filter(
+    (candidate, index) =>
+      !candidates.some(
+        (other, otherIndex) =>
+          otherIndex !== index &&
+          isPrefixOf(other, candidate) &&
+          // on a tie keep the first occurrence, so a duplicate collapses to one entry
+          (other.length < candidate.length || otherIndex < index),
+      ),
+  );
+}
+
+function isPrefixOf(prefix: ReadonlyArray<unknown>, key: ReadonlyArray<unknown>): boolean {
+  return prefix.length <= key.length && prefix.every((element, index) => sameElement(element, key[index]));
+}

--- a/packages/odata-service/src/cacheKey/BuildDeepEdit.ts
+++ b/packages/odata-service/src/cacheKey/BuildDeepEdit.ts
@@ -1,0 +1,26 @@
+import type { QEntityFn } from "./CacheKeyState";
+import { walkEntityGraph } from "./EntityGraphWalk";
+
+/**
+ * The entity sets a write's own payload deep-inserts into, one entry per deep-inserted entity found - never
+ * touching the write's own cache key, only ever feeding `invalidates` (see `buildInvalidates`'s reading of
+ * `state.params.deepEdit`).
+ *
+ * A binding (`{"@id": key}` and nothing else) links an *existing* entity - nothing new is created, so there
+ * is no new resource to name here; only an actual nested entity payload counts. See `walkEntityGraph` for
+ * how the payload is walked and indexed.
+ */
+export function buildDeepEditHops(qEntityFn: QEntityFn | undefined, data: unknown): ReadonlyArray<string> | undefined {
+  const entitySetNames: Array<string> = [];
+  walkEntityGraph(
+    qEntityFn,
+    data,
+    (visit) => {
+      if (visit.entitySetName) {
+        entitySetNames.push(visit.entitySetName);
+      }
+    },
+    { skipBindings: true },
+  );
+  return entitySetNames.length ? entitySetNames : undefined;
+}

--- a/packages/odata-service/src/cacheKey/CacheKeyState.ts
+++ b/packages/odata-service/src/cacheKey/CacheKeyState.ts
@@ -1,0 +1,163 @@
+import type { QueryObjectModel } from "@odata2ts/odata-query-objects";
+
+/** Whether a resource is a collection or a single entity / complex value. */
+export type CacheKeyKind = "list" | "detail";
+
+/** A factory for a fresh, unprefixed Q-object instance of one entity/complex type - the same shape a Q-object's own nav-property wrappers already use (`QModelBasePath`'s `qEntityFn`), reused here so a write's payload can be walked without any generated lookup table. */
+export type QEntityFn = () => new (prefix?: string, separator?: string) => QueryObjectModel;
+
+/**
+ * Builds the addressed resource's own canonical id - entity-set name plus key predicate, e.g. `Copies(3)`.
+ * The same encoding `ConcurrencyHandler`'s ETag keys already use, from a fresh `QId` instance parametrized
+ * with the entity set's own name - never the route taken to reach it, which is exactly what makes it
+ * comparable across routes at all.
+ *
+ * See `QId.buildCanonicalId` for the shapes `entity` may take: a bare value, an already key-only object, or
+ * a full entity representation with unrelated fields alongside the key - the last is what a response row
+ * (this resource's own, or one reached through `$expand`) actually is. `undefined` where the key cannot be
+ * built from what was given - a required property missing from `entity`, most commonly.
+ */
+export type CanonicalIdFn = (entity: unknown) => string | undefined;
+
+/**
+ * What a generated service knows about the resource it addresses, in the form a cache key is built from.
+ *
+ * Threaded downwards through construction and never derived from a URL: the typed key value exists one call
+ * frame up, and a built URL has rendered it beyond recovery. Nothing here is ever computed from `name` or
+ * `path` - `name` for a `byId`-created service is the rendered key predicate, which must not appear in a key.
+ */
+export interface CacheKeyState {
+  /** The route's own root name - an entity set's, a singleton's, or `"$operation"`. Never a type. */
+  readonly name: string;
+  /** Hops and kind markers accumulated so far. */
+  readonly steps: ReadonlyArray<unknown>;
+  /**
+   * Where in {@link steps} the current resource's kind marker sits, so `byId` can flip it to
+   * `"detail"` without having to guess. A root puts it at 0; a hierarchical hop appends `[name, kind]` and
+   * so puts it at the last position. Guessing from the array's shape silently overwrote the hop's name and
+   * collided two sibling navigations onto one key.
+   */
+  readonly kindIndex: number;
+  /** Restrictions contributed by the resource itself: cast, singleton, operation. */
+  readonly params?: Readonly<Record<string, unknown>>;
+  /**
+   * The entity set the addressed resource belongs to, by its own name - never a type. Feeds `invalidates`.
+   * Absent for a resource with no entity set of its own: a contained entity, a complex value, a singleton
+   * (which has no "list" form to invalidate), an operation with no declared result set.
+   */
+  readonly entitySetName?: string;
+  /** See {@link CanonicalIdFn}. Present exactly where {@link entitySetName} is - a resource with no entity set of its own has no canonical id to build either. */
+  readonly canonicalIdFn?: CanonicalIdFn;
+  /** Key of every hop from the root down to the parent, params already dropped. Feeds `invalidates`. */
+  readonly ancestors?: ReadonlyArray<ReadonlyArray<unknown>>;
+  /**
+   * The addressed resource's own key or id, exactly as given to `byId` - bare for a single primary key, an
+   * object keyed by the model's own mapped property names otherwise. The same shape {@link CanonicalIdFn}
+   * accepts, so a write's own canonical id can still be built even when its response carries no body to
+   * read one from (a `DELETE`, or a `PATCH`/`PUT` answered with `204 No Content`).
+   *
+   * Not derivable from `steps`, which holds the key OData-name-keyed (the shape a hand-written `$filter`
+   * would use) - a different convention than `QId.buildUrl` accepts an object in. Reset by a hop, since the
+   * resource the route arrives at has no key until `byId` says so.
+   */
+  readonly key?: unknown;
+  /**
+   * A factory for the addressed resource's own Q-object, where it is an entity or complex type - absent for
+   * `"$operation"`, the one root with no type behind it at all. The one piece of type information this state
+   * still carries, deliberately never exposed in a cache key: it exists solely so a write's payload can be
+   * walked for deep-inserted entities (`buildDeepEditHops`) without a generated, type-keyed lookup table.
+   */
+  readonly qEntityFn?: QEntityFn;
+}
+
+/**
+ * What the generator emits for one traversal step.
+ *
+ * `kind`'s presence is what distinguishes a structured hop (an entity, complex value, or bound operation
+ * result - something with its own kind and kind-index) from a primitive one (a bare property or stream,
+ * which stays on its parent's resource and keeps its parent's kind index).
+ */
+export interface HopDescriptor {
+  readonly name: string;
+  readonly kind?: CacheKeyKind;
+  /**
+   * The entity set the hop's target belongs to, by its own name - absent for a contained entity or a
+   * complex value, which have none.
+   */
+  readonly entitySetName?: string;
+  /** See {@link CacheKeyState.canonicalIdFn}. Present exactly where {@link entitySetName} is. */
+  readonly canonicalIdFn?: CanonicalIdFn;
+  /** See {@link CacheKeyState.qEntityFn}. Absent where the hop's target has none of its own to offer (e.g. a primitive or stream property). */
+  readonly qEntityFn?: QEntityFn;
+}
+
+/**
+ * The state of an entity set, a singleton, or an unbound operation import - the start of a route. An
+ * unbound operation roots at its own import name (OData v4.01 Part 1 §11.5.4.1/§11.5.5.1: "the canonical
+ * URL for a function/action import is the service root, followed by the name of the function/action
+ * import") - import names share the container namespace with entity sets and singletons, so this is
+ * already a safe, unambiguous root with no sentinel needed.
+ */
+export function rootState(
+  name: string,
+  kind: CacheKeyKind,
+  options?: {
+    params?: Readonly<Record<string, unknown>>;
+    entitySetName?: string;
+    canonicalIdFn?: CanonicalIdFn;
+    qEntityFn?: QEntityFn;
+  },
+): CacheKeyState {
+  return {
+    name,
+    steps: [kind],
+    kindIndex: 0,
+    ...(options?.params ? { params: options.params } : {}),
+    ...(options?.entitySetName ? { entitySetName: options.entitySetName } : {}),
+    ...(options?.canonicalIdFn ? { canonicalIdFn: options.canonicalIdFn } : {}),
+    ...(options?.qEntityFn ? { qEntityFn: options.qEntityFn } : {}),
+  };
+}
+
+/**
+ * Narrows the current resource to the entity the given key addresses.
+ *
+ * Rewrites the trailing kind marker rather than appending one, and pushes no ancestor: `byId` refines the
+ * resource the route is at, it does not leave it.
+ */
+export function withKey(state: CacheKeyState, stepKey: unknown, id: unknown): CacheKeyState {
+  const steps = [...state.steps];
+  steps[state.kindIndex] = "detail";
+  steps.push(stepKey);
+
+  return { ...state, steps, key: id };
+}
+
+/** Adds a restriction the resource itself carries - a cast, a singleton marker, an operation. */
+export function withParams(state: CacheKeyState, params: Readonly<Record<string, unknown>>): CacheKeyState {
+  return { ...state, params: { ...state.params, ...params } };
+}
+
+/**
+ * Follows one traversal step.
+ *
+ * The route leaves the current resource here, so its key - params dropped - is pushed onto `ancestors`. The
+ * hop's own name and kind are appended to `steps` (a primitive hop's bare name only, staying on its
+ * parent's resource); the route's root `name` never changes, since a `cacheKey` is always the literal route
+ * taken, never re-rooted.
+ */
+export function hopState(state: CacheKeyState, hop: HopDescriptor): CacheKeyState {
+  const ancestors = [...(state.ancestors ?? []), [state.name, ...state.steps]];
+  const steps = hop.kind ? [...state.steps, hop.name, hop.kind] : [...state.steps, hop.name];
+  const kindIndex = hop.kind ? steps.length - 1 : state.kindIndex;
+
+  return {
+    name: state.name,
+    steps,
+    kindIndex,
+    ancestors,
+    ...(hop.entitySetName ? { entitySetName: hop.entitySetName } : {}),
+    ...(hop.canonicalIdFn ? { canonicalIdFn: hop.canonicalIdFn } : {}),
+    ...((hop.qEntityFn ?? state.qEntityFn) ? { qEntityFn: hop.qEntityFn ?? state.qEntityFn } : {}),
+  };
+}

--- a/packages/odata-service/src/cacheKey/EntityGraphWalk.ts
+++ b/packages/odata-service/src/cacheKey/EntityGraphWalk.ts
@@ -1,0 +1,90 @@
+import type { QEntityFn } from "./CacheKeyState";
+
+/** The discriminators of a Q-object path wrapper that leads to another entity, as opposed to a complex value or a primitive property/collection - see `QEntityPath`/`QEntityCollectionPath`. */
+const ENTITY_DISCRIMINATORS = new Set(["EntityType", "EntitySet"]);
+
+interface EntityBinding {
+  getEntitySetName(): string;
+  buildCanonicalId(entity: unknown): string | undefined;
+}
+
+/** One entity-shaped value found while walking a data object alongside its Q-object. */
+export interface EntityGraphVisit {
+  /** The entity set this entity belongs to - absent for a contained one, which has none of its own. */
+  entitySetName: string | undefined;
+  /** This entity's own canonical id, from its own data - absent exactly where `entitySetName` is. */
+  buildCanonicalId: ((entity: unknown) => string | undefined) | undefined;
+  /** This entity's own data, as found in the payload/response - keyed by its Q-object's own declared field names. */
+  data: Record<string, unknown>;
+  /** A factory for this entity's own Q-object, for recursing further. */
+  qEntityFn: QEntityFn;
+}
+
+/**
+ * Walks a data object (a write payload or a converted read response) alongside a fresh, unprefixed Q-object
+ * instance, visiting every entity-shaped nav property's own value(s) - the shared primitive both
+ * `buildDeepEditHops` (a write's own deep-inserted entities) and the response-observed identity recorder
+ * (every entity actually present in a read/write response) build on, rather than a generated,
+ * type-keyed lookup table: a Q-object's own nav-property wrappers already carry everything needed - whether
+ * they lead to another entity via their `discriminator`, the target entity set's own name and canonical-id
+ * builder via `getBinding()` (absent exactly where the target is contained, which is also exactly where
+ * neither exists), and the target's own Q-object factory via `getEntityFn()`, for recursing further.
+ *
+ * The data object is indexed by each property's own **declared field name** (the enumeration key), not
+ * `getPath()`: a write's payload and a converted read response are both TS-facing, whose property names a
+ * naming strategy may have mapped away from the OData wire name entirely - `getPath()` would look up the
+ * wrong key wherever the two differ.
+ *
+ * `skipBindings`: a binding (`{"@id": key}`) links an *existing* entity rather than embedding one -
+ * relevant only for a write payload (a response never takes this shape), so a response walk must not
+ * filter it out - an entity could coincidentally carry an "@id" field of its own.
+ */
+export function walkEntityGraph(
+  qEntityFn: QEntityFn | undefined,
+  data: unknown,
+  visit: (visit: EntityGraphVisit) => void,
+  options: { skipBindings: boolean },
+  seen: Set<unknown> = new Set(),
+): void {
+  if (!qEntityFn || !data || typeof data !== "object" || seen.has(data)) {
+    return;
+  }
+  seen.add(data);
+
+  const qEntity = new (qEntityFn())() as unknown as Record<string, unknown>;
+  for (const key in qEntity) {
+    const prop = qEntity[key] as
+      { discriminator?: string; getEntityFn(): QEntityFn; getBinding?(): EntityBinding | undefined } | undefined;
+    if (!prop || typeof prop.discriminator !== "string" || !ENTITY_DISCRIMINATORS.has(prop.discriminator)) {
+      continue;
+    }
+
+    const value = (data as Record<string, unknown>)[key];
+    if (value === undefined || value === null) {
+      continue;
+    }
+
+    const binding = prop.getBinding?.();
+    const nestedQEntityFn = prop.getEntityFn();
+    const items = Array.isArray(value) ? value : [value];
+    for (const item of items) {
+      if (options.skipBindings && isBinding(item)) {
+        continue;
+      }
+      if (item && typeof item === "object") {
+        visit({
+          entitySetName: binding?.getEntitySetName(),
+          buildCanonicalId: binding && ((entity: unknown) => binding.buildCanonicalId(entity)),
+          data: item as Record<string, unknown>,
+          qEntityFn: nestedQEntityFn,
+        });
+      }
+      walkEntityGraph(nestedQEntityFn, item, visit, options, seen);
+    }
+  }
+}
+
+/** `{"@id": key}` and nothing else - the editable model's shape for "link an existing entity". */
+function isBinding(item: unknown): boolean {
+  return typeof item === "object" && item !== null && Object.keys(item).length === 1 && "@id" in item;
+}

--- a/packages/odata-service/src/cacheKey/KeyElementEquality.ts
+++ b/packages/odata-service/src/cacheKey/KeyElementEquality.ts
@@ -1,0 +1,24 @@
+/**
+ * Element equality for a cache key: primitives compare by value, a key object (a composite key, a params
+ * entry) by its serialisation - which is exactly how a cache hashes them, and every value in a key is
+ * JSON-serialisable by construction.
+ *
+ * Shared by {@link buildInvalidates}'s prefix/dedup logic and {@link touchesResource}'s array-needle matching -
+ * both need the same notion of "the same element", not just `===`.
+ */
+export function sameElement(a: unknown, b: unknown): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (typeof a === "object" && a !== null && typeof b === "object" && b !== null) {
+    return JSON.stringify(sortRecord(a)) === JSON.stringify(sortRecord(b));
+  }
+  return false;
+}
+
+function sortRecord(value: object): unknown {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  return Object.fromEntries(Object.entries(value).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)));
+}

--- a/packages/odata-service/src/cacheKey/ObservedIdentity.ts
+++ b/packages/odata-service/src/cacheKey/ObservedIdentity.ts
@@ -1,0 +1,125 @@
+import type { ResourceIdentityHandler } from "@odata2ts/http-client-api";
+import type { CacheKeyState } from "./CacheKeyState";
+import { walkEntityGraph } from "./EntityGraphWalk";
+
+/**
+ * Records every entity actually present in a *read's* response body against the request's own hierarchical
+ * cache key - the directly addressed resource itself (every row, for a list response) plus every
+ * `$expand`'d entity at any depth - so a write reached via a completely different route can later
+ * `resolve()` its way back to this one (see `ResourceIdentityHandler`).
+ *
+ * Read-only by construction, not by a special case here: `hierarchicalKey` is `RequestCmd.cacheKey`, which
+ * is always `undefined` for a write (mirrors `undefined` right back), since a write was never itself
+ * addressable under any read-shaped key for a route to reuse. What a write's own response teaches is
+ * `invalidates`' concern instead - see {@link resolveCrossRouteInvalidates}.
+ *
+ * A contained resource - `entitySetName`/`canonicalIdFn` both absent, on `state` or on a nested visit alike
+ * - is never recorded: it has no canonical resource of its own to record against, by construction.
+ */
+export function recordObservedIdentities(
+  resourceIdentity: ResourceIdentityHandler | undefined,
+  hierarchicalKey: ReadonlyArray<unknown> | undefined,
+  state: CacheKeyState,
+  data: unknown,
+): void {
+  if (!resourceIdentity || !hierarchicalKey || data === undefined || data === null) {
+    return;
+  }
+
+  const rows = extractRows(data);
+  for (const row of rows) {
+    recordRow(resourceIdentity, hierarchicalKey, state.canonicalIdFn, row);
+
+    walkEntityGraph(
+      state.qEntityFn,
+      row,
+      (visit) => recordRow(resourceIdentity, hierarchicalKey, visit.buildCanonicalId, visit.data),
+      { skipBindings: false },
+    );
+  }
+}
+
+/**
+ * The rows a converted response body actually carries - a bare entity for a "detail" response, the
+ * elements of a collection otherwise, however that collection happens to be wrapped: `{value: [...]}` (V4,
+ * and V2 reshaped `v2ResponseAsV4`), `{d: {results: [...]}}` (V2, `responseResultsWrapping`) or
+ * `{results: [...]}` (V2 with the `d` envelope already stripped elsewhere). Same three shapes
+ * `getCollectionConcurrencyOptions`'s own `harvest` already unwraps, for the identical reason - none of
+ * `value`/`d`/`results` is a legal OData property name, so checking for them structurally, without needing
+ * to know which OData version or wrapping option produced this particular body, is safe.
+ */
+function extractRows(data: unknown): ReadonlyArray<unknown> {
+  const body = data as { value?: unknown; d?: { results?: unknown }; results?: unknown };
+  if (Array.isArray(body.value)) {
+    return body.value;
+  }
+  if (Array.isArray(body.d?.results)) {
+    return body.d!.results as ReadonlyArray<unknown>;
+  }
+  if (Array.isArray(body.results)) {
+    return body.results;
+  }
+  return [data];
+}
+
+/**
+ * A single-entity body's own fields, unwrapped from V2's `{d: {...}}` envelope where present - `d` is not a
+ * legal OData property name, so its presence is always the envelope, never real entity data.
+ */
+function extractEntity(data: unknown): Record<string, unknown> | undefined {
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    return undefined;
+  }
+  const body = data as { d?: unknown };
+  return (body.d && typeof body.d === "object" && !Array.isArray(body.d) ? body.d : data) as Record<string, unknown>;
+}
+
+function recordRow(
+  resourceIdentity: ResourceIdentityHandler,
+  hierarchicalKey: ReadonlyArray<unknown>,
+  buildCanonicalId: ((entity: unknown) => string | undefined) | undefined,
+  row: unknown,
+): void {
+  if (!buildCanonicalId || !row || typeof row !== "object") {
+    return;
+  }
+  const canonicalId = buildCanonicalId(row);
+  if (canonicalId) {
+    resourceIdentity.record(canonicalId, hierarchicalKey);
+  }
+}
+
+/**
+ * Every hierarchical cache key ever `record()`ed as resolving to the very resource this *write* just
+ * addressed - added to `invalidates` alongside the write's own route-derived entries (see
+ * `buildInvalidates`), so a write reached via one route also invalidates a cache entry some other route
+ * filled in.
+ *
+ * The write's own canonical id is built from whichever of two sources is actually available: `state.key` -
+ * the write's own address, always known, whatever the response says - wins where present (`PATCH`/`PUT`/
+ * `DELETE`, already addressing one entity by key); the response body is the only source for a `POST` to a
+ * collection, whose server-assigned key was never known beforehand - unwrapped from a V2 `{d: {...}}`
+ * envelope first, the same one `ServiceStateHelperV2.etagOf` already unwraps for the identical reason. Never
+ * both at once, and never a list body - a collection response names no single resource to resolve.
+ *
+ * Deliberately narrow: only the write's *own* resource is resolved here, never anything nested inside its
+ * payload. A deep-inserted child is brand new - nothing could have cached a route to an entity that did not
+ * exist a moment ago - so there is nothing for it to resolve against.
+ */
+export function resolveCrossRouteInvalidates(
+  resourceIdentity: ResourceIdentityHandler | undefined,
+  state: CacheKeyState,
+  data: unknown,
+): ReadonlyArray<ReadonlyArray<unknown>> {
+  if (!resourceIdentity || !state.canonicalIdFn) {
+    return [];
+  }
+
+  const source = state.key ?? extractEntity(data);
+  if (source === undefined) {
+    return [];
+  }
+
+  const canonicalId = state.canonicalIdFn(source);
+  return canonicalId ? resourceIdentity.resolve(canonicalId) : [];
+}

--- a/packages/odata-service/src/cacheKey/TouchesResource.ts
+++ b/packages/odata-service/src/cacheKey/TouchesResource.ts
@@ -1,0 +1,68 @@
+import { sameElement } from "./KeyElementEquality";
+
+/**
+ * Whether the given cache key touches the given `(name, kind, key?)` - exactly the shape of a root or an
+ * `[entitySetName, "list"]` entry, wherever it occurs in the key, as a contiguous run - including inside an
+ * `expand` entry of its params object, however deeply `expanding()` nested those.
+ *
+ * A hierarchical key is rooted at the name the route started at, so a prefix match on a name reached
+ * further down the route can never reach it - one array has one prefix. This is what makes such a key
+ * reachable at all without a generated table alongside it: root and every hop already share this same
+ * `(name, kind, key?)` shape, so a plain contiguous scan is all `invalidates` needs.
+ *
+ * **`expand` entries are searched too, recursively.** They live inside the trailing params object, not as
+ * top-level elements, so a plain scan of `key` itself does not find them - a hop hidden two objects deep is
+ * still exactly the same `(name, kind)` shape, so the very same matching logic applies to it once found;
+ * only *finding* it needs an extra step, which is what this does.
+ *
+ * Kept library-neutral - it takes a key, not a cache-library query object:
+ * `invalidateQueries({predicate: (q) => touchesResource(entry, q.queryKey)})`.
+ */
+export function touchesResource(needle: ReadonlyArray<unknown>, key: ReadonlyArray<unknown>): boolean {
+  if (isPrefixAt(needle, key, 0)) {
+    return true;
+  }
+  return expandHopsOf(key).some((hop) => isPrefixAt(needle, hop, 0));
+}
+
+function isPrefixAt(needle: ReadonlyArray<unknown>, haystack: ReadonlyArray<unknown>, start: number): boolean {
+  for (let offset = start; offset <= haystack.length - needle.length; offset++) {
+    if (needle.every((element, index) => sameElement(element, haystack[offset + index]))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Every `(name, kind)` hop reachable through an `expand` entry of any params object among `key`'s own
+ * elements - recursively, since a hop's own 3rd element may carry further nested params with an `expand`
+ * of its own. A bare (unenriched) expand entry is just a rendered path string and contributes nothing here
+ * - there is no name to find in it beyond what a plain scan of `key` already covers.
+ */
+function expandHopsOf(key: ReadonlyArray<unknown>): Array<ReadonlyArray<unknown>> {
+  const hops: Array<ReadonlyArray<unknown>> = [];
+  for (const element of key) {
+    if (typeof element === "object" && element !== null && !Array.isArray(element)) {
+      collectExpandHops(element as Record<string, unknown>, hops);
+    }
+  }
+  return hops;
+}
+
+function collectExpandHops(params: Record<string, unknown>, out: Array<ReadonlyArray<unknown>>): void {
+  const expand = params.expand;
+  if (!Array.isArray(expand)) {
+    return;
+  }
+  for (const entry of expand) {
+    if (!Array.isArray(entry)) {
+      continue;
+    }
+    out.push(entry);
+    const nestedParams = entry[2];
+    if (typeof nestedParams === "object" && nestedParams !== null) {
+      collectExpandHops(nestedParams as Record<string, unknown>, out);
+    }
+  }
+}

--- a/packages/odata-service/src/cacheKey/index.ts
+++ b/packages/odata-service/src/cacheKey/index.ts
@@ -1,0 +1,6 @@
+export * from "./CacheKeyState";
+export * from "./BuildCacheKey";
+export * from "./BuildDeepEdit";
+export * from "./EntityGraphWalk";
+export * from "./ObservedIdentity";
+export * from "./TouchesResource";

--- a/packages/odata-service/src/index.ts
+++ b/packages/odata-service/src/index.ts
@@ -7,3 +7,4 @@ export * from "./v2/index";
 export * from "./v4/index";
 export * from "./RequestHeaders";
 export * from "./request/index";
+export * from "./cacheKey/index";

--- a/packages/odata-service/src/request/RequestCmd.ts
+++ b/packages/odata-service/src/request/RequestCmd.ts
@@ -1,5 +1,12 @@
 import { HttpResponseModel, ODataHttpClient, ODataHttpMethods, ODataRequestConfig } from "@odata2ts/http-client-api";
 import { MainResponseConverter } from "@odata2ts/odata-query-objects";
+import {
+  buildCacheKey,
+  buildInvalidates,
+  CacheKeyState,
+  recordObservedIdentities,
+  resolveCrossRouteInvalidates,
+} from "../cacheKey/index.js";
 import { getHeaderETag } from "../ETagExtraction";
 import { isConcurrencyConflict, ODataConcurrencyError } from "../ODataConcurrencyError";
 import { MainRequestConverter, RequestConverter } from "./converter/RequestConverter";
@@ -47,6 +54,20 @@ export interface RequestCmdOptions<ResponseStructure, DataStructure> {
    * to the user facing model.
    */
   mainResponseConverter?: MainResponseConverter<ResponseStructure, any>;
+  /**
+   * What resource this request addresses - see {@link CacheKeyState}. Absent where the client was
+   * generated without `cacheKeys`, which is what makes {@link RequestCmd.cacheKey} optional.
+   */
+  cacheKeyState?: CacheKeyState;
+  /**
+   * The query's own restrictions, snapshotted off the query builder rather than parsed back out of the
+   * URL. Set only by a read: these are what the *query* restricts the resource by, so a read is keyed
+   * by them, while a write's builder - where it has one at all - only shapes the response it asks back,
+   * never the identity of the resource it changes. `buildInvalidates` strips a resource's own params from
+   * its key for the same reason, so a write folding its `$select`/`$expand` in here would buy nothing but
+   * a mismatch between two identical writes that differ only in what they ask back.
+   */
+  queryParams?: Record<string, unknown>;
 }
 
 /**
@@ -65,6 +86,9 @@ export abstract class RequestCmd<
    * through the write command classes; when present it wins over the store.
    */
   protected etagOverride?: string;
+
+  private cachedCacheKey?: ReadonlyArray<unknown>;
+  private cacheKeyComputed = false;
 
   public constructor(
     protected client: ODataHttpClient,
@@ -88,9 +112,9 @@ export abstract class RequestCmd<
    * The data (if any) is presented with user facing typings.
    */
   public getInfo(): RequestInfo<DataStructure> {
-    const { headers } = this.options;
+    const { headers, cacheKeyState } = this.options;
 
-    return new RequestInfo<DataStructure>(this.method, this.getUrl(), headers, this.data);
+    return new RequestInfo<DataStructure>(this.method, this.getUrl(), headers, this.data, cacheKeyState);
   }
 
   /**
@@ -111,6 +135,31 @@ export abstract class RequestCmd<
     }
 
     return converter.convert(request);
+  }
+
+  /**
+   * The key this request's resource should be cached under - available before the request goes out, which
+   * is when a cache needs it.
+   *
+   * `undefined` for any method but `GET`: a write has nothing to be stored under, only something to make
+   * stale - that is what {@link invalidates} on its response is for. Mirrors that asymmetry from the other
+   * side: a read never gets `invalidates`, a write never gets a `cacheKey`.
+   *
+   * Read through the converter chain, so any converter's effect on the resource identity is visible
+   * without a second call. Lazy is required rather than stylistic: `getUrl()` cannot run from the base
+   * constructor, because subclasses overriding it read parameter-property fields TypeScript assigns only
+   * after `super()` returns.
+   *
+   * `undefined` also means this client was not generated with `cacheKeys` - which a consuming application
+   * has to handle anyway when it is shared across services.
+   */
+  public get cacheKey(): ReadonlyArray<unknown> | undefined {
+    if (!this.cacheKeyComputed) {
+      const state = this.method === ODataHttpMethods.Get ? this.getInfoConverted().cacheKeyState : undefined;
+      this.cachedCacheKey = state && buildCacheKey(state, this.options.queryParams);
+      this.cacheKeyComputed = true;
+    }
+    return this.cachedCacheKey;
   }
 
   /**
@@ -184,7 +233,7 @@ export abstract class RequestCmd<
    */
   public async execute<RequestConfig extends ODataRequestConfig = ODataRequestConfig>(
     requestConfig?: NoInferConfig<RequestConfig>,
-  ) {
+  ): Promise<HttpResponseModel<FinalResponseStructure>> {
     // apply request converters
     const request = this.applyConcurrency(this.getInfoConverted());
 
@@ -204,7 +253,31 @@ export abstract class RequestCmd<
     // the mapped, user-facing ones, which only exist once the converters have run
     this.updateConcurrency(response);
 
-    return converted;
+    // same reasoning as concurrency harvesting: response-observed identity is read off the converted,
+    // mapped-name body too - a read only, by construction, since `this.cacheKey` is `undefined` for
+    // anything else (see ObservedIdentity.recordObservedIdentities)
+    if (request.cacheKeyState) {
+      recordObservedIdentities(this.client.resourceIdentity, this.cacheKey, request.cacheKeyState, converted.data);
+    }
+
+    return this.withInvalidates(converted, request.cacheKeyState);
+  }
+
+  /**
+   * Attaches what this write makes stale - from the very same state the key is built from, so key and
+   * invalidation set cannot drift apart, plus whatever route to this same resource
+   * `resolveCrossRouteInvalidates` finds already cached under some other route. A read adds nothing: what
+   * it should be stored under is {@link cacheKey}.
+   */
+  private withInvalidates(
+    response: HttpResponseModel<FinalResponseStructure>,
+    state: CacheKeyState | undefined,
+  ): HttpResponseModel<FinalResponseStructure> {
+    if (!state || this.method === ODataHttpMethods.Get) {
+      return response;
+    }
+    const crossRouteKeys = resolveCrossRouteInvalidates(this.client.resourceIdentity, state, response.data);
+    return { ...response, invalidates: buildInvalidates(state, crossRouteKeys) };
   }
 
   /**
@@ -231,7 +304,13 @@ export abstract class RequestCmd<
       return request;
     }
 
-    return new RequestInfo(request.method, request.url, { ...request.headers, "If-Match": etag }, request.data);
+    return new RequestInfo(
+      request.method,
+      request.url,
+      { ...request.headers, "If-Match": etag },
+      request.data,
+      request.cacheKeyState,
+    );
   }
 
   /**

--- a/packages/odata-service/src/request/RequestHelper.ts
+++ b/packages/odata-service/src/request/RequestHelper.ts
@@ -20,5 +20,6 @@ export const GetToPostConverter: RequestConverter<any> = (request) => {
     url + GET_AS_POST_URL_SUFFIX,
     { ...request.headers, ...GET_AS_POST_HEADER },
     body,
+    request.cacheKeyState,
   );
 };

--- a/packages/odata-service/src/request/RequestInfo.ts
+++ b/packages/odata-service/src/request/RequestInfo.ts
@@ -1,4 +1,5 @@
 import { ODataHttpMethods } from "@odata2ts/http-client-api";
+import { CacheKeyState } from "../cacheKey/CacheKeyState";
 
 export class RequestInfo<DataStructure = undefined> {
   public constructor(
@@ -6,9 +7,17 @@ export class RequestInfo<DataStructure = undefined> {
     readonly url: string,
     readonly headers?: Record<string, string>,
     readonly data?: DataStructure,
+    /**
+     * What resource this request addresses, in the form a cache key is built from.
+     *
+     * Carried on the request rather than beside it, deliberately: a request converter must be able to
+     * change the resource identity in the *same* immutable step that rewrites `url`, `method` and `data`,
+     * so composition falls out of the converter chain's existing `reduce`. No mutator, no escape hatch.
+     */
+    readonly cacheKeyState?: CacheKeyState,
   ) {}
 
   public withData<NewDataStructure = DataStructure>(data: NewDataStructure) {
-    return new RequestInfo(this.method, this.url, this.headers, data);
+    return new RequestInfo(this.method, this.url, this.headers, data, this.cacheKeyState);
   }
 }

--- a/packages/odata-service/src/v2/CollectionServiceV2.ts
+++ b/packages/odata-service/src/v2/CollectionServiceV2.ts
@@ -7,6 +7,7 @@ import {
   PrimitiveCollectionType,
   QueryObjectModel,
 } from "@odata2ts/odata-query-objects";
+import { CacheKeyState } from "../cacheKey/index.js";
 import { ODataServiceOptionsInternalV2 } from "../ODataServiceOptions";
 import { UrlBuilderRequestCmdV2, UrlRequestCmd } from "../request";
 import { CollectionModificationResponseV2 } from "./ResponseTypeChoicesV2";
@@ -28,12 +29,17 @@ export class CollectionServiceV2<
     name: string,
     qModel: Q,
     options?: ODataServiceOptionsInternalV2<AsV4>,
+    cacheKeyState?: CacheKeyState,
   ) {
-    this.__base = new ServiceStateHelperV2(client, basePath, name, qModel, options);
+    this.__base = new ServiceStateHelperV2(client, basePath, name, qModel, options, cacheKeyState);
   }
 
   public getPath() {
     return this.__base.path;
+  }
+
+  public getCacheKeyState() {
+    return this.__base.cacheKeyState;
   }
 
   /**
@@ -54,7 +60,7 @@ export class CollectionServiceV2<
     model: PrimitiveT,
     queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void,
   ) {
-    const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
+    const { client, qModel, getDefaultHeaders, createModelQueryBuilder, cacheKeyState } = this.__base;
 
     return new UrlBuilderRequestCmdV2<
       CollectionModificationResponseV2<Response, PrimitiveT, AsV4>,
@@ -68,6 +74,7 @@ export class CollectionServiceV2<
         CollectionModificationResponseV2<Response, PrimitiveT, AsV4>,
         T
       >,
+      cacheKeyState,
     });
   }
 
@@ -89,7 +96,7 @@ export class CollectionServiceV2<
     models: Array<PrimitiveT>,
     queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void,
   ) {
-    const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
+    const { client, qModel, getDefaultHeaders, createModelQueryBuilder, cacheKeyState } = this.__base;
 
     return new UrlBuilderRequestCmdV2<
       CollectionModificationResponseV2<Response, PrimitiveT, AsV4>,
@@ -103,6 +110,7 @@ export class CollectionServiceV2<
         CollectionModificationResponseV2<Response, PrimitiveT, AsV4>,
         T
       >,
+      cacheKeyState,
     });
   }
 
@@ -110,23 +118,26 @@ export class CollectionServiceV2<
    * Delete the whole collection.
    */
   public delete() {
-    const { client, path } = this.__base;
+    const { client, path, cacheKeyState } = this.__base;
 
-    return new UrlRequestCmd<undefined>(client, ODataHttpMethods.Delete, path, undefined);
+    return new UrlRequestCmd<undefined>(client, ODataHttpMethods.Delete, path, undefined, { cacheKeyState });
   }
 
   /**
    * Query collection.
    */
   public query<ReturnType = T>(queryFn?: (builder: CollectionQueryBuilderV2<Q>, qObject: Q) => void) {
-    const { client, qModel, getDefaultHeaders, createQueryBuilder } = this.__base;
+    const { client, qModel, getDefaultHeaders, createQueryBuilder, cacheKeyState } = this.__base;
+    const builder = createQueryBuilder(queryFn);
 
     return new UrlBuilderRequestCmdV2<
       AsV4 extends true ? ODataCollectionResponseV4<ReturnType> : ODataCollectionResponseV2<ReturnType>,
       Q
-    >(client, ODataHttpMethods.Get, createQueryBuilder(queryFn), qModel, undefined, {
+    >(client, ODataHttpMethods.Get, builder, qModel, undefined, {
       headers: getDefaultHeaders(),
       mainResponseConverter: new CollectionResponseConverterV2<ReturnType, AsV4>(qModel, this.__base.isAsV4()),
+      cacheKeyState,
+      queryParams: builder.getCacheKeyParams(),
     });
   }
 }

--- a/packages/odata-service/src/v2/ComplexTypeServiceV2.ts
+++ b/packages/odata-service/src/v2/ComplexTypeServiceV2.ts
@@ -2,6 +2,7 @@ import { ODataHttpClient, ODataHttpMethods } from "@odata2ts/http-client-api";
 import { ODataComplexModelResponseV2, ODataModelResponseV4 } from "@odata2ts/odata-core";
 import { ModelQueryBuilderV2 } from "@odata2ts/odata-query-builder";
 import { ComplexResponseConverterV2, QueryObjectModel } from "@odata2ts/odata-query-objects";
+import { CacheKeyState } from "../cacheKey/index.js";
 import { ODataServiceOptionsInternalV2 } from "../ODataServiceOptions";
 import { UrlBuilderRequestCmdV2, UrlRequestCmd } from "../request";
 import { MERGE_HEADERS } from "../RequestHeaders.js";
@@ -22,16 +23,21 @@ export class ComplexTypeServiceV2<T, UpdatableT, Q extends QueryObjectModel, AsV
     name: string,
     qModel: Q,
     options?: ODataServiceOptionsInternalV2<AsV4>,
+    cacheKeyState?: CacheKeyState,
   ) {
-    this.__base = new ServiceStateHelperV2(client, basePath, name, qModel, options);
+    this.__base = new ServiceStateHelperV2(client, basePath, name, qModel, options, cacheKeyState);
   }
 
   public getPath() {
     return this.__base.path;
   }
 
+  public getCacheKeyState() {
+    return this.__base.cacheKeyState;
+  }
+
   public patch(model: Partial<UpdatableT>, queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void) {
-    const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
+    const { client, qModel, getDefaultHeaders, createModelQueryBuilder, cacheKeyState } = this.__base;
     const headers = { ...getDefaultHeaders(), ...MERGE_HEADERS };
 
     return new UrlBuilderRequestCmdV2<undefined, Q, ModelQueryBuilderV2<Q>, Partial<UpdatableT>>(
@@ -43,12 +49,13 @@ export class ComplexTypeServiceV2<T, UpdatableT, Q extends QueryObjectModel, AsV
       {
         headers,
         mainRequestConverter: qModel,
+        cacheKeyState,
       },
     );
   }
 
   public update(model: UpdatableT, queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void) {
-    const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
+    const { client, qModel, getDefaultHeaders, createModelQueryBuilder, cacheKeyState } = this.__base;
 
     return new UrlBuilderRequestCmdV2<undefined, Q, ModelQueryBuilderV2<Q>, UpdatableT>(
       client,
@@ -59,26 +66,30 @@ export class ComplexTypeServiceV2<T, UpdatableT, Q extends QueryObjectModel, AsV
       {
         headers: getDefaultHeaders(),
         mainRequestConverter: qModel,
+        cacheKeyState,
       },
     );
   }
 
   public delete() {
-    const { client, path } = this.__base;
+    const { client, path, cacheKeyState } = this.__base;
 
-    return new UrlRequestCmd<undefined>(client, ODataHttpMethods.Delete, path, undefined);
+    return new UrlRequestCmd<undefined>(client, ODataHttpMethods.Delete, path, undefined, { cacheKeyState });
   }
 
   public query<ReturnType extends Partial<T> = T>(queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void) {
-    const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
+    const { client, qModel, getDefaultHeaders, createModelQueryBuilder, cacheKeyState } = this.__base;
+    const builder = createModelQueryBuilder(queryFn);
 
     return new UrlBuilderRequestCmdV2<
       AsV4 extends true ? ODataModelResponseV4<ReturnType> : ODataComplexModelResponseV2<ReturnType>,
       Q,
       ModelQueryBuilderV2<Q>
-    >(client, ODataHttpMethods.Get, createModelQueryBuilder(queryFn), qModel, undefined, {
+    >(client, ODataHttpMethods.Get, builder, qModel, undefined, {
       headers: getDefaultHeaders(),
       mainResponseConverter: new ComplexResponseConverterV2<ReturnType, AsV4>(qModel, this.__base.isAsV4()),
+      cacheKeyState,
+      queryParams: builder.getCacheKeyParams(),
     });
   }
 }

--- a/packages/odata-service/src/v2/EntitySetServiceV2.ts
+++ b/packages/odata-service/src/v2/EntitySetServiceV2.ts
@@ -12,6 +12,7 @@ import {
   QId,
   QueryObjectModel,
 } from "@odata2ts/odata-query-objects";
+import { buildDeepEditHops, CacheKeyState, withKey, withParams } from "../cacheKey/index.js";
 import { getBodyETagV2, getBodyETagV4 } from "../ETagExtraction.js";
 import { ODataServiceOptionsInternalV2 } from "../ODataServiceOptions";
 import { ConcurrencyOptions, UrlBuilderRequestCmdV2 } from "../request";
@@ -41,13 +42,18 @@ export abstract class EntitySetServiceV2<
     qModel: Q,
     idFunction: QId<EIdType>,
     options?: ODataServiceOptionsInternalV2<AsV4>,
+    cacheKeyState?: CacheKeyState,
   ) {
-    this.__base = new ServiceStateHelperV2(client, basePath, name, qModel, options);
+    this.__base = new ServiceStateHelperV2(client, basePath, name, qModel, options, cacheKeyState);
     this.__idFunction = idFunction;
   }
 
   public getPath() {
     return this.__base.path;
+  }
+
+  public getCacheKeyState() {
+    return this.__base.cacheKeyState;
   }
 
   /**
@@ -59,6 +65,7 @@ export abstract class EntitySetServiceV2<
     path: string,
     name: string,
     options: ODataServiceOptionsInternalV2<AsV4> | undefined,
+    cacheKeyState?: CacheKeyState,
   ): ES;
 
   /**
@@ -67,8 +74,29 @@ export abstract class EntitySetServiceV2<
   public byId(id: EIdType): ES {
     // basePath, not path: __idFunction already builds the key predicate under this set's own name -
     // path would double that segment
-    const { client, basePath, options, isUrlNotEncoded } = this.__base;
-    return this.createEntityService(client, basePath, this.__idFunction.buildUrl(id, isUrlNotEncoded()), options);
+    const { client, basePath, options, isUrlNotEncoded, cacheKeyState } = this.__base;
+    return this.createEntityService(
+      client,
+      basePath,
+      this.__idFunction.buildUrl(id, isUrlNotEncoded()),
+      options,
+      cacheKeyState && withKey(cacheKeyState, this.cacheKeyOf(id), id),
+    );
+  }
+
+  /**
+   * The key of the addressed entity as a cache key carries it - see {@link EntitySetServiceV4.cacheKeyOf},
+   * whose reasoning applies unchanged here.
+   */
+  private cacheKeyOf(id: EIdType): unknown {
+    const params = this.__idFunction.getParamsFor(id);
+    const primary = this.__idFunction.getPrimaryParams();
+    const isPrimarySingle = params.length === 1 && primary.length === 1 && primary[0].getName() === params[0].getName();
+
+    const values = Object.fromEntries(
+      params.map((param) => [param.getName(), param.convertTo((id as any)?.[param.getMappedName()] ?? id)]),
+    );
+    return isPrimarySingle ? Object.values(values)[0] : values;
   }
 
   /**
@@ -162,17 +190,23 @@ export abstract class EntitySetServiceV2<
   }
 
   public create(model: EditableT, queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void) {
-    const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
+    const { client, qModel, getDefaultHeaders, createModelQueryBuilder, cacheKeyState } = this.__base;
+    const builder = createModelQueryBuilder(queryFn);
+
+    const deepEditHops = cacheKeyState && buildDeepEditHops(cacheKeyState.qEntityFn, model);
+    const stateForRequest =
+      deepEditHops && cacheKeyState ? withParams(cacheKeyState, { deepEdit: deepEditHops }) : cacheKeyState;
 
     return new UrlBuilderRequestCmdV2<
       AsV4 extends true ? ODataModelResponseV4<T> : ODataEntityModelResponseV2<T>,
       Q,
       ModelQueryBuilderV2<Q>,
       EditableT
-    >(client, ODataHttpMethods.Post, createModelQueryBuilder(queryFn), qModel, model, {
+    >(client, ODataHttpMethods.Post, builder, qModel, model, {
       headers: getDefaultHeaders(),
       mainRequestConverter: qModel,
       mainResponseConverter: new EntityResponseConverterV2<T, AsV4>(qModel, this.__base.isAsV4()),
+      cacheKeyState: stateForRequest,
     });
   }
 
@@ -184,15 +218,18 @@ export abstract class EntitySetServiceV2<
   public query<ReturnType extends Partial<T> = T>(
     queryFn?: (builder: CollectionQueryBuilderV2<Q>, qObject: Q) => void,
   ) {
-    const { client, qModel, getDefaultHeaders, createQueryBuilder } = this.__base;
+    const { client, qModel, getDefaultHeaders, createQueryBuilder, cacheKeyState } = this.__base;
+    const builder = createQueryBuilder(queryFn);
 
     return new UrlBuilderRequestCmdV2<
       AsV4 extends true ? ODataCollectionResponseV4<ReturnType> : ODataCollectionResponseV2<ReturnType>,
       Q
-    >(client, ODataHttpMethods.Get, createQueryBuilder(queryFn), qModel, undefined, {
+    >(client, ODataHttpMethods.Get, builder, qModel, undefined, {
       concurrency: this.getCollectionConcurrencyOptions(),
       headers: getDefaultHeaders(),
       mainResponseConverter: new CollectionResponseConverterV2<ReturnType, AsV4>(qModel, this.__base.isAsV4()),
+      cacheKeyState,
+      queryParams: builder.getCacheKeyParams(),
     });
   }
 }

--- a/packages/odata-service/src/v2/EntityTypeServiceV2.ts
+++ b/packages/odata-service/src/v2/EntityTypeServiceV2.ts
@@ -2,6 +2,7 @@ import { ODataHttpClient, ODataHttpMethods } from "@odata2ts/http-client-api";
 import { ODataEntityModelResponseV2, ODataModelResponseV4 } from "@odata2ts/odata-core";
 import { ModelQueryBuilderV2 } from "@odata2ts/odata-query-builder";
 import { EntityResponseConverterV2, QueryObjectModel } from "@odata2ts/odata-query-objects";
+import { buildDeepEditHops, CacheKeyState, withParams } from "../cacheKey/index.js";
 import { ODataServiceOptionsInternalV2 } from "../ODataServiceOptions";
 import { UrlBuilderRequestCmdV2, UrlBuilderWriteRequestCmdV2, UrlWriteRequestCmd } from "../request";
 import { MERGE_HEADERS } from "../RequestHeaders.js";
@@ -22,12 +23,17 @@ export class EntityTypeServiceV2<T, UpdatableT, Q extends QueryObjectModel, AsV4
     name: string,
     qModel: Q,
     options?: ODataServiceOptionsInternalV2<AsV4>,
+    cacheKeyState?: CacheKeyState,
   ) {
-    this.__base = new ServiceStateHelperV2(client, basePath, name, qModel, options);
+    this.__base = new ServiceStateHelperV2(client, basePath, name, qModel, options, cacheKeyState);
   }
 
   public getPath() {
     return this.__base.path;
+  }
+
+  public getCacheKeyState() {
+    return this.__base.cacheKeyState;
   }
 
   /**
@@ -40,9 +46,14 @@ export class EntityTypeServiceV2<T, UpdatableT, Q extends QueryObjectModel, AsV4
    * @param model
    */
   public patch(model: Partial<UpdatableT>, queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void) {
-    const { client, qModel, getDefaultHeaders, createModelQueryBuilder, getConcurrencyOptions } = this.__base;
+    const { client, qModel, getDefaultHeaders, createModelQueryBuilder, getConcurrencyOptions, cacheKeyState } =
+      this.__base;
     // the If-Match header rides alongside the X-Http-Method one: a V2 patch travels as MERGE
     const headers = { ...getDefaultHeaders(), ...MERGE_HEADERS };
+
+    const deepEditHops = cacheKeyState && buildDeepEditHops(cacheKeyState.qEntityFn, model);
+    const stateForRequest =
+      deepEditHops && cacheKeyState ? withParams(cacheKeyState, { deepEdit: deepEditHops }) : cacheKeyState;
 
     return new UrlBuilderWriteRequestCmdV2<undefined, Q, ModelQueryBuilderV2<Q>, Partial<UpdatableT>>(
       client,
@@ -54,6 +65,7 @@ export class EntityTypeServiceV2<T, UpdatableT, Q extends QueryObjectModel, AsV4
         headers,
         mainRequestConverter: qModel,
         concurrency: getConcurrencyOptions(),
+        cacheKeyState: stateForRequest,
       },
     );
   }
@@ -67,7 +79,12 @@ export class EntityTypeServiceV2<T, UpdatableT, Q extends QueryObjectModel, AsV4
    * @param model
    */
   public update(model: UpdatableT, queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void) {
-    const { client, qModel, getDefaultHeaders, createModelQueryBuilder, getConcurrencyOptions } = this.__base;
+    const { client, qModel, getDefaultHeaders, createModelQueryBuilder, getConcurrencyOptions, cacheKeyState } =
+      this.__base;
+
+    const deepEditHops = cacheKeyState && buildDeepEditHops(cacheKeyState.qEntityFn, model);
+    const stateForRequest =
+      deepEditHops && cacheKeyState ? withParams(cacheKeyState, { deepEdit: deepEditHops }) : cacheKeyState;
 
     return new UrlBuilderWriteRequestCmdV2<undefined, Q, ModelQueryBuilderV2<Q>, UpdatableT>(
       client,
@@ -79,6 +96,7 @@ export class EntityTypeServiceV2<T, UpdatableT, Q extends QueryObjectModel, AsV4
         headers: getDefaultHeaders(),
         mainRequestConverter: qModel,
         concurrency: getConcurrencyOptions(),
+        cacheKeyState: stateForRequest,
       },
     );
   }
@@ -90,24 +108,29 @@ export class EntityTypeServiceV2<T, UpdatableT, Q extends QueryObjectModel, AsV4
    * The service should respond with status 204 and no data.
    */
   public delete() {
-    const { client, path, getDefaultHeaders, getConcurrencyOptions } = this.__base;
+    const { client, path, getDefaultHeaders, getConcurrencyOptions, cacheKeyState } = this.__base;
     return new UrlWriteRequestCmd<undefined>(client, ODataHttpMethods.Delete, path, undefined, {
       headers: getDefaultHeaders(),
       concurrency: getConcurrencyOptions(),
+      cacheKeyState,
     });
   }
 
   public query<ReturnType extends Partial<T> = T>(queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void) {
-    const { client, qModel, getDefaultHeaders, createModelQueryBuilder, getConcurrencyOptions } = this.__base;
+    const { client, qModel, getDefaultHeaders, createModelQueryBuilder, getConcurrencyOptions, cacheKeyState } =
+      this.__base;
+    const builder = createModelQueryBuilder(queryFn);
 
     return new UrlBuilderRequestCmdV2<
       AsV4 extends true ? ODataModelResponseV4<ReturnType> : ODataEntityModelResponseV2<ReturnType>,
       Q,
       ModelQueryBuilderV2<Q>
-    >(client, ODataHttpMethods.Get, createModelQueryBuilder(queryFn), qModel, undefined, {
+    >(client, ODataHttpMethods.Get, builder, qModel, undefined, {
       headers: getDefaultHeaders(),
       mainResponseConverter: new EntityResponseConverterV2<ReturnType, AsV4>(qModel, this.__base.isAsV4()),
       concurrency: getConcurrencyOptions(),
+      cacheKeyState,
+      queryParams: builder.getCacheKeyParams(),
     });
   }
 }

--- a/packages/odata-service/src/v2/MediaEntityServiceV2.ts
+++ b/packages/odata-service/src/v2/MediaEntityServiceV2.ts
@@ -33,8 +33,8 @@ export class MediaEntityServiceV2<
    */
   public content(): StreamServiceV2 {
     if (!this._content) {
-      const { client, path, options } = this.__base;
-      this._content = new StreamServiceV2(client, path, VALUE_SEGMENT, options);
+      const { client, path, options, cacheKeyState } = this.__base;
+      this._content = new StreamServiceV2(client, path, VALUE_SEGMENT, options, cacheKeyState);
     }
 
     return this._content;

--- a/packages/odata-service/src/v2/PrimitiveTypeServiceV2.ts
+++ b/packages/odata-service/src/v2/PrimitiveTypeServiceV2.ts
@@ -8,6 +8,7 @@ import {
   ResponseValueConverterV2,
   ValueResponseConverterV2,
 } from "@odata2ts/odata-query-objects";
+import { CacheKeyState } from "../cacheKey/index.js";
 import { ODataServiceOptionsInternalV2 } from "../ODataServiceOptions";
 import { UrlRequestCmd } from "../request";
 import { ServiceStateHelper } from "../ServiceStateHelper.js";
@@ -39,8 +40,9 @@ export class PrimitiveTypeServiceV2<T, AsV4 extends boolean = false> {
     converter: ValueConverter<any, T> = getIdentityConverter(),
     mappedName?: string,
     options?: ODataServiceOptionsInternalV2<AsV4>,
+    cacheKeyState?: CacheKeyState,
   ) {
-    this.__base = new ServiceStateHelper(client, basePath, name, options);
+    this.__base = new ServiceStateHelper(client, basePath, name, options, cacheKeyState);
     this.__asV4 = options?.v2ResponseAsV4;
     /*
      * The two conversion methods are delegated to rather than pulled off the converter, because a
@@ -65,6 +67,10 @@ export class PrimitiveTypeServiceV2<T, AsV4 extends boolean = false> {
     return this.__base.path;
   }
 
+  public getCacheKeyState() {
+    return this.__base.cacheKeyState;
+  }
+
   /**
    * Get the primitive value.
    * Spec: {@link https://www.odata.org/documentation/odata-version-2-0/operations/} - 2.2 Retrieving individual properties
@@ -72,7 +78,7 @@ export class PrimitiveTypeServiceV2<T, AsV4 extends boolean = false> {
    * Always returns the response structure, the value might be `null`.
    */
   public getValue() {
-    const { client, path, getDefaultHeaders } = this.__base;
+    const { client, path, getDefaultHeaders, cacheKeyState } = this.__base;
     const converter = this.__converter;
 
     return new UrlRequestCmd<AsV4 extends true ? ODataValueResponseV4<T> : ODataValueResponseV2<T>>(
@@ -83,6 +89,7 @@ export class PrimitiveTypeServiceV2<T, AsV4 extends boolean = false> {
       {
         headers: getDefaultHeaders(),
         mainResponseConverter: new ValueResponseConverterV2<T, AsV4>(converter, this.__asV4 as AsV4),
+        cacheKeyState,
       },
     );
   }
@@ -96,12 +103,13 @@ export class PrimitiveTypeServiceV2<T, AsV4 extends boolean = false> {
    * @param value
    */
   public updateValue(value: T) {
-    const { client, path, getDefaultHeaders, name } = this.__base;
+    const { client, path, getDefaultHeaders, name, cacheKeyState } = this.__base;
     const converter = this.__converter;
 
     return new UrlRequestCmd<undefined, T>(client, ODataHttpMethods.Put, path, value, {
       headers: getDefaultHeaders(),
       mainRequestConverter: new ValueRequestConverter(converter, name!),
+      cacheKeyState,
     });
   }
 
@@ -111,8 +119,8 @@ export class PrimitiveTypeServiceV2<T, AsV4 extends boolean = false> {
    * Returns 204 with no data.
    */
   public deleteValue() {
-    const { client, path } = this.__base;
+    const { client, path, cacheKeyState } = this.__base;
 
-    return new UrlRequestCmd<undefined>(client, ODataHttpMethods.Delete, path, undefined);
+    return new UrlRequestCmd<undefined>(client, ODataHttpMethods.Delete, path, undefined, { cacheKeyState });
   }
 }

--- a/packages/odata-service/src/v2/ServiceStateHelperV2.ts
+++ b/packages/odata-service/src/v2/ServiceStateHelperV2.ts
@@ -1,6 +1,7 @@
 import { ODataHttpClient } from "@odata2ts/http-client-api";
 import { CollectionQueryBuilderV2, createQueryBuilderV2, ModelQueryBuilderV2 } from "@odata2ts/odata-query-builder";
 import { QueryObjectModel } from "@odata2ts/odata-query-objects";
+import { CacheKeyState } from "../cacheKey/index.js";
 import { getBodyETagV2, getBodyETagV4 } from "../ETagExtraction.js";
 import { ODataServiceOptionsInternalV2 } from "../ODataServiceOptions";
 import { ConcurrencyOptions } from "../request/RequestCmd.js";
@@ -21,8 +22,9 @@ export class ServiceStateHelperV2<Q extends QueryObjectModel, AsV4 extends boole
     name: string,
     public qModel: Q,
     options?: ODataServiceOptionsInternalV2<AsV4>,
+    cacheKeyState?: CacheKeyState,
   ) {
-    super(client, basePath, name, options);
+    super(client, basePath, name, options, cacheKeyState);
     this.asV4 = !!options?.v2ResponseAsV4 as AsV4;
   }
 

--- a/packages/odata-service/src/v2/StreamServiceV2.ts
+++ b/packages/odata-service/src/v2/StreamServiceV2.ts
@@ -1,4 +1,5 @@
 import { ODataHttpClient } from "@odata2ts/http-client-api";
+import { CacheKeyState } from "../cacheKey/index.js";
 import { ODataServiceOptions } from "../ODataServiceOptions";
 import { StreamServiceBase } from "../StreamServiceBase.js";
 
@@ -12,7 +13,13 @@ import { StreamServiceBase } from "../StreamServiceBase.js";
  * That is also why it is not generated for any property - a V2 model has no way of declaring one.
  */
 export class StreamServiceV2 extends StreamServiceBase {
-  public constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptions) {
-    super(client, basePath, name, options);
+  public constructor(
+    client: ODataHttpClient,
+    basePath: string,
+    name: string,
+    options?: ODataServiceOptions,
+    cacheKeyState?: CacheKeyState,
+  ) {
+    super(client, basePath, name, options, cacheKeyState);
   }
 }

--- a/packages/odata-service/src/v4/CollectionServiceV4.ts
+++ b/packages/odata-service/src/v4/CollectionServiceV4.ts
@@ -7,6 +7,7 @@ import {
   PrimitiveCollectionType,
   QueryObjectModel,
 } from "@odata2ts/odata-query-objects";
+import { CacheKeyState } from "../cacheKey/index.js";
 import { ODataServiceOptionsInternal } from "../ODataServiceOptions";
 import { UrlBuilderRequestCmdV4, UrlRequestCmd } from "../request";
 import { CollectionModificationResponseV4 } from "./ResponseTypeChoicesV4";
@@ -44,12 +45,17 @@ export class CollectionServiceV4<
     name: string,
     qModel: Q,
     options?: ODataServiceOptionsInternal<V>,
+    cacheKeyState?: CacheKeyState,
   ) {
-    this.__base = new ServiceStateHelperV4(client, basePath, name, qModel, options);
+    this.__base = new ServiceStateHelperV4(client, basePath, name, qModel, options, cacheKeyState);
   }
 
   public getPath() {
     return this.__base.path;
+  }
+
+  public getCacheKeyState() {
+    return this.__base.cacheKeyState;
   }
 
   /**
@@ -71,20 +77,23 @@ export class CollectionServiceV4<
     model: PrimitiveT,
     queryFn?: (builder: ModelQueryBuilderV4<Q>, qObject: Q) => void,
   ) {
-    const { client, getDefaultHeaders, getVersionHeaders, qModel, createModelQueryBuilder } = this.__base;
+    const { client, getDefaultHeaders, getVersionHeaders, qModel, createModelQueryBuilder, cacheKeyState } =
+      this.__base;
+    const builder = createModelQueryBuilder(queryFn);
 
     return new UrlBuilderRequestCmdV4<
       CollectionModificationResponseV4<Response, PrimitiveT, V>,
       Q,
       ModelQueryBuilderV4<Q>,
       PrimitiveT
-    >(client, ODataHttpMethods.Post, createModelQueryBuilder(queryFn), qModel, model, {
+    >(client, ODataHttpMethods.Post, builder, qModel, model, {
       headers: { ...getDefaultHeaders(), ...getVersionHeaders() },
       mainRequestConverter: qModel,
       mainResponseConverter: new CollectionResponseConverterV4(qModel) as MainResponseConverter<
         CollectionModificationResponseV4<Response, PrimitiveT, V>,
         T
       >,
+      cacheKeyState,
     });
   }
 
@@ -107,14 +116,16 @@ export class CollectionServiceV4<
     models: Array<PrimitiveT>,
     queryFn?: (builder: ModelQueryBuilderV4<Q>, qObject: Q) => void,
   ) {
-    const { client, getDefaultHeaders, getVersionHeaders, qModel, createModelQueryBuilder } = this.__base;
+    const { client, getDefaultHeaders, getVersionHeaders, qModel, createModelQueryBuilder, cacheKeyState } =
+      this.__base;
+    const builder = createModelQueryBuilder(queryFn);
 
     return new UrlBuilderRequestCmdV4<
       CollectionModificationResponseV4<Response, PrimitiveT, V>,
       Q,
       ModelQueryBuilderV4<Q>,
       Array<PrimitiveT>
-    >(client, ODataHttpMethods.Put, createModelQueryBuilder(queryFn), qModel, models, {
+    >(client, ODataHttpMethods.Put, builder, qModel, models, {
       headers: { ...getDefaultHeaders(), ...getVersionHeaders() },
       mainRequestConverter: new CollectionRequestConverter<Array<PrimitiveT>>(
         qModel as unknown as Pick<QueryObjectModel<Array<PrimitiveT>>, "convertToOData">,
@@ -123,6 +134,7 @@ export class CollectionServiceV4<
         CollectionModificationResponseV4<Response, PrimitiveT, V>,
         T
       >,
+      cacheKeyState,
     });
   }
 
@@ -131,9 +143,9 @@ export class CollectionServiceV4<
    * Spec: https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_UpdateaCollectionProperty
    */
   public delete() {
-    const { client, path } = this.__base;
+    const { client, path, cacheKeyState } = this.__base;
 
-    return new UrlRequestCmd<undefined>(client, ODataHttpMethods.Delete, path, undefined);
+    return new UrlRequestCmd<undefined>(client, ODataHttpMethods.Delete, path, undefined, { cacheKeyState });
   }
 
   /**
@@ -143,17 +155,20 @@ export class CollectionServiceV4<
    * @param queryFn provide the query logic with the help of the builder and the query-object
    */
   public query<ReturnType = T>(queryFn?: (builder: CollectionQueryBuilderV4<Q>, qObject: Q) => void) {
-    const { client, qModel, getDefaultHeaders, createQueryBuilder } = this.__base;
+    const { client, qModel, getDefaultHeaders, createQueryBuilder, cacheKeyState } = this.__base;
+    const builder = createQueryBuilder(queryFn);
 
     return new UrlBuilderRequestCmdV4<ODataCollectionResponseFor<V, ReturnType>, Q>(
       client,
       ODataHttpMethods.Get,
-      createQueryBuilder(queryFn),
+      builder,
       qModel,
       undefined,
       {
         headers: getDefaultHeaders(),
         mainResponseConverter: new CollectionResponseConverterV4(qModel),
+        cacheKeyState,
+        queryParams: builder.getCacheKeyParams(),
       },
     );
   }

--- a/packages/odata-service/src/v4/EntitySetServiceV4.ts
+++ b/packages/odata-service/src/v4/EntitySetServiceV4.ts
@@ -7,6 +7,7 @@ import {
   QId,
   QueryObjectModel,
 } from "@odata2ts/odata-query-objects";
+import { buildDeepEditHops, CacheKeyState, withKey, withParams } from "../cacheKey/index.js";
 import { getBodyETagV4 } from "../ETagExtraction.js";
 import { ODataServiceOptionsInternal } from "../ODataServiceOptions";
 import { ConcurrencyOptions, UrlBuilderRequestCmdV4 } from "../request";
@@ -49,13 +50,18 @@ export abstract class EntitySetServiceV4<
     qModel: Q,
     idFunction: QId<EIdType>,
     options?: ODataServiceOptionsInternal<V>,
+    cacheKeyState?: CacheKeyState,
   ) {
-    this.__base = new ServiceStateHelperV4(client, basePath, name, qModel, options);
+    this.__base = new ServiceStateHelperV4(client, basePath, name, qModel, options, cacheKeyState);
     this.__idFunction = idFunction;
   }
 
   public getPath() {
     return this.__base.path;
+  }
+
+  public getCacheKeyState() {
+    return this.__base.cacheKeyState;
   }
 
   /**
@@ -68,6 +74,7 @@ export abstract class EntitySetServiceV4<
     path: string,
     name: string,
     options: ODataServiceOptionsInternal<V> | undefined,
+    cacheKeyState?: CacheKeyState,
   ): ES;
 
   /**
@@ -81,8 +88,42 @@ export abstract class EntitySetServiceV4<
   public byId(id: EIdType): ES {
     // basePath, not path: __idFunction already builds the key predicate under this set's own name (or,
     // after a subtype cast, the cast segment's name) - path would double that segment
-    const { client, basePath, options, isUrlNotEncoded } = this.__base;
-    return this.createEntityService(client, basePath, this.__idFunction.buildUrl(id, isUrlNotEncoded()), options);
+    const { client, basePath, options, isUrlNotEncoded, cacheKeyState } = this.__base;
+    return this.createEntityService(
+      client,
+      basePath,
+      this.__idFunction.buildUrl(id, isUrlNotEncoded()),
+      options,
+      cacheKeyState && withKey(cacheKeyState, this.cacheKeyOf(id), id),
+    );
+  }
+
+  /**
+   * The key element a cache key carries for the addressed entity - the bare value for a single-property
+   * key and an object for a composite or alternate one, the very shape a hand-written key would take.
+   *
+   * "Single-property key" means the *primary* key and only the primary key: an alternate key never gets
+   * the bare form, even where it too has just one property, because the bare form is what a bare
+   * primitive `byId(5)` resolves to (`QId.findSingleParam`, always the primary key's own single-property
+   * set where one exists) - a single-property alternate key must stay disambiguated as `{Isbn: "..."}` or
+   * it would collide with the primary key's own bare cache entry. Matched structurally, by name, since
+   * `getParamsFor`/`getPrimaryParams` construct their param objects afresh on every call.
+   *
+   * OData-side: `convertTo` applied, `formatUrlValue` not. A caller-side value may be a `bigint`, which
+   * `JSON.stringify` refuses, and a cache hashes its keys with exactly that.
+   *
+   * `id` itself - not this - is what `withKey` stores for canonical-id purposes (`CacheKeyState.key`):
+   * `QId.buildCanonicalId` wants mapped names, this wants OData ones, and the two must not be confused.
+   */
+  private cacheKeyOf(id: EIdType): unknown {
+    const params = this.__idFunction.getParamsFor(id);
+    const primary = this.__idFunction.getPrimaryParams();
+    const isPrimarySingle = params.length === 1 && primary.length === 1 && primary[0].getName() === params[0].getName();
+
+    const values = Object.fromEntries(
+      params.map((param) => [param.getName(), param.convertTo((id as any)?.[param.getMappedName()] ?? id)]),
+    );
+    return isPrimarySingle ? Object.values(values)[0] : values;
   }
 
   /**
@@ -196,13 +237,25 @@ export abstract class EntitySetServiceV4<
     createOptions?: SubtypeOptions,
     queryFn?: (builder: ModelQueryBuilderV4<Q>, qObject: Q) => void,
   ) {
-    const { client, basePath, path, getDefaultHeaders, getVersionHeaders, qModel, createModelQueryBuilder } =
-      this.__base;
+    const {
+      client,
+      basePath,
+      path,
+      getDefaultHeaders,
+      getVersionHeaders,
+      qModel,
+      createModelQueryBuilder,
+      cacheKeyState,
+    } = this.__base;
     const { dontUseCastPathSegment, useTypeCi } = this.__base.evaluateSubtypeOptions(createOptions);
 
     // add control info automatically, if required
     const data = useTypeCi ? this.__base.addTypeControlInfo(model) : model;
     const actualPath = dontUseCastPathSegment ? basePath : path;
+
+    const deepEditHops = cacheKeyState && buildDeepEditHops(cacheKeyState.qEntityFn, model);
+    const stateForRequest =
+      deepEditHops && cacheKeyState ? withParams(cacheKeyState, { deepEdit: deepEditHops }) : cacheKeyState;
 
     return new UrlBuilderRequestCmdV4<
       EntityModificationResponseV4<Response, T, V>,
@@ -216,6 +269,7 @@ export abstract class EntitySetServiceV4<
       // an entity that does not exist yet cannot require its own ETag, so a create is never gated - it
       // only harvests, storing the ETag of what it just made
       concurrency: { ...this.getCollectionConcurrencyOptions(), controlled: false },
+      cacheKeyState: stateForRequest,
     });
   }
 
@@ -228,18 +282,21 @@ export abstract class EntitySetServiceV4<
   public query<ReturnType extends Partial<T> = T>(
     queryFn?: (builder: CollectionQueryBuilderV4<Q>, qObject: Q) => void,
   ) {
-    const { client, qModel, createQueryBuilder, getDefaultHeaders } = this.__base;
+    const { client, qModel, createQueryBuilder, getDefaultHeaders, cacheKeyState } = this.__base;
+    const builder = createQueryBuilder(queryFn);
 
     return new UrlBuilderRequestCmdV4<ODataCollectionResponseFor<V, ReturnType>, Q>(
       client,
       ODataHttpMethods.Get,
-      createQueryBuilder(queryFn),
+      builder,
       qModel,
       undefined,
       {
         headers: getDefaultHeaders(),
         mainResponseConverter: new CollectionResponseConverterV4(qModel),
         concurrency: this.getCollectionConcurrencyOptions(),
+        cacheKeyState,
+        queryParams: builder.getCacheKeyParams(),
       },
     );
   }

--- a/packages/odata-service/src/v4/EntityTypeServiceV4.ts
+++ b/packages/odata-service/src/v4/EntityTypeServiceV4.ts
@@ -2,6 +2,7 @@ import { ODataHttpClient, ODataHttpMethods } from "@odata2ts/http-client-api";
 import { ODataModelPayloadFor, ODataModelResponseFor, ODataVersionV4 } from "@odata2ts/odata-core";
 import { ModelQueryBuilderV4 } from "@odata2ts/odata-query-builder";
 import { ModelResponseConverterV4, QueryObjectModel } from "@odata2ts/odata-query-objects";
+import { buildDeepEditHops, CacheKeyState, withParams } from "../cacheKey/index.js";
 import { ODataServiceOptionsInternal } from "../ODataServiceOptions";
 import { UrlBuilderRequestCmdV4, UrlBuilderWriteRequestCmdV4, UrlWriteRequestCmd } from "../request";
 import { EntityModificationResponseV4 } from "./ResponseTypeChoicesV4";
@@ -22,12 +23,17 @@ export class EntityTypeServiceV4<T, UpdatableT, Q extends QueryObjectModel, V ex
     name: string,
     qModel: Q,
     options?: ODataServiceOptionsInternal<V>,
+    cacheKeyState?: CacheKeyState,
   ) {
-    this.__base = new ServiceStateHelperV4(client, basePath, name, qModel, options);
+    this.__base = new ServiceStateHelperV4(client, basePath, name, qModel, options, cacheKeyState);
   }
 
   public getPath() {
     return this.__base.path;
+  }
+
+  public getCacheKeyState() {
+    return this.__base.cacheKeyState;
   }
 
   /**
@@ -60,23 +66,30 @@ export class EntityTypeServiceV4<T, UpdatableT, Q extends QueryObjectModel, V ex
       getVersionHeaders,
       createModelQueryBuilder,
       getConcurrencyOptions,
+      cacheKeyState,
     } = this.__base;
     const { dontUseCastPathSegment, useTypeCi } = this.__base.evaluateSubtypeOptions(patchOptions);
 
     // add control info automatically, if required
     const data = useTypeCi ? this.__base.addTypeControlInfo(model) : model;
     const actualPath = dontUseCastPathSegment ? basePath : path;
+    const builder = createModelQueryBuilder(queryFn, actualPath);
+
+    const deepEditHops = cacheKeyState && buildDeepEditHops(cacheKeyState.qEntityFn, model);
+    const stateForRequest =
+      deepEditHops && cacheKeyState ? withParams(cacheKeyState, { deepEdit: deepEditHops }) : cacheKeyState;
 
     return new UrlBuilderWriteRequestCmdV4<
       EntityModificationResponseV4<Response, T, V>,
       Q,
       ModelQueryBuilderV4<Q>,
       ODataModelPayloadFor<V, Partial<UpdatableT>>
-    >(client, ODataHttpMethods.Patch, createModelQueryBuilder(queryFn, actualPath), qModel, data, {
+    >(client, ODataHttpMethods.Patch, builder, qModel, data, {
       headers: { ...getDefaultHeaders(), ...getVersionHeaders() },
       mainRequestConverter: qModel,
       mainResponseConverter: new ModelResponseConverterV4(qModel),
       concurrency: getConcurrencyOptions(),
+      cacheKeyState: stateForRequest,
     });
   }
 
@@ -110,12 +123,17 @@ export class EntityTypeServiceV4<T, UpdatableT, Q extends QueryObjectModel, V ex
       qModel,
       createModelQueryBuilder,
       getConcurrencyOptions,
+      cacheKeyState,
     } = this.__base;
     const { dontUseCastPathSegment, useTypeCi } = this.__base.evaluateSubtypeOptions(updateOptions);
 
     // add control info automatically, if required
     const data = useTypeCi ? this.__base.addTypeControlInfo(model) : model;
     const actualPath = dontUseCastPathSegment ? basePath : path;
+
+    const deepEditHops = cacheKeyState && buildDeepEditHops(cacheKeyState.qEntityFn, model);
+    const stateForRequest =
+      deepEditHops && cacheKeyState ? withParams(cacheKeyState, { deepEdit: deepEditHops }) : cacheKeyState;
 
     return new UrlBuilderWriteRequestCmdV4<
       EntityModificationResponseV4<Response, T, V>,
@@ -127,6 +145,7 @@ export class EntityTypeServiceV4<T, UpdatableT, Q extends QueryObjectModel, V ex
       mainRequestConverter: qModel,
       mainResponseConverter: new ModelResponseConverterV4(qModel),
       concurrency: getConcurrencyOptions(),
+      cacheKeyState: stateForRequest,
     });
   }
 
@@ -138,10 +157,11 @@ export class EntityTypeServiceV4<T, UpdatableT, Q extends QueryObjectModel, V ex
    * Spec: {@link https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html#sec_DeleteanEntity}
    */
   public delete() {
-    const { client, path, getDefaultHeaders, getConcurrencyOptions } = this.__base;
+    const { client, path, getDefaultHeaders, getConcurrencyOptions, cacheKeyState } = this.__base;
     return new UrlWriteRequestCmd<undefined>(client, ODataHttpMethods.Delete, path, undefined, {
       headers: getDefaultHeaders(),
       concurrency: getConcurrencyOptions(),
+      cacheKeyState,
     });
   }
 
@@ -153,18 +173,22 @@ export class EntityTypeServiceV4<T, UpdatableT, Q extends QueryObjectModel, V ex
    * @param queryFn provide the query logic with the help of the builder and the query-object
    */
   public query<ReturnType extends Partial<T> = T>(queryFn?: (builder: ModelQueryBuilderV4<Q>, qObject: Q) => void) {
-    const { client, qModel, createModelQueryBuilder, getDefaultHeaders, getConcurrencyOptions } = this.__base;
+    const { client, qModel, createModelQueryBuilder, getDefaultHeaders, getConcurrencyOptions, cacheKeyState } =
+      this.__base;
+    const builder = createModelQueryBuilder(queryFn);
 
     return new UrlBuilderRequestCmdV4<ODataModelResponseFor<V, ReturnType>, Q, ModelQueryBuilderV4<Q>>(
       client,
       ODataHttpMethods.Get,
-      createModelQueryBuilder(queryFn),
+      builder,
       qModel,
       undefined,
       {
         headers: getDefaultHeaders(),
         mainResponseConverter: new ModelResponseConverterV4(qModel),
         concurrency: getConcurrencyOptions(),
+        cacheKeyState,
+        queryParams: builder.getCacheKeyParams(),
       },
     );
   }

--- a/packages/odata-service/src/v4/MediaEntityServiceV4.ts
+++ b/packages/odata-service/src/v4/MediaEntityServiceV4.ts
@@ -34,16 +34,16 @@ export class MediaEntityServiceV4<
    * @param subtypeOptions opt the cast path segment back in
    */
   public content(subtypeOptions?: SubtypeOptions): StreamServiceV4<V> {
-    const { client, basePath, path, options } = this.__base;
+    const { client, basePath, path, options, cacheKeyState } = this.__base;
     const { dontUseCastPathSegment } = this.__base.evaluateSubtypeOptions(subtypeOptions);
     const actualPath = dontUseCastPathSegment ? basePath : path;
 
     // only the default is worth caching; anything else is a one-off request shape
     if (subtypeOptions) {
-      return new StreamServiceV4<V>(client, actualPath, VALUE_SEGMENT, options);
+      return new StreamServiceV4<V>(client, actualPath, VALUE_SEGMENT, options, cacheKeyState);
     }
     if (!this._content) {
-      this._content = new StreamServiceV4<V>(client, actualPath, VALUE_SEGMENT, options);
+      this._content = new StreamServiceV4<V>(client, actualPath, VALUE_SEGMENT, options, cacheKeyState);
     }
 
     return this._content;

--- a/packages/odata-service/src/v4/PrimitiveTypeServiceV4.ts
+++ b/packages/odata-service/src/v4/PrimitiveTypeServiceV4.ts
@@ -7,6 +7,7 @@ import {
   MainResponseConverter,
   ValueResponseConverterV4,
 } from "@odata2ts/odata-query-objects";
+import { CacheKeyState } from "../cacheKey/index.js";
 import { ODataServiceOptionsInternal } from "../ODataServiceOptions";
 import { UrlRequestCmd } from "../request";
 import { ServiceStateHelper } from "../ServiceStateHelper.js";
@@ -32,13 +33,18 @@ export class PrimitiveTypeServiceV4<T, V extends ODataVersionV4 = "4.0"> {
     name: string,
     converter: ValueConverter<any, any> = getIdentityConverter(),
     options?: ODataServiceOptionsInternal<V>,
+    cacheKeyState?: CacheKeyState,
   ) {
-    this.__base = new ServiceStateHelper(client, basePath, name, options);
+    this.__base = new ServiceStateHelper(client, basePath, name, options, cacheKeyState);
     this.__converter = converter;
   }
 
   public getPath() {
     return this.__base.path;
+  }
+
+  public getCacheKeyState() {
+    return this.__base.cacheKeyState;
   }
 
   /**
@@ -48,12 +54,13 @@ export class PrimitiveTypeServiceV4<T, V extends ODataVersionV4 = "4.0"> {
    * Requesting a `null` value actually results in 204 (No Content), so `data: undefined` and not `data: { value: undefined }`.
    */
   public getValue() {
-    const { client, path, getDefaultHeaders } = this.__base;
+    const { client, path, getDefaultHeaders, cacheKeyState } = this.__base;
     const converter = this.__converter;
 
     return new UrlRequestCmd<ODataValueResponseFor<V, T> | undefined>(client, ODataHttpMethods.Get, path, undefined, {
       headers: getDefaultHeaders(),
       mainResponseConverter: new ValueResponseConverterV4(converter),
+      cacheKeyState,
     });
   }
 
@@ -72,7 +79,7 @@ export class PrimitiveTypeServiceV4<T, V extends ODataVersionV4 = "4.0"> {
    * @param value
    */
   public updateValue<Response extends boolean = false>(value: T) {
-    const { client, path, getDefaultHeaders, getVersionHeaders } = this.__base;
+    const { client, path, getDefaultHeaders, getVersionHeaders, cacheKeyState } = this.__base;
     const converter = this.__converter;
 
     return new UrlRequestCmd<ValueModificationResponseV4<Response, T, V>, T>(
@@ -87,6 +94,7 @@ export class PrimitiveTypeServiceV4<T, V extends ODataVersionV4 = "4.0"> {
           ValueModificationResponseV4<Response, T, V>,
           T
         >,
+        cacheKeyState,
       },
     );
   }
@@ -98,7 +106,7 @@ export class PrimitiveTypeServiceV4<T, V extends ODataVersionV4 = "4.0"> {
    * The response should be 204 and no data.
    */
   public deleteValue() {
-    const { client, path } = this.__base;
-    return new UrlRequestCmd<undefined>(client, ODataHttpMethods.Delete, path);
+    const { client, path, cacheKeyState } = this.__base;
+    return new UrlRequestCmd<undefined>(client, ODataHttpMethods.Delete, path, undefined, { cacheKeyState });
   }
 }

--- a/packages/odata-service/src/v4/ServiceStateHelperV4.ts
+++ b/packages/odata-service/src/v4/ServiceStateHelperV4.ts
@@ -2,6 +2,7 @@ import { ODataHttpClient } from "@odata2ts/http-client-api";
 import { ODataModelPayloadFor, ODataVersionV4 } from "@odata2ts/odata-core";
 import { CollectionQueryBuilderV4, createQueryBuilderV4, ModelQueryBuilderV4 } from "@odata2ts/odata-query-builder";
 import { QueryObjectModel } from "@odata2ts/odata-query-objects";
+import { CacheKeyState } from "../cacheKey/index.js";
 import { getBodyETagV4 } from "../ETagExtraction.js";
 import { ODataServiceOptionsInternal } from "../ODataServiceOptions";
 import { ConcurrencyOptions } from "../request/RequestCmd.js";
@@ -22,8 +23,9 @@ export class ServiceStateHelperV4<
     name: string,
     public qModel: Q,
     options?: ODataServiceOptionsInternal<V>,
+    cacheKeyState?: CacheKeyState,
   ) {
-    super(client, basePath, name, options);
+    super(client, basePath, name, options, cacheKeyState);
   }
 
   public createQueryBuilder = (

--- a/packages/odata-service/test/ServiceStateHelper.test.ts
+++ b/packages/odata-service/test/ServiceStateHelper.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "vitest";
+import { rootState } from "../src/cacheKey/index.js";
 import { BIG_NUMBERS_HEADERS, DEFAULT_HEADERS } from "../src/RequestHeaders.js";
 import { ServiceStateHelper } from "../src/ServiceStateHelper";
 import { MockClient } from "./mock/MockClient";
+
+const MEDIUM = "Library.Catalog.Medium";
 
 describe("ServiceStateHelper tests", () => {
   const client = new MockClient(false);
@@ -73,5 +76,22 @@ describe("ServiceStateHelper tests", () => {
   test("isUrlNotEncoded", () => {
     expect(new ServiceStateHelper(client, "base").isUrlNotEncoded()).toBe(false);
     expect(new ServiceStateHelper(client, "base", "name", { noUrlEncoding: true }).isUrlNotEncoded()).toBe(true);
+  });
+
+  describe("cacheKeyState", () => {
+    test("it stores the state verbatim", () => {
+      const state = rootState(MEDIUM, "list");
+      expect(new ServiceStateHelper(client, "/root", "Media", {}, state).cacheKeyState).toBe(state);
+    });
+
+    test("it defaults to undefined and computes nothing", () => {
+      expect(new ServiceStateHelper(client, "/root", "Media").cacheKeyState).toBeUndefined();
+    });
+
+    test("it never derives the state from name or path", () => {
+      // `name` for a byId-created service is the rendered key predicate, which must never reach a key
+      const helper = new ServiceStateHelper(client, "/root", "Media(5)");
+      expect(helper.cacheKeyState).toBeUndefined();
+    });
   });
 });

--- a/packages/odata-service/test/cacheKey/BuildCacheKey.test.ts
+++ b/packages/odata-service/test/cacheKey/BuildCacheKey.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, test } from "vitest";
+import { buildCacheKey, buildInvalidates, hopState, rootState, withKey, withParams } from "../../src/cacheKey";
+
+const MEDIA = "Media";
+const COPIES = "Copies";
+const MEMBERS = "Members";
+const RESERVATIONS = "Reservations";
+const LOANS = "Loans";
+
+describe("buildCacheKey", () => {
+  test("an entity set collection", () => {
+    expect(buildCacheKey(rootState(MEDIA, "list"))).toEqual([MEDIA, "list"]);
+  });
+
+  test("query params become the trailing object", () => {
+    expect(buildCacheKey(rootState(MEDIA, "list"), { top: 10, select: ["Title"] })).toEqual([
+      MEDIA,
+      "list",
+      { top: 10, select: ["Title"] },
+    ]);
+  });
+
+  test("an empty params object is dropped entirely", () => {
+    expect(buildCacheKey(rootState(MEDIA, "list"), {})).toEqual([MEDIA, "list"]);
+    expect(buildCacheKey(rootState(MEDIA, "list"), undefined)).toEqual([MEDIA, "list"]);
+  });
+
+  test("an entity by key", () => {
+    expect(buildCacheKey(withKey(rootState(MEDIA, "list"), 5, { Id: 5 }))).toEqual([MEDIA, "detail", 5]);
+  });
+
+  test("a composite key travels as an object", () => {
+    const key = { MediumId: 5, InventoryNumber: 7 };
+    expect(buildCacheKey(withKey(rootState(COPIES, "list"), key, key))).toEqual([COPIES, "detail", key]);
+  });
+
+  test("a singleton - its own name is the root directly, no params marker needed", () => {
+    expect(buildCacheKey(rootState("MainBranch", "detail"))).toEqual(["MainBranch", "detail"]);
+  });
+
+  test("a cast is a params entry - the one place a type still legitimately appears, since it is a real URL segment", () => {
+    const state = withParams(rootState(MEDIA, "list"), { cast: "Library.Catalog.Book" });
+    expect(buildCacheKey(state)).toEqual([MEDIA, "list", { cast: "Library.Catalog.Book" }]);
+  });
+
+  test("a navigation hop is named by the property's own OData name, never a type", () => {
+    const state = hopState(withKey(rootState(MEDIA, "list"), 5, { Id: 5 }), {
+      name: "copies",
+      kind: "list",
+      entitySetName: COPIES,
+    });
+    expect(buildCacheKey(state)).toEqual([MEDIA, "detail", 5, "copies", "list"]);
+  });
+
+  test("the state's own params and the query params merge", () => {
+    const state = withParams(rootState(MEDIA, "list"), { cast: "Library.Catalog.Book" });
+    expect(buildCacheKey(state, { top: 10 })).toEqual([MEDIA, "list", { cast: "Library.Catalog.Book", top: 10 }]);
+  });
+
+  test("an unbound operation with no result entity set is rooted at the import's own name, never a type", () => {
+    const key = buildCacheKey(rootState("TotalMediaCount", "detail"));
+    expect(key).toEqual(["TotalMediaCount", "detail"]);
+  });
+
+  test("an unbound operation still carries its invocation params, nested under their own key", () => {
+    const key = buildCacheKey(rootState("Search", "list", { params: { params: { term: "Kafka" } } }));
+    expect(key).toEqual(["Search", "list", { params: { term: "Kafka" } }]);
+  });
+});
+
+describe("buildInvalidates", () => {
+  test("a write to a root entity: own key and own entity set, coarsest first", () => {
+    const state = withKey(rootState(MEDIA, "list", { entitySetName: MEDIA }), 5, { Id: 5 });
+    expect(buildInvalidates(state)).toEqual([
+      [MEDIA, "detail", 5],
+      [MEDIA, "list"],
+    ]);
+  });
+
+  test("the own key is taken without its params object", () => {
+    const state = withParams(withKey(rootState(MEDIA, "list", { entitySetName: MEDIA }), 5, { Id: 5 }), {
+      cast: "Library.Catalog.Book",
+    });
+    expect(buildInvalidates(state)).toContainEqual([MEDIA, "detail", 5]);
+  });
+
+  test("a hierarchical write's own key is a prefix-redundant with its ancestor, and drops out - the ancestor and the entity-set list entry are what remain", () => {
+    const copies = hopState(withKey(rootState(MEDIA, "list", { entitySetName: MEDIA }), 5, { Id: 5 }), {
+      name: "copies",
+      kind: "list",
+      entitySetName: COPIES,
+    });
+    const key = { MediumId: 5, InventoryNumber: 7 };
+    expect(buildInvalidates(withKey(copies, key, key))).toEqual([
+      [MEDIA, "detail", 5],
+      [COPIES, "list"],
+    ]);
+  });
+
+  test("a POST to a hierarchical collection: the own key without a key value is the ancestor plus the entity-set list", () => {
+    const copies = hopState(withKey(rootState(MEDIA, "list", { entitySetName: MEDIA }), 5, { Id: 5 }), {
+      name: "copies",
+      kind: "list",
+      entitySetName: COPIES,
+    });
+    expect(buildInvalidates(copies)).toEqual([
+      [MEDIA, "detail", 5],
+      [COPIES, "list"],
+    ]);
+  });
+
+  test("an entry another entry is a prefix of is dropped", () => {
+    const reservations = hopState(withKey(rootState(MEMBERS, "list", { entitySetName: MEMBERS }), 42, { Id: 42 }), {
+      name: "reservations",
+      kind: "list",
+      entitySetName: RESERVATIONS,
+    });
+    expect(buildInvalidates(withKey(reservations, 9, { Id: 9 }))).toEqual([
+      [MEMBERS, "detail", 42],
+      [RESERVATIONS, "list"],
+    ]);
+  });
+
+  test("a contained resource contributes no entity-set entry", () => {
+    const chapters = hopState(withKey(rootState(MEDIA, "list", { entitySetName: MEDIA }), 1, { Id: 1 }), {
+      name: "chapters",
+      kind: "list",
+    });
+    expect(buildInvalidates(withKey(chapters, 3, { Id: 3 }))).toEqual([[MEDIA, "detail", 1]]);
+  });
+
+  test("two structurally equal key objects built independently compare as one entry", () => {
+    // the prefix/dedup rule compares key elements by value, not by reference - two objects with the
+    // same entries in a different insertion order are the same key
+    const state = withKey(
+      rootState(COPIES, "list", { entitySetName: COPIES }),
+      { MediumId: 5, InventoryNumber: 7 },
+      { MediumId: 5, InventoryNumber: 7 },
+    );
+    const withOtherOrder = { ...state, ancestors: [[COPIES, "detail", { InventoryNumber: 7, MediumId: 5 }]] };
+    expect(buildInvalidates(withOtherOrder as typeof state)).toEqual([
+      [COPIES, "detail", { InventoryNumber: 7, MediumId: 5 }],
+      [COPIES, "list"],
+    ]);
+  });
+
+  test("deepEdit params contribute an additional bare entity-set entry per deep-inserted set", () => {
+    const state = withParams(rootState(MEMBERS, "list", { entitySetName: MEMBERS }), {
+      deepEdit: [LOANS],
+    });
+    expect(buildInvalidates(state)).toEqual([
+      [MEMBERS, "list"],
+      [LOANS, "list"],
+    ]);
+  });
+
+  test("a deepEdit hop matching the write's own entity set collapses via the existing redundancy pass", () => {
+    const state = withParams(rootState(MEMBERS, "list", { entitySetName: MEMBERS }), {
+      deepEdit: [MEMBERS],
+    });
+    expect(buildInvalidates(state)).toEqual([[MEMBERS, "list"]]);
+  });
+
+  test("multiple different deepEdit hops each contribute their own entry", () => {
+    expect(
+      buildInvalidates(
+        withParams(rootState(MEMBERS, "list", { entitySetName: MEMBERS }), {
+          deepEdit: [LOANS, RESERVATIONS],
+        }),
+      ),
+    ).toEqual([
+      [MEMBERS, "list"],
+      [LOANS, "list"],
+      [RESERVATIONS, "list"],
+    ]);
+  });
+
+  test("crossRouteKeys - a route to this same resource resolved via ResourceIdentityHandler - are added alongside the route-derived entries", () => {
+    const state = withKey(rootState(MEDIA, "list", { entitySetName: MEDIA }), 5, { Id: 5 });
+    const crossRoute = ["Library.Circulation.Loan", "detail", 1, "medium", "detail", 5];
+    expect(buildInvalidates(state, [crossRoute])).toEqual([[MEDIA, "detail", 5], [MEDIA, "list"], crossRoute]);
+  });
+
+  test("a crossRouteKey identical to an already-listed entry collapses via the same redundancy pass", () => {
+    const state = withKey(rootState(MEDIA, "list", { entitySetName: MEDIA }), 5, { Id: 5 });
+    expect(buildInvalidates(state, [[MEDIA, "list"]])).toEqual([
+      [MEDIA, "detail", 5],
+      [MEDIA, "list"],
+    ]);
+  });
+
+  test("no crossRouteKeys given: behaves exactly as before", () => {
+    const state = withKey(rootState(MEDIA, "list", { entitySetName: MEDIA }), 5, { Id: 5 });
+    expect(buildInvalidates(state)).toEqual(buildInvalidates(state, []));
+  });
+});

--- a/packages/odata-service/test/cacheKey/BuildDeepEdit.test.ts
+++ b/packages/odata-service/test/cacheKey/BuildDeepEdit.test.ts
@@ -1,0 +1,109 @@
+import { QBinding, QEntityCollectionPath, QEntityPath, QId, QueryObject } from "@odata2ts/odata-query-objects";
+import { describe, expect, test } from "vitest";
+import { buildDeepEditHops, QEntityFn } from "../../src/cacheKey";
+
+/** A binding whose only use here is `getEntitySetName()` - a real `QId` is more machinery than this needs. */
+function bindingTo(entitySetName: string): QBinding<any> {
+  return new QBinding(() => ({ getName: () => entitySetName }) as unknown as QId<any>, "4.0");
+}
+
+class QCopy extends QueryObject {}
+class QReservation extends QueryObject {}
+class QIdDocument extends QueryObject {}
+
+class QLoan extends QueryObject {
+  public readonly Copy = new QEntityPath(this.withPrefix("Copy"), () => QCopy, bindingTo("Copies"));
+}
+
+class QMember extends QueryObject {
+  public readonly Loans = new QEntityCollectionPath(this.withPrefix("Loans"), () => QLoan, bindingTo("Loans"));
+  public readonly Reservations = new QEntityCollectionPath(
+    this.withPrefix("Reservations"),
+    () => QReservation,
+    bindingTo("Reservations"),
+  );
+  public readonly IdDocument = new QEntityPath(
+    this.withPrefix("IdDocument"),
+    () => QIdDocument,
+    bindingTo("IdDocuments"),
+  );
+}
+
+/** A nav property with no `QBinding` at all - the shape a contained navigation property's Q-object gets. */
+class QChapter extends QueryObject {}
+class QMediumContainedOnly extends QueryObject {
+  public readonly Chapters = new QEntityCollectionPath(this.withPrefix("Chapters"), () => QChapter);
+}
+
+/** A naming strategy has renamed the TS-facing field away from the OData wire name entirely. */
+class QTrip extends QueryObject {}
+class QPersonWithMappedName extends QueryObject {
+  public readonly friends = new QEntityCollectionPath(this.withPrefix("Friends"), () => QTrip, bindingTo("Trips"));
+}
+
+const qMember: QEntityFn = () => QMember as any;
+const qMediumContainedOnly: QEntityFn = () => QMediumContainedOnly as any;
+const qPersonWithMappedName: QEntityFn = () => QPersonWithMappedName as any;
+
+describe("buildDeepEditHops", () => {
+  test("no Q-object factory at all (e.g. an operation root): undefined", () => {
+    expect(buildDeepEditHops(undefined, { Name: "x" })).toBeUndefined();
+  });
+
+  test("no nav properties in the payload: undefined", () => {
+    expect(buildDeepEditHops(qMember, { Name: "x" })).toBeUndefined();
+  });
+
+  test("a plain deep insert contributes its entity set's name", () => {
+    const data = { Name: "x", Loans: [{ LoanedAt: "2026-01-01" }] };
+    expect(buildDeepEditHops(qMember, data)).toEqual(["Loans"]);
+  });
+
+  test('a binding ({"@id": key}) is not a deep insert and contributes nothing', () => {
+    const data = { Name: "x", Loans: [{ "@id": 5 }] };
+    expect(buildDeepEditHops(qMember, data)).toBeUndefined();
+  });
+
+  test("a mix of a binding and a real deep insert in the same to-many array: only the real one counts", () => {
+    const data = { Loans: [{ "@id": 5 }, { LoanedAt: "2026-01-01" }] };
+    expect(buildDeepEditHops(qMember, data)).toEqual(["Loans"]);
+  });
+
+  test("recurses into a nested deep insert, following the nav property's own Q-object factory", () => {
+    const data = { Loans: [{ LoanedAt: "2026-01-01", Copy: { Condition: 3 } }] };
+    expect(buildDeepEditHops(qMember, data)).toEqual(["Loans", "Copies"]);
+  });
+
+  test("a to-one deep insert (single object, not an array) is found too", () => {
+    const data = { IdDocument: { Number: "x" } };
+    expect(buildDeepEditHops(qMember, data)).toEqual(["IdDocuments"]);
+  });
+
+  test("the payload is indexed by the property's own declared field name, not its OData wire name - a naming strategy may have mapped the two apart", () => {
+    // the field is declared "friends" but its wire name (withPrefix) is "Friends" - the payload, being
+    // the TS-facing editable model, only ever has "friends"
+    const data = { friends: [{ Name: "x" }] };
+    expect(buildDeepEditHops(qPersonWithMappedName, data)).toEqual(["Trips"]);
+  });
+
+  test("a contained navigation property (no QBinding) is walked for further deep inserts but contributes no entity-set entry of its own", () => {
+    const data = { Chapters: [{ Title: "x" }] };
+    expect(buildDeepEditHops(qMediumContainedOnly, data)).toBeUndefined();
+  });
+
+  test("multiple deep-inserted nav properties each contribute their own entry", () => {
+    const data = { Loans: [{ LoanedAt: "x" }], Reservations: [{ ReservedAt: "y" }] };
+    expect(buildDeepEditHops(qMember, data)).toEqual(["Loans", "Reservations"]);
+  });
+
+  test("null/undefined payload contributes nothing", () => {
+    expect(buildDeepEditHops(qMember, undefined)).toBeUndefined();
+    expect(buildDeepEditHops(qMember, null)).toBeUndefined();
+  });
+
+  test("a self-referential structure does not loop forever", () => {
+    const cyclical: any = { Name: "x" };
+    cyclical.Loans = [cyclical];
+    expect(() => buildDeepEditHops(qMember, cyclical)).not.toThrow();
+  });
+});

--- a/packages/odata-service/test/cacheKey/CacheKeyState.test.ts
+++ b/packages/odata-service/test/cacheKey/CacheKeyState.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from "vitest";
+import { CanonicalIdFn, hopState, QEntityFn, rootState, withKey, withParams } from "../../src/cacheKey";
+
+const MEDIA = "Media";
+const COPIES = "Copies";
+const CHAPTERS = "chapters";
+
+// a stand-in for a real Q-object factory: CacheKeyState never inspects its contents, only threads it
+// forward, so identity comparison (toBe) is all any test here needs
+const qMedium = (() => class {}) as unknown as QEntityFn;
+const qCopy = (() => class {}) as unknown as QEntityFn;
+
+// a stand-in for a generated `(key) => new QMediumId("Media").buildUrl(key)` closure
+const canonicalIdOfMedia: CanonicalIdFn = (key: any) => `Media(${key.Id})`;
+const canonicalIdOfCopies: CanonicalIdFn = (key: any) => `Copies(${key.Id})`;
+
+describe("CacheKeyState", () => {
+  test("a bare root has no entity set and no Q-object factory of its own - the singleton shape", () => {
+    expect(rootState(MEDIA, "list")).toEqual({
+      name: MEDIA,
+      steps: ["list"],
+      kindIndex: 0,
+    });
+  });
+
+  test("a root carries the entity set name, canonical id builder and Q-object factory it is given", () => {
+    expect(
+      rootState(MEDIA, "list", { entitySetName: MEDIA, canonicalIdFn: canonicalIdOfMedia, qEntityFn: qMedium }),
+    ).toEqual({
+      name: MEDIA,
+      steps: ["list"],
+      kindIndex: 0,
+      entitySetName: MEDIA,
+      canonicalIdFn: canonicalIdOfMedia,
+      qEntityFn: qMedium,
+    });
+  });
+
+  test("a root carries params where given", () => {
+    const state = rootState(MEDIA, "detail", { params: { singleton: "MainBranch" } });
+    expect(state.params).toEqual({ singleton: "MainBranch" });
+  });
+
+  test("withKey rewrites the trailing kind marker, appends the typed key, and stores the given id for canonical-id purposes", () => {
+    const state = withKey(rootState(MEDIA, "list"), 5, 5);
+    expect(state.steps).toEqual(["detail", 5]);
+    expect(state.key).toBe(5);
+  });
+
+  test("withKey on a composite key appends the object and stores it as the id too", () => {
+    const key = { mediumId: 5, inventoryNumber: 7 };
+    const state = withKey(rootState(COPIES, "list"), key, key);
+    expect(state.steps).toEqual(["detail", key]);
+    expect(state.key).toBe(key);
+  });
+
+  test("withKey pushes no ancestor - it refines the resource, it does not leave it", () => {
+    expect(withKey(rootState(MEDIA, "list"), 5, { Id: 5 }).ancestors).toBeUndefined();
+  });
+
+  test("withKey carries params forward unchanged - there is no derived filter to drop any more", () => {
+    const cast = withParams(rootState(COPIES, "list"), { cast: "Library.Catalog.Book" });
+    const state = withKey(cast, { MediumId: 5, InventoryNumber: 7 }, { MediumId: 5, InventoryNumber: 7 });
+    expect(state.params).toEqual({ cast: "Library.Catalog.Book" });
+  });
+
+  test("withParams merges into the resource's own params and pushes no ancestor", () => {
+    const state = withParams(rootState(MEDIA, "list"), { cast: "Library.Catalog.Book" });
+    expect(state.params).toEqual({ cast: "Library.Catalog.Book" });
+    expect(state.ancestors).toBeUndefined();
+  });
+
+  test("a hop appends its own name and kind, and pushes the resource it leaves as an ancestor", () => {
+    const parent = withKey(rootState(MEDIA, "list"), 5, { Id: 5 });
+    const state = hopState(parent, {
+      name: COPIES.toLowerCase(),
+      kind: "list",
+      entitySetName: COPIES,
+      canonicalIdFn: canonicalIdOfCopies,
+      qEntityFn: qCopy,
+    });
+
+    expect(state.name).toBe(MEDIA);
+    expect(state.steps).toEqual(["detail", 5, "copies", "list"]);
+    expect(state.ancestors).toEqual([[MEDIA, "detail", 5]]);
+    expect(state.entitySetName).toBe(COPIES);
+    expect(state.canonicalIdFn).toBe(canonicalIdOfCopies);
+    expect(state.qEntityFn).toBe(qCopy);
+    expect(state.key).toBeUndefined();
+  });
+
+  test("an ancestor is pushed without its params object", () => {
+    const parent = withParams(withKey(rootState(MEDIA, "list"), 5, { Id: 5 }), { cast: "Library.Catalog.Book" });
+    const state = hopState(parent, { name: "copies", kind: "list", entitySetName: COPIES });
+    expect(state.ancestors).toEqual([[MEDIA, "detail", 5]]);
+  });
+
+  test("a hop to a contained property has no entity set, so entitySetName and canonicalIdFn stay undefined", () => {
+    const parent = withKey(rootState(MEDIA, "list"), 1, { Id: 1 });
+    const state = hopState(parent, { name: CHAPTERS, kind: "list" });
+    expect(state.entitySetName).toBeUndefined();
+    expect(state.canonicalIdFn).toBeUndefined();
+  });
+
+  test("a hop without a Q-object factory carries the parent's forward - it stays inert unless something reads it", () => {
+    const parent = withKey(rootState(MEDIA, "list", { qEntityFn: qMedium }), 5, { Id: 5 });
+    const state = hopState(parent, { name: "details", kind: "detail" });
+    expect(state.qEntityFn).toBe(qMedium);
+  });
+
+  test("a hop's own Q-object factory replaces the parent's", () => {
+    const parent = withKey(rootState(MEDIA, "list", { qEntityFn: qMedium }), 5, { Id: 5 });
+    const state = hopState(parent, { name: "copies", kind: "list", qEntityFn: qCopy });
+    expect(state.qEntityFn).toBe(qCopy);
+  });
+
+  test("a route continues hierarchically through several hops", () => {
+    const media = withKey(rootState(MEDIA, "list"), 5, { Id: 5 });
+    const copies = hopState(media, { name: "copies", kind: "list", entitySetName: COPIES });
+    const copy = withKey(copies, { MediumId: 5, InventoryNumber: 7 }, { MediumId: 5, InventoryNumber: 7 });
+    const condition = hopState(copy, { name: "condition", kind: "detail" });
+
+    expect(condition.name).toBe(MEDIA);
+    expect(condition.steps).toEqual([
+      "detail",
+      5,
+      "copies",
+      "detail",
+      { MediumId: 5, InventoryNumber: 7 },
+      "condition",
+      "detail",
+    ]);
+    expect(condition.ancestors).toEqual([
+      [MEDIA, "detail", 5],
+      [MEDIA, "detail", 5, "copies", "detail", { MediumId: 5, InventoryNumber: 7 }],
+    ]);
+  });
+
+  test("a primitive hop is the bare name, with no kind", () => {
+    const parent = withKey(rootState("IdDocuments", "list"), "x", { Id: "x" });
+    const state = hopState(parent, { name: "scan" });
+    expect(state.steps).toEqual(["detail", "x", "scan"]);
+  });
+
+  test("a stream value appends $value", () => {
+    const parent = withKey(rootState("IdDocuments", "list"), "x", { Id: "x" });
+    const state = hopState(hopState(parent, { name: "scan" }), { name: "$value" });
+    expect(state.steps).toEqual(["detail", "x", "scan", "$value"]);
+  });
+
+  test("withKey after a hop keeps the navigation property's own name", () => {
+    const parent = withKey(rootState(MEDIA, "list"), 5, { Id: 5 });
+    const copies = hopState(parent, { name: "copies", kind: "list", entitySetName: COPIES });
+    const state = withKey(copies, 7, { InventoryNumber: 7 });
+    expect(state.steps).toEqual(["detail", 5, "copies", "detail", 7]);
+  });
+
+  test("two sibling navigations of the same target entity set do not collide - each keeps its own name", () => {
+    const parent = withKey(rootState(MEDIA, "list"), 5, { Id: 5 });
+    const primary = withKey(hopState(parent, { name: "copies", kind: "list", entitySetName: COPIES }), 3, {
+      InventoryNumber: 3,
+    });
+    const backup = withKey(hopState(parent, { name: "backupCopies", kind: "list", entitySetName: COPIES }), 3, {
+      InventoryNumber: 3,
+    });
+    expect(primary.steps).not.toEqual(backup.steps);
+  });
+
+  test("a primitive hop does not move the kind index", () => {
+    const parent = withKey(rootState("IdDocuments", "list"), "x", { Id: "x" });
+    const state = hopState(parent, { name: "scan" });
+    expect(state.kindIndex).toBe(parent.kindIndex);
+  });
+
+  test("a structured hop puts the kind index at the end, not two-from-the-end - there is no name slot after it any more", () => {
+    const parent = withKey(rootState(MEDIA, "list"), 5, { Id: 5 });
+    const state = hopState(parent, { name: "copies", kind: "list", entitySetName: COPIES });
+    expect(state.kindIndex).toBe(state.steps.length - 1);
+    expect(state.steps[state.kindIndex]).toBe("list");
+  });
+});

--- a/packages/odata-service/test/cacheKey/ObservedIdentity.test.ts
+++ b/packages/odata-service/test/cacheKey/ObservedIdentity.test.ts
@@ -1,0 +1,176 @@
+import { QBinding, QEntityCollectionPath, QId, QNumberParam, QueryObject } from "@odata2ts/odata-query-objects";
+import { describe, expect, test } from "vitest";
+import { CacheKeyState, recordObservedIdentities, resolveCrossRouteInvalidates, rootState } from "../../src/cacheKey";
+import { MockResourceIdentityHandler } from "../mock/MockClient";
+
+class QCopyId extends QId<any> {
+  getParams() {
+    return [new QNumberParam("Id", "id")];
+  }
+}
+class QMediumId extends QId<any> {
+  getParams() {
+    return [new QNumberParam("Id", "id")];
+  }
+}
+
+class QCopy extends QueryObject {}
+class QMedium extends QueryObject {
+  public readonly copies = new QEntityCollectionPath(
+    this.withPrefix("Copies"),
+    () => QCopy,
+    new QBinding(() => new QCopyId("Copies"), "4.0"),
+  );
+}
+
+/** A contained nav property has no QBinding, so no entity set and no canonical id of its own. */
+class QChapter extends QueryObject {}
+class QMediumWithContainedChapters extends QueryObject {
+  public readonly chapters = new QEntityCollectionPath(this.withPrefix("Chapters"), () => QChapter);
+}
+
+function mediaState(overrides: Partial<CacheKeyState> = {}): CacheKeyState {
+  return {
+    ...rootState("Media", "detail", {
+      entitySetName: "Media",
+      canonicalIdFn: (entity) => new QMediumId("Media").buildCanonicalId(entity),
+      qEntityFn: () => QMedium as any,
+    }),
+    ...overrides,
+  };
+}
+
+describe("recordObservedIdentities", () => {
+  test("no resourceIdentity: harmless", () => {
+    expect(() => recordObservedIdentities(undefined, ["Media", "detail", 5], mediaState(), { id: 5 })).not.toThrow();
+  });
+
+  test("no hierarchical key (e.g. cacheKeys off): nothing recorded", () => {
+    const handler = new MockResourceIdentityHandler();
+    recordObservedIdentities(handler, undefined, mediaState(), { id: 5 });
+    expect(handler.store.size).toBe(0);
+  });
+
+  test("records the directly addressed resource itself", () => {
+    const handler = new MockResourceIdentityHandler();
+    const key = ["Media", "detail", 5];
+    recordObservedIdentities(handler, key, mediaState(), { id: 5, title: "The Trial" });
+    expect(handler.resolve("Media(5)")).toEqual([key]);
+  });
+
+  test("records every row of a list response, against the same key", () => {
+    // a real V4/V2 collection response is `{value: [...]}`, never a bare array itself
+    const handler = new MockResourceIdentityHandler();
+    const key = ["Media", "list"];
+    recordObservedIdentities(handler, key, mediaState({ entitySetName: "Media" }), {
+      value: [{ id: 1 }, { id: 2 }],
+    });
+    expect(handler.resolve("Media(1)")).toEqual([key]);
+    expect(handler.resolve("Media(2)")).toEqual([key]);
+  });
+
+  test("records every row of a V2-wrapped list response too (`{d: {results: [...]}}`)", () => {
+    const handler = new MockResourceIdentityHandler();
+    const key = ["Media", "list"];
+    recordObservedIdentities(handler, key, mediaState({ entitySetName: "Media" }), {
+      d: { results: [{ id: 1 }, { id: 2 }] },
+    });
+    expect(handler.resolve("Media(1)")).toEqual([key]);
+    expect(handler.resolve("Media(2)")).toEqual([key]);
+  });
+
+  test("records every row of a `{results: [...]}` list response too (V2 with the `d` envelope already stripped)", () => {
+    const handler = new MockResourceIdentityHandler();
+    const key = ["Media", "list"];
+    recordObservedIdentities(handler, key, mediaState({ entitySetName: "Media" }), {
+      results: [{ id: 1 }],
+    });
+    expect(handler.resolve("Media(1)")).toEqual([key]);
+  });
+
+  test("records every $expand'd entity too, at the same outer key - not a synthesized one", () => {
+    const handler = new MockResourceIdentityHandler();
+    const key = ["Media", "detail", 5, { expand: [["copies", "list"]] }];
+    recordObservedIdentities(handler, key, mediaState(), { id: 5, copies: [{ id: 1 }, { id: 2 }] });
+    expect(handler.resolve("Media(5)")).toEqual([key]);
+    expect(handler.resolve("Copies(1)")).toEqual([key]);
+    expect(handler.resolve("Copies(2)")).toEqual([key]);
+  });
+
+  test("a contained resource is never recorded - no canonicalIdFn, nothing to record against", () => {
+    const handler = new MockResourceIdentityHandler();
+    const state = mediaState({ qEntityFn: () => QMediumWithContainedChapters as any });
+    recordObservedIdentities(handler, ["Media", "detail", 5, "chapters", "list"], state, {
+      chapters: [{ id: 1 }],
+    });
+    expect(handler.store.size).toBe(0);
+  });
+
+  test("a row missing its key property is not recorded", () => {
+    const handler = new MockResourceIdentityHandler();
+    recordObservedIdentities(handler, ["Media", "detail", 5], mediaState(), { title: "no id here" });
+    expect(handler.store.size).toBe(0);
+  });
+});
+
+describe("resolveCrossRouteInvalidates", () => {
+  test("no resourceIdentity: nothing to resolve", () => {
+    expect(resolveCrossRouteInvalidates(undefined, mediaState(), { id: 5 })).toEqual([]);
+  });
+
+  test("no canonicalIdFn (a contained resource): nothing to resolve", () => {
+    const handler = new MockResourceIdentityHandler();
+    const state: CacheKeyState = { ...mediaState(), canonicalIdFn: undefined };
+    expect(resolveCrossRouteInvalidates(handler, state, { id: 5 })).toEqual([]);
+  });
+
+  test("uses state.key when present - a PATCH/DELETE with no response body still resolves", () => {
+    const handler = new MockResourceIdentityHandler();
+    const otherRoute = ["SomeOther", "detail", 9, "media", "detail", 5];
+    handler.record("Media(5)", otherRoute);
+
+    const state = mediaState({ key: 5 });
+    expect(resolveCrossRouteInvalidates(handler, state, undefined)).toEqual([otherRoute]);
+  });
+
+  test("falls back to the response body when state.key is absent - a POST's server-assigned id", () => {
+    const handler = new MockResourceIdentityHandler();
+    const otherRoute = ["SomeOther", "detail", 9, "media", "detail", 5];
+    handler.record("Media(5)", otherRoute);
+
+    const state = mediaState();
+    expect(resolveCrossRouteInvalidates(handler, state, { id: 5, title: "The Trial" })).toEqual([otherRoute]);
+  });
+
+  test("unwraps a V2 `{d: {...}}` envelope before reading the response body's server-assigned id", () => {
+    const handler = new MockResourceIdentityHandler();
+    const otherRoute = ["SomeOther", "detail", 9, "media", "detail", 5];
+    handler.record("Media(5)", otherRoute);
+
+    const state = mediaState();
+    expect(resolveCrossRouteInvalidates(handler, state, { d: { id: 5, title: "The Trial" } })).toEqual([otherRoute]);
+  });
+
+  test("state.key wins over the response body when both are present", () => {
+    const handler = new MockResourceIdentityHandler();
+    const otherRoute = ["SomeOther", "detail", 9, "media", "detail", 5];
+    handler.record("Media(5)", otherRoute);
+
+    const state = mediaState({ key: 5 });
+    // the response body names a different id entirely - state.key must be what actually gets resolved
+    expect(resolveCrossRouteInvalidates(handler, state, { id: 999 })).toEqual([otherRoute]);
+  });
+
+  test("a list body resolves nothing - a collection response names no single resource", () => {
+    const handler = new MockResourceIdentityHandler();
+    handler.record("Media(5)", ["SomeOther", "detail", 9]);
+
+    const state = mediaState();
+    expect(resolveCrossRouteInvalidates(handler, state, [{ id: 5 }])).toEqual([]);
+  });
+
+  test("nothing recorded for this canonical id yet: an empty array, not undefined", () => {
+    const handler = new MockResourceIdentityHandler();
+    expect(resolveCrossRouteInvalidates(handler, mediaState({ key: 5 }), undefined)).toEqual([]);
+  });
+});

--- a/packages/odata-service/test/cacheKey/ServiceThreading.test.ts
+++ b/packages/odata-service/test/cacheKey/ServiceThreading.test.ts
@@ -1,0 +1,114 @@
+import { ODataHttpClient } from "@odata2ts/http-client-api";
+import { QId, QNumberParam } from "@odata2ts/odata-query-objects";
+import { describe, expect, test } from "vitest";
+import { CacheKeyState, EntitySetServiceV4, EntityTypeServiceV4, ODataServiceOptionsInternal } from "../../src";
+import { rootState } from "../../src/cacheKey/index.js";
+import {
+  EditableTestModel,
+  qTest,
+  QTest,
+  QTestIdFunction,
+  QTestIdWithAlternateKeyFunction,
+  TestModel,
+  TestModelId,
+  TestModelIdWithAlternateKey,
+} from "../fixture/v4/TypingModelService";
+import { MockClient } from "../mock/MockClient";
+
+const MEDIUM = "Library.Catalog.Medium";
+const COPY = "Library.Catalog.Copy";
+
+type TestEntityService = EntityTypeServiceV4<TestModel, EditableTestModel, QTest, "4.0">;
+
+/**
+ * A minimal `EntitySetServiceV4` around a given id function, built here rather than via the shared
+ * `TestCollectionService`/`TestCollectionServiceWithAlternateKey` fixtures: neither fixture's constructor
+ * forwards a `cacheKeyState`, and reshaping them to do so would touch fixtures other tests already rely on.
+ * `createEntityService` just needs to hand the state to *some* entity-type service, so a bare
+ * `EntityTypeServiceV4` does the job without a fixture-specific subclass.
+ */
+class TestSetService<EIdType> extends EntitySetServiceV4<
+  TestModel,
+  EditableTestModel,
+  QTest,
+  EIdType,
+  TestEntityService
+> {
+  constructor(
+    client: ODataHttpClient,
+    basePath: string,
+    name: string,
+    idFunction: QId<EIdType>,
+    cacheKeyState?: CacheKeyState,
+  ) {
+    super(client, basePath, name, qTest, idFunction, undefined, cacheKeyState);
+  }
+
+  protected createEntityService(
+    client: ODataHttpClient,
+    path: string,
+    name: string,
+    options: ODataServiceOptionsInternal<"4.0"> | undefined,
+    cacheKeyState?: CacheKeyState,
+  ): TestEntityService {
+    return new EntityTypeServiceV4(client, path, name, qTest, options, cacheKeyState);
+  }
+}
+
+/**
+ * A composite primary key, constructed here rather than borrowed from a shared fixture: no fixture in
+ * this package declares a multi-property primary key.
+ */
+type CompositeId = { mediumId: number; inventoryNumber: number };
+
+class QCompositeIdFunction extends QId<CompositeId> {
+  getParams() {
+    return [new QNumberParam("MediumId", "mediumId"), new QNumberParam("InventoryNumber", "inventoryNumber")];
+  }
+}
+
+describe("byId produces the typed key, not the rendered predicate", () => {
+  const client = new MockClient(false);
+
+  test("a single key travels bare", () => {
+    const service = new TestSetService<TestModelId>(
+      client,
+      "/root",
+      "Media",
+      new QTestIdFunction("Media"),
+      rootState(MEDIUM, "list"),
+    );
+
+    expect(service.byId("5").getCacheKeyState()!.steps).toEqual(["detail", 5]);
+  });
+
+  test("a composite key travels as an object of OData names", () => {
+    const service = new TestSetService<CompositeId>(
+      client,
+      "/root",
+      "Copies",
+      new QCompositeIdFunction("Copies"),
+      rootState(COPY, "list"),
+    );
+
+    const id = { mediumId: 5, inventoryNumber: 7 };
+    const state = service.byId(id).getCacheKeyState()!;
+    expect(state.steps).toEqual(["detail", { MediumId: 5, InventoryNumber: 7 }]);
+    // .key stores the id exactly as byId received it - mapped names, for canonical-id purposes - not the
+    // OData-named form .steps carries
+    expect(state.key).toBe(id);
+  });
+
+  test("an alternate key travels as its own object", () => {
+    const service = new TestSetService<TestModelIdWithAlternateKey>(
+      client,
+      "/root",
+      "Media",
+      new QTestIdWithAlternateKeyFunction("Media"),
+      rootState(MEDIUM, "list"),
+    );
+
+    const state = service.byId({ name: "978-3" }).getCacheKeyState()!;
+    expect(state.steps).toEqual(["detail", { NAME: "978-3" }]);
+  });
+});

--- a/packages/odata-service/test/cacheKey/TouchesResource.test.ts
+++ b/packages/odata-service/test/cacheKey/TouchesResource.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "vitest";
+import { touchesResource } from "../../src/cacheKey";
+
+const MEDIA = "Media";
+const MEMBERS = "Members";
+const COPIES = "Copies";
+
+describe("touchesResource - array needle, top level", () => {
+  test("a root-shaped needle matches itself exactly", () => {
+    expect(touchesResource([MEDIA, "detail", 5], [MEDIA, "detail", 5])).toBe(true);
+  });
+
+  test("a root-shaped needle matches as a plain prefix", () => {
+    const key = [MEDIA, "detail", 5, "copies", "list"];
+    expect(touchesResource([MEDIA, "detail", 5], key)).toBe(true);
+  });
+
+  test("a composite key object matches by value, not by reference", () => {
+    const key = [COPIES, "detail", { MediumId: 5, InventoryNumber: 7 }];
+    expect(touchesResource([COPIES, "detail", { InventoryNumber: 7, MediumId: 5 }], key)).toBe(true);
+  });
+
+  test("a bare entity-set list entry reaches a nested hop only where the hop's own name happens to match", () => {
+    // this is the sharper, name-based replacement for the old coarse by-type reach: it only finds a hop
+    // whose own navigation-property name coincides with the entity set's name - there is no generated
+    // table to bridge the two where they differ, that job belongs to ResourceIdentityHandler instead
+    const key = ["Library.Circulation.Loan", "detail", 1, "copies", "list"];
+    expect(touchesResource(["copies", "list"], key)).toBe(true);
+    expect(touchesResource([COPIES, "list"], key)).toBe(false);
+  });
+
+  test("a detail needle does not match a list occurrence of the same name", () => {
+    const key = ["Library.Circulation.Loan", "detail", 1, "copies", "list"];
+    expect(touchesResource(["copies", "detail", 7], key)).toBe(false);
+  });
+
+  test("a specific-key needle reaches the same entity addressed as a hop under an unrelated parent", () => {
+    // /SomeOther(9)/Copies(MediumId=5,InventoryNumber=7) - a completely different route to the very
+    // same Copy this write's own key names, reachable because the hop's own name happens to be "Copies"
+    const key = ["Library.Circulation.SomeOther", "detail", 9, "Copies", "detail", { MediumId: 5, InventoryNumber: 7 }];
+    expect(touchesResource([COPIES, "detail", { MediumId: 5, InventoryNumber: 7 }], key)).toBe(true);
+  });
+
+  test("a specific-key needle does not match a different key reached the same way", () => {
+    const key = ["Library.Circulation.SomeOther", "detail", 9, "Copies", "detail", { MediumId: 5, InventoryNumber: 7 }];
+    expect(touchesResource([COPIES, "detail", { MediumId: 9, InventoryNumber: 1 }], key)).toBe(false);
+  });
+
+  test("a to-one hop with no addressed key of its own is not reachable by a keyed needle", () => {
+    // /Copies(...)/Medium hierarchical: the hop only ever carries its own name and kind - never the
+    // target's own key - so no needle carrying a key value can match it
+    const key = [COPIES, "detail", { MediumId: 5, InventoryNumber: 7 }, "medium", "detail"];
+    expect(touchesResource([MEDIA, "detail", 5], key)).toBe(false);
+  });
+
+  test("an unrelated name does not match", () => {
+    expect(touchesResource([MEMBERS, "list"], [MEDIA, "list"])).toBe(false);
+  });
+
+  test("an empty key matches nothing", () => {
+    expect(touchesResource([MEDIA, "detail", 5], [])).toBe(false);
+  });
+});
+
+describe("touchesResource - expand entries, buried inside the trailing params object", () => {
+  test("finds a hop-shaped expand entry, exactly or by prefix", () => {
+    const key = [MEDIA, "detail", 5, { expand: [["copies", "list"]] }];
+    expect(touchesResource(["copies", "list"], key)).toBe(true);
+    expect(touchesResource(["copies"], key)).toBe(true);
+  });
+
+  test("a bare, unenriched expand path contributes nothing to search - there is no name to find in a plain rendered path", () => {
+    const key = [MEDIA, "detail", 5, { expand: ["address"] }];
+    expect(touchesResource(["copies", "list"], key)).toBe(false);
+  });
+
+  test("recurses into a nested expanding()'s own nested params", () => {
+    const key = [MEDIA, "detail", 5, { expand: [["copies", "list", { expand: [["reservations", "list"]] }]] }];
+    expect(touchesResource(["reservations", "list"], key)).toBe(true);
+  });
+
+  test("an unrelated name inside an unrelated expand entry does not match", () => {
+    const key = [MEDIA, "detail", 5, { expand: [["copies", "list"]] }];
+    expect(touchesResource(["members", "list"], key)).toBe(false);
+  });
+
+  test("a key with no params object at all is unaffected - nothing to recurse into", () => {
+    const key = [MEDIA, "detail", 5];
+    expect(touchesResource(["copies", "list"], key)).toBe(false);
+  });
+});

--- a/packages/odata-service/test/fixture/v2/PersonModelV2Service.ts
+++ b/packages/odata-service/test/fixture/v2/PersonModelV2Service.ts
@@ -2,6 +2,7 @@ import { ODataHttpClient, ODataHttpMethods } from "@odata2ts/http-client-api";
 import { ODataEntityModelResponseV2 } from "@odata2ts/odata-core";
 import { EntityResponseConverterV2, QEnumCollection } from "@odata2ts/odata-query-objects";
 import {
+  CacheKeyState,
   CollectionServiceV2,
   EntitySetServiceV2,
   EntityTypeServiceV2,
@@ -39,8 +40,14 @@ export class PersonModelV2Service extends EntityTypeServiceV2<PersonModel, Edita
     return new PersonModelV2CollectionService(client, path, "Friends", options);
   }
 
-  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternalV2) {
-    super(client, basePath, name, new QPersonV2(), options);
+  constructor(
+    client: ODataHttpClient,
+    basePath: string,
+    name: string,
+    options?: ODataServiceOptionsInternalV2,
+    cacheKeyState?: CacheKeyState,
+  ) {
+    super(client, basePath, name, new QPersonV2(), options, cacheKeyState);
   }
 
   public getSomething(params: GetSomethingFunctionParams) {
@@ -66,8 +73,14 @@ export class PersonModelV2CollectionService extends EntitySetServiceV2<
   PersonId,
   PersonModelV2Service
 > {
-  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternalV2) {
-    super(client, basePath, name, qPersonV2, new QPersonIdFunction(name), options);
+  constructor(
+    client: ODataHttpClient,
+    basePath: string,
+    name: string,
+    options?: ODataServiceOptionsInternalV2,
+    cacheKeyState?: CacheKeyState,
+  ) {
+    super(client, basePath, name, qPersonV2, new QPersonIdFunction(name), options, cacheKeyState);
   }
 
   protected createEntityService(
@@ -75,7 +88,8 @@ export class PersonModelV2CollectionService extends EntitySetServiceV2<
     path: string,
     name: string,
     options: ODataServiceOptionsInternalV2 | undefined,
+    cacheKeyState?: CacheKeyState,
   ) {
-    return new PersonModelV2Service(client, path, name, options);
+    return new PersonModelV2Service(client, path, name, options, cacheKeyState);
   }
 }

--- a/packages/odata-service/test/fixture/v4/PersonModelService.ts
+++ b/packages/odata-service/test/fixture/v4/PersonModelService.ts
@@ -2,6 +2,7 @@ import { ODataHttpClient, ODataHttpMethods } from "@odata2ts/http-client-api";
 import { ODataModelResponseV4, ODataValueResponseV4, ODataVersionV4 } from "@odata2ts/odata-core";
 import { ModelResponseConverterV4, QEnumCollection } from "@odata2ts/odata-query-objects";
 import {
+  CacheKeyState,
   CollectionServiceV4,
   ComposableUrlRequestCmd,
   EntitySetServiceV4,
@@ -27,8 +28,14 @@ export class PersonModelService<V extends ODataVersionV4 = "4.0"> extends Entity
 
   private _qGetScore = new QGetScoreFunction();
 
-  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
-    super(client, basePath, name, new QPersonV4(), options);
+  constructor(
+    client: ODataHttpClient,
+    basePath: string,
+    name: string,
+    options?: ODataServiceOptionsInternal<V>,
+    cacheKeyState?: CacheKeyState,
+  ) {
+    super(client, basePath, name, new QPersonV4(), options, cacheKeyState);
   }
 
   public userName() {
@@ -112,8 +119,14 @@ export class PersonModelCollectionService<V extends ODataVersionV4 = "4.0"> exte
 > {
   private _qGetSomething = new QGetSomethingFunction();
 
-  constructor(client: ODataHttpClient, basePath: string, name: string, options?: ODataServiceOptionsInternal<V>) {
-    super(client, basePath, name, qPersonV4, new QPersonIdFunction(name), options);
+  constructor(
+    client: ODataHttpClient,
+    basePath: string,
+    name: string,
+    options?: ODataServiceOptionsInternal<V>,
+    cacheKeyState?: CacheKeyState,
+  ) {
+    super(client, basePath, name, qPersonV4, new QPersonIdFunction(name), options, cacheKeyState);
   }
 
   protected createEntityService(
@@ -121,8 +134,9 @@ export class PersonModelCollectionService<V extends ODataVersionV4 = "4.0"> exte
     path: string,
     name: string,
     options: ODataServiceOptionsInternal<V> | undefined,
+    cacheKeyState?: CacheKeyState,
   ) {
-    return new PersonModelService<V>(client, path, name, options);
+    return new PersonModelService<V>(client, path, name, options, cacheKeyState);
   }
 
   /**

--- a/packages/odata-service/test/mock/MockClient.ts
+++ b/packages/odata-service/test/mock/MockClient.ts
@@ -1,9 +1,13 @@
 import {
+  BatchClientOptions,
+  BatchRequestBody,
+  BatchResponseBody,
   ConcurrencyHandler,
   ODataHttpClient,
   ODataHttpMethods,
   ODataRequestConfig,
   ODataResponse,
+  ResourceIdentityHandler,
 } from "@odata2ts/http-client-api";
 
 export interface MockRequestConfig extends ODataRequestConfig {
@@ -34,6 +38,42 @@ export class MockConcurrencyHandler implements ConcurrencyHandler {
     return this.store.get(key) ?? (this.blindWrites ? "*" : undefined);
   }
 }
+
+/**
+ * The route↔canonical-resource store of a {@link MockClient}, with its contents exposed so a test can
+ * arrange and assert it - hand-rolled against the {@link ResourceIdentityHandler} contract, for the same
+ * reason {@link MockConcurrencyHandler} is.
+ */
+export class MockResourceIdentityHandler implements ResourceIdentityHandler {
+  public readonly store = new Map<string, Array<ReadonlyArray<unknown>>>();
+
+  public record(canonicalId: string, hierarchicalKey: ReadonlyArray<unknown>): void {
+    const keys = this.store.get(canonicalId) ?? [];
+    keys.push(hierarchicalKey);
+    this.store.set(canonicalId, keys);
+  }
+
+  public resolve(canonicalId: string): ReadonlyArray<ReadonlyArray<unknown>> {
+    return this.store.get(canonicalId) ?? [];
+  }
+
+  public evict(canonicalId: string): void {
+    this.store.delete(canonicalId);
+  }
+
+  public dehydrate(): ReadonlyArray<readonly [string, ReadonlyArray<ReadonlyArray<unknown>>]> {
+    return [...this.store.entries()];
+  }
+
+  public hydrate(entries: ReadonlyArray<readonly [string, ReadonlyArray<ReadonlyArray<unknown>>]>): void {
+    for (const [canonicalId, keys] of entries) {
+      for (const key of keys) {
+        this.record(canonicalId, key);
+      }
+    }
+  }
+}
+
 /**
  * Mock for an ODataHttpClient.
  * Use `client.lastUrl` or `client.lastData` to acces passed data.
@@ -62,6 +102,7 @@ export class MockClient implements ODataHttpClient<MockRequestConfig> {
   public failWithStatus?: number;
 
   public readonly concurrency = new MockConcurrencyHandler();
+  public readonly resourceIdentity = new MockResourceIdentityHandler();
 
   constructor(public isV2: boolean) {}
 
@@ -186,6 +227,16 @@ export class MockClient implements ODataHttpClient<MockRequestConfig> {
 
     // @ts-ignore
     return this.respond();
+  }
+
+  batch(
+    url: string,
+    body: BatchRequestBody,
+    options?: BatchClientOptions,
+    requestConfig?: MockRequestConfig,
+    additionalHeaders?: Record<string, string>,
+  ): ODataResponse<BatchResponseBody> {
+    throw new Error("Operation batch not supported!");
   }
 
   createBlob(

--- a/packages/odata-service/test/request/CacheKeyThreading.test.ts
+++ b/packages/odata-service/test/request/CacheKeyThreading.test.ts
@@ -1,0 +1,231 @@
+import { ODataHttpMethods } from "@odata2ts/http-client-api";
+import { beforeEach, describe, expect, test } from "vitest";
+import { CacheKeyState, CanonicalIdFn, rootState, withKey } from "../../src/cacheKey";
+import { RequestInfo, UrlGetRequestCmd, UrlWriteRequestCmd } from "../../src/request";
+import { GetToPostConverter } from "../../src/request/RequestHelper";
+import { MockClient } from "../mock/MockClient";
+
+const MEDIUM = "Library.Catalog.Medium";
+
+/** A stand-in for a generated `(entity) => new QMediumId("Media").buildCanonicalId(entity)` closure. */
+const canonicalIdOfMedia: CanonicalIdFn = (entity) => {
+  const id = entity && typeof entity === "object" ? (entity as any).id : entity;
+  return id === undefined ? undefined : `Media(${id})`;
+};
+
+describe("cache key threading", () => {
+  let client: MockClient;
+
+  beforeEach(() => {
+    client = new MockClient(false);
+  });
+
+  test("RequestInfo forwards the state through withData", () => {
+    const state = rootState(MEDIUM, "list");
+    const info = new RequestInfo(ODataHttpMethods.Get, "Media", undefined, undefined, state);
+    expect(info.withData({ a: 1 }).cacheKeyState).toBe(state);
+  });
+
+  test("the key is undefined when no state was threaded", () => {
+    expect(new UrlGetRequestCmd(client, "Media").cacheKey).toBeUndefined();
+  });
+
+  test("the key is built from the threaded state and the query params", () => {
+    const cmd = new UrlGetRequestCmd(client, "Media?$top=10", {
+      cacheKeyState: rootState(MEDIUM, "list"),
+      queryParams: { top: 10 },
+    });
+    expect(cmd.cacheKey).toEqual([MEDIUM, "list", { top: 10 }]);
+  });
+
+  test("the getter is memoized", () => {
+    const cmd = new UrlGetRequestCmd(client, "Media", { cacheKeyState: rootState(MEDIUM, "list") });
+    expect(cmd.cacheKey).toBe(cmd.cacheKey);
+  });
+
+  test("GetToPostConverter leaves the key byte-for-byte identical", () => {
+    const cmd = new UrlGetRequestCmd(client, "Media?$top=10", {
+      cacheKeyState: rootState(MEDIUM, "list"),
+      queryParams: { top: 10 },
+    });
+    const before = JSON.stringify(cmd.cacheKey);
+    cmd.asPostRequest();
+    expect(JSON.stringify(cmd.cacheKey)).toBe(before);
+  });
+
+  test("an appended converter that changes the state changes the key, with no extra call", () => {
+    const cmd = new UrlGetRequestCmd(client, "Media", { cacheKeyState: rootState(MEDIUM, "list") });
+    cmd.appendRequestConverter((request) => {
+      return new RequestInfo(
+        request.method,
+        request.url,
+        request.headers,
+        request.data,
+        withKey(request.cacheKeyState as CacheKeyState, 5, { Id: 5 }),
+      );
+    });
+    expect(cmd.cacheKey).toEqual([MEDIUM, "detail", 5]);
+  });
+
+  test("two composed converters both take effect in order", () => {
+    const cmd = new UrlGetRequestCmd(client, "Media", { cacheKeyState: rootState(MEDIUM, "list") });
+    cmd.appendRequestConverter(
+      (request) =>
+        new RequestInfo(
+          request.method,
+          request.url,
+          request.headers,
+          request.data,
+          withKey(request.cacheKeyState as CacheKeyState, 5, { Id: 5 }),
+        ),
+    );
+    cmd.appendRequestConverter((request) => {
+      const state = request.cacheKeyState as CacheKeyState;
+      return new RequestInfo(request.method, request.url, request.headers, request.data, {
+        ...state,
+        params: { cast: "Library.Catalog.Book" },
+      });
+    });
+    expect(cmd.cacheKey).toEqual([MEDIUM, "detail", 5, { cast: "Library.Catalog.Book" }]);
+  });
+
+  test("a write response carries invalidates", async () => {
+    const cmd = new UrlWriteRequestCmd(
+      client,
+      ODataHttpMethods.Patch,
+      "Media(5)",
+      { title: "x" },
+      {
+        cacheKeyState: withKey(rootState(MEDIUM, "list", { entitySetName: MEDIUM }), 5, { Id: 5 }),
+      },
+    );
+    const response = await cmd.execute();
+    expect(response.invalidates).toEqual([
+      [MEDIUM, "detail", 5],
+      [MEDIUM, "list"],
+    ]);
+  });
+
+  test("a read response carries no invalidates", async () => {
+    const cmd = new UrlGetRequestCmd(client, "Media", { cacheKeyState: rootState(MEDIUM, "list") });
+    const response = await cmd.execute();
+    expect(response.invalidates).toBeUndefined();
+  });
+
+  test("no state means no invalidates on a write either", async () => {
+    const cmd = new UrlWriteRequestCmd(client, ODataHttpMethods.Patch, "Media(5)", { title: "x" });
+    const response = await cmd.execute();
+    expect(response.invalidates).toBeUndefined();
+  });
+
+  test("a command with no state computes its (undefined) key once, not on every access", () => {
+    // `undefined` is both "not computed yet" and the legitimate answer for a client generated without
+    // `cacheKeys` - the memo must tell those apart, or every access re-runs the whole converter chain.
+    let calls = 0;
+    const cmd = new UrlGetRequestCmd(client, "Media", {
+      mainRequestConverter: {
+        convertToOData: (data: any) => {
+          calls++;
+          return data;
+        },
+      },
+    });
+
+    expect(cmd.cacheKey).toBeUndefined();
+    expect(cmd.cacheKey).toBeUndefined();
+    expect(calls).toBe(1);
+  });
+
+  test("a write's cacheKey is undefined even with a full cacheKeyState - and never touches the converter chain to find that out", () => {
+    let calls = 0;
+    const cmd = new UrlWriteRequestCmd(
+      client,
+      ODataHttpMethods.Patch,
+      "Media(5)",
+      { title: "x" },
+      {
+        cacheKeyState: withKey(rootState(MEDIUM, "list"), 5, { Id: 5 }),
+        mainRequestConverter: {
+          convertToOData: (data: any) => {
+            calls++;
+            return data;
+          },
+        },
+      },
+    );
+
+    expect(cmd.cacheKey).toBeUndefined();
+    expect(cmd.cacheKey).toBeUndefined();
+    // a write has nothing to be stored under - only something to make stale, via `invalidates` on its
+    // response - so the getter never even runs the request converter chain to look
+    expect(calls).toBe(0);
+  });
+
+  describe("response-observed identity", () => {
+    test("a read records the resource its response describes, against its own cache key", async () => {
+      const state = rootState("Media", "detail", { entitySetName: "Media", canonicalIdFn: canonicalIdOfMedia });
+      const cmd = new UrlGetRequestCmd(client, "Media(5)", { cacheKeyState: state });
+      client.setModelResponse({ id: 5, title: "The Trial" });
+
+      await cmd.execute();
+
+      expect(client.resourceIdentity.resolve("Media(5)")).toEqual([cmd.cacheKey]);
+    });
+
+    test("a read with no resourceIdentity-eligible state (no entitySetName) records nothing", async () => {
+      const cmd = new UrlGetRequestCmd(client, "Media(5)", { cacheKeyState: rootState(MEDIUM, "list") });
+      client.setModelResponse({ id: 5 });
+
+      await cmd.execute();
+
+      expect(client.resourceIdentity.dehydrate()).toEqual([]);
+    });
+
+    test("a write resolves a route to this same resource recorded via a different one, into invalidates", async () => {
+      const otherRoute = ["SomeOtherRoot", "detail", 9, "media", "detail", 5];
+      client.resourceIdentity.record("Media(5)", otherRoute);
+
+      const state = withKey(
+        rootState("Media", "list", { entitySetName: "Media", canonicalIdFn: canonicalIdOfMedia }),
+        5,
+        5,
+      );
+      const cmd = new UrlWriteRequestCmd(
+        client,
+        ODataHttpMethods.Patch,
+        "Media(5)",
+        { title: "x" },
+        {
+          cacheKeyState: state,
+        },
+      );
+
+      const response = await cmd.execute();
+
+      expect(response.invalidates).toEqual(
+        expect.arrayContaining([["Media", "detail", 5], ["Media", "list"], otherRoute]),
+      );
+    });
+
+    test("a create resolves the server-assigned id from its own response body", async () => {
+      const otherRoute = ["SomeOtherRoot", "detail", 9, "media", "list"];
+      client.resourceIdentity.record("Media(5)", otherRoute);
+
+      const state = rootState("Media", "list", { entitySetName: "Media", canonicalIdFn: canonicalIdOfMedia });
+      const cmd = new UrlWriteRequestCmd(
+        client,
+        ODataHttpMethods.Post,
+        "Media",
+        { title: "x" },
+        {
+          cacheKeyState: state,
+        },
+      );
+      client.setModelResponse({ id: 5, title: "x" });
+
+      const response = await cmd.execute();
+
+      expect(response.invalidates).toEqual(expect.arrayContaining([otherRoute]));
+    });
+  });
+});

--- a/packages/odata-service/test/v2/EntitySetServiceV2.test.ts
+++ b/packages/odata-service/test/v2/EntitySetServiceV2.test.ts
@@ -1,7 +1,8 @@
 import { HttpResponseModel } from "@odata2ts/http-client-api";
 import { ODataEntityModelResponseV2 } from "@odata2ts/odata-core";
+import { QBinding, QEntityCollectionPath, QId, QueryObject } from "@odata2ts/odata-query-objects";
 import { beforeEach, describe, expect, expectTypeOf, test } from "vitest";
-import { DEFAULT_HEADERS, RequestInfo } from "../../src";
+import { DEFAULT_HEADERS, RequestInfo, rootState } from "../../src";
 import { commonEntitySetTests } from "../EntitySetServiceTests";
 import { EditablePersonModel, Feature, PersonModel } from "../fixture/PersonModel";
 import { PersonModelV2CollectionService } from "../fixture/v2/PersonModelV2Service";
@@ -87,5 +88,61 @@ describe("V2 EntitySetService Test", () => {
     expect(request.getInfo().url).toBe(EXPECTED_PATH + "?$select=UserName");
     expect(request.getInfo().method).toBe("POST");
     expect(request.getInfo().data).toEqual(model);
+  });
+
+  describe("cache keys: expand enrichment and deepEdit", () => {
+    const PERSON = "Test.Person";
+
+    /**
+     * The shared fixture's own `friends` has no `QBinding` at all, so it is unsuitable for proving deepEdit
+     * finds the *deep-inserted* entity set, not the parent's own - a distinct, purpose-built Q-object is
+     * used instead of reshaping the shared fixture. Its field is deliberately named "friends" (matching the
+     * payload's own TS-facing name) while its wire name ("Friends") and bound entity set ("Trips") both
+     * differ from it, exercising that indexing and identity are two separate lookups.
+     */
+    class QTrip extends QueryObject {}
+    class QPersonWithTripFriends extends QueryObject {
+      public readonly friends = new QEntityCollectionPath(
+        this.withPrefix("Friends"),
+        () => QTrip,
+        new QBinding(() => ({ getName: () => "Trips" }) as unknown as QId<any>, "4.0"),
+      );
+    }
+
+    test("query() enriches expand entries by reading the property's own name and kind directly off the Q-object - no table needed", async () => {
+      const service = new PersonModelV2CollectionService(
+        odataClient,
+        BASE_URL,
+        NAME,
+        undefined,
+        rootState(PERSON, "list"),
+      );
+      const request = service.query((b) => b.expand("friends"));
+      expect(request.cacheKey).toEqual([PERSON, "list", { expand: [["Friends", "list"]] }]);
+    });
+
+    test("create() attaches deepEdit to invalidates when the payload deep-inserts a nav property", async () => {
+      const TRIPS = "Trips";
+      const service = new PersonModelV2CollectionService(
+        odataClient,
+        BASE_URL,
+        NAME,
+        undefined,
+        rootState(PERSON, "list", { qEntityFn: () => QPersonWithTripFriends as any }),
+      );
+      const model = {
+        userName: "tester",
+        age: "14",
+        favFeature: Feature.Feature1,
+        features: [Feature.Feature1],
+        friends: [{ userName: "buddy", age: "15", favFeature: Feature.Feature1, features: [] }],
+      } as unknown as EditablePersonModel;
+
+      const response = await service.create(model).execute();
+      expect(response.invalidates).toEqual([
+        [PERSON, "list"],
+        [TRIPS, "list"],
+      ]);
+    });
   });
 });

--- a/packages/odata-service/test/v2/EntityTypeServiceV2.test.ts
+++ b/packages/odata-service/test/v2/EntityTypeServiceV2.test.ts
@@ -1,6 +1,7 @@
 import { HttpResponseModel } from "@odata2ts/http-client-api";
+import { QBinding, QEntityCollectionPath, QId, QueryObject } from "@odata2ts/odata-query-objects";
 import { beforeEach, describe, expect, expectTypeOf, test } from "vitest";
-import { DEFAULT_HEADERS, EntityTypeServiceV2, MERGE_HEADERS, RequestInfo } from "../../src";
+import { DEFAULT_HEADERS, EntityTypeServiceV2, MERGE_HEADERS, RequestInfo, rootState } from "../../src";
 import { commonEntityTypeServiceTests } from "../EntityTypeServiceTests";
 import { EditablePersonModel, Feature, PersonModel } from "../fixture/PersonModel";
 import { PersonModelV2Service } from "../fixture/v2/PersonModelV2Service";
@@ -150,5 +151,53 @@ describe("EntityTypeService V2 Test", () => {
     expect(request.url).toBe(expected);
     expect(request.data).toBeUndefined();
     expect(request.method).toBe("GET");
+  });
+
+  describe("cache keys: expand enrichment and deepEdit", () => {
+    const PERSON = "Test.Person";
+
+    /**
+     * The shared fixture's own `friends` has no `QBinding` at all, so it is unsuitable for proving deepEdit
+     * finds the *deep-inserted* entity set, not the parent's own - a distinct, purpose-built Q-object is
+     * used instead of reshaping the shared fixture. Its field is deliberately named "friends" (matching the
+     * payload's own TS-facing name) while its wire name ("Friends") and bound entity set ("Trips") both
+     * differ from it, exercising that indexing and identity are two separate lookups.
+     */
+    class QTrip extends QueryObject {}
+    class QPersonWithTripFriends extends QueryObject {
+      public readonly friends = new QEntityCollectionPath(
+        this.withPrefix("Friends"),
+        () => QTrip,
+        new QBinding(() => ({ getName: () => "Trips" }) as unknown as QId<any>, "4.0"),
+      );
+    }
+
+    test("query() enriches expand entries by reading the property's own name and kind directly off the Q-object - no table needed", async () => {
+      const service = new PersonModelV2Service(odataClient, BASE_URL, NAME, undefined, rootState(PERSON, "detail"));
+      const request = service.query((b) => b.expand("friends"));
+      expect(request.cacheKey).toEqual([PERSON, "detail", { expand: [["Friends", "list"]] }]);
+    });
+
+    test("patch() attaches deepEdit to invalidates when the payload deep-inserts a nav property", async () => {
+      const TRIPS = "Trips";
+      const service = new PersonModelV2Service(
+        odataClient,
+        BASE_URL,
+        NAME,
+        undefined,
+        rootState(PERSON, "detail", { entitySetName: PERSON, qEntityFn: () => QPersonWithTripFriends as any }),
+      );
+      const model = {
+        age: "45",
+        friends: [{ userName: "buddy", age: "15", favFeature: Feature.Feature1, features: [] }],
+      } as unknown as Partial<EditablePersonModel>;
+
+      const response = await service.patch(model).ignoreETag().execute();
+      expect(response.invalidates).toEqual([
+        [PERSON, "detail"],
+        [PERSON, "list"],
+        [TRIPS, "list"],
+      ]);
+    });
   });
 });

--- a/packages/odata-service/test/v4/EntitySetServiceV4.test.ts
+++ b/packages/odata-service/test/v4/EntitySetServiceV4.test.ts
@@ -1,7 +1,8 @@
 import { HttpResponseModel } from "@odata2ts/http-client-api";
 import { FlexibleODataModelPayloadV4, ODataModelPayloadV4, ODataModelResponseV4 } from "@odata2ts/odata-core";
+import { QBinding, QEntityCollectionPath, QId, QueryObject } from "@odata2ts/odata-query-objects";
 import { beforeEach, describe, expect, expectTypeOf, test } from "vitest";
-import { DEFAULT_HEADERS, getODataVersionHeaders, RequestInfo } from "../../src";
+import { DEFAULT_HEADERS, getODataVersionHeaders, RequestInfo, rootState } from "../../src";
 import { commonEntitySetTests } from "../EntitySetServiceTests";
 import { EditablePersonModel, Feature, PersonModel } from "../fixture/PersonModel";
 import {
@@ -284,6 +285,62 @@ describe("V4 EntitySetService Test", () => {
     test("byId builds the entity-type service for the alternate key just as well as for the primary one", () => {
       expect(toTest.byId("7").getPath()).toBe(`${NAME}(7)`);
       expect(toTest.byId({ name: "russell" }).getPath()).toBe(`${NAME}(NAME='russell')`);
+    });
+  });
+
+  describe("cache keys: expand enrichment and deepEdit", () => {
+    const PERSON = "Test.Person";
+
+    /**
+     * `QPersonV4`'s own `friends` (the shared fixture) has no `QBinding` at all, so it is unsuitable for
+     * proving deepEdit finds the *deep-inserted* entity set, not the parent's own - a distinct, purpose-built
+     * Q-object is used instead of reshaping the shared fixture. Its field is deliberately named "friends"
+     * (matching the payload's own TS-facing name) while its wire name ("Friends") and bound entity set
+     * ("Trips") both differ from it, exercising that indexing and identity are two separate lookups.
+     */
+    class QTrip extends QueryObject {}
+    class QPersonWithTripFriends extends QueryObject {
+      public readonly friends = new QEntityCollectionPath(
+        this.withPrefix("Friends"),
+        () => QTrip,
+        new QBinding(() => ({ getName: () => "Trips" }) as unknown as QId<any>, "4.0"),
+      );
+    }
+
+    test("query() enriches expand entries by reading the property's own name and kind directly off the Q-object - no table needed", async () => {
+      const service = new PersonModelCollectionService(
+        odataClient,
+        BASE_URL,
+        NAME,
+        undefined,
+        rootState(PERSON, "list"),
+      );
+      const request = service.query((b) => b.expand("friends"));
+      expect(request.cacheKey).toEqual([PERSON, "list", { expand: [["Friends", "list"]] }]);
+    });
+
+    test("create() attaches deepEdit to invalidates when the payload deep-inserts a nav property", async () => {
+      const TRIPS = "Trips";
+      const service = new PersonModelCollectionService(
+        odataClient,
+        BASE_URL,
+        NAME,
+        undefined,
+        rootState(PERSON, "list", { qEntityFn: () => QPersonWithTripFriends as any }),
+      );
+      const model = {
+        userName: "tester",
+        age: "14",
+        favFeature: Feature.Feature1,
+        features: [Feature.Feature1],
+        friends: [{ userName: "buddy", age: "15", favFeature: Feature.Feature1, features: [] }],
+      } as unknown as EditablePersonModel;
+
+      const response = await service.create(model).execute();
+      expect(response.invalidates).toEqual([
+        [PERSON, "list"],
+        [TRIPS, "list"],
+      ]);
     });
   });
 });

--- a/packages/odata-service/test/v4/EntityTypeServiceV4.test.ts
+++ b/packages/odata-service/test/v4/EntityTypeServiceV4.test.ts
@@ -1,7 +1,8 @@
 import { HttpResponseModel } from "@odata2ts/http-client-api";
 import { FlexibleODataModelPayloadV4, ODataModelPayloadV4, ODataModelResponseV4 } from "@odata2ts/odata-core";
+import { QBinding, QEntityCollectionPath, QId, QueryObject } from "@odata2ts/odata-query-objects";
 import { beforeEach, describe, expect, expectTypeOf, test } from "vitest";
-import { DEFAULT_HEADERS, EntityTypeServiceV4, getODataVersionHeaders, RequestInfo } from "../../src";
+import { DEFAULT_HEADERS, EntityTypeServiceV4, getODataVersionHeaders, RequestInfo, rootState } from "../../src";
 import { commonEntityTypeServiceTests } from "../EntityTypeServiceTests";
 import { EditablePersonModel, Feature, PersonModel } from "../fixture/PersonModel";
 import { EditableFlightModel, PlanItemService } from "../fixture/v4/BaseTypeModel";
@@ -349,5 +350,53 @@ describe("EntityTypeService V4 Tests", () => {
     const response = await testService.getScore().execute();
 
     expect(response.data?.value).toBe("45");
+  });
+
+  describe("cache keys: expand enrichment and deepEdit", () => {
+    const PERSON = "Test.Person";
+
+    /**
+     * `QPersonV4`'s own `friends` (the shared fixture) has no `QBinding` at all, so it is unsuitable for
+     * proving deepEdit finds the *deep-inserted* entity set, not the parent's own - a distinct, purpose-built
+     * Q-object is used instead of reshaping the shared fixture. Its field is deliberately named "friends"
+     * (matching the payload's own TS-facing name) while its wire name ("Friends") and bound entity set
+     * ("Trips") both differ from it, exercising that indexing and identity are two separate lookups.
+     */
+    class QTrip extends QueryObject {}
+    class QPersonWithTripFriends extends QueryObject {
+      public readonly friends = new QEntityCollectionPath(
+        this.withPrefix("Friends"),
+        () => QTrip,
+        new QBinding(() => ({ getName: () => "Trips" }) as unknown as QId<any>, "4.0"),
+      );
+    }
+
+    test("query() enriches expand entries by reading the property's own name and kind directly off the Q-object - no table needed", async () => {
+      const service = new PersonModelService(odataClient, BASE_URL, NAME, undefined, rootState(PERSON, "detail"));
+      const request = service.query((b) => b.expand("friends"));
+      expect(request.cacheKey).toEqual([PERSON, "detail", { expand: [["Friends", "list"]] }]);
+    });
+
+    test("patch() attaches deepEdit to invalidates when the payload deep-inserts a nav property", async () => {
+      const TRIPS = "Trips";
+      const service = new PersonModelService(
+        odataClient,
+        BASE_URL,
+        NAME,
+        undefined,
+        rootState(PERSON, "detail", { entitySetName: PERSON, qEntityFn: () => QPersonWithTripFriends as any }),
+      );
+      const model = {
+        age: "45",
+        friends: [{ userName: "buddy", age: "15", favFeature: Feature.Feature1, features: [] }],
+      } as unknown as Partial<EditablePersonModel>;
+
+      const response = await service.patch(model).ignoreETag().execute();
+      expect(response.invalidates).toEqual([
+        [PERSON, "detail"],
+        [PERSON, "list"],
+        [TRIPS, "list"],
+      ]);
+    });
   });
 });

--- a/packages/odata2ts/package.json
+++ b/packages/odata2ts/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@odata2ts/converter-api": "^0.3.0",
     "@odata2ts/converter-runtime": "^0.6.0",
-    "@odata2ts/http-client-api": "^0.6.8",
+    "@odata2ts/http-client-api": "^0.7.1",
     "@odata2ts/odata-core": "^0.7.1",
     "@prettier/plugin-xml": "^3.4.2",
     "@types/xml2js": "^0.4.14",

--- a/packages/odata2ts/src/OptionModel.ts
+++ b/packages/odata2ts/src/OptionModel.ts
@@ -233,6 +233,34 @@ export enum EnumSynthesis {
 }
 
 /**
+ * How a generated client builds `RequestCmd.cacheKey` - see the docs on `cacheKeys`.
+ *
+ * Purely hierarchical, always: the key is the literal, named route taken to reach a response, never
+ * re-rooted at a resource's own type - that used to be a second mode (`typeFlattening`), and is now what
+ * `ResourceIdentityHandler` does at runtime instead, from actual responses rather than a generation-time
+ * prediction. One behaviour, so a binary switch is all `mode` needs to be.
+ */
+export enum CacheKeyMode {
+  /** Generate `cacheKey`/`invalidates` on every `RequestCmd`. */
+  on = "on",
+  /** Nothing is generated - identical to omitting `cacheKeys` entirely. */
+  off = "off",
+}
+
+export interface CacheKeysOptions {
+  /**
+   * Required: naming the object is not itself a decision, and a silently defaulted mode would make
+   * whether a generated key exists at all depend on a value nobody wrote down.
+   */
+  mode: CacheKeyMode;
+}
+
+/** The mode actually in force - `off` where the whole `cacheKeys` object was never configured. */
+export function resolveCacheKeyMode(options: CacheKeysOptions | undefined): CacheKeyMode {
+  return options?.mode ?? CacheKeyMode.off;
+}
+
+/**
  * Config options for CLI.
  */
 export interface CliOptions {
@@ -552,6 +580,16 @@ export interface ConfigFileOptions extends Omit<CliOptions, "sourceUrl" | "sourc
    * ({@code "Author@odata.bind"}).
    */
   deepInsertProps?: DeepInsertProps;
+  /**
+   * Generate `RequestCmd.cacheKey`: a structured, typed key identifying the *resource* a request
+   * addresses, for a cache built on top of the generated client (TanStack Query is the motivating case,
+   * hence the array shape).
+   *
+   * Off by default. An object rather than a bare string, because the shape has to have room for the
+   * further switches this will attract - which properties become key segments, whether operations are
+   * keyed at all - without a second top-level option.
+   */
+  cacheKeys?: CacheKeysOptions;
 }
 
 /**

--- a/packages/odata2ts/src/data-model/DataModelDigestion.ts
+++ b/packages/odata2ts/src/data-model/DataModelDigestion.ts
@@ -201,6 +201,31 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
     return false;
   }
 
+  /**
+   * The inverse navigation property on the related type, where the model declares one.
+   *
+   * Undefined here, because a navigation property only states its partner outright in V4. V2 has to
+   * resolve it from the `<Association>` the navigation property points at and overrides this
+   * accordingly.
+   */
+  protected getPartner(p: Property, fqOwnerName?: string): string | undefined {
+    return undefined;
+  }
+
+  /**
+   * The foreign key a navigation property is realized by: the dependent property and the principal
+   * property it references, one entry per property of a composite key.
+   *
+   * Undefined here, because only V4 states the constraint on the navigation property itself. V2 states
+   * it once on the `<Association>` instead and overrides this to resolve it from there.
+   */
+  protected getReferentialConstraints(
+    p: Property,
+    fqOwnerName?: string,
+  ): ReadonlyArray<{ property: string; referencedProperty: string }> | undefined {
+    return undefined;
+  }
+
   protected abstract digestOperations(schema: SchemaV3 | SchemaV4): void;
 
   protected abstract digestEntityContainer(schema: SchemaV3 | SchemaV4): void;
@@ -891,6 +916,9 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
       );
     }
 
+    const partner = this.getPartner(p, fqOwnerName);
+    const referentialConstraints = this.getReferentialConstraints(p, fqOwnerName);
+
     return {
       odataName: p.$.Name,
       name: modelName,
@@ -901,6 +929,8 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
       // only set when it applies: a flag on every single property would be noise
       ...(odataDataType === ODataTypesV4.Stream ? { isStream: true } : undefined),
       ...(this.isContained(p) ? { contained: true } : undefined),
+      ...(partner ? { partner } : undefined),
+      ...(referentialConstraints?.length ? { referentialConstraints } : undefined),
       ...(isOptionalParameter(p.Annotation) ? { omittable: true } : undefined),
       managed: toManagedState(
         typeof entityPropConfig?.managed !== "undefined" ? entityPropConfig.managed : configProp?.managed,

--- a/packages/odata2ts/src/data-model/DataModelDigestionV2.ts
+++ b/packages/odata2ts/src/data-model/DataModelDigestionV2.ts
@@ -7,6 +7,7 @@ import { Digester, TypeModel } from "./DataModelDigestion.js";
 import { NavPropBindingType, ODataVersion, OperationTypes, PropertyModel } from "./DataTypeModel.js";
 import { ComplexType, Property, Reference } from "./edmx/ODataEdmxModelBase.js";
 import {
+  Association,
   AssociationEnd,
   ComplexTypeV3,
   EntityContainerV3,
@@ -41,18 +42,30 @@ class DigesterV3 extends Digester<SchemaV3, EntityTypeV3, ComplexTypeV3> {
     super(ODataVersion.V2, schemas, options, namingHelper, converters, references);
   }
 
-  private findAssociationEnd(np: NavigationProperty): AssociationEnd {
+  /**
+   * The `<Association>` a navigation property points at, found by its (unqualified) relationship name.
+   * Shared by {@link findAssociationEnd}, which additionally needs the specific end, and by
+   * {@link getPartner}/{@link getReferentialConstraints}, which need the association as a whole - the
+   * partner lookup for the other end's type, the constraint because it is stated once per association
+   * rather than per end.
+   */
+  private findAssociation(np: NavigationProperty): Association {
+    const relationship = this.namingHelper.stripServicePrefix(np.$.Relationship);
     for (let schema of this.schemas) {
-      if (schema.Association) {
-        const relationship = this.namingHelper.stripServicePrefix(np.$.Relationship);
-        const association = schema.Association?.find((a) => a.$.Name === relationship);
-        const result = association?.End.find((e) => e.$.Role === np.$.ToRole);
-        if (result) {
-          return result;
-        }
+      const association = schema.Association?.find((a) => a.$.Name === relationship);
+      if (association) {
+        return association;
       }
     }
     throw new Error(`Association end couldn't be determined for NavigationProperty [${np.$.Name}]`);
+  }
+
+  private findAssociationEnd(np: NavigationProperty): AssociationEnd {
+    const end = this.findAssociation(np).End.find((e) => e.$.Role === np.$.ToRole);
+    if (!end) {
+      throw new Error(`Association end couldn't be determined for NavigationProperty [${np.$.Name}]`);
+    }
+    return end;
   }
 
   private findEdmxEntityType(fqTypeName: string): EntityTypeV3 | undefined {
@@ -64,6 +77,79 @@ class DigesterV3 extends Digester<SchemaV3, EntityTypeV3, ComplexTypeV3> {
       }
     }
     return undefined;
+  }
+
+  /**
+   * The raw `<NavigationProperty>` a mapped {@link Property} was built from, resolved by declaring entity
+   * type and name. {@link getNavigationProps} reshapes navigation properties into the same `{ $: { Name,
+   * Type, Nullable } }` shape as a plain `<Property>`, so `Relationship`/`FromRole`/`ToRole` - everything
+   * {@link getPartner} and {@link getReferentialConstraints} need - are gone by the time `mapProp` sees it.
+   * Looking the original element back up by owner and name is what gets them back.
+   */
+  private findNavProp(fqOwnerName: string, name: string): NavigationProperty | undefined {
+    return this.findEdmxEntityType(fqOwnerName)?.NavigationProperty?.find((np) => np.$.Name === name);
+  }
+
+  /**
+   * The inverse navigation property, resolved from the association's other end: the entity type declared
+   * there, and on it the navigation property realizing the same association with `FromRole`/`ToRole`
+   * swapped. Undefined where no such navigation property exists - an association end nothing navigates
+   * back from is legal.
+   */
+  protected getPartner(p: Property, fqOwnerName?: string): string | undefined {
+    const np = fqOwnerName ? this.findNavProp(fqOwnerName, p.$.Name) : undefined;
+    if (!np) {
+      return undefined;
+    }
+
+    const association = this.findAssociation(np);
+    const targetEnd = association.End.find((e) => e.$.Role === np.$.ToRole);
+    const targetType = targetEnd && this.findEdmxEntityType(targetEnd.$.Type);
+    const relationship = this.namingHelper.stripServicePrefix(np.$.Relationship);
+
+    const partnerNavProp = targetType?.NavigationProperty?.find(
+      (candidate) =>
+        this.namingHelper.stripServicePrefix(candidate.$.Relationship) === relationship &&
+        candidate.$.FromRole === np.$.ToRole &&
+        candidate.$.ToRole === np.$.FromRole,
+    );
+    return partnerNavProp?.$.Name;
+  }
+
+  /**
+   * The foreign key stated on the `<Association>`'s `<ReferentialConstraint>`, resolved to the same shape
+   * V4 states directly on its navigation property. V2 states the constraint once, naming its two sides by
+   * role, so it applies only to the navigation property that points *at* the principal - that one's own
+   * declaring type is the dependent side, which is where the foreign key actually lives. The navigation
+   * property pointing at the dependent side gets nothing, mirroring V4 exactly and keeping the two versions
+   * indistinguishable from here on.
+   */
+  protected getReferentialConstraints(
+    p: Property,
+    fqOwnerName?: string,
+  ): ReadonlyArray<{ property: string; referencedProperty: string }> | undefined {
+    const np = fqOwnerName ? this.findNavProp(fqOwnerName, p.$.Name) : undefined;
+    if (!np) {
+      return undefined;
+    }
+
+    const constraint = this.findAssociation(np).ReferentialConstraint?.[0];
+    const principal = constraint?.Principal[0];
+    const dependent = constraint?.Dependent[0];
+    if (!principal || !dependent || np.$.ToRole !== principal.$.Role) {
+      return undefined;
+    }
+
+    // a composite key gone out of sync between the two sides would produce a half-derived constraint that
+    // is worse than none - so this is skipped rather than repaired by guesswork
+    if (dependent.PropertyRef.length !== principal.PropertyRef.length) {
+      return undefined;
+    }
+
+    return dependent.PropertyRef.map((ref, index) => ({
+      property: ref.$.Name,
+      referencedProperty: principal.PropertyRef[index].$.Name,
+    }));
   }
 
   /**

--- a/packages/odata2ts/src/data-model/DataModelDigestionV4.ts
+++ b/packages/odata2ts/src/data-model/DataModelDigestionV4.ts
@@ -35,6 +35,22 @@ class DigesterV4 extends Digester<SchemaV4, EntityTypeV4, ComplexTypeV4> {
     return (p as NavigationProperty).$.ContainsTarget === "true";
   }
 
+  protected getPartner(p: Property): string | undefined {
+    return (p as NavigationProperty).$.Partner;
+  }
+
+  protected getReferentialConstraints(
+    p: Property,
+  ): ReadonlyArray<{ property: string; referencedProperty: string }> | undefined {
+    const referentialConstraint = (p as NavigationProperty).ReferentialConstraint;
+    return referentialConstraint?.length
+      ? referentialConstraint.map((rc) => ({
+          property: rc.$.Property,
+          referencedProperty: rc.$.ReferencedProperty,
+        }))
+      : undefined;
+  }
+
   protected digestOperations(schema: SchemaV4) {
     const nsWithAlias: NamespaceWithAlias = [schema.$.Namespace, schema.$.Alias];
     // functions & actions

--- a/packages/odata2ts/src/data-model/DataTypeModel.ts
+++ b/packages/odata2ts/src/data-model/DataTypeModel.ts
@@ -60,6 +60,19 @@ export interface PropertyModel {
    */
   contained?: boolean;
   /**
+   * The inverse navigation property on the related type, where the model declares one (V4's `Partner`
+   * attribute) - the name of the navigation property on the other side that points back to this one.
+   * Never set for anything but a navigation property.
+   */
+  partner?: string;
+  /**
+   * The foreign key this navigation property is realized by: each entry pairs a dependent property on
+   * this side with the principal property it references on the related type (V4's
+   * `<ReferentialConstraint>`), one entry per property of a composite key. Never set for anything but a
+   * navigation property.
+   */
+  referentialConstraints?: ReadonlyArray<{ property: string; referencedProperty: string }>;
+  /**
    * `Core.OptionalParameter`: the client may omit this operation parameter from the call even though
    * `required` (from `Nullable`) says otherwise - the server applies a default of its own. Independent
    * of `required`: unlike `Nullable`, it says nothing about whether the parameter accepts `null` when

--- a/packages/odata2ts/src/data-model/edmx/ODataEdmxModelV3.ts
+++ b/packages/odata2ts/src/data-model/edmx/ODataEdmxModelV3.ts
@@ -77,6 +77,14 @@ export interface Association {
     Name: string;
   };
   End: Array<AssociationEnd>;
+  /**
+   * The foreign key this association is realized by. Unlike V4, where the constraint sits on the
+   * navigation property, V2 states it once on the association and names the two sides by role.
+   */
+  ReferentialConstraint?: Array<{
+    Principal: Array<AssociationConstraintEnd>;
+    Dependent: Array<AssociationConstraintEnd>;
+  }>;
 }
 
 export interface AssociationEnd {
@@ -85,4 +93,9 @@ export interface AssociationEnd {
     Multiplicity: string;
     Role?: string;
   };
+}
+
+export interface AssociationConstraintEnd {
+  $: { Role: string };
+  PropertyRef: Array<{ $: { Name: string } }>;
 }

--- a/packages/odata2ts/src/data-model/edmx/ODataEdmxModelV4.ts
+++ b/packages/odata2ts/src/data-model/edmx/ODataEdmxModelV4.ts
@@ -38,7 +38,13 @@ export interface NavigationProperty extends Annotatable {
      */
     ContainsTarget?: "true" | "false";
   };
-  // TODO: OnDelete, ReferentialConstraint, etc.
+  /**
+   * The foreign key this navigation is realized by, as stated on the dependent side: `Property` is the
+   * dependent property, `ReferencedProperty` the principal one it refers to. Repeatable, one element per
+   * property pair of a composite key.
+   */
+  ReferentialConstraint?: Array<{ $: { Property: string; ReferencedProperty: string } }>;
+  // TODO: OnDelete
 }
 
 export interface EntityContainerV4 extends EntityContainer<EntitySetV4> {

--- a/packages/odata2ts/src/defaultConfig.ts
+++ b/packages/odata2ts/src/defaultConfig.ts
@@ -1,6 +1,14 @@
 import deepmerge from "deepmerge";
 import { NameSettings, NamingStrategies } from "./NamingModel.js";
-import { DeepInsertProps, EmitModes, KeyProperties, ManagedPropertyMode, Modes, RunOptions } from "./OptionModel.js";
+import {
+  CacheKeyMode,
+  DeepInsertProps,
+  EmitModes,
+  KeyProperties,
+  ManagedPropertyMode,
+  Modes,
+  RunOptions,
+} from "./OptionModel.js";
 
 export type DefaultConfiguration = Omit<RunOptions, "sourceUrl" | "source" | "output" | "serviceName">;
 /**
@@ -119,6 +127,7 @@ const defaultConfig: DefaultConfiguration = {
   byTypeAndName: [],
   disableBindingProps: false,
   deepInsertProps: DeepInsertProps.all,
+  cacheKeys: { mode: CacheKeyMode.off },
 };
 
 const { models, queryObjects, services } = defaultConfig.naming;

--- a/packages/odata2ts/src/generator/ImportContainer.ts
+++ b/packages/odata2ts/src/generator/ImportContainer.ts
@@ -138,6 +138,19 @@ export class ImportContainer {
     return importName;
   }
 
+  /**
+   * Imports an arbitrary named export from the service package by its exact name - the cache-key helpers
+   * (`rootState`, `hopState`, ...) are plain, version-neutral functions and constants, unlike the
+   * versioned classes {@link addServiceObject} resolves, so no `ServiceImports` entry fits them: that enum
+   * reverse-maps a numeric key to a PascalCase class name, which would mismatch a camelCase function.
+   */
+  public addServiceFunction(name: string, isTypeOnly = false) {
+    const importName = this.importedNameValidator.validateName(LIB_MODULES.service, name);
+    const imports = isTypeOnly ? this.libs.service.typeOnly : this.libs.service.regular;
+    imports.set(name, importName);
+    return importName;
+  }
+
   // TODO: make sure that regular imports win over additional typeOnly imports
   /**
    * Adds an import for a type coming from an arbitrary module, e.g. a converter's target type.

--- a/packages/odata2ts/src/generator/ServiceGenerator.ts
+++ b/packages/odata2ts/src/generator/ServiceGenerator.ts
@@ -15,16 +15,18 @@ import {
   ComplexType,
   DataTypes,
   EntityContainerModel,
+  EntitySetType,
   EntityType,
   FunctionImportType,
   hasUpdatableModel,
   OperationType,
   OperationTypes,
   PropertyModel,
+  ReturnTypeModel,
   SingletonType,
 } from "../data-model/DataTypeModel.js";
 import { NamingHelper } from "../data-model/NamingHelper.js";
-import { ConfigFileOptions, Modes } from "../OptionModel.js";
+import { CacheKeyMode, ConfigFileOptions, Modes, resolveCacheKeyMode } from "../OptionModel.js";
 import { FileHandler } from "../project/FileHandler.js";
 import { ProjectManager } from "../project/ProjectManager.js";
 import { ClientApiImports, CoreImports, QueryObjectImports, ServiceImports } from "./import/ImportObjects.js";
@@ -35,7 +37,7 @@ export interface PropsAndOps extends Required<Pick<ClassDeclarationStructure, "p
 
 export interface ServiceGeneratorOptions extends Pick<
   ConfigFileOptions,
-  "enablePrimitivePropertyServices" | "enumType" | "managedPropertyMode"
+  "enablePrimitivePropertyServices" | "enumType" | "managedPropertyMode" | "cacheKeys"
 > {
   v2: Pick<NonNullable<ConfigFileOptions["v2"]>, "responseAsV4">;
   v4: Pick<NonNullable<ConfigFileOptions["v4"]>, "bigNumberAsString" | "odataVersion">;
@@ -61,6 +63,8 @@ class ServiceGenerator {
     private options: ServiceGeneratorOptions = { v2: {}, v4: {} },
   ) {}
 
+  private readonly cacheKeyMode = resolveCacheKeyMode(this.options.cacheKeys);
+
   private isV4BigNumber() {
     return this.options.v4.bigNumberAsString && this.version === ODataVersions.V4;
   }
@@ -71,6 +75,179 @@ class ServiceGenerator {
 
   private isV2AsV4() {
     return !!this.options.v2.responseAsV4 && this.version === ODataVersions.V2;
+  }
+
+  // ---------------------------------------------------------------------------------------------------
+  // cache-key emission
+  //
+  // Every method below returns the bare runtime expression building a `CacheKeyState` - or `""` when the
+  // feature is off, which is what keeps `off` output byte-identical to before this feature existed. A
+  // root expression is self-contained (`rootState(...)`); every other expression reads the parent's state
+  // off a `cacheKeyState` variable the call site must destructure from `this.__base` - but only when the
+  // expression is non-empty, or the `off` output gains an unused binding.
+  // ---------------------------------------------------------------------------------------------------
+
+  /** The runtime expression for a fresh, unprefixed Q-object factory of the given type - `CacheKeyState.qEntityFn`, threaded solely so a write's payload can be walked for deep-inserted entities, never exposed in a cache key itself. */
+  private qEntityFnExpr(imports: ImportContainer, model: { fqName: string; qName: string }): string {
+    return `() => ${imports.addGeneratedQObject(model.fqName, model.qName)}`;
+  }
+
+  /**
+   * The runtime expression for `CacheKeyState.canonicalIdFn` - a fresh `QId` instance parametrized with the
+   * entity *set's* own name (never the route taken to reach it), so calling it with a response's own key
+   * values always produces the same canonical id regardless of which hop led here.
+   */
+  private canonicalIdFnExpr(imports: ImportContainer, entityType: EntityType, entitySetOdataName: string): string {
+    const qId = imports.addGeneratedQObject(entityType.id.fqName, entityType.id.qName);
+    return `(entity: unknown) => new ${qId}("${entitySetOdataName}").buildCanonicalId(entity)`;
+  }
+
+  /** The root of a route: an entity set or a singleton. An operation with no declared result set is the one root with no type to head with - built as a plain object literal instead, see `emitUnboundOperationRootExpr`. */
+  private emitRootStateExpr(
+    imports: ImportContainer,
+    name: string,
+    kind: "list" | "detail",
+    entityType: EntityType,
+    options?: { paramsSource?: string; isEntitySet?: boolean },
+  ): string {
+    if (this.cacheKeyMode === CacheKeyMode.off) {
+      return "";
+    }
+    const rootStateFn = imports.addServiceFunction("rootState");
+    const optionsEntries = [
+      options?.paramsSource ? `params: ${options.paramsSource}` : "",
+      options?.isEntitySet ? `entitySetName: "${name}"` : "",
+      options?.isEntitySet ? `canonicalIdFn: ${this.canonicalIdFnExpr(imports, entityType, name)}` : "",
+      `qEntityFn: ${this.qEntityFnExpr(imports, entityType)}`,
+    ]
+      .filter(Boolean)
+      .join(", ");
+    return `${rootStateFn}("${name}", "${kind}", { ${optionsEntries} })`;
+  }
+
+  /**
+   * A navigation property hop - always hierarchical, named by the navigation property's own OData name,
+   * never re-rooted at its target's type: that used to be a second mode (`typeFlattening`), and is now what
+   * `ResourceIdentityHandler` does at runtime instead, from actual responses. `entitySetName`/`canonicalIdFn`
+   * (feeding `invalidates` and response-observed recording respectively) name the entity *set* the target
+   * belongs to, absent for a contained navigation property, which has none of its own.
+   */
+  private emitNavHopExpr(
+    imports: ImportContainer,
+    ownerFqName: string,
+    navPropOdataName: string,
+    elementType: EntityType,
+    isCollection: boolean,
+    contained: boolean,
+  ): string {
+    if (this.cacheKeyMode === CacheKeyMode.off) {
+      return "";
+    }
+
+    const kind = isCollection ? "list" : "detail";
+    const targetSet = !contained ? this.dataModel.getNavPropBindingTarget(ownerFqName, navPropOdataName) : undefined;
+    const entitySetNameEntry = targetSet ? `, entitySetName: "${targetSet.odataName}"` : "";
+    const canonicalIdFnEntry = targetSet
+      ? `, canonicalIdFn: ${this.canonicalIdFnExpr(imports, targetSet.entityType, targetSet.odataName)}`
+      : "";
+    const qEntityFnEntry = `, qEntityFn: ${this.qEntityFnExpr(imports, elementType)}`;
+
+    const hopStateFn = imports.addServiceFunction("hopState");
+    return `cacheKeyState && ${hopStateFn}(cacheKeyState, { name: "${navPropOdataName}", kind: "${kind}"${entitySetNameEntry}${canonicalIdFnEntry}${qEntityFnEntry} })`;
+  }
+
+  /** A complex property hop: the same shape as a navigation hop, minus any entity-set identity - a complex value is never a navigation property and belongs to no entity set. */
+  private emitComplexHopExpr(imports: ImportContainer, isCollection: boolean, name: string): string {
+    if (this.cacheKeyMode === CacheKeyMode.off) {
+      return "";
+    }
+    const hopStateFn = imports.addServiceFunction("hopState");
+    return `cacheKeyState && ${hopStateFn}(cacheKeyState, { name: "${name}", kind: "${isCollection ? "list" : "detail"}" })`;
+  }
+
+  /** A primitive property, primitive collection or stream property hop: bare name, no kind - stays on its parent's resource. */
+  private emitBareHopExpr(imports: ImportContainer, name: string): string {
+    if (this.cacheKeyMode === CacheKeyMode.off) {
+      return "";
+    }
+    const hopStateFn = imports.addServiceFunction("hopState");
+    return `cacheKeyState && ${hopStateFn}(cacheKeyState, { name: "${name}" })`;
+  }
+
+  /** A stream property's raw value: the property hop, then a further hop appending `$value`. */
+  private emitStreamHopExpr(imports: ImportContainer, odataName: string): string {
+    if (this.cacheKeyMode === CacheKeyMode.off) {
+      return "";
+    }
+    const hopStateFn = imports.addServiceFunction("hopState");
+    return `cacheKeyState && ${hopStateFn}(${hopStateFn}(cacheKeyState, { name: "${odataName}" }), { name: "$value" })`;
+  }
+
+  /** A subtype cast: a restriction on the very same resource, not a hop away from it. */
+  private emitCastParamsExpr(imports: ImportContainer, castFqName: string): string {
+    if (this.cacheKeyMode === CacheKeyMode.off) {
+      return "";
+    }
+    const withParamsFn = imports.addServiceFunction("withParams");
+    return `cacheKeyState && ${withParamsFn}(cacheKeyState, { cast: "${castFqName}" })`;
+  }
+
+  /**
+   * The root of an unbound function/action import: always the import's own OData name (OData v4.01 Part 1
+   * §11.5.4.1/§11.5.5.1 - the canonical URL is the service root plus the *import's* name, never the
+   * operation's own qualified name, and never its declared result `EntitySet`'s name either). Where the
+   * import does declare a result `EntitySet`, `entitySetName`/`canonicalIdFn`/`qEntityFn` are still attached
+   * so `ResourceIdentityHandler` can record the real entities the response carries - a separate concern from
+   * what the root's own identity in the key is.
+   */
+  private emitUnboundOperationRootExpr(
+    imports: ImportContainer,
+    op: OperationType,
+    importOdataName: string,
+    entitySetOdataName: string | undefined,
+    hasParams: boolean,
+  ): string {
+    if (this.cacheKeyMode === CacheKeyMode.off) {
+      return "";
+    }
+
+    const entitySet = entitySetOdataName
+      ? Object.values(this.dataModel.getEntityContainer().entitySets).find((es) => es.odataName === entitySetOdataName)
+      : undefined;
+    const rootStateFn = imports.addServiceFunction("rootState");
+    const kind = op.returnType?.isCollection ? "list" : "detail";
+    // nested under its own "params" key, never spread directly - a composable operation's cache key later
+    // merges in real query params (select/filter/...) via buildCacheKey, and those must not collide with
+    // the operation's own invocation arguments
+    const paramsEntry = hasParams ? `params: { params }, ` : "";
+
+    if (entitySet) {
+      const canonicalIdFnEntry = `canonicalIdFn: ${this.canonicalIdFnExpr(imports, entitySet.entityType, entitySet.odataName)}, `;
+      const qEntityFnEntry = `qEntityFn: ${this.qEntityFnExpr(imports, entitySet.entityType)}`;
+      return (
+        `${rootStateFn}("${importOdataName}", "${kind}", ` +
+        `{ ${paramsEntry}entitySetName: "${entitySet.odataName}", ${canonicalIdFnEntry}${qEntityFnEntry} })`
+      );
+    }
+
+    return hasParams
+      ? `${rootStateFn}("${importOdataName}", "${kind}", { params: { params } })`
+      : `${rootStateFn}("${importOdataName}", "${kind}")`;
+  }
+
+  /** A bound function/action: a hop off the resource it is bound to, with its own kind marker where the return type is structured - never a type, matching every other hop. */
+  private emitBoundOperationHopExpr(
+    imports: ImportContainer,
+    fqOperationName: string,
+    returnType: ReturnTypeModel | undefined,
+  ): string {
+    if (this.cacheKeyMode === CacheKeyMode.off) {
+      return "";
+    }
+    const hopStateFn = imports.addServiceFunction("hopState");
+    const isStructured = !!returnType?.fqType && returnType.dataType !== DataTypes.PrimitiveType;
+    const kindEntry = isStructured ? `, kind: "${returnType!.isCollection ? "list" : "detail"}"` : "";
+    return `cacheKeyState && ${hopStateFn}(cacheKeyState, { name: "${fqOperationName}"${kindEntry} })`;
   }
 
   /**
@@ -280,29 +457,55 @@ class ServiceGenerator {
   ): PropsAndOps {
     const result: PropsAndOps = { properties: [], methods: [] };
 
-    ops.forEach(({ operation, name }) => {
+    ops.forEach((funcOrActionImport) => {
+      const { operation, name, odataName } = funcOrActionImport;
       const op = this.dataModel.getUnboundOperationType(operation);
       if (!op) {
         throw new Error(`Operation "${operation}" not found!`);
       }
+      // only a function import ever declares one - CSDL has no equivalent for an action import
+      const entitySetOdataName = "entitySet" in funcOrActionImport ? funcOrActionImport.entitySet : undefined;
 
       result.properties.push(this.generateQOperationProp(op));
-      result.methods.push(this.generateMethod(name, op, importContainer, "", this.getMainVersionArg(), false));
+      result.methods.push(
+        this.generateMethod(
+          name,
+          op,
+          importContainer,
+          "",
+          this.getMainVersionArg(),
+          false,
+          entitySetOdataName,
+          odataName,
+        ),
+      );
     });
 
     return result;
   }
 
+  /**
+   * `ownerFqName` distinguishes the two contexts this getter serves: `undefined` for an entity set on the
+   * main service (the root of a route), a real FQ type for a navigation property reached from another
+   * entity or complex type (a hop off `ownerFqName`'s `contained`/`odataPropName`).
+   */
   private generateRelatedServiceGetter(
     propName: string,
     odataPropName: string,
     entityType: EntityType,
     imports: ImportContainer,
     versionArg: string,
+    ownerFqName?: string,
+    contained = false,
   ): OptionalKind<MethodDeclarationStructure> {
     const idName = imports.addGeneratedModel(entityType.id.fqName, entityType.id.modelName);
     const serviceName = imports.addGeneratedService(entityType.fqName, entityType.serviceName);
     const collectionName = imports.addGeneratedService(entityType.fqName, entityType.serviceCollectionName);
+    const cacheKeyExpr =
+      ownerFqName === undefined
+        ? this.emitRootStateExpr(imports, odataPropName, "list", entityType, { isEntitySet: true })
+        : this.emitNavHopExpr(imports, ownerFqName, odataPropName, entityType, true, contained);
+    const cacheKeyDestructure = ownerFqName !== undefined && cacheKeyExpr ? ", cacheKeyState" : "";
 
     return {
       scope: Scope.Public,
@@ -331,12 +534,12 @@ class ServiceGenerator {
       ],
       statements: [
         `const fieldName = "${odataPropName}";`,
-        `const { client, path, options } = this.__base;`,
+        `const { client, path, options${cacheKeyDestructure} } = this.__base;`,
         // the version argument is only spelled out on the constructor call for v2ResponseAsV4: without it,
         // "new Type(...)" infers AsV4's default (false), which mismatches the declared return type above
         // wherever it isn't itself the abstract AsV4 - concretely, on every getter of the main service,
         // which pins the literal true rather than passing an abstract type parameter along
-        `const collection = new ${collectionName}${this.isV2AsV4() ? versionArg : ""}(client, path, fieldName, options);`,
+        `const collection = new ${collectionName}${this.isV2AsV4() ? versionArg : ""}(client, path, fieldName, options${cacheKeyExpr ? `, ${cacheKeyExpr}` : ""});`,
         'return typeof id === "undefined" || id === null ? collection : collection.byId(id);',
       ],
     };
@@ -378,6 +581,11 @@ class ServiceGenerator {
     // the registered name rather than the plain one: an import may have been aliased to avoid a clash,
     // and the property declaration above went through the same call, so the two agree
     const serviceType = importContainer.addGeneratedService(entityType.fqName, entityType.serviceName);
+    // the singleton's own name is the root's identity directly - no params marker needed, unlike the old
+    // type-rooted shape, which had to smuggle it in since the root position was occupied by a type. No
+    // `isEntitySet` either: a singleton is not itself a member of an entity set, so it has no "list" form
+    // for `invalidates` to ever name.
+    const cacheKeyExpr = this.emitRootStateExpr(importContainer, odataName, "detail", entityType);
 
     return {
       scope: Scope.Public,
@@ -386,7 +594,7 @@ class ServiceGenerator {
         `if(!${propName}) {`,
         `  const { client, path, options } = this.__base;`,
         // prettier-ignore
-        `  ${propName} = new ${serviceType}(client, path, "${odataName}", options)`,
+        `  ${propName} = new ${serviceType}(client, path, "${odataName}", options${cacheKeyExpr ? `, ${cacheKeyExpr}` : ""})`,
         "}",
         `return ${propName}`,
       ],
@@ -423,7 +631,7 @@ class ServiceGenerator {
 
     const { properties, methods }: PropsAndOps = deepmerge(
       deepmerge(
-        this.generateServiceProperties(importContainer, model.serviceName, props),
+        this.generateServiceProperties(importContainer, model.fqName, props),
         this.generateServiceOperations(importContainer, model, operations, true),
       ),
       this.generateCastOperations(importContainer, model, false),
@@ -447,9 +655,21 @@ class ServiceGenerator {
               type: `${serviceOptions}${this.getServiceVersionArg()}`,
               hasQuestionToken: true,
             },
+            // a getter elsewhere constructs this very class as a hop off its own state (see emitNavHopExpr
+            // et al.) - without this parameter that hop's cache-key state would have nowhere to go, and the
+            // base class's own trailing parameter would sit unreachable behind a narrower constructor
+            ...(this.cacheKeyMode !== CacheKeyMode.off
+              ? [
+                  {
+                    name: "cacheKeyState",
+                    type: importContainer.addServiceFunction("CacheKeyState", true),
+                    hasQuestionToken: true,
+                  },
+                ]
+              : []),
           ],
           statements: [
-            `super(client, basePath, name, ${qObjectName}, ${this.getServiceRuntimeOptions(model, isComplexType)});`,
+            `super(client, basePath, name, ${qObjectName}, ${this.getServiceRuntimeOptions(model, isComplexType)}${this.cacheKeyMode !== CacheKeyMode.off ? ", cacheKeyState" : ""});`,
           ],
         },
       ],
@@ -460,7 +680,7 @@ class ServiceGenerator {
 
   private generateServiceProperties(
     importContainer: ImportContainer,
-    serviceName: string,
+    ownerFqName: string,
     props: Array<PropertyModel>,
   ): PropsAndOps {
     const result: PropsAndOps = { properties: [], methods: [] };
@@ -479,7 +699,7 @@ class ServiceGenerator {
         prop.dataType === DataTypes.ComplexType
       ) {
         result.properties.push(this.generateModelProp(importContainer, prop));
-        result.methods.push(this.generateModelPropGetter(importContainer, prop));
+        result.methods.push(this.generateModelPropGetter(importContainer, prop, ownerFqName));
       } else if (prop.isCollection) {
         // collection of EntityTypes
         if (prop.dataType === DataTypes.ModelType) {
@@ -495,6 +715,8 @@ class ServiceGenerator {
               entityType,
               importContainer,
               this.getServiceVersionArg(),
+              ownerFqName,
+              prop.contained,
             ),
           );
         }
@@ -636,14 +858,16 @@ class ServiceGenerator {
   ): OptionalKind<MethodDeclarationStructure> {
     const serviceType = imports.addServiceObject(this.version, ServiceImports.StreamService);
     const propName = "this." + this.namingHelper.getPrivatePropName(prop.name);
+    const cacheKeyExpr = this.emitStreamHopExpr(imports, prop.odataName);
+    const cacheKeyDestructure = cacheKeyExpr ? ", cacheKeyState" : "";
 
     return {
       scope: Scope.Public,
       name: this.namingHelper.getRelatedServiceGetter(prop.name),
       statements: [
         `if(!${propName}) {`,
-        `  const { client, path, options } = this.__base;`,
-        `  ${propName} = new ${serviceType}(client, path, "${prop.odataName}", options)`,
+        `  const { client, path, options${cacheKeyDestructure} } = this.__base;`,
+        `  ${propName} = new ${serviceType}(client, path, "${prop.odataName}", options${cacheKeyExpr ? `, ${cacheKeyExpr}` : ""})`,
         "}",
         `return ${propName}`,
       ],
@@ -653,9 +877,14 @@ class ServiceGenerator {
   private generateModelPropGetter(
     imports: ImportContainer,
     prop: PropertyModel,
+    ownerFqName: string,
   ): OptionalKind<MethodDeclarationStructure> {
     const model = this.dataModel.getModel(prop.fqType) as ComplexType;
     const isComplexCollection = prop.isCollection && model.dataType === DataTypes.ComplexType;
+    // an entity navigation property (never a collection here - that shape goes through
+    // generateRelatedServiceGetter instead) is grade-aware; a complex property never is, since a complex
+    // value is never a navigation property and has no relation to derive
+    const isEntityNav = model.dataType !== DataTypes.ComplexType;
 
     const type = isComplexCollection
       ? imports.addServiceObject(this.version, ServiceImports.CollectionService)
@@ -671,6 +900,10 @@ class ServiceGenerator {
       : `${type}${this.getServiceVersionArg()}`;
 
     const privateSrvProp = "this." + this.namingHelper.getPrivatePropName(prop.name);
+    const cacheKeyExpr = isEntityNav
+      ? this.emitNavHopExpr(imports, ownerFqName, prop.odataName, model as EntityType, false, !!prop.contained)
+      : this.emitComplexHopExpr(imports, prop.isCollection, prop.odataName);
+    const cacheKeyDestructure = cacheKeyExpr ? ", cacheKeyState" : "";
 
     return {
       scope: Scope.Public,
@@ -678,9 +911,9 @@ class ServiceGenerator {
       returnType: typeWithGenerics,
       statements: [
         `if(!${privateSrvProp}) {`,
-        `  const { client, path, options } = this.__base;`,
+        `  const { client, path, options${cacheKeyDestructure} } = this.__base;`,
         // prettier-ignore
-        `  ${privateSrvProp} = new ${type}(client, path, "${prop.odataName}"${isComplexCollection ? `, ${imports.addGeneratedQObject(model.fqName, firstCharLowerCase(model.qName))}`: ""}, options)`,
+        `  ${privateSrvProp} = new ${type}(client, path, "${prop.odataName}"${isComplexCollection ? `, ${imports.addGeneratedQObject(model.fqName, firstCharLowerCase(model.qName))}`: ""}, options${cacheKeyExpr ? `, ${cacheKeyExpr}` : ""})`,
         "}",
         `return ${privateSrvProp}`,
       ],
@@ -697,14 +930,16 @@ class ServiceGenerator {
       prop.dataType === DataTypes.EnumType ? imports.addGeneratedModel(prop.fqType, prop.type) : undefined;
 
     const propName = "this." + this.namingHelper.getPrivatePropName(prop.name);
+    const cacheKeyExpr = this.emitBareHopExpr(imports, prop.odataName);
+    const cacheKeyDestructure = cacheKeyExpr ? ", cacheKeyState" : "";
     return {
       scope: Scope.Public,
       name: this.namingHelper.getRelatedServiceGetter(prop.name),
       statements: [
         `if(!${propName}) {`,
-        `  const { client, path, options } = this.__base;`,
+        `  const { client, path, options${cacheKeyDestructure} } = this.__base;`,
         // prettier-ignore
-        `  ${propName} = new ${collectionServiceType}(client, path, "${prop.odataName}", new ${qCollectionName}(${enumName ?? ""}), options)`,
+        `  ${propName} = new ${collectionServiceType}(client, path, "${prop.odataName}", new ${qCollectionName}(${enumName ?? ""}), options${cacheKeyExpr ? `, ${cacheKeyExpr}` : ""})`,
         "}",
         `return ${propName}`,
       ],
@@ -720,14 +955,16 @@ class ServiceGenerator {
     // for V2: mapped name must be specified
     const v2MappedName =
       this.version === ODataVersions.V4 ? "" : prop.name !== prop.odataName ? `, "${prop.name}"` : ", undefined";
+    const cacheKeyExpr = this.emitBareHopExpr(imports, prop.odataName);
+    const cacheKeyDestructure = cacheKeyExpr ? ", cacheKeyState" : "";
 
     return {
       scope: Scope.Public,
       name: this.namingHelper.getRelatedServiceGetter(prop.name),
       statements: [
         `if(!${propName}) {`,
-        `  const { client, path, qModel, options } = this.__base;`,
-        `  ${propName} = new ${serviceType}(client, path, "${prop.odataName}", qModel.${prop.name}.converter${v2MappedName}, options)`,
+        `  const { client, path, qModel, options${cacheKeyDestructure} } = this.__base;`,
+        `  ${propName} = new ${serviceType}(client, path, "${prop.odataName}", qModel.${prop.name}.converter${v2MappedName}, options${cacheKeyExpr ? `, ${cacheKeyExpr}` : ""})`,
         "}",
         `return ${propName}`,
       ],
@@ -786,9 +1023,22 @@ class ServiceGenerator {
               type: `${serviceOptions}${this.getServiceVersionArg()}`,
               hasQuestionToken: true,
             },
+            // a getter elsewhere constructs this very class as a hop off its own state (see
+            // emitNavHopExpr et al.) - without this parameter that hop's cache-key state would have
+            // nowhere to go, and the base class's own trailing parameter would sit unreachable behind a
+            // narrower constructor
+            ...(this.cacheKeyMode !== CacheKeyMode.off
+              ? [
+                  {
+                    name: "cacheKeyState",
+                    type: importContainer.addServiceFunction("CacheKeyState", true),
+                    hasQuestionToken: true,
+                  },
+                ]
+              : []),
           ],
           statements: [
-            `super(client, basePath, name, ${qObjectName}, new ${qIdFunctionName}(name), ${this.getServiceRuntimeOptions(model)});`,
+            `super(client, basePath, name, ${qObjectName}, new ${qIdFunctionName}(name), ${this.getServiceRuntimeOptions(model)}${this.cacheKeyMode !== CacheKeyMode.off ? ", cacheKeyState" : ""});`,
           ],
         },
       ],
@@ -803,8 +1053,21 @@ class ServiceGenerator {
             { name: "path", type: "string" },
             { name: "name", type: "string" },
             { name: "options", type: `${serviceOptions}${this.getServiceVersionArg()} | undefined` },
+            // this base class's own `byId` computes the entity's cache-key state (see EntitySetServiceV4/V2);
+            // this override only has to forward it, never compute it itself
+            ...(this.cacheKeyMode !== CacheKeyMode.off
+              ? [
+                  {
+                    name: "cacheKeyState",
+                    type: importContainer.addServiceFunction("CacheKeyState", true),
+                    hasQuestionToken: true,
+                  },
+                ]
+              : []),
           ],
-          statements: [`return new ${entityServiceName}${this.getServiceVersionArg()}(client, path, name, options);`],
+          statements: [
+            `return new ${entityServiceName}${this.getServiceVersionArg()}(client, path, name, options${this.cacheKeyMode !== CacheKeyMode.off ? ", cacheKeyState" : ""});`,
+          ],
         },
       ],
     });
@@ -854,6 +1117,8 @@ class ServiceGenerator {
     baseFqName: string,
     versionArg: string,
     isEntityBound = false,
+    entitySetOdataName?: string,
+    importOdataName?: string,
   ): OptionalKind<MethodDeclarationStructure> {
     const isFunc = operation.type === OperationTypes.Function;
     const returnType = operation.returnType;
@@ -900,12 +1165,20 @@ class ServiceGenerator {
 
     const qOpProp = "this." + this.namingHelper.getPrivatePropName(operation.qName);
 
+    // an unbound operation (baseFqName === "") roots the key at its own import name; a bound one is a hop
+    // off the resource it hangs on
+    const cacheKeyExpr = !baseFqName
+      ? this.emitUnboundOperationRootExpr(importContainer, operation, importOdataName!, entitySetOdataName, !!hasParams)
+      : this.emitBoundOperationHopExpr(importContainer, operation.fqName, returnType);
+    const needsCacheKeyState = !!baseFqName && !!cacheKeyExpr;
+
     const optionStmt =
       `{ ` +
       `headers: getDefaultHeaders()` +
       (!isFunc && hasParams ? `, mainRequestConverter: ${qOpProp}.getRequestConverter()` : "") +
       (returnType ? `, mainResponseConverter: ${qOpProp}.getResponseConverter()` : "") +
       (withConcurrency ? `, concurrency: getConcurrencyOptions()` : "") +
+      (cacheKeyExpr ? `, cacheKeyState: ${cacheKeyExpr}` : "") +
       `}`;
     const requestCmdStmt = isComposable
       ? `return new ${requestCmd}<${responseService}${versionArg}, ${responseStructure}<${rtType}>>(` +
@@ -933,7 +1206,7 @@ class ServiceGenerator {
         `  ${qOpProp} = new ${qOperationName}()`,
         "}",
 
-        `const { addFullPath, client, getDefaultHeaders${isFunc ? `, isUrlNotEncoded${isComposable ? ", options" : ""}` : ""}${withConcurrency ? ", getConcurrencyOptions" : ""} } = this.__base;`,
+        `const { addFullPath, client, getDefaultHeaders${isFunc ? `, isUrlNotEncoded${isComposable ? ", options" : ""}` : ""}${withConcurrency ? ", getConcurrencyOptions" : ""}${needsCacheKeyState ? ", cacheKeyState" : ""} } = this.__base;`,
         `const url = addFullPath(${qOpProp}.buildUrl(${!isFunc ? "" : hasParams ? "params, isUrlNotEncoded()" : "isUrlNotEncoded()"}));`,
         ``,
         requestCmdStmt,
@@ -953,12 +1226,14 @@ class ServiceGenerator {
         const subClass = this.dataModel.getModel(subtype) as ComplexType;
         const serviceName = isCollection ? subClass.serviceCollectionName : subClass.serviceName;
         const serviceType = importContainer.addGeneratedService(subClass.fqName, serviceName);
+        const cacheKeyExpr = this.emitCastParamsExpr(importContainer, subClass.fqName);
+        const cacheKeyDestructure = cacheKeyExpr ? ", cacheKeyState" : "";
         result.methods.push({
           name: `as${upperCaseFirst(serviceName)}`,
           scope: Scope.Public,
           statements: [
-            "const { client, path, options } = this.__base;",
-            `return new ${serviceType}(client, path, "${subClass.fqName}", { ...options, subtype: true });`,
+            `const { client, path, options${cacheKeyDestructure} } = this.__base;`,
+            `return new ${serviceType}(client, path, "${subClass.fqName}", { ...options, subtype: true }${cacheKeyExpr ? `, ${cacheKeyExpr}` : ""});`,
           ],
         });
       });

--- a/packages/odata2ts/test/data-model/builder/v2/ODataEntityTypeBuilderV2.ts
+++ b/packages/odata2ts/test/data-model/builder/v2/ODataEntityTypeBuilderV2.ts
@@ -22,6 +22,12 @@ export class ODataEntityTypeBuilderV2 extends ODataEntityTypeBuilderBase<EntityT
   /**
    * @param roles the association roles; by default they are derived from the two type names, which is not
    * unique as soon as one entity type points at another one more than once - specify them in that case
+   * @param referentialConstraint the foreign key realizing this association, stated from this navigation
+   * property's own side: `property` names one of this entity type's own properties, `referencedProperty`
+   * the property of the target type it references. V2 states the constraint once per association rather
+   * than per end, so this is only meaningful on the call for the side that actually points at the
+   * principal - the merge in {@link ODataModelBuilderV2.addEntityType} carries it onto the shared
+   * `<Association>` regardless of which of the two `addNavProp` calls supplies it.
    */
   public addNavProp(
     name: string,
@@ -29,6 +35,7 @@ export class ODataEntityTypeBuilderV2 extends ODataEntityTypeBuilderBase<EntityT
     relationship: string,
     multiplicity: string,
     roles?: { fromRole: string; toRole: string },
+    referentialConstraint?: Array<{ property: string; referencedProperty: string }>,
   ) {
     if (!this.entityType.NavigationProperty) {
       this.entityType.NavigationProperty = [];
@@ -50,6 +57,26 @@ export class ODataEntityTypeBuilderV2 extends ODataEntityTypeBuilderBase<EntityT
           },
         },
       ],
+      ...(referentialConstraint
+        ? {
+            ReferentialConstraint: [
+              {
+                Principal: [
+                  {
+                    $: { Role: toRole },
+                    PropertyRef: referentialConstraint.map((rc) => ({ $: { Name: rc.referencedProperty } })),
+                  },
+                ],
+                Dependent: [
+                  {
+                    $: { Role: fromRole },
+                    PropertyRef: referentialConstraint.map((rc) => ({ $: { Name: rc.property } })),
+                  },
+                ],
+              },
+            ],
+          }
+        : undefined),
     });
 
     this.entityType.NavigationProperty.push({

--- a/packages/odata2ts/test/data-model/builder/v2/ODataModelBuilderV2.ts
+++ b/packages/odata2ts/test/data-model/builder/v2/ODataModelBuilderV2.ts
@@ -93,6 +93,12 @@ export class ODataModelBuilderV2 extends ODataModelBuilder<ODataEdmxModelV3, Sch
         const existingAssoc = this.currentSchema.Association!.find((a) => a.$.Name === assoc.$.Name);
         if (existingAssoc) {
           existingAssoc.End.push(...assoc.End);
+          // the constraint is stated once per association, not per end, but addNavProp only ever
+          // supplies it from the side that carries the foreign key - so it is picked up on whichever of
+          // the two merged calls happens to have it
+          if (assoc.ReferentialConstraint) {
+            existingAssoc.ReferentialConstraint = assoc.ReferentialConstraint;
+          }
         } else {
           this.currentSchema.Association!.push(assoc);
         }

--- a/packages/odata2ts/test/data-model/builder/v4/ODataBuilderV4Helper.ts
+++ b/packages/odata2ts/test/data-model/builder/v4/ODataBuilderV4Helper.ts
@@ -1,6 +1,13 @@
 import { NavigationProperty } from "../../../../src/data-model/edmx/ODataEdmxModelV4.js";
 
-export function createNavProp(name: string, type: string, partner?: string, nullable?: boolean, contained?: boolean) {
+export function createNavProp(
+  name: string,
+  type: string,
+  partner?: string,
+  nullable?: boolean,
+  contained?: boolean,
+  referentialConstraints?: Array<{ property: string; referencedProperty: string }>,
+) {
   const navProp: NavigationProperty = {
     $: {
       Name: name,
@@ -15,6 +22,11 @@ export function createNavProp(name: string, type: string, partner?: string, null
   }
   if (contained) {
     navProp.$.ContainsTarget = "true";
+  }
+  if (referentialConstraints?.length) {
+    navProp.ReferentialConstraint = referentialConstraints.map((rc) => ({
+      $: { Property: rc.property, ReferencedProperty: rc.referencedProperty },
+    }));
   }
 
   return navProp;

--- a/packages/odata2ts/test/data-model/builder/v4/ODataEntityTypeBuilderV4.ts
+++ b/packages/odata2ts/test/data-model/builder/v4/ODataEntityTypeBuilderV4.ts
@@ -7,11 +7,20 @@ export class ODataEntityTypeBuilderV4 extends ODataEntityTypeBuilderBase<EntityT
     return this.createEntityType();
   }
 
-  public addNavProp(name: string, type: string, partner?: string, nullable?: boolean, contained?: boolean) {
+  public addNavProp(
+    name: string,
+    type: string,
+    partner?: string,
+    nullable?: boolean,
+    contained?: boolean,
+    referentialConstraints?: Array<{ property: string; referencedProperty: string }>,
+  ) {
     if (!this.entityType.NavigationProperty) {
       this.entityType.NavigationProperty = [];
     }
-    this.entityType.NavigationProperty.push(createNavProp(name, type, partner, nullable, contained));
+    this.entityType.NavigationProperty.push(
+      createNavProp(name, type, partner, nullable, contained, referentialConstraints),
+    );
 
     return this;
   }

--- a/packages/odata2ts/test/data-model/helper/DigestFixture.ts
+++ b/packages/odata2ts/test/data-model/helper/DigestFixture.ts
@@ -1,0 +1,65 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { ODataVersions } from "@odata2ts/odata-core";
+import { pascalCase } from "change-case";
+import { parseStringPromise } from "xml2js";
+import { DataModel, NamespaceWithAlias } from "../../../src/data-model/DataModel.js";
+import { digest as digestV2 } from "../../../src/data-model/DataModelDigestionV2.js";
+import { digest as digestV4 } from "../../../src/data-model/DataModelDigestionV4.js";
+import { ODataEdmxModelBase } from "../../../src/data-model/edmx/ODataEdmxModelBase.js";
+import { SchemaV3 } from "../../../src/data-model/edmx/ODataEdmxModelV3.js";
+import { SchemaV4 } from "../../../src/data-model/edmx/ODataEdmxModelV4.js";
+import { NamingHelper } from "../../../src/data-model/NamingHelper.js";
+import { resolveV2Annotations } from "../../../src/data-model/V2AnnotationResolver.js";
+import { getTestConfig } from "../../test.config.js";
+
+// The int-test fixtures (`int-test/<server>/resource/library.xml`) live outside this package, at the
+// workspace repo's root - not under `packages/odata2ts`. Resolving against this file's own location
+// rather than the process cwd is what keeps the path correct regardless of where vitest is invoked from.
+const REPO_ROOT = fileURLToPath(new URL("../../../../../", import.meta.url));
+
+/**
+ * Digests a real metadata file from disk exactly the way the CLI does it (see
+ * `src/cli/serviceGenerationRun.ts` and `src/app.ts`): parse with xml2js, then hand the schemas to the
+ * version-specific digester. Exists so tests can exercise the data model against a server's actual
+ * declarations instead of a hand-built fixture, which is the whole point where a rule depends on what a
+ * real service happens to state in its metadata.
+ *
+ * @param relativePath path to the metadata file, relative to the repo root, e.g.
+ *   `"int-test/asp-net/resource/library.xml"`
+ */
+export async function digestMetadataFile(relativePath: string): Promise<DataModel> {
+  const metadataXml = await readFile(path.join(REPO_ROOT, relativePath));
+  const metadataJson = (await parseStringPromise(metadataXml)) as ODataEdmxModelBase<any>;
+
+  const edmxVersion = metadataJson["edmx:Edmx"].$.Version;
+  const version = edmxVersion === "1.0" ? ODataVersions.V2 : ODataVersions.V4;
+
+  const dataService = metadataJson["edmx:Edmx"]["edmx:DataServices"][0];
+  const schemas = dataService.Schema as Array<SchemaV3 | SchemaV4>;
+  // the vocabularies the document draws annotation terms from; they sit outside of the schemas
+  const references = metadataJson["edmx:Edmx"]["edmx:Reference"];
+
+  // V2 states what V4 says with a vocabulary term as an attribute in a foreign namespace; translated
+  // here, against the whole document, because resolving those namespaces needs the root element
+  if (version === ODataVersions.V2) {
+    resolveV2Annotations(metadataJson);
+  }
+
+  const namespaces = schemas.map<NamespaceWithAlias>((schema) => [schema.$.Namespace, schema.$.Alias]);
+  const detectedSchema = schemas.find((schema) => schema.$.Namespace && schema.EntityType?.length) || schemas[0];
+  const serviceName = pascalCase(detectedSchema.$.Namespace);
+
+  const config = getTestConfig();
+  // asp-net's real metadata declares both `Location_` (the shelf mark) and `Location` (a navigation
+  // property to the branch an item sits in) on `Copy`; camelCase collapses both onto `location`, which
+  // `getTestConfig()`'s `allowRenaming: true` turns into a hard digestion error. `int-test/asp-net`'s own
+  // `libraryRenamed` service carries the identical fix - see its `odata2ts.config.ts`.
+  config.propertiesByName = [{ name: "Location_", mappedName: "shelfLocation" }];
+  const namingHelper = new NamingHelper(config, serviceName, namespaces);
+
+  return version === ODataVersions.V2
+    ? digestV2(schemas as Array<SchemaV3>, config, namingHelper, references)
+    : digestV4(schemas as Array<SchemaV4>, config, namingHelper, references);
+}

--- a/packages/odata2ts/test/data-model/v2/EntityTypeDigestion.test.ts
+++ b/packages/odata2ts/test/data-model/v2/EntityTypeDigestion.test.ts
@@ -456,6 +456,8 @@ describe("V2: EntityTypeDigestion Test", () => {
       dataType: DataTypes.ModelType,
       managed: undefined,
       required: true,
+      // a genuine pair: Category.products points back with FromRole/ToRole swapped
+      partner: "products",
     } as PropertyModel);
     expect(product.props[2]).toEqual({
       name: "supplier",
@@ -470,6 +472,8 @@ describe("V2: EntityTypeDigestion Test", () => {
       dataType: DataTypes.ModelType,
       managed: undefined,
       required: false,
+      // a genuine pair: Supplier.products points back with FromRole/ToRole swapped
+      partner: "products",
     } as PropertyModel);
 
     const category = result.getEntityTypes()[1];
@@ -487,6 +491,8 @@ describe("V2: EntityTypeDigestion Test", () => {
       dataType: DataTypes.ModelType,
       managed: undefined,
       required: false,
+      // a genuine pair: Product.Category points back with FromRole/ToRole swapped
+      partner: "Category",
     } as PropertyModel);
   });
 

--- a/packages/odata2ts/test/data-model/v2/NavPropDigestion.test.ts
+++ b/packages/odata2ts/test/data-model/v2/NavPropDigestion.test.ts
@@ -1,0 +1,132 @@
+import { ODataTypesV2 } from "@odata2ts/odata-core";
+import { beforeEach, describe, expect, test } from "vitest";
+import { digest } from "../../../src/data-model/DataModelDigestionV2.js";
+import { NamingHelper } from "../../../src/data-model/NamingHelper.js";
+import { getTestConfig } from "../../test.config.js";
+import { ODataModelBuilderV2 } from "../builder/v2/ODataModelBuilderV2.js";
+
+describe("V2: navigation property digestion (partner, referential constraint)", () => {
+  const SERVICE_NAME = "Test";
+  const CONFIG = getTestConfig();
+  const NAMING_HELPER = new NamingHelper(CONFIG, SERVICE_NAME);
+
+  let odataBuilder: ODataModelBuilderV2;
+
+  function withNs(name: string) {
+    return `${SERVICE_NAME}.${name}`;
+  }
+
+  function doDigest() {
+    return digest(odataBuilder.getSchemas(), CONFIG, NAMING_HELPER);
+  }
+
+  beforeEach(() => {
+    odataBuilder = new ODataModelBuilderV2(SERVICE_NAME);
+
+    // Medium 1--n Copy, realized by a single-property ReferentialConstraint stated on the association:
+    // Copy carries the foreign key back to Medium, so Copy's own navigation property (pointing at the
+    // principal) gets the constraint, while Medium's collection end gets only the Partner.
+    odataBuilder
+      .addEntityType("Medium", undefined, (builder) => {
+        builder
+          .addKeyProp("Id", ODataTypesV2.String)
+          .addNavProp("Copies", withNs("Copy"), "Medium_Copies", "*", { fromRole: "Medium", toRole: "Copy" });
+      })
+      .addEntityType("Copy", undefined, (builder) => {
+        builder
+          .addKeyProp("MediumId", ODataTypesV2.String)
+          .addKeyProp("InventoryNumber", ODataTypesV2.String)
+          .addNavProp("Medium", withNs("Medium"), "Medium_Copies", "1", { fromRole: "Copy", toRole: "Medium" }, [
+            { property: "MediumId", referencedProperty: "Id" },
+          ])
+          // points at Location, but Location never declares a navigation property back - a legal end
+          // that nothing navigates back from
+          .addNavProp("Location", withNs("Location"), "Copy_Location", "0..1", {
+            fromRole: "Copy",
+            toRole: "Location",
+          })
+          // the principal side of a composite-key constraint (see Reservation below): Copy itself
+          // carries no constraint, only Reservation does
+          .addNavProp("Reservations", withNs("Reservation"), "Reservation_Copy", "*", {
+            fromRole: "Copy",
+            toRole: "Reservation",
+          });
+      })
+      .addEntityType("Location", undefined, (builder) => {
+        builder.addKeyProp("Id", ODataTypesV2.String);
+      })
+      .addEntityType("Reservation", undefined, (builder) => {
+        builder
+          .addKeyProp("Id", ODataTypesV2.String)
+          .addProp("Copy_MediumId", ODataTypesV2.String)
+          .addProp("Copy_InventoryNumber", ODataTypesV2.String)
+          .addNavProp("copy", withNs("Copy"), "Reservation_Copy", "1", { fromRole: "Reservation", toRole: "Copy" }, [
+            { property: "Copy_MediumId", referencedProperty: "MediumId" },
+            { property: "Copy_InventoryNumber", referencedProperty: "InventoryNumber" },
+          ]);
+      })
+      // Member 1--n Loan, with no ReferentialConstraint on the association at all
+      .addEntityType("Member", undefined, (builder) => {
+        builder.addKeyProp("Id", ODataTypesV2.String).addNavProp("Loans", withNs("Loan"), "Member_Loans", "*", {
+          fromRole: "Member",
+          toRole: "Loan",
+        });
+      })
+      .addEntityType("Loan", undefined, (builder) => {
+        builder
+          .addKeyProp("Id", ODataTypesV2.String)
+          .addNavProp("Member", withNs("Member"), "Member_Loans", "1", { fromRole: "Loan", toRole: "Member" });
+      });
+  });
+
+  test("the inverse navigation property is derived from the association's other end", async () => {
+    const result = await doDigest();
+    const copies = result.getEntityType(withNs("Medium"))!.props.find((p) => p.odataName === "Copies");
+    const medium = result.getEntityType(withNs("Copy"))!.props.find((p) => p.odataName === "Medium");
+
+    expect(copies!.partner).toBe("Medium");
+    expect(medium!.partner).toBe("Copies");
+  });
+
+  test("no inverse navigation property means no partner", async () => {
+    const result = await doDigest();
+    const orphan = result.getEntityType(withNs("Copy"))!.props.find((p) => p.odataName === "Location");
+
+    expect(orphan!.partner).toBeUndefined();
+  });
+
+  test("the constraint is carried on the dependent side's navigation property", async () => {
+    const result = await doDigest();
+    const medium = result.getEntityType(withNs("Copy"))!.props.find((p) => p.odataName === "Medium");
+
+    expect(medium!.referentialConstraints).toEqual([{ property: "MediumId", referencedProperty: "Id" }]);
+  });
+
+  test("the principal side's navigation property carries no constraint", async () => {
+    const result = await doDigest();
+    const copies = result.getEntityType(withNs("Medium"))!.props.find((p) => p.odataName === "Copies");
+
+    expect(copies!.referentialConstraints).toBeUndefined();
+  });
+
+  test("a composite-key constraint is carried in source order, on the dependent side only", async () => {
+    const result = await doDigest();
+    const copy = result.getEntityType(withNs("Reservation"))!.props.find((p) => p.odataName === "copy");
+    const reservations = result.getEntityType(withNs("Copy"))!.props.find((p) => p.odataName === "Reservations");
+
+    expect(copy!.referentialConstraints).toEqual([
+      { property: "Copy_MediumId", referencedProperty: "MediumId" },
+      { property: "Copy_InventoryNumber", referencedProperty: "InventoryNumber" },
+    ]);
+    expect(reservations!.referentialConstraints).toBeUndefined();
+  });
+
+  test("an association without a constraint yields none on either side", async () => {
+    const result = await doDigest();
+    const loans = result.getEntityType(withNs("Member"))!.props.find((p) => p.odataName === "Loans");
+    const member = result.getEntityType(withNs("Loan"))!.props.find((p) => p.odataName === "Member");
+
+    expect(loans!.referentialConstraints).toBeUndefined();
+    expect(member!.referentialConstraints).toBeUndefined();
+  });
+});

--- a/packages/odata2ts/test/data-model/v4/NavPropDigestion.test.ts
+++ b/packages/odata2ts/test/data-model/v4/NavPropDigestion.test.ts
@@ -1,0 +1,97 @@
+import { ODataTypesV4 } from "@odata2ts/odata-core";
+import { beforeEach, describe, expect, test } from "vitest";
+import { digest } from "../../../src/data-model/DataModelDigestionV4.js";
+import { NamingHelper } from "../../../src/data-model/NamingHelper.js";
+import { getTestConfig } from "../../test.config.js";
+import { ODataModelBuilderV4 } from "../builder/v4/ODataModelBuilderV4.js";
+
+describe("V4: navigation property digestion (Partner, ReferentialConstraint)", () => {
+  const SERVICE_NAME = "Test";
+  const CONFIG = getTestConfig();
+  const NAMING_HELPER = new NamingHelper(CONFIG, SERVICE_NAME);
+
+  let odataBuilder: ODataModelBuilderV4;
+
+  function withNs(name: string) {
+    return `${SERVICE_NAME}.${name}`;
+  }
+
+  function doDigest() {
+    return digest(odataBuilder.getSchemas(), CONFIG, NAMING_HELPER);
+  }
+
+  beforeEach(() => {
+    odataBuilder = new ODataModelBuilderV4(SERVICE_NAME);
+
+    // Medium 1--n Copy: Copy carries the foreign key back to Medium via a composite-key style
+    // ReferentialConstraint (two properties, so source order is actually observable), Medium's collection
+    // end carries only the Partner.
+    odataBuilder
+      .addEntityType("Medium", undefined, (builder) => {
+        builder
+          .addKeyProp("Id", ODataTypesV4.String)
+          .addNavProp("Copies", `Collection(${withNs("Copy")})`, "Medium")
+          .addNavProp("Reservations", `Collection(${withNs("Reservation")})`);
+      })
+      .addEntityType("Copy", undefined, (builder) => {
+        builder
+          .addKeyProp("MediumId", ODataTypesV4.String)
+          .addKeyProp("InventoryNumber", ODataTypesV4.String)
+          .addNavProp("medium", withNs("Medium"), "Copies", undefined, undefined, [
+            { property: "MediumId", referencedProperty: "Id" },
+          ])
+          .addNavProp("location", withNs("Location"));
+      })
+      .addEntityType("Reservation", undefined, (builder) => {
+        builder
+          .addKeyProp("Id", ODataTypesV4.String)
+          .addProp("Copy_MediumId", ODataTypesV4.String)
+          .addProp("Copy_InventoryNumber", ODataTypesV4.String)
+          .addNavProp("copy", withNs("Copy"), undefined, undefined, undefined, [
+            { property: "Copy_MediumId", referencedProperty: "MediumId" },
+            { property: "Copy_InventoryNumber", referencedProperty: "InventoryNumber" },
+          ]);
+      })
+      .addEntityType("Location", undefined, (builder) => {
+        builder.addKeyProp("Id", ODataTypesV4.String);
+      });
+  });
+
+  test("Partner reaches the property model", async () => {
+    const result = await doDigest();
+    const copies = result.getEntityType(withNs("Medium"))!.props.find((p) => p.odataName === "Copies");
+
+    expect(copies!.partner).toBe("Medium");
+  });
+
+  test("a navigation property without Partner has none", async () => {
+    const result = await doDigest();
+    const reservations = result.getEntityType(withNs("Medium"))!.props.find((p) => p.odataName === "Reservations");
+
+    expect(reservations!.partner).toBeUndefined();
+  });
+
+  test("ReferentialConstraint reaches the property model", async () => {
+    const result = await doDigest();
+    const medium = result.getEntityType(withNs("Copy"))!.props.find((p) => p.odataName === "medium");
+
+    expect(medium!.referentialConstraints).toEqual([{ property: "MediumId", referencedProperty: "Id" }]);
+  });
+
+  test("several ReferentialConstraints are all carried, in source order", async () => {
+    const result = await doDigest();
+    const copy = result.getEntityType(withNs("Reservation"))!.props.find((p) => p.odataName === "copy");
+
+    expect(copy!.referentialConstraints).toEqual([
+      { property: "Copy_MediumId", referencedProperty: "MediumId" },
+      { property: "Copy_InventoryNumber", referencedProperty: "InventoryNumber" },
+    ]);
+  });
+
+  test("a navigation property without a constraint has none", async () => {
+    const result = await doDigest();
+    const location = result.getEntityType(withNs("Copy"))!.props.find((p) => p.odataName === "location");
+
+    expect(location!.referentialConstraints).toBeUndefined();
+  });
+});

--- a/packages/odata2ts/test/evaluateConfig.test.ts
+++ b/packages/odata2ts/test/evaluateConfig.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { evaluateConfigOptions } from "../src/evaluateConfig.js";
 import {
+  CacheKeyMode,
   CliOptions,
   ConfigFileOptions,
   DeepInsertProps,
@@ -8,6 +9,7 @@ import {
   getDefaultConfig,
   Modes,
   NamingStrategies,
+  resolveCacheKeyMode,
 } from "../src/index.js";
 
 describe("Config Evaluation Tests", () => {
@@ -309,6 +311,47 @@ describe("Config Evaluation Tests", () => {
       const result = evaluateConfigOptions(cliOpts, { mode, deepInsertProps: DeepInsertProps.compositionOnly });
 
       expect(result[0], `mode ${mode}`).toMatchObject({ deepInsertProps: DeepInsertProps.compositionOnly });
+    });
+  });
+
+  describe("cacheKeys option", () => {
+    test("absent means off", () => {
+      expect(resolveCacheKeyMode(undefined)).toBe(CacheKeyMode.off);
+    });
+
+    test("a named mode is passed through", () => {
+      expect(resolveCacheKeyMode({ mode: CacheKeyMode.on })).toBe(CacheKeyMode.on);
+      expect(resolveCacheKeyMode({ mode: CacheKeyMode.off })).toBe(CacheKeyMode.off);
+    });
+
+    test("the default is off, so a config saying nothing generates nothing", () => {
+      const [only] = evaluateConfigOptions({}, { services: { a: { source: "a.xml", output: "a" } } });
+      expect(only.cacheKeys).toEqual({ mode: CacheKeyMode.off });
+      expect(resolveCacheKeyMode(only.cacheKeys)).toBe(CacheKeyMode.off);
+    });
+
+    test("it is a per-service option, overridable from the base settings", () => {
+      const [first, second] = evaluateConfigOptions(
+        {},
+        {
+          cacheKeys: { mode: CacheKeyMode.on },
+          services: {
+            a: { source: "a.xml", output: "a" },
+            b: { source: "b.xml", output: "b", cacheKeys: { mode: CacheKeyMode.off } },
+          },
+        },
+      );
+      expect(first.cacheKeys).toEqual({ mode: CacheKeyMode.on });
+      expect(second.cacheKeys).toEqual({ mode: CacheKeyMode.off });
+    });
+
+    test("a service overrides the default rather than merging with it", () => {
+      // deepmerge folds the default {mode:"off"} under the service's own entry; the service must win
+      const [only] = evaluateConfigOptions(
+        {},
+        { services: { a: { source: "a.xml", output: "a", cacheKeys: { mode: CacheKeyMode.on } } } },
+      );
+      expect(only.cacheKeys).toEqual({ mode: CacheKeyMode.on });
     });
   });
 });

--- a/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
@@ -5,6 +5,7 @@ import { beforeAll, beforeEach, describe, expect, test } from "vitest";
 import { digest } from "../../../src/data-model/DataModelDigestionV4.js";
 import { NamingHelper } from "../../../src/data-model/NamingHelper.js";
 import {
+  CacheKeyMode,
   ConfigFileOptions,
   EmitModes,
   KeyProperties,
@@ -170,6 +171,174 @@ describe("Service Generator Tests V4", () => {
       await doGenerate();
 
       expect(generatedText()).not.toContain("getConcurrencyOptions");
+    });
+  });
+
+  describe("cacheKeys: root", () => {
+    function generatedText() {
+      return projectManager.getMainServiceFile().getFile().getFullText();
+    }
+
+    function addEntity() {
+      odataBuilder
+        .addEntityType("TestEntity", undefined, (builder) => builder.addKeyProp("id", ODataTypesV4.Guid))
+        .addEntitySet("Ents", withNs("TestEntity"));
+    }
+
+    test("a collection getter roots the key at the entity set's own name, not its type, when the feature is on", async () => {
+      addEntity();
+
+      await doGenerate({ cacheKeys: { mode: CacheKeyMode.on } });
+
+      // "Ents" - the entity set's own name - never the entity type's FQ name ("Tester.TestEntity")
+      expect(generatedText()).toContain(
+        `rootState("Ents", "list", { entitySetName: "Ents", canonicalIdFn: (entity: unknown) => new QTestEntityId("Ents").buildCanonicalId(entity), qEntityFn: () => QTestEntity })`,
+      );
+    });
+
+    test("nothing is emitted when cacheKeys is absent", async () => {
+      addEntity();
+
+      await doGenerate();
+
+      expect(generatedText()).not.toContain("rootState");
+      expect(generatedText()).not.toContain("cacheKeyState");
+    });
+
+    test("nothing is emitted under mode: off - identical to cacheKeys being absent", async () => {
+      addEntity();
+
+      await doGenerate({ cacheKeys: { mode: CacheKeyMode.off } });
+
+      expect(generatedText()).not.toContain("rootState");
+      expect(generatedText()).not.toContain("cacheKeyState");
+    });
+  });
+
+  describe("cacheKeys: hops", () => {
+    function generatedText() {
+      return projectManager.getMainServiceFile().getFile().getFullText();
+    }
+
+    /**
+     * Every navigation property is handled identically now - purely hierarchical, named by its own OData
+     * name, no grade/derivation reasoning involved (that machinery, and `typeFlattening` itself, is gone).
+     * `chapters` is contained (no entity set of its own, so no `entitySetName`); every other navigation
+     * property targets a real one.
+     */
+    function buildModel() {
+      odataBuilder
+        .addComplexType("Details", undefined, (builder) => builder.addProp("note", ODataTypesV4.String))
+        .addEntityType("Chapter", undefined, (builder) => builder.addKeyProp("id", ODataTypesV4.Guid))
+        .addEntityType("Review", undefined, (builder) => builder.addKeyProp("id", ODataTypesV4.Guid))
+        .addEntityType("Copy", undefined, (builder) =>
+          builder
+            .addKeyProp("mediumId", ODataTypesV4.Guid)
+            .addKeyProp("inventoryNumber", ODataTypesV4.Int32)
+            .addNavProp("medium", withNs("Medium"), "copies", false, false, [
+              { property: "mediumId", referencedProperty: "id" },
+            ]),
+        )
+        .addEntityType("Medium", undefined, (builder) =>
+          builder
+            .addKeyProp("id", ODataTypesV4.Guid)
+            .addProp("title", ODataTypesV4.String)
+            .addProp("rating", ODataTypesV4.Int32)
+            .addProp("scan", ODataTypesV4.Stream)
+            .addProp("keywords", `Collection(${ODataTypesV4.String})`)
+            .addProp("details", withNs("Details"))
+            .addNavProp("copies", `Collection(${withNs("Copy")})`, "medium")
+            .addNavProp("reviews", `Collection(${withNs("Review")})`)
+            .addNavProp("chapters", `Collection(${withNs("Chapter")})`, undefined, undefined, true),
+        )
+        .addEntityType("Book", { baseType: withNs("Medium") }, () => {})
+        .addEntitySet("Media", withNs("Medium"), [
+          { path: "copies", target: "Copies" },
+          { path: "reviews", target: "Reviews" },
+        ])
+        .addEntitySet("Copies", withNs("Copy"), [{ path: "medium", target: "Media" }])
+        .addEntitySet("Reviews", withNs("Review"))
+        .addSingleton("MainBranch", withNs("Medium"))
+        .addAction("checkOut", undefined, true, (builder) => builder.addParam("medium", withNs("Medium")))
+        .addFunction("newReleases", `Collection(${withNs("Medium")})`, false)
+        .addFunctionImport("NewReleases", withNs("newReleases"), "Media")
+        .addFunction("totalCount", ODataTypesV4.Int32, false)
+        .addFunctionImport("TotalCount", withNs("totalCount"));
+    }
+
+    async function generateWith(mode: CacheKeyMode) {
+      buildModel();
+      await doGenerate({ cacheKeys: { mode }, enablePrimitivePropertyServices: true });
+      return generatedText();
+    }
+
+    test("off: no cache-key expression is emitted anywhere", async () => {
+      const text = await generateWith(CacheKeyMode.off);
+
+      expect(text).not.toContain("rootState");
+      expect(text).not.toContain("hopState");
+      expect(text).not.toContain("withParams");
+      expect(text).not.toContain("cacheKeyState");
+      expect(text).not.toContain("CacheKeyNavHops");
+      expect(text).not.toContain("CACHE_KEY_NAV_HOPS");
+    });
+
+    test("root, hop, complex, primitive, stream, cast and operation hops all name themselves - never a type", async () => {
+      const text = await generateWith(CacheKeyMode.on);
+
+      // root: entity set getter on the main service - "Media", the entity SET's own name, never
+      // "Tester.Medium" (the type this used to, wrongly, be rooted at)
+      expect(text).toContain(
+        `rootState("Media", "list", { entitySetName: "Media", canonicalIdFn: (entity: unknown) => new QMediumId("Media").buildCanonicalId(entity), qEntityFn: () => QMedium })`,
+      );
+      // root: singleton getter - its own name directly, no params marker needed, no entitySetName (a
+      // singleton has no "list" form for `invalidates` to ever name)
+      expect(text).toContain(`rootState("MainBranch", "detail", { qEntityFn: () => QMedium })`);
+      // navigation hop with no Partner/ReferentialConstraint - irrelevant now, every navigation property
+      // is handled the same way regardless of what metadata backs it
+      expect(text).toContain(
+        `hopState(cacheKeyState, { name: "reviews", kind: "list", entitySetName: "Reviews", canonicalIdFn: (entity: unknown) => new QReviewId("Reviews").buildCanonicalId(entity), qEntityFn: () => QReview })`,
+      );
+      // contained: no entity set of its own
+      expect(text).toContain(`hopState(cacheKeyState, { name: "chapters", kind: "list", qEntityFn: () => QChapter })`);
+      // the old grade-A relation is just another hierarchical hop now, both directions, no re-rooting
+      expect(text).toContain(
+        `hopState(cacheKeyState, { name: "copies", kind: "list", entitySetName: "Copies", canonicalIdFn: (entity: unknown) => new QCopyId("Copies").buildCanonicalId(entity), qEntityFn: () => QCopy })`,
+      );
+      expect(text).toContain(
+        `hopState(cacheKeyState, { name: "medium", kind: "detail", entitySetName: "Media", canonicalIdFn: (entity: unknown) => new QMediumId("Media").buildCanonicalId(entity), qEntityFn: () => QMedium })`,
+      );
+      expect(text).not.toContain("reRoot");
+      // complex property: never a navigation property, no entity set, no Q-object factory of its own
+      expect(text).toContain(`hopState(cacheKeyState, { name: "details", kind: "detail" })`);
+      // primitive collection and primitive property: bare name, no kind - stays on its parent's resource
+      expect(text).toContain(`hopState(cacheKeyState, { name: "keywords" })`);
+      expect(text).toContain(`hopState(cacheKeyState, { name: "rating" })`);
+      // stream property: the property hop, then a further hop appending $value
+      expect(text).toContain(`hopState(hopState(cacheKeyState, { name: "scan" }), { name: "$value" })`);
+      // subtype cast: a restriction on the same resource, not a hop away from it - a genuine spec URL
+      // segment, so it stays a type here, unlike everything else
+      expect(text).toContain(`withParams(cacheKeyState, { cast: "${withNs("Book")}" })`);
+      // bound action: a hop off the resource it is bound to, unstructured return -> bare name
+      expect(text).toContain(`hopState(cacheKeyState, { name: "${withNs("checkOut")}" })`);
+      // unbound function with a declared EntitySet: still rooted at the *import's* own name ("NewReleases"),
+      // never the entity set's ("Media") - entitySetName/canonicalIdFn/qEntityFn are attached alongside it
+      // only so ResourceIdentityHandler can record the actual Media entities the response carries
+      expect(text).toContain(
+        `rootState("NewReleases", "list", { entitySetName: "Media", canonicalIdFn: (entity: unknown) => new QMediumId("Media").buildCanonicalId(entity), qEntityFn: () => QMedium })`,
+      );
+      // unbound function with no EntitySet: rooted at its own import name too, no sentinel needed
+      expect(text).toContain(`rootState("TotalCount", "detail")`);
+      expect(text).not.toContain("OPERATION_ROOT");
+      // no generated nav-hops table anywhere - removed along with type-rooted identity
+      expect(text).not.toContain("CacheKeyNavHops");
+      expect(text).not.toContain("CACHE_KEY_NAV_HOPS");
+    });
+
+    test("createEntityService forwards the cache-key state it is handed, without computing one", async () => {
+      const text = await generateWith(CacheKeyMode.on);
+
+      expect(text).toContain("new MediumService<V>(client, path, name, options, cacheKeyState);");
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -670,7 +670,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@odata2ts/odata-service@workspace:packages/odata-service"
   dependencies:
-    "@odata2ts/http-client-api": "npm:^0.6.8"
+    "@odata2ts/http-client-api": "npm:^0.7.1"
     "@odata2ts/odata-query-builder": "npm:^0.19.3"
     "@odata2ts/odata-query-objects": "npm:^0.31.0"
     "@vitest/coverage-istanbul": "npm:^4.1.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -477,6 +477,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@odata2ts/http-client-api@npm:^0.7.1":
+  version: 0.7.1
+  resolution: "@odata2ts/http-client-api@npm:0.7.1"
+  dependencies:
+    tslib: "npm:^2.8.1"
+  checksum: 10/c9d53b75410beb93f70445e1ce91c56c1622dcb11c938df30cfbb49d83761f1ad59b79cffcf5501a40a2a92c342a61351befe562af0d9f848af8d2620002e28d
+  languageName: node
+  linkType: hard
+
 "@odata2ts/http-client-axios@npm:^0.14.0":
   version: 0.14.0
   resolution: "@odata2ts/http-client-axios@npm:0.14.0"
@@ -645,7 +654,7 @@ __metadata:
   resolution: "@odata2ts/odata-query-objects@workspace:packages/odata-query-objects"
   dependencies:
     "@odata2ts/converter-api": "npm:^0.3.0"
-    "@odata2ts/http-client-api": "npm:^0.6.8"
+    "@odata2ts/http-client-api": "npm:^0.7.1"
     "@odata2ts/odata-core": "npm:^0.7.1"
     "@vitest/coverage-istanbul": "npm:^4.1.10"
     madge: "npm:^8.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -690,7 +690,7 @@ __metadata:
     "@odata2ts/converter-api": "npm:^0.3.0"
     "@odata2ts/converter-runtime": "npm:^0.6.0"
     "@odata2ts/converter-v2-to-v4": "npm:^0.5.8"
-    "@odata2ts/http-client-api": "npm:^0.6.8"
+    "@odata2ts/http-client-api": "npm:^0.7.1"
     "@odata2ts/odata-core": "npm:^0.7.1"
     "@odata2ts/odata-query-objects": "npm:^0.31.0"
     "@odata2ts/odata-service": "npm:^0.27.0"


### PR DESCRIPTION
## Summary
Fourth of a 5-PR stack splitting `feat/cache-keys` (#526) into one PR per package. Stacked on #530 (odata-service) — merge #528, #529 and #530 first.

- `OptionModel.ts`: `cacheKeys` option, `CacheKeyMode` collapsed to `on|off`.
- `ServiceGenerator.ts`: every generated root/hop names itself by entity set, singleton, or navigation/containment property - never a type. `entitySetName`/`canonicalIdFn`/`qEntityFn` are emitted wherever a resource has independent identity (never for a contained one). An unbound operation import always roots at its own OData name (never the operation's qualified name, never its declared result `EntitySet`'s name either) - the canonical URL for a function/action import is always the service root plus the import's own name, confirmed against OData v4.01 Part 1 §11.5.4.1/§11.5.5.1. A bound operation is unchanged: a hop off the resource it hangs on, its own qualified name is a genuine URL segment. Invocation params are nested under their own key, never dropped, never colliding with a composable operation's own `$select`/`$filter`/... params.
- `DataModelDigestion(V2/V4).ts`: still digest `Partner`/`ReferentialConstraint` metadata (used elsewhere), but cache-key generation no longer consumes the grade it used to derive from them - a cache key is always the literal route taken, never re-rooted at a referentially-constrained target.
- No more generated `NavHopsTable`: the Q-object passed into `expand()`/`expanding()` already carries everything `$expand` enrichment needs directly (see #529).

## Test plan
- [x] `yarn workspace @odata2ts/odata2ts test` — 740/740 passing (+3 pre-existing skipped), on top of #528+#529+#530
- [x] `yarn prettier --check`