### PR TITLE
feat(odata2ts): generate name-rooted cache keys

### DIFF
--- a/packages/odata2ts/src/OptionModel.ts
+++ b/packages/odata2ts/src/OptionModel.ts
@@ -233,6 +233,34 @@ export enum EnumSynthesis {
 }
 
 /**
+ * How a generated client builds `RequestCmd.cacheKey` - see the docs on `cacheKeys`.
+ *
+ * Purely hierarchical, always: the key is the literal, named route taken to reach a response, never
+ * re-rooted at a resource's own type - that used to be a second mode (`typeFlattening`), and is now what
+ * `ResourceIdentityHandler` does at runtime instead, from actual responses rather than a generation-time
+ * prediction. One behaviour, so a binary switch is all `mode` needs to be.
+ */
+export enum CacheKeyMode {
+  /** Generate `cacheKey`/`invalidates` on every `RequestCmd`. */
+  on = "on",
+  /** Nothing is generated - identical to omitting `cacheKeys` entirely. */
+  off = "off",
+}
+
+export interface CacheKeysOptions {
+  /**
+   * Required: naming the object is not itself a decision, and a silently defaulted mode would make
+   * whether a generated key exists at all depend on a value nobody wrote down.
+   */
+  mode: CacheKeyMode;
+}
+
+/** The mode actually in force - `off` where the whole `cacheKeys` object was never configured. */
+export function resolveCacheKeyMode(options: CacheKeysOptions | undefined): CacheKeyMode {
+  return options?.mode ?? CacheKeyMode.off;
+}
+
+/**
  * Config options for CLI.
  */
 export interface CliOptions {
@@ -552,6 +580,16 @@ export interface ConfigFileOptions extends Omit<CliOptions, "sourceUrl" | "sourc
    * ({@code "Author@odata.bind"}).
    */
   deepInsertProps?: DeepInsertProps;
+  /**
+   * Generate `RequestCmd.cacheKey`: a structured, typed key identifying the *resource* a request
+   * addresses, for a cache built on top of the generated client (TanStack Query is the motivating case,
+   * hence the array shape).
+   *
+   * Off by default. An object rather than a bare string, because the shape has to have room for the
+   * further switches this will attract - which properties become key segments, whether operations are
+   * keyed at all - without a second top-level option.
+   */
+  cacheKeys?: CacheKeysOptions;
 }
 
 /**

--- a/packages/odata2ts/src/data-model/DataModelDigestion.ts
+++ b/packages/odata2ts/src/data-model/DataModelDigestion.ts
@@ -201,6 +201,31 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
     return false;
   }
 
+  /**
+   * The inverse navigation property on the related type, where the model declares one.
+   *
+   * Undefined here, because a navigation property only states its partner outright in V4. V2 has to
+   * resolve it from the `<Association>` the navigation property points at and overrides this
+   * accordingly.
+   */
+  protected getPartner(p: Property, fqOwnerName?: string): string | undefined {
+    return undefined;
+  }
+
+  /**
+   * The foreign key a navigation property is realized by: the dependent property and the principal
+   * property it references, one entry per property of a composite key.
+   *
+   * Undefined here, because only V4 states the constraint on the navigation property itself. V2 states
+   * it once on the `<Association>` instead and overrides this to resolve it from there.
+   */
+  protected getReferentialConstraints(
+    p: Property,
+    fqOwnerName?: string,
+  ): ReadonlyArray<{ property: string; referencedProperty: string }> | undefined {
+    return undefined;
+  }
+
   protected abstract digestOperations(schema: SchemaV3 | SchemaV4): void;
 
   protected abstract digestEntityContainer(schema: SchemaV3 | SchemaV4): void;
@@ -891,6 +916,9 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
       );
     }
 
+    const partner = this.getPartner(p, fqOwnerName);
+    const referentialConstraints = this.getReferentialConstraints(p, fqOwnerName);
+
     return {
       odataName: p.$.Name,
       name: modelName,
@@ -901,6 +929,8 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
       // only set when it applies: a flag on every single property would be noise
       ...(odataDataType === ODataTypesV4.Stream ? { isStream: true } : undefined),
       ...(this.isContained(p) ? { contained: true } : undefined),
+      ...(partner ? { partner } : undefined),
+      ...(referentialConstraints?.length ? { referentialConstraints } : undefined),
       ...(isOptionalParameter(p.Annotation) ? { omittable: true } : undefined),
       managed: toManagedState(
         typeof entityPropConfig?.managed !== "undefined" ? entityPropConfig.managed : configProp?.managed,

--- a/packages/odata2ts/src/data-model/DataModelDigestionV2.ts
+++ b/packages/odata2ts/src/data-model/DataModelDigestionV2.ts
@@ -7,6 +7,7 @@ import { Digester, TypeModel } from "./DataModelDigestion.js";
 import { NavPropBindingType, ODataVersion, OperationTypes, PropertyModel } from "./DataTypeModel.js";
 import { ComplexType, Property, Reference } from "./edmx/ODataEdmxModelBase.js";
 import {
+  Association,
   AssociationEnd,
   ComplexTypeV3,
   EntityContainerV3,
@@ -41,18 +42,30 @@ class DigesterV3 extends Digester<SchemaV3, EntityTypeV3, ComplexTypeV3> {
     super(ODataVersion.V2, schemas, options, namingHelper, converters, references);
   }
 
-  private findAssociationEnd(np: NavigationProperty): AssociationEnd {
+  /**
+   * The `<Association>` a navigation property points at, found by its (unqualified) relationship name.
+   * Shared by {@link findAssociationEnd}, which additionally needs the specific end, and by
+   * {@link getPartner}/{@link getReferentialConstraints}, which need the association as a whole - the
+   * partner lookup for the other end's type, the constraint because it is stated once per association
+   * rather than per end.
+   */
+  private findAssociation(np: NavigationProperty): Association {
+    const relationship = this.namingHelper.stripServicePrefix(np.$.Relationship);
     for (let schema of this.schemas) {
-      if (schema.Association) {
-        const relationship = this.namingHelper.stripServicePrefix(np.$.Relationship);
-        const association = schema.Association?.find((a) => a.$.Name === relationship);
-        const result = association?.End.find((e) => e.$.Role === np.$.ToRole);
-        if (result) {
-          return result;
-        }
+      const association = schema.Association?.find((a) => a.$.Name === relationship);
+      if (association) {
+        return association;
       }
     }
     throw new Error(`Association end couldn't be determined for NavigationProperty [${np.$.Name}]`);
+  }
+
+  private findAssociationEnd(np: NavigationProperty): AssociationEnd {
+    const end = this.findAssociation(np).End.find((e) => e.$.Role === np.$.ToRole);
+    if (!end) {
+      throw new Error(`Association end couldn't be determined for NavigationProperty [${np.$.Name}]`);
+    }
+    return end;
   }
 
   private findEdmxEntityType(fqTypeName: string): EntityTypeV3 | undefined {
@@ -64,6 +77,79 @@ class DigesterV3 extends Digester<SchemaV3, EntityTypeV3, ComplexTypeV3> {
       }
     }
     return undefined;
+  }
+
+  /**
+   * The raw `<NavigationProperty>` a mapped {@link Property} was built from, resolved by declaring entity
+   * type and name. {@link getNavigationProps} reshapes navigation properties into the same `{ $: { Name,
+   * Type, Nullable } }` shape as a plain `<Property>`, so `Relationship`/`FromRole`/`ToRole` - everything
+   * {@link getPartner} and {@link getReferentialConstraints} need - are gone by the time `mapProp` sees it.
+   * Looking the original element back up by owner and name is what gets them back.
+   */
+  private findNavProp(fqOwnerName: string, name: string): NavigationProperty | undefined {
+    return this.findEdmxEntityType(fqOwnerName)?.NavigationProperty?.find((np) => np.$.Name === name);
+  }
+
+  /**
+   * The inverse navigation property, resolved from the association's other end: the entity type declared
+   * there, and on it the navigation property realizing the same association with `FromRole`/`ToRole`
+   * swapped. Undefined where no such navigation property exists - an association end nothing navigates
+   * back from is legal.
+   */
+  protected getPartner(p: Property, fqOwnerName?: string): string | undefined {
+    const np = fqOwnerName ? this.findNavProp(fqOwnerName, p.$.Name) : undefined;
+    if (!np) {
+      return undefined;
+    }
+
+    const association = this.findAssociation(np);
+    const targetEnd = association.End.find((e) => e.$.Role === np.$.ToRole);
+    const targetType = targetEnd && this.findEdmxEntityType(targetEnd.$.Type);
+    const relationship = this.namingHelper.stripServicePrefix(np.$.Relationship);
+
+    const partnerNavProp = targetType?.NavigationProperty?.find(
+      (candidate) =>
+        this.namingHelper.stripServicePrefix(candidate.$.Relationship) === relationship &&
+        candidate.$.FromRole === np.$.ToRole &&
+        candidate.$.ToRole === np.$.FromRole,
+    );
+    return partnerNavProp?.$.Name;
+  }
+
+  /**
+   * The foreign key stated on the `<Association>`'s `<ReferentialConstraint>`, resolved to the same shape
+   * V4 states directly on its navigation property. V2 states the constraint once, naming its two sides by
+   * role, so it applies only to the navigation property that points *at* the principal - that one's own
+   * declaring type is the dependent side, which is where the foreign key actually lives. The navigation
+   * property pointing at the dependent side gets nothing, mirroring V4 exactly and keeping the two versions
+   * indistinguishable from here on.
+   */
+  protected getReferentialConstraints(
+    p: Property,
+    fqOwnerName?: string,
+  ): ReadonlyArray<{ property: string; referencedProperty: string }> | undefined {
+    const np = fqOwnerName ? this.findNavProp(fqOwnerName, p.$.Name) : undefined;
+    if (!np) {
+      return undefined;
+    }
+
+    const constraint = this.findAssociation(np).ReferentialConstraint?.[0];
+    const principal = constraint?.Principal[0];
+    const dependent = constraint?.Dependent[0];
+    if (!principal || !dependent || np.$.ToRole !== principal.$.Role) {
+      return undefined;
+    }
+
+    // a composite key gone out of sync between the two sides would produce a half-derived constraint that
+    // is worse than none - so this is skipped rather than repaired by guesswork
+    if (dependent.PropertyRef.length !== principal.PropertyRef.length) {
+      return undefined;
+    }
+
+    return dependent.PropertyRef.map((ref, index) => ({
+      property: ref.$.Name,
+      referencedProperty: principal.PropertyRef[index].$.Name,
+    }));
   }
 
   /**

--- a/packages/odata2ts/src/data-model/DataModelDigestionV4.ts
+++ b/packages/odata2ts/src/data-model/DataModelDigestionV4.ts
@@ -35,6 +35,22 @@ class DigesterV4 extends Digester<SchemaV4, EntityTypeV4, ComplexTypeV4> {
     return (p as NavigationProperty).$.ContainsTarget === "true";
   }
 
+  protected getPartner(p: Property): string | undefined {
+    return (p as NavigationProperty).$.Partner;
+  }
+
+  protected getReferentialConstraints(
+    p: Property,
+  ): ReadonlyArray<{ property: string; referencedProperty: string }> | undefined {
+    const referentialConstraint = (p as NavigationProperty).ReferentialConstraint;
+    return referentialConstraint?.length
+      ? referentialConstraint.map((rc) => ({
+          property: rc.$.Property,
+          referencedProperty: rc.$.ReferencedProperty,
+        }))
+      : undefined;
+  }
+
   protected digestOperations(schema: SchemaV4) {
     const nsWithAlias: NamespaceWithAlias = [schema.$.Namespace, schema.$.Alias];
     // functions & actions

--- a/packages/odata2ts/src/data-model/DataTypeModel.ts
+++ b/packages/odata2ts/src/data-model/DataTypeModel.ts
@@ -60,6 +60,19 @@ export interface PropertyModel {
    */
   contained?: boolean;
   /**
+   * The inverse navigation property on the related type, where the model declares one (V4's `Partner`
+   * attribute) - the name of the navigation property on the other side that points back to this one.
+   * Never set for anything but a navigation property.
+   */
+  partner?: string;
+  /**
+   * The foreign key this navigation property is realized by: each entry pairs a dependent property on
+   * this side with the principal property it references on the related type (V4's
+   * `<ReferentialConstraint>`), one entry per property of a composite key. Never set for anything but a
+   * navigation property.
+   */
+  referentialConstraints?: ReadonlyArray<{ property: string; referencedProperty: string }>;
+  /**
    * `Core.OptionalParameter`: the client may omit this operation parameter from the call even though
    * `required` (from `Nullable`) says otherwise - the server applies a default of its own. Independent
    * of `required`: unlike `Nullable`, it says nothing about whether the parameter accepts `null` when

--- a/packages/odata2ts/src/data-model/edmx/ODataEdmxModelV3.ts
+++ b/packages/odata2ts/src/data-model/edmx/ODataEdmxModelV3.ts
@@ -77,6 +77,14 @@ export interface Association {
     Name: string;
   };
   End: Array<AssociationEnd>;
+  /**
+   * The foreign key this association is realized by. Unlike V4, where the constraint sits on the
+   * navigation property, V2 states it once on the association and names the two sides by role.
+   */
+  ReferentialConstraint?: Array<{
+    Principal: Array<AssociationConstraintEnd>;
+    Dependent: Array<AssociationConstraintEnd>;
+  }>;
 }
 
 export interface AssociationEnd {
@@ -85,4 +93,9 @@ export interface AssociationEnd {
     Multiplicity: string;
     Role?: string;
   };
+}
+
+export interface AssociationConstraintEnd {
+  $: { Role: string };
+  PropertyRef: Array<{ $: { Name: string } }>;
 }

--- a/packages/odata2ts/src/data-model/edmx/ODataEdmxModelV4.ts
+++ b/packages/odata2ts/src/data-model/edmx/ODataEdmxModelV4.ts
@@ -38,7 +38,13 @@ export interface NavigationProperty extends Annotatable {
      */
     ContainsTarget?: "true" | "false";
   };
-  // TODO: OnDelete, ReferentialConstraint, etc.
+  /**
+   * The foreign key this navigation is realized by, as stated on the dependent side: `Property` is the
+   * dependent property, `ReferencedProperty` the principal one it refers to. Repeatable, one element per
+   * property pair of a composite key.
+   */
+  ReferentialConstraint?: Array<{ $: { Property: string; ReferencedProperty: string } }>;
+  // TODO: OnDelete
 }
 
 export interface EntityContainerV4 extends EntityContainer<EntitySetV4> {

--- a/packages/odata2ts/src/defaultConfig.ts
+++ b/packages/odata2ts/src/defaultConfig.ts
@@ -1,6 +1,14 @@
 import deepmerge from "deepmerge";
 import { NameSettings, NamingStrategies } from "./NamingModel.js";
-import { DeepInsertProps, EmitModes, KeyProperties, ManagedPropertyMode, Modes, RunOptions } from "./OptionModel.js";
+import {
+  CacheKeyMode,
+  DeepInsertProps,
+  EmitModes,
+  KeyProperties,
+  ManagedPropertyMode,
+  Modes,
+  RunOptions,
+} from "./OptionModel.js";
 
 export type DefaultConfiguration = Omit<RunOptions, "sourceUrl" | "source" | "output" | "serviceName">;
 /**
@@ -119,6 +127,7 @@ const defaultConfig: DefaultConfiguration = {
   byTypeAndName: [],
   disableBindingProps: false,
   deepInsertProps: DeepInsertProps.all,
+  cacheKeys: { mode: CacheKeyMode.off },
 };
 
 const { models, queryObjects, services } = defaultConfig.naming;

--- a/packages/odata2ts/src/generator/ImportContainer.ts
+++ b/packages/odata2ts/src/generator/ImportContainer.ts
@@ -138,6 +138,19 @@ export class ImportContainer {
     return importName;
   }
 
+  /**
+   * Imports an arbitrary named export from the service package by its exact name - the cache-key helpers
+   * (`rootState`, `hopState`, ...) are plain, version-neutral functions and constants, unlike the
+   * versioned classes {@link addServiceObject} resolves, so no `ServiceImports` entry fits them: that enum
+   * reverse-maps a numeric key to a PascalCase class name, which would mismatch a camelCase function.
+   */
+  public addServiceFunction(name: string, isTypeOnly = false) {
+    const importName = this.importedNameValidator.validateName(LIB_MODULES.service, name);
+    const imports = isTypeOnly ? this.libs.service.typeOnly : this.libs.service.regular;
+    imports.set(name, importName);
+    return importName;
+  }
+
   // TODO: make sure that regular imports win over additional typeOnly imports
   /**
    * Adds an import for a type coming from an arbitrary module, e.g. a converter's target type.

--- a/packages/odata2ts/src/generator/ServiceGenerator.ts
+++ b/packages/odata2ts/src/generator/ServiceGenerator.ts
@@ -15,16 +15,18 @@ import {
   ComplexType,
   DataTypes,
   EntityContainerModel,
+  EntitySetType,
   EntityType,
   FunctionImportType,
   hasUpdatableModel,
   OperationType,
   OperationTypes,
   PropertyModel,
+  ReturnTypeModel,
   SingletonType,
 } from "../data-model/DataTypeModel.js";
 import { NamingHelper } from "../data-model/NamingHelper.js";
-import { ConfigFileOptions, Modes } from "../OptionModel.js";
+import { CacheKeyMode, ConfigFileOptions, Modes, resolveCacheKeyMode } from "../OptionModel.js";
 import { FileHandler } from "../project/FileHandler.js";
 import { ProjectManager } from "../project/ProjectManager.js";
 import { ClientApiImports, CoreImports, QueryObjectImports, ServiceImports } from "./import/ImportObjects.js";
@@ -35,7 +37,7 @@ export interface PropsAndOps extends Required<Pick<ClassDeclarationStructure, "p
 
 export interface ServiceGeneratorOptions extends Pick<
   ConfigFileOptions,
-  "enablePrimitivePropertyServices" | "enumType" | "managedPropertyMode"
+  "enablePrimitivePropertyServices" | "enumType" | "managedPropertyMode" | "cacheKeys"
 > {
   v2: Pick<NonNullable<ConfigFileOptions["v2"]>, "responseAsV4">;
   v4: Pick<NonNullable<ConfigFileOptions["v4"]>, "bigNumberAsString" | "odataVersion">;
@@ -61,6 +63,8 @@ class ServiceGenerator {
     private options: ServiceGeneratorOptions = { v2: {}, v4: {} },
   ) {}
 
+  private readonly cacheKeyMode = resolveCacheKeyMode(this.options.cacheKeys);
+
   private isV4BigNumber() {
     return this.options.v4.bigNumberAsString && this.version === ODataVersions.V4;
   }
@@ -71,6 +75,179 @@ class ServiceGenerator {
 
   private isV2AsV4() {
     return !!this.options.v2.responseAsV4 && this.version === ODataVersions.V2;
+  }
+
+  // ---------------------------------------------------------------------------------------------------
+  // cache-key emission
+  //
+  // Every method below returns the bare runtime expression building a `CacheKeyState` - or `""` when the
+  // feature is off, which is what keeps `off` output byte-identical to before this feature existed. A
+  // root expression is self-contained (`rootState(...)`); every other expression reads the parent's state
+  // off a `cacheKeyState` variable the call site must destructure from `this.__base` - but only when the
+  // expression is non-empty, or the `off` output gains an unused binding.
+  // ---------------------------------------------------------------------------------------------------
+
+  /** The runtime expression for a fresh, unprefixed Q-object factory of the given type - `CacheKeyState.qEntityFn`, threaded solely so a write's payload can be walked for deep-inserted entities, never exposed in a cache key itself. */
+  private qEntityFnExpr(imports: ImportContainer, model: { fqName: string; qName: string }): string {
+    return `() => ${imports.addGeneratedQObject(model.fqName, model.qName)}`;
+  }
+
+  /**
+   * The runtime expression for `CacheKeyState.canonicalIdFn` - a fresh `QId` instance parametrized with the
+   * entity *set's* own name (never the route taken to reach it), so calling it with a response's own key
+   * values always produces the same canonical id regardless of which hop led here.
+   */
+  private canonicalIdFnExpr(imports: ImportContainer, entityType: EntityType, entitySetOdataName: string): string {
+    const qId = imports.addGeneratedQObject(entityType.id.fqName, entityType.id.qName);
+    return `(entity: unknown) => new ${qId}("${entitySetOdataName}").buildCanonicalId(entity)`;
+  }
+
+  /** The root of a route: an entity set or a singleton. An operation with no declared result set is the one root with no type to head with - built as a plain object literal instead, see `emitUnboundOperationRootExpr`. */
+  private emitRootStateExpr(
+    imports: ImportContainer,
+    name: string,
+    kind: "list" | "detail",
+    entityType: EntityType,
+    options?: { paramsSource?: string; isEntitySet?: boolean },
+  ): string {
+    if (this.cacheKeyMode === CacheKeyMode.off) {
+      return "";
+    }
+    const rootStateFn = imports.addServiceFunction("rootState");
+    const optionsEntries = [
+      options?.paramsSource ? `params: ${options.paramsSource}` : "",
+      options?.isEntitySet ? `entitySetName: "${name}"` : "",
+      options?.isEntitySet ? `canonicalIdFn: ${this.canonicalIdFnExpr(imports, entityType, name)}` : "",
+      `qEntityFn: ${this.qEntityFnExpr(imports, entityType)}`,
+    ]
+      .filter(Boolean)
+      .join(", ");
+    return `${rootStateFn}("${name}", "${kind}", { ${optionsEntries} })`;
+  }
+
+  /**
+   * A navigation property hop - always hierarchical, named by the navigation property's own OData name,
+   * never re-rooted at its target's type: that used to be a second mode (`typeFlattening`), and is now what
+   * `ResourceIdentityHandler` does at runtime instead, from actual responses. `entitySetName`/`canonicalIdFn`
+   * (feeding `invalidates` and response-observed recording respectively) name the entity *set* the target
+   * belongs to, absent for a contained navigation property, which has none of its own.
+   */
+  private emitNavHopExpr(
+    imports: ImportContainer,
+    ownerFqName: string,
+    navPropOdataName: string,
+    elementType: EntityType,
+    isCollection: boolean,
+    contained: boolean,
+  ): string {
+    if (this.cacheKeyMode === CacheKeyMode.off) {
+      return "";
+    }
+
+    const kind = isCollection ? "list" : "detail";
+    const targetSet = !contained ? this.dataModel.getNavPropBindingTarget(ownerFqName, navPropOdataName) : undefined;
+    const entitySetNameEntry = targetSet ? `, entitySetName: "${targetSet.odataName}"` : "";
+    const canonicalIdFnEntry = targetSet
+      ? `, canonicalIdFn: ${this.canonicalIdFnExpr(imports, targetSet.entityType, targetSet.odataName)}`
+      : "";
+    const qEntityFnEntry = `, qEntityFn: ${this.qEntityFnExpr(imports, elementType)}`;
+
+    const hopStateFn = imports.addServiceFunction("hopState");
+    return `cacheKeyState && ${hopStateFn}(cacheKeyState, { name: "${navPropOdataName}", kind: "${kind}"${entitySetNameEntry}${canonicalIdFnEntry}${qEntityFnEntry} })`;
+  }
+
+  /** A complex property hop: the same shape as a navigation hop, minus any entity-set identity - a complex value is never a navigation property and belongs to no entity set. */
+  private emitComplexHopExpr(imports: ImportContainer, isCollection: boolean, name: string): string {
+    if (this.cacheKeyMode === CacheKeyMode.off) {
+      return "";
+    }
+    const hopStateFn = imports.addServiceFunction("hopState");
+    return `cacheKeyState && ${hopStateFn}(cacheKeyState, { name: "${name}", kind: "${isCollection ? "list" : "detail"}" })`;
+  }
+
+  /** A primitive property, primitive collection or stream property hop: bare name, no kind - stays on its parent's resource. */
+  private emitBareHopExpr(imports: ImportContainer, name: string): string {
+    if (this.cacheKeyMode === CacheKeyMode.off) {
+      return "";
+    }
+    const hopStateFn = imports.addServiceFunction("hopState");
+    return `cacheKeyState && ${hopStateFn}(cacheKeyState, { name: "${name}" })`;
+  }
+
+  /** A stream property's raw value: the property hop, then a further hop appending `$value`. */
+  private emitStreamHopExpr(imports: ImportContainer, odataName: string): string {
+    if (this.cacheKeyMode === CacheKeyMode.off) {
+      return "";
+    }
+    const hopStateFn = imports.addServiceFunction("hopState");
+    return `cacheKeyState && ${hopStateFn}(${hopStateFn}(cacheKeyState, { name: "${odataName}" }), { name: "$value" })`;
+  }
+
+  /** A subtype cast: a restriction on the very same resource, not a hop away from it. */
+  private emitCastParamsExpr(imports: ImportContainer, castFqName: string): string {
+    if (this.cacheKeyMode === CacheKeyMode.off) {
+      return "";
+    }
+    const withParamsFn = imports.addServiceFunction("withParams");
+    return `cacheKeyState && ${withParamsFn}(cacheKeyState, { cast: "${castFqName}" })`;
+  }
+
+  /**
+   * The root of an unbound function/action import: always the import's own OData name (OData v4.01 Part 1
+   * §11.5.4.1/§11.5.5.1 - the canonical URL is the service root plus the *import's* name, never the
+   * operation's own qualified name, and never its declared result `EntitySet`'s name either). Where the
+   * import does declare a result `EntitySet`, `entitySetName`/`canonicalIdFn`/`qEntityFn` are still attached
+   * so `ResourceIdentityHandler` can record the real entities the response carries - a separate concern from
+   * what the root's own identity in the key is.
+   */
+  private emitUnboundOperationRootExpr(
+    imports: ImportContainer,
+    op: OperationType,
+    importOdataName: string,
+    entitySetOdataName: string | undefined,
+    hasParams: boolean,
+  ): string {
+    if (this.cacheKeyMode === CacheKeyMode.off) {
+      return "";
+    }
+
+    const entitySet = entitySetOdataName
+      ? Object.values(this.dataModel.getEntityContainer().entitySets).find((es) => es.odataName === entitySetOdataName)
+      : undefined;
+    const rootStateFn = imports.addServiceFunction("rootState");
+    const kind = op.returnType?.isCollection ? "list" : "detail";
+    // nested under its own "params" key, never spread directly - a composable operation's cache key later
+    // merges in real query params (select/filter/...) via buildCacheKey, and those must not collide with
+    // the operation's own invocation arguments
+    const paramsEntry = hasParams ? `params: { params }, ` : "";
+
+    if (entitySet) {
+      const canonicalIdFnEntry = `canonicalIdFn: ${this.canonicalIdFnExpr(imports, entitySet.entityType, entitySet.odataName)}, `;
+      const qEntityFnEntry = `qEntityFn: ${this.qEntityFnExpr(imports, entitySet.entityType)}`;
+      return (
+        `${rootStateFn}("${importOdataName}", "${kind}", ` +
+        `{ ${paramsEntry}entitySetName: "${entitySet.odataName}", ${canonicalIdFnEntry}${qEntityFnEntry} })`
+      );
+    }
+
+    return hasParams
+      ? `${rootStateFn}("${importOdataName}", "${kind}", { params: { params } })`
+      : `${rootStateFn}("${importOdataName}", "${kind}")`;
+  }
+
+  /** A bound function/action: a hop off the resource it is bound to, with its own kind marker where the return type is structured - never a type, matching every other hop. */
+  private emitBoundOperationHopExpr(
+    imports: ImportContainer,
+    fqOperationName: string,
+    returnType: ReturnTypeModel | undefined,
+  ): string {
+    if (this.cacheKeyMode === CacheKeyMode.off) {
+      return "";
+    }
+    const hopStateFn = imports.addServiceFunction("hopState");
+    const isStructured = !!returnType?.fqType && returnType.dataType !== DataTypes.PrimitiveType;
+    const kindEntry = isStructured ? `, kind: "${returnType!.isCollection ? "list" : "detail"}"` : "";
+    return `cacheKeyState && ${hopStateFn}(cacheKeyState, { name: "${fqOperationName}"${kindEntry} })`;
   }
 
   /**
@@ -280,29 +457,55 @@ class ServiceGenerator {
   ): PropsAndOps {
     const result: PropsAndOps = { properties: [], methods: [] };
 
-    ops.forEach(({ operation, name }) => {
+    ops.forEach((funcOrActionImport) => {
+      const { operation, name, odataName } = funcOrActionImport;
       const op = this.dataModel.getUnboundOperationType(operation);
       if (!op) {
         throw new Error(`Operation "${operation}" not found!`);
       }
+      // only a function import ever declares one - CSDL has no equivalent for an action import
+      const entitySetOdataName = "entitySet" in funcOrActionImport ? funcOrActionImport.entitySet : undefined;
 
       result.properties.push(this.generateQOperationProp(op));
-      result.methods.push(this.generateMethod(name, op, importContainer, "", this.getMainVersionArg(), false));
+      result.methods.push(
+        this.generateMethod(
+          name,
+          op,
+          importContainer,
+          "",
+          this.getMainVersionArg(),
+          false,
+          entitySetOdataName,
+          odataName,
+        ),
+      );
     });
 
     return result;
   }
 
+  /**
+   * `ownerFqName` distinguishes the two contexts this getter serves: `undefined` for an entity set on the
+   * main service (the root of a route), a real FQ type for a navigation property reached from another
+   * entity or complex type (a hop off `ownerFqName`'s `contained`/`odataPropName`).
+   */
   private generateRelatedServiceGetter(
     propName: string,
     odataPropName: string,
     entityType: EntityType,
     imports: ImportContainer,
     versionArg: string,
+    ownerFqName?: string,
+    contained = false,
   ): OptionalKind<MethodDeclarationStructure> {
     const idName = imports.addGeneratedModel(entityType.id.fqName, entityType.id.modelName);
     const serviceName = imports.addGeneratedService(entityType.fqName, entityType.serviceName);
     const collectionName = imports.addGeneratedService(entityType.fqName, entityType.serviceCollectionName);
+    const cacheKeyExpr =
+      ownerFqName === undefined
+        ? this.emitRootStateExpr(imports, odataPropName, "list", entityType, { isEntitySet: true })
+        : this.emitNavHopExpr(imports, ownerFqName, odataPropName, entityType, true, contained);
+    const cacheKeyDestructure = ownerFqName !== undefined && cacheKeyExpr ? ", cacheKeyState" : "";
 
     return {
       scope: Scope.Public,
@@ -331,12 +534,12 @@ class ServiceGenerator {
       ],
       statements: [
         `const fieldName = "${odataPropName}";`,
-        `const { client, path, options } = this.__base;`,
+        `const { client, path, options${cacheKeyDestructure} } = this.__base;`,
         // the version argument is only spelled out on the constructor call for v2ResponseAsV4: without it,
         // "new Type(...)" infers AsV4's default (false), which mismatches the declared return type above
         // wherever it isn't itself the abstract AsV4 - concretely, on every getter of the main service,
         // which pins the literal true rather than passing an abstract type parameter along
-        `const collection = new ${collectionName}${this.isV2AsV4() ? versionArg : ""}(client, path, fieldName, options);`,
+        `const collection = new ${collectionName}${this.isV2AsV4() ? versionArg : ""}(client, path, fieldName, options${cacheKeyExpr ? `, ${cacheKeyExpr}` : ""});`,
         'return typeof id === "undefined" || id === null ? collection : collection.byId(id);',
       ],
     };
@@ -378,6 +581,11 @@ class ServiceGenerator {
     // the registered name rather than the plain one: an import may have been aliased to avoid a clash,
     // and the property declaration above went through the same call, so the two agree
     const serviceType = importContainer.addGeneratedService(entityType.fqName, entityType.serviceName);
+    // the singleton's own name is the root's identity directly - no params marker needed, unlike the old
+    // type-rooted shape, which had to smuggle it in since the root position was occupied by a type. No
+    // `isEntitySet` either: a singleton is not itself a member of an entity set, so it has no "list" form
+    // for `invalidates` to ever name.
+    const cacheKeyExpr = this.emitRootStateExpr(importContainer, odataName, "detail", entityType);
 
     return {
       scope: Scope.Public,
@@ -386,7 +594,7 @@ class ServiceGenerator {
         `if(!${propName}) {`,
         `  const { client, path, options } = this.__base;`,
         // prettier-ignore
-        `  ${propName} = new ${serviceType}(client, path, "${odataName}", options)`,
+        `  ${propName} = new ${serviceType}(client, path, "${odataName}", options${cacheKeyExpr ? `, ${cacheKeyExpr}` : ""})`,
         "}",
         `return ${propName}`,
       ],
@@ -423,7 +631,7 @@ class ServiceGenerator {
 
     const { properties, methods }: PropsAndOps = deepmerge(
       deepmerge(
-        this.generateServiceProperties(importContainer, model.serviceName, props),
+        this.generateServiceProperties(importContainer, model.fqName, props),
         this.generateServiceOperations(importContainer, model, operations, true),
       ),
       this.generateCastOperations(importContainer, model, false),
@@ -447,9 +655,21 @@ class ServiceGenerator {
               type: `${serviceOptions}${this.getServiceVersionArg()}`,
               hasQuestionToken: true,
             },
+            // a getter elsewhere constructs this very class as a hop off its own state (see emitNavHopExpr
+            // et al.) - without this parameter that hop's cache-key state would have nowhere to go, and the
+            // base class's own trailing parameter would sit unreachable behind a narrower constructor
+            ...(this.cacheKeyMode !== CacheKeyMode.off
+              ? [
+                  {
+                    name: "cacheKeyState",
+                    type: importContainer.addServiceFunction("CacheKeyState", true),
+                    hasQuestionToken: true,
+                  },
+                ]
+              : []),
           ],
           statements: [
-            `super(client, basePath, name, ${qObjectName}, ${this.getServiceRuntimeOptions(model, isComplexType)});`,
+            `super(client, basePath, name, ${qObjectName}, ${this.getServiceRuntimeOptions(model, isComplexType)}${this.cacheKeyMode !== CacheKeyMode.off ? ", cacheKeyState" : ""});`,
           ],
         },
       ],
@@ -460,7 +680,7 @@ class ServiceGenerator {
 
   private generateServiceProperties(
     importContainer: ImportContainer,
-    serviceName: string,
+    ownerFqName: string,
     props: Array<PropertyModel>,
   ): PropsAndOps {
     const result: PropsAndOps = { properties: [], methods: [] };
@@ -479,7 +699,7 @@ class ServiceGenerator {
         prop.dataType === DataTypes.ComplexType
       ) {
         result.properties.push(this.generateModelProp(importContainer, prop));
-        result.methods.push(this.generateModelPropGetter(importContainer, prop));
+        result.methods.push(this.generateModelPropGetter(importContainer, prop, ownerFqName));
       } else if (prop.isCollection) {
         // collection of EntityTypes
         if (prop.dataType === DataTypes.ModelType) {
@@ -495,6 +715,8 @@ class ServiceGenerator {
               entityType,
               importContainer,
               this.getServiceVersionArg(),
+              ownerFqName,
+              prop.contained,
             ),
           );
         }
@@ -636,14 +858,16 @@ class ServiceGenerator {
   ): OptionalKind<MethodDeclarationStructure> {
     const serviceType = imports.addServiceObject(this.version, ServiceImports.StreamService);
     const propName = "this." + this.namingHelper.getPrivatePropName(prop.name);
+    const cacheKeyExpr = this.emitStreamHopExpr(imports, prop.odataName);
+    const cacheKeyDestructure = cacheKeyExpr ? ", cacheKeyState" : "";
 
     return {
       scope: Scope.Public,
       name: this.namingHelper.getRelatedServiceGetter(prop.name),
       statements: [
         `if(!${propName}) {`,
-        `  const { client, path, options } = this.__base;`,
-        `  ${propName} = new ${serviceType}(client, path, "${prop.odataName}", options)`,
+        `  const { client, path, options${cacheKeyDestructure} } = this.__base;`,
+        `  ${propName} = new ${serviceType}(client, path, "${prop.odataName}", options${cacheKeyExpr ? `, ${cacheKeyExpr}` : ""})`,
         "}",
         `return ${propName}`,
       ],
@@ -653,9 +877,14 @@ class ServiceGenerator {
   private generateModelPropGetter(
     imports: ImportContainer,
     prop: PropertyModel,
+    ownerFqName: string,
   ): OptionalKind<MethodDeclarationStructure> {
     const model = this.dataModel.getModel(prop.fqType) as ComplexType;
     const isComplexCollection = prop.isCollection && model.dataType === DataTypes.ComplexType;
+    // an entity navigation property (never a collection here - that shape goes through
+    // generateRelatedServiceGetter instead) is grade-aware; a complex property never is, since a complex
+    // value is never a navigation property and has no relation to derive
+    const isEntityNav = model.dataType !== DataTypes.ComplexType;
 
     const type = isComplexCollection
       ? imports.addServiceObject(this.version, ServiceImports.CollectionService)
@@ -671,6 +900,10 @@ class ServiceGenerator {
       : `${type}${this.getServiceVersionArg()}`;
 
     const privateSrvProp = "this." + this.namingHelper.getPrivatePropName(prop.name);
+    const cacheKeyExpr = isEntityNav
+      ? this.emitNavHopExpr(imports, ownerFqName, prop.odataName, model as EntityType, false, !!prop.contained)
+      : this.emitComplexHopExpr(imports, prop.isCollection, prop.odataName);
+    const cacheKeyDestructure = cacheKeyExpr ? ", cacheKeyState" : "";
 
     return {
       scope: Scope.Public,
@@ -678,9 +911,9 @@ class ServiceGenerator {
       returnType: typeWithGenerics,
       statements: [
         `if(!${privateSrvProp}) {`,
-        `  const { client, path, options } = this.__base;`,
+        `  const { client, path, options${cacheKeyDestructure} } = this.__base;`,
         // prettier-ignore
-        `  ${privateSrvProp} = new ${type}(client, path, "${prop.odataName}"${isComplexCollection ? `, ${imports.addGeneratedQObject(model.fqName, firstCharLowerCase(model.qName))}`: ""}, options)`,
+        `  ${privateSrvProp} = new ${type}(client, path, "${prop.odataName}"${isComplexCollection ? `, ${imports.addGeneratedQObject(model.fqName, firstCharLowerCase(model.qName))}`: ""}, options${cacheKeyExpr ? `, ${cacheKeyExpr}` : ""})`,
         "}",
         `return ${privateSrvProp}`,
       ],
@@ -697,14 +930,16 @@ class ServiceGenerator {
       prop.dataType === DataTypes.EnumType ? imports.addGeneratedModel(prop.fqType, prop.type) : undefined;
 
     const propName = "this." + this.namingHelper.getPrivatePropName(prop.name);
+    const cacheKeyExpr = this.emitBareHopExpr(imports, prop.odataName);
+    const cacheKeyDestructure = cacheKeyExpr ? ", cacheKeyState" : "";
     return {
       scope: Scope.Public,
       name: this.namingHelper.getRelatedServiceGetter(prop.name),
       statements: [
         `if(!${propName}) {`,
-        `  const { client, path, options } = this.__base;`,
+        `  const { client, path, options${cacheKeyDestructure} } = this.__base;`,
         // prettier-ignore
-        `  ${propName} = new ${collectionServiceType}(client, path, "${prop.odataName}", new ${qCollectionName}(${enumName ?? ""}), options)`,
+        `  ${propName} = new ${collectionServiceType}(client, path, "${prop.odataName}", new ${qCollectionName}(${enumName ?? ""}), options${cacheKeyExpr ? `, ${cacheKeyExpr}` : ""})`,
         "}",
         `return ${propName}`,
       ],
@@ -720,14 +955,16 @@ class ServiceGenerator {
     // for V2: mapped name must be specified
     const v2MappedName =
       this.version === ODataVersions.V4 ? "" : prop.name !== prop.odataName ? `, "${prop.name}"` : ", undefined";
+    const cacheKeyExpr = this.emitBareHopExpr(imports, prop.odataName);
+    const cacheKeyDestructure = cacheKeyExpr ? ", cacheKeyState" : "";
 
     return {
       scope: Scope.Public,
       name: this.namingHelper.getRelatedServiceGetter(prop.name),
       statements: [
         `if(!${propName}) {`,
-        `  const { client, path, qModel, options } = this.__base;`,
-        `  ${propName} = new ${serviceType}(client, path, "${prop.odataName}", qModel.${prop.name}.converter${v2MappedName}, options)`,
+        `  const { client, path, qModel, options${cacheKeyDestructure} } = this.__base;`,
+        `  ${propName} = new ${serviceType}(client, path, "${prop.odataName}", qModel.${prop.name}.converter${v2MappedName}, options${cacheKeyExpr ? `, ${cacheKeyExpr}` : ""})`,
         "}",
         `return ${propName}`,
       ],
@@ -786,9 +1023,22 @@ class ServiceGenerator {
               type: `${serviceOptions}${this.getServiceVersionArg()}`,
               hasQuestionToken: true,
             },
+            // a getter elsewhere constructs this very class as a hop off its own state (see
+            // emitNavHopExpr et al.) - without this parameter that hop's cache-key state would have
+            // nowhere to go, and the base class's own trailing parameter would sit unreachable behind a
+            // narrower constructor
+            ...(this.cacheKeyMode !== CacheKeyMode.off
+              ? [
+                  {
+                    name: "cacheKeyState",
+                    type: importContainer.addServiceFunction("CacheKeyState", true),
+                    hasQuestionToken: true,
+                  },
+                ]
+              : []),
           ],
           statements: [
-            `super(client, basePath, name, ${qObjectName}, new ${qIdFunctionName}(name), ${this.getServiceRuntimeOptions(model)});`,
+            `super(client, basePath, name, ${qObjectName}, new ${qIdFunctionName}(name), ${this.getServiceRuntimeOptions(model)}${this.cacheKeyMode !== CacheKeyMode.off ? ", cacheKeyState" : ""});`,
           ],
         },
       ],
@@ -803,8 +1053,21 @@ class ServiceGenerator {
             { name: "path", type: "string" },
             { name: "name", type: "string" },
             { name: "options", type: `${serviceOptions}${this.getServiceVersionArg()} | undefined` },
+            // this base class's own `byId` computes the entity's cache-key state (see EntitySetServiceV4/V2);
+            // this override only has to forward it, never compute it itself
+            ...(this.cacheKeyMode !== CacheKeyMode.off
+              ? [
+                  {
+                    name: "cacheKeyState",
+                    type: importContainer.addServiceFunction("CacheKeyState", true),
+                    hasQuestionToken: true,
+                  },
+                ]
+              : []),
           ],
-          statements: [`return new ${entityServiceName}${this.getServiceVersionArg()}(client, path, name, options);`],
+          statements: [
+            `return new ${entityServiceName}${this.getServiceVersionArg()}(client, path, name, options${this.cacheKeyMode !== CacheKeyMode.off ? ", cacheKeyState" : ""});`,
+          ],
         },
       ],
     });
@@ -854,6 +1117,8 @@ class ServiceGenerator {
     baseFqName: string,
     versionArg: string,
     isEntityBound = false,
+    entitySetOdataName?: string,
+    importOdataName?: string,
   ): OptionalKind<MethodDeclarationStructure> {
     const isFunc = operation.type === OperationTypes.Function;
     const returnType = operation.returnType;
@@ -900,12 +1165,20 @@ class ServiceGenerator {
 
     const qOpProp = "this." + this.namingHelper.getPrivatePropName(operation.qName);
 
+    // an unbound operation (baseFqName === "") roots the key at its own import name; a bound one is a hop
+    // off the resource it hangs on
+    const cacheKeyExpr = !baseFqName
+      ? this.emitUnboundOperationRootExpr(importContainer, operation, importOdataName!, entitySetOdataName, !!hasParams)
+      : this.emitBoundOperationHopExpr(importContainer, operation.fqName, returnType);
+    const needsCacheKeyState = !!baseFqName && !!cacheKeyExpr;
+
     const optionStmt =
       `{ ` +
       `headers: getDefaultHeaders()` +
       (!isFunc && hasParams ? `, mainRequestConverter: ${qOpProp}.getRequestConverter()` : "") +
       (returnType ? `, mainResponseConverter: ${qOpProp}.getResponseConverter()` : "") +
       (withConcurrency ? `, concurrency: getConcurrencyOptions()` : "") +
+      (cacheKeyExpr ? `, cacheKeyState: ${cacheKeyExpr}` : "") +
       `}`;
     const requestCmdStmt = isComposable
       ? `return new ${requestCmd}<${responseService}${versionArg}, ${responseStructure}<${rtType}>>(` +
@@ -933,7 +1206,7 @@ class ServiceGenerator {
         `  ${qOpProp} = new ${qOperationName}()`,
         "}",
 
-        `const { addFullPath, client, getDefaultHeaders${isFunc ? `, isUrlNotEncoded${isComposable ? ", options" : ""}` : ""}${withConcurrency ? ", getConcurrencyOptions" : ""} } = this.__base;`,
+        `const { addFullPath, client, getDefaultHeaders${isFunc ? `, isUrlNotEncoded${isComposable ? ", options" : ""}` : ""}${withConcurrency ? ", getConcurrencyOptions" : ""}${needsCacheKeyState ? ", cacheKeyState" : ""} } = this.__base;`,
         `const url = addFullPath(${qOpProp}.buildUrl(${!isFunc ? "" : hasParams ? "params, isUrlNotEncoded()" : "isUrlNotEncoded()"}));`,
         ``,
         requestCmdStmt,
@@ -953,12 +1226,14 @@ class ServiceGenerator {
         const subClass = this.dataModel.getModel(subtype) as ComplexType;
         const serviceName = isCollection ? subClass.serviceCollectionName : subClass.serviceName;
         const serviceType = importContainer.addGeneratedService(subClass.fqName, serviceName);
+        const cacheKeyExpr = this.emitCastParamsExpr(importContainer, subClass.fqName);
+        const cacheKeyDestructure = cacheKeyExpr ? ", cacheKeyState" : "";
         result.methods.push({
           name: `as${upperCaseFirst(serviceName)}`,
           scope: Scope.Public,
           statements: [
-            "const { client, path, options } = this.__base;",
-            `return new ${serviceType}(client, path, "${subClass.fqName}", { ...options, subtype: true });`,
+            `const { client, path, options${cacheKeyDestructure} } = this.__base;`,
+            `return new ${serviceType}(client, path, "${subClass.fqName}", { ...options, subtype: true }${cacheKeyExpr ? `, ${cacheKeyExpr}` : ""});`,
           ],
         });
       });

--- a/packages/odata2ts/test/data-model/builder/v2/ODataEntityTypeBuilderV2.ts
+++ b/packages/odata2ts/test/data-model/builder/v2/ODataEntityTypeBuilderV2.ts
@@ -22,6 +22,12 @@ export class ODataEntityTypeBuilderV2 extends ODataEntityTypeBuilderBase<EntityT
   /**
    * @param roles the association roles; by default they are derived from the two type names, which is not
    * unique as soon as one entity type points at another one more than once - specify them in that case
+   * @param referentialConstraint the foreign key realizing this association, stated from this navigation
+   * property's own side: `property` names one of this entity type's own properties, `referencedProperty`
+   * the property of the target type it references. V2 states the constraint once per association rather
+   * than per end, so this is only meaningful on the call for the side that actually points at the
+   * principal - the merge in {@link ODataModelBuilderV2.addEntityType} carries it onto the shared
+   * `<Association>` regardless of which of the two `addNavProp` calls supplies it.
    */
   public addNavProp(
     name: string,
@@ -29,6 +35,7 @@ export class ODataEntityTypeBuilderV2 extends ODataEntityTypeBuilderBase<EntityT
     relationship: string,
     multiplicity: string,
     roles?: { fromRole: string; toRole: string },
+    referentialConstraint?: Array<{ property: string; referencedProperty: string }>,
   ) {
     if (!this.entityType.NavigationProperty) {
       this.entityType.NavigationProperty = [];
@@ -50,6 +57,26 @@ export class ODataEntityTypeBuilderV2 extends ODataEntityTypeBuilderBase<EntityT
           },
         },
       ],
+      ...(referentialConstraint
+        ? {
+            ReferentialConstraint: [
+              {
+                Principal: [
+                  {
+                    $: { Role: toRole },
+                    PropertyRef: referentialConstraint.map((rc) => ({ $: { Name: rc.referencedProperty } })),
+                  },
+                ],
+                Dependent: [
+                  {
+                    $: { Role: fromRole },
+                    PropertyRef: referentialConstraint.map((rc) => ({ $: { Name: rc.property } })),
+                  },
+                ],
+              },
+            ],
+          }
+        : undefined),
     });
 
     this.entityType.NavigationProperty.push({

--- a/packages/odata2ts/test/data-model/builder/v2/ODataModelBuilderV2.ts
+++ b/packages/odata2ts/test/data-model/builder/v2/ODataModelBuilderV2.ts
@@ -93,6 +93,12 @@ export class ODataModelBuilderV2 extends ODataModelBuilder<ODataEdmxModelV3, Sch
         const existingAssoc = this.currentSchema.Association!.find((a) => a.$.Name === assoc.$.Name);
         if (existingAssoc) {
           existingAssoc.End.push(...assoc.End);
+          // the constraint is stated once per association, not per end, but addNavProp only ever
+          // supplies it from the side that carries the foreign key - so it is picked up on whichever of
+          // the two merged calls happens to have it
+          if (assoc.ReferentialConstraint) {
+            existingAssoc.ReferentialConstraint = assoc.ReferentialConstraint;
+          }
         } else {
           this.currentSchema.Association!.push(assoc);
         }

--- a/packages/odata2ts/test/data-model/builder/v4/ODataBuilderV4Helper.ts
+++ b/packages/odata2ts/test/data-model/builder/v4/ODataBuilderV4Helper.ts
@@ -1,6 +1,13 @@
 import { NavigationProperty } from "../../../../src/data-model/edmx/ODataEdmxModelV4.js";
 
-export function createNavProp(name: string, type: string, partner?: string, nullable?: boolean, contained?: boolean) {
+export function createNavProp(
+  name: string,
+  type: string,
+  partner?: string,
+  nullable?: boolean,
+  contained?: boolean,
+  referentialConstraints?: Array<{ property: string; referencedProperty: string }>,
+) {
   const navProp: NavigationProperty = {
     $: {
       Name: name,
@@ -15,6 +22,11 @@ export function createNavProp(name: string, type: string, partner?: string, null
   }
   if (contained) {
     navProp.$.ContainsTarget = "true";
+  }
+  if (referentialConstraints?.length) {
+    navProp.ReferentialConstraint = referentialConstraints.map((rc) => ({
+      $: { Property: rc.property, ReferencedProperty: rc.referencedProperty },
+    }));
   }
 
   return navProp;

--- a/packages/odata2ts/test/data-model/builder/v4/ODataEntityTypeBuilderV4.ts
+++ b/packages/odata2ts/test/data-model/builder/v4/ODataEntityTypeBuilderV4.ts
@@ -7,11 +7,20 @@ export class ODataEntityTypeBuilderV4 extends ODataEntityTypeBuilderBase<EntityT
     return this.createEntityType();
   }
 
-  public addNavProp(name: string, type: string, partner?: string, nullable?: boolean, contained?: boolean) {
+  public addNavProp(
+    name: string,
+    type: string,
+    partner?: string,
+    nullable?: boolean,
+    contained?: boolean,
+    referentialConstraints?: Array<{ property: string; referencedProperty: string }>,
+  ) {
     if (!this.entityType.NavigationProperty) {
       this.entityType.NavigationProperty = [];
     }
-    this.entityType.NavigationProperty.push(createNavProp(name, type, partner, nullable, contained));
+    this.entityType.NavigationProperty.push(
+      createNavProp(name, type, partner, nullable, contained, referentialConstraints),
+    );
 
     return this;
   }

--- a/packages/odata2ts/test/data-model/helper/DigestFixture.ts
+++ b/packages/odata2ts/test/data-model/helper/DigestFixture.ts
@@ -1,0 +1,65 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { ODataVersions } from "@odata2ts/odata-core";
+import { pascalCase } from "change-case";
+import { parseStringPromise } from "xml2js";
+import { DataModel, NamespaceWithAlias } from "../../../src/data-model/DataModel.js";
+import { digest as digestV2 } from "../../../src/data-model/DataModelDigestionV2.js";
+import { digest as digestV4 } from "../../../src/data-model/DataModelDigestionV4.js";
+import { ODataEdmxModelBase } from "../../../src/data-model/edmx/ODataEdmxModelBase.js";
+import { SchemaV3 } from "../../../src/data-model/edmx/ODataEdmxModelV3.js";
+import { SchemaV4 } from "../../../src/data-model/edmx/ODataEdmxModelV4.js";
+import { NamingHelper } from "../../../src/data-model/NamingHelper.js";
+import { resolveV2Annotations } from "../../../src/data-model/V2AnnotationResolver.js";
+import { getTestConfig } from "../../test.config.js";
+
+// The int-test fixtures (`int-test/<server>/resource/library.xml`) live outside this package, at the
+// workspace repo's root - not under `packages/odata2ts`. Resolving against this file's own location
+// rather than the process cwd is what keeps the path correct regardless of where vitest is invoked from.
+const REPO_ROOT = fileURLToPath(new URL("../../../../../", import.meta.url));
+
+/**
+ * Digests a real metadata file from disk exactly the way the CLI does it (see
+ * `src/cli/serviceGenerationRun.ts` and `src/app.ts`): parse with xml2js, then hand the schemas to the
+ * version-specific digester. Exists so tests can exercise the data model against a server's actual
+ * declarations instead of a hand-built fixture, which is the whole point where a rule depends on what a
+ * real service happens to state in its metadata.
+ *
+ * @param relativePath path to the metadata file, relative to the repo root, e.g.
+ *   `"int-test/asp-net/resource/library.xml"`
+ */
+export async function digestMetadataFile(relativePath: string): Promise<DataModel> {
+  const metadataXml = await readFile(path.join(REPO_ROOT, relativePath));
+  const metadataJson = (await parseStringPromise(metadataXml)) as ODataEdmxModelBase<any>;
+
+  const edmxVersion = metadataJson["edmx:Edmx"].$.Version;
+  const version = edmxVersion === "1.0" ? ODataVersions.V2 : ODataVersions.V4;
+
+  const dataService = metadataJson["edmx:Edmx"]["edmx:DataServices"][0];
+  const schemas = dataService.Schema as Array<SchemaV3 | SchemaV4>;
+  // the vocabularies the document draws annotation terms from; they sit outside of the schemas
+  const references = metadataJson["edmx:Edmx"]["edmx:Reference"];
+
+  // V2 states what V4 says with a vocabulary term as an attribute in a foreign namespace; translated
+  // here, against the whole document, because resolving those namespaces needs the root element
+  if (version === ODataVersions.V2) {
+    resolveV2Annotations(metadataJson);
+  }
+
+  const namespaces = schemas.map<NamespaceWithAlias>((schema) => [schema.$.Namespace, schema.$.Alias]);
+  const detectedSchema = schemas.find((schema) => schema.$.Namespace && schema.EntityType?.length) || schemas[0];
+  const serviceName = pascalCase(detectedSchema.$.Namespace);
+
+  const config = getTestConfig();
+  // asp-net's real metadata declares both `Location_` (the shelf mark) and `Location` (a navigation
+  // property to the branch an item sits in) on `Copy`; camelCase collapses both onto `location`, which
+  // `getTestConfig()`'s `allowRenaming: true` turns into a hard digestion error. `int-test/asp-net`'s own
+  // `libraryRenamed` service carries the identical fix - see its `odata2ts.config.ts`.
+  config.propertiesByName = [{ name: "Location_", mappedName: "shelfLocation" }];
+  const namingHelper = new NamingHelper(config, serviceName, namespaces);
+
+  return version === ODataVersions.V2
+    ? digestV2(schemas as Array<SchemaV3>, config, namingHelper, references)
+    : digestV4(schemas as Array<SchemaV4>, config, namingHelper, references);
+}

--- a/packages/odata2ts/test/data-model/v2/EntityTypeDigestion.test.ts
+++ b/packages/odata2ts/test/data-model/v2/EntityTypeDigestion.test.ts
@@ -456,6 +456,8 @@ describe("V2: EntityTypeDigestion Test", () => {
       dataType: DataTypes.ModelType,
       managed: undefined,
       required: true,
+      // a genuine pair: Category.products points back with FromRole/ToRole swapped
+      partner: "products",
     } as PropertyModel);
     expect(product.props[2]).toEqual({
       name: "supplier",
@@ -470,6 +472,8 @@ describe("V2: EntityTypeDigestion Test", () => {
       dataType: DataTypes.ModelType,
       managed: undefined,
       required: false,
+      // a genuine pair: Supplier.products points back with FromRole/ToRole swapped
+      partner: "products",
     } as PropertyModel);
 
     const category = result.getEntityTypes()[1];
@@ -487,6 +491,8 @@ describe("V2: EntityTypeDigestion Test", () => {
       dataType: DataTypes.ModelType,
       managed: undefined,
       required: false,
+      // a genuine pair: Product.Category points back with FromRole/ToRole swapped
+      partner: "Category",
     } as PropertyModel);
   });
 

--- a/packages/odata2ts/test/data-model/v2/NavPropDigestion.test.ts
+++ b/packages/odata2ts/test/data-model/v2/NavPropDigestion.test.ts
@@ -1,0 +1,132 @@
+import { ODataTypesV2 } from "@odata2ts/odata-core";
+import { beforeEach, describe, expect, test } from "vitest";
+import { digest } from "../../../src/data-model/DataModelDigestionV2.js";
+import { NamingHelper } from "../../../src/data-model/NamingHelper.js";
+import { getTestConfig } from "../../test.config.js";
+import { ODataModelBuilderV2 } from "../builder/v2/ODataModelBuilderV2.js";
+
+describe("V2: navigation property digestion (partner, referential constraint)", () => {
+  const SERVICE_NAME = "Test";
+  const CONFIG = getTestConfig();
+  const NAMING_HELPER = new NamingHelper(CONFIG, SERVICE_NAME);
+
+  let odataBuilder: ODataModelBuilderV2;
+
+  function withNs(name: string) {
+    return `${SERVICE_NAME}.${name}`;
+  }
+
+  function doDigest() {
+    return digest(odataBuilder.getSchemas(), CONFIG, NAMING_HELPER);
+  }
+
+  beforeEach(() => {
+    odataBuilder = new ODataModelBuilderV2(SERVICE_NAME);
+
+    // Medium 1--n Copy, realized by a single-property ReferentialConstraint stated on the association:
+    // Copy carries the foreign key back to Medium, so Copy's own navigation property (pointing at the
+    // principal) gets the constraint, while Medium's collection end gets only the Partner.
+    odataBuilder
+      .addEntityType("Medium", undefined, (builder) => {
+        builder
+          .addKeyProp("Id", ODataTypesV2.String)
+          .addNavProp("Copies", withNs("Copy"), "Medium_Copies", "*", { fromRole: "Medium", toRole: "Copy" });
+      })
+      .addEntityType("Copy", undefined, (builder) => {
+        builder
+          .addKeyProp("MediumId", ODataTypesV2.String)
+          .addKeyProp("InventoryNumber", ODataTypesV2.String)
+          .addNavProp("Medium", withNs("Medium"), "Medium_Copies", "1", { fromRole: "Copy", toRole: "Medium" }, [
+            { property: "MediumId", referencedProperty: "Id" },
+          ])
+          // points at Location, but Location never declares a navigation property back - a legal end
+          // that nothing navigates back from
+          .addNavProp("Location", withNs("Location"), "Copy_Location", "0..1", {
+            fromRole: "Copy",
+            toRole: "Location",
+          })
+          // the principal side of a composite-key constraint (see Reservation below): Copy itself
+          // carries no constraint, only Reservation does
+          .addNavProp("Reservations", withNs("Reservation"), "Reservation_Copy", "*", {
+            fromRole: "Copy",
+            toRole: "Reservation",
+          });
+      })
+      .addEntityType("Location", undefined, (builder) => {
+        builder.addKeyProp("Id", ODataTypesV2.String);
+      })
+      .addEntityType("Reservation", undefined, (builder) => {
+        builder
+          .addKeyProp("Id", ODataTypesV2.String)
+          .addProp("Copy_MediumId", ODataTypesV2.String)
+          .addProp("Copy_InventoryNumber", ODataTypesV2.String)
+          .addNavProp("copy", withNs("Copy"), "Reservation_Copy", "1", { fromRole: "Reservation", toRole: "Copy" }, [
+            { property: "Copy_MediumId", referencedProperty: "MediumId" },
+            { property: "Copy_InventoryNumber", referencedProperty: "InventoryNumber" },
+          ]);
+      })
+      // Member 1--n Loan, with no ReferentialConstraint on the association at all
+      .addEntityType("Member", undefined, (builder) => {
+        builder.addKeyProp("Id", ODataTypesV2.String).addNavProp("Loans", withNs("Loan"), "Member_Loans", "*", {
+          fromRole: "Member",
+          toRole: "Loan",
+        });
+      })
+      .addEntityType("Loan", undefined, (builder) => {
+        builder
+          .addKeyProp("Id", ODataTypesV2.String)
+          .addNavProp("Member", withNs("Member"), "Member_Loans", "1", { fromRole: "Loan", toRole: "Member" });
+      });
+  });
+
+  test("the inverse navigation property is derived from the association's other end", async () => {
+    const result = await doDigest();
+    const copies = result.getEntityType(withNs("Medium"))!.props.find((p) => p.odataName === "Copies");
+    const medium = result.getEntityType(withNs("Copy"))!.props.find((p) => p.odataName === "Medium");
+
+    expect(copies!.partner).toBe("Medium");
+    expect(medium!.partner).toBe("Copies");
+  });
+
+  test("no inverse navigation property means no partner", async () => {
+    const result = await doDigest();
+    const orphan = result.getEntityType(withNs("Copy"))!.props.find((p) => p.odataName === "Location");
+
+    expect(orphan!.partner).toBeUndefined();
+  });
+
+  test("the constraint is carried on the dependent side's navigation property", async () => {
+    const result = await doDigest();
+    const medium = result.getEntityType(withNs("Copy"))!.props.find((p) => p.odataName === "Medium");
+
+    expect(medium!.referentialConstraints).toEqual([{ property: "MediumId", referencedProperty: "Id" }]);
+  });
+
+  test("the principal side's navigation property carries no constraint", async () => {
+    const result = await doDigest();
+    const copies = result.getEntityType(withNs("Medium"))!.props.find((p) => p.odataName === "Copies");
+
+    expect(copies!.referentialConstraints).toBeUndefined();
+  });
+
+  test("a composite-key constraint is carried in source order, on the dependent side only", async () => {
+    const result = await doDigest();
+    const copy = result.getEntityType(withNs("Reservation"))!.props.find((p) => p.odataName === "copy");
+    const reservations = result.getEntityType(withNs("Copy"))!.props.find((p) => p.odataName === "Reservations");
+
+    expect(copy!.referentialConstraints).toEqual([
+      { property: "Copy_MediumId", referencedProperty: "MediumId" },
+      { property: "Copy_InventoryNumber", referencedProperty: "InventoryNumber" },
+    ]);
+    expect(reservations!.referentialConstraints).toBeUndefined();
+  });
+
+  test("an association without a constraint yields none on either side", async () => {
+    const result = await doDigest();
+    const loans = result.getEntityType(withNs("Member"))!.props.find((p) => p.odataName === "Loans");
+    const member = result.getEntityType(withNs("Loan"))!.props.find((p) => p.odataName === "Member");
+
+    expect(loans!.referentialConstraints).toBeUndefined();
+    expect(member!.referentialConstraints).toBeUndefined();
+  });
+});

--- a/packages/odata2ts/test/data-model/v4/NavPropDigestion.test.ts
+++ b/packages/odata2ts/test/data-model/v4/NavPropDigestion.test.ts
@@ -1,0 +1,97 @@
+import { ODataTypesV4 } from "@odata2ts/odata-core";
+import { beforeEach, describe, expect, test } from "vitest";
+import { digest } from "../../../src/data-model/DataModelDigestionV4.js";
+import { NamingHelper } from "../../../src/data-model/NamingHelper.js";
+import { getTestConfig } from "../../test.config.js";
+import { ODataModelBuilderV4 } from "../builder/v4/ODataModelBuilderV4.js";
+
+describe("V4: navigation property digestion (Partner, ReferentialConstraint)", () => {
+  const SERVICE_NAME = "Test";
+  const CONFIG = getTestConfig();
+  const NAMING_HELPER = new NamingHelper(CONFIG, SERVICE_NAME);
+
+  let odataBuilder: ODataModelBuilderV4;
+
+  function withNs(name: string) {
+    return `${SERVICE_NAME}.${name}`;
+  }
+
+  function doDigest() {
+    return digest(odataBuilder.getSchemas(), CONFIG, NAMING_HELPER);
+  }
+
+  beforeEach(() => {
+    odataBuilder = new ODataModelBuilderV4(SERVICE_NAME);
+
+    // Medium 1--n Copy: Copy carries the foreign key back to Medium via a composite-key style
+    // ReferentialConstraint (two properties, so source order is actually observable), Medium's collection
+    // end carries only the Partner.
+    odataBuilder
+      .addEntityType("Medium", undefined, (builder) => {
+        builder
+          .addKeyProp("Id", ODataTypesV4.String)
+          .addNavProp("Copies", `Collection(${withNs("Copy")})`, "Medium")
+          .addNavProp("Reservations", `Collection(${withNs("Reservation")})`);
+      })
+      .addEntityType("Copy", undefined, (builder) => {
+        builder
+          .addKeyProp("MediumId", ODataTypesV4.String)
+          .addKeyProp("InventoryNumber", ODataTypesV4.String)
+          .addNavProp("medium", withNs("Medium"), "Copies", undefined, undefined, [
+            { property: "MediumId", referencedProperty: "Id" },
+          ])
+          .addNavProp("location", withNs("Location"));
+      })
+      .addEntityType("Reservation", undefined, (builder) => {
+        builder
+          .addKeyProp("Id", ODataTypesV4.String)
+          .addProp("Copy_MediumId", ODataTypesV4.String)
+          .addProp("Copy_InventoryNumber", ODataTypesV4.String)
+          .addNavProp("copy", withNs("Copy"), undefined, undefined, undefined, [
+            { property: "Copy_MediumId", referencedProperty: "MediumId" },
+            { property: "Copy_InventoryNumber", referencedProperty: "InventoryNumber" },
+          ]);
+      })
+      .addEntityType("Location", undefined, (builder) => {
+        builder.addKeyProp("Id", ODataTypesV4.String);
+      });
+  });
+
+  test("Partner reaches the property model", async () => {
+    const result = await doDigest();
+    const copies = result.getEntityType(withNs("Medium"))!.props.find((p) => p.odataName === "Copies");
+
+    expect(copies!.partner).toBe("Medium");
+  });
+
+  test("a navigation property without Partner has none", async () => {
+    const result = await doDigest();
+    const reservations = result.getEntityType(withNs("Medium"))!.props.find((p) => p.odataName === "Reservations");
+
+    expect(reservations!.partner).toBeUndefined();
+  });
+
+  test("ReferentialConstraint reaches the property model", async () => {
+    const result = await doDigest();
+    const medium = result.getEntityType(withNs("Copy"))!.props.find((p) => p.odataName === "medium");
+
+    expect(medium!.referentialConstraints).toEqual([{ property: "MediumId", referencedProperty: "Id" }]);
+  });
+
+  test("several ReferentialConstraints are all carried, in source order", async () => {
+    const result = await doDigest();
+    const copy = result.getEntityType(withNs("Reservation"))!.props.find((p) => p.odataName === "copy");
+
+    expect(copy!.referentialConstraints).toEqual([
+      { property: "Copy_MediumId", referencedProperty: "MediumId" },
+      { property: "Copy_InventoryNumber", referencedProperty: "InventoryNumber" },
+    ]);
+  });
+
+  test("a navigation property without a constraint has none", async () => {
+    const result = await doDigest();
+    const location = result.getEntityType(withNs("Copy"))!.props.find((p) => p.odataName === "location");
+
+    expect(location!.referentialConstraints).toBeUndefined();
+  });
+});

--- a/packages/odata2ts/test/evaluateConfig.test.ts
+++ b/packages/odata2ts/test/evaluateConfig.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { evaluateConfigOptions } from "../src/evaluateConfig.js";
 import {
+  CacheKeyMode,
   CliOptions,
   ConfigFileOptions,
   DeepInsertProps,
@@ -8,6 +9,7 @@ import {
   getDefaultConfig,
   Modes,
   NamingStrategies,
+  resolveCacheKeyMode,
 } from "../src/index.js";
 
 describe("Config Evaluation Tests", () => {
@@ -309,6 +311,47 @@ describe("Config Evaluation Tests", () => {
       const result = evaluateConfigOptions(cliOpts, { mode, deepInsertProps: DeepInsertProps.compositionOnly });
 
       expect(result[0], `mode ${mode}`).toMatchObject({ deepInsertProps: DeepInsertProps.compositionOnly });
+    });
+  });
+
+  describe("cacheKeys option", () => {
+    test("absent means off", () => {
+      expect(resolveCacheKeyMode(undefined)).toBe(CacheKeyMode.off);
+    });
+
+    test("a named mode is passed through", () => {
+      expect(resolveCacheKeyMode({ mode: CacheKeyMode.on })).toBe(CacheKeyMode.on);
+      expect(resolveCacheKeyMode({ mode: CacheKeyMode.off })).toBe(CacheKeyMode.off);
+    });
+
+    test("the default is off, so a config saying nothing generates nothing", () => {
+      const [only] = evaluateConfigOptions({}, { services: { a: { source: "a.xml", output: "a" } } });
+      expect(only.cacheKeys).toEqual({ mode: CacheKeyMode.off });
+      expect(resolveCacheKeyMode(only.cacheKeys)).toBe(CacheKeyMode.off);
+    });
+
+    test("it is a per-service option, overridable from the base settings", () => {
+      const [first, second] = evaluateConfigOptions(
+        {},
+        {
+          cacheKeys: { mode: CacheKeyMode.on },
+          services: {
+            a: { source: "a.xml", output: "a" },
+            b: { source: "b.xml", output: "b", cacheKeys: { mode: CacheKeyMode.off } },
+          },
+        },
+      );
+      expect(first.cacheKeys).toEqual({ mode: CacheKeyMode.on });
+      expect(second.cacheKeys).toEqual({ mode: CacheKeyMode.off });
+    });
+
+    test("a service overrides the default rather than merging with it", () => {
+      // deepmerge folds the default {mode:"off"} under the service's own entry; the service must win
+      const [only] = evaluateConfigOptions(
+        {},
+        { services: { a: { source: "a.xml", output: "a", cacheKeys: { mode: CacheKeyMode.on } } } },
+      );
+      expect(only.cacheKeys).toEqual({ mode: CacheKeyMode.on });
     });
   });
 });

--- a/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
@@ -5,6 +5,7 @@ import { beforeAll, beforeEach, describe, expect, test } from "vitest";
 import { digest } from "../../../src/data-model/DataModelDigestionV4.js";
 import { NamingHelper } from "../../../src/data-model/NamingHelper.js";
 import {
+  CacheKeyMode,
   ConfigFileOptions,
   EmitModes,
   KeyProperties,
@@ -170,6 +171,174 @@ describe("Service Generator Tests V4", () => {
       await doGenerate();
 
       expect(generatedText()).not.toContain("getConcurrencyOptions");
+    });
+  });
+
+  describe("cacheKeys: root", () => {
+    function generatedText() {
+      return projectManager.getMainServiceFile().getFile().getFullText();
+    }
+
+    function addEntity() {
+      odataBuilder
+        .addEntityType("TestEntity", undefined, (builder) => builder.addKeyProp("id", ODataTypesV4.Guid))
+        .addEntitySet("Ents", withNs("TestEntity"));
+    }
+
+    test("a collection getter roots the key at the entity set's own name, not its type, when the feature is on", async () => {
+      addEntity();
+
+      await doGenerate({ cacheKeys: { mode: CacheKeyMode.on } });
+
+      // "Ents" - the entity set's own name - never the entity type's FQ name ("Tester.TestEntity")
+      expect(generatedText()).toContain(
+        `rootState("Ents", "list", { entitySetName: "Ents", canonicalIdFn: (entity: unknown) => new QTestEntityId("Ents").buildCanonicalId(entity), qEntityFn: () => QTestEntity })`,
+      );
+    });
+
+    test("nothing is emitted when cacheKeys is absent", async () => {
+      addEntity();
+
+      await doGenerate();
+
+      expect(generatedText()).not.toContain("rootState");
+      expect(generatedText()).not.toContain("cacheKeyState");
+    });
+
+    test("nothing is emitted under mode: off - identical to cacheKeys being absent", async () => {
+      addEntity();
+
+      await doGenerate({ cacheKeys: { mode: CacheKeyMode.off } });
+
+      expect(generatedText()).not.toContain("rootState");
+      expect(generatedText()).not.toContain("cacheKeyState");
+    });
+  });
+
+  describe("cacheKeys: hops", () => {
+    function generatedText() {
+      return projectManager.getMainServiceFile().getFile().getFullText();
+    }
+
+    /**
+     * Every navigation property is handled identically now - purely hierarchical, named by its own OData
+     * name, no grade/derivation reasoning involved (that machinery, and `typeFlattening` itself, is gone).
+     * `chapters` is contained (no entity set of its own, so no `entitySetName`); every other navigation
+     * property targets a real one.
+     */
+    function buildModel() {
+      odataBuilder
+        .addComplexType("Details", undefined, (builder) => builder.addProp("note", ODataTypesV4.String))
+        .addEntityType("Chapter", undefined, (builder) => builder.addKeyProp("id", ODataTypesV4.Guid))
+        .addEntityType("Review", undefined, (builder) => builder.addKeyProp("id", ODataTypesV4.Guid))
+        .addEntityType("Copy", undefined, (builder) =>
+          builder
+            .addKeyProp("mediumId", ODataTypesV4.Guid)
+            .addKeyProp("inventoryNumber", ODataTypesV4.Int32)
+            .addNavProp("medium", withNs("Medium"), "copies", false, false, [
+              { property: "mediumId", referencedProperty: "id" },
+            ]),
+        )
+        .addEntityType("Medium", undefined, (builder) =>
+          builder
+            .addKeyProp("id", ODataTypesV4.Guid)
+            .addProp("title", ODataTypesV4.String)
+            .addProp("rating", ODataTypesV4.Int32)
+            .addProp("scan", ODataTypesV4.Stream)
+            .addProp("keywords", `Collection(${ODataTypesV4.String})`)
+            .addProp("details", withNs("Details"))
+            .addNavProp("copies", `Collection(${withNs("Copy")})`, "medium")
+            .addNavProp("reviews", `Collection(${withNs("Review")})`)
+            .addNavProp("chapters", `Collection(${withNs("Chapter")})`, undefined, undefined, true),
+        )
+        .addEntityType("Book", { baseType: withNs("Medium") }, () => {})
+        .addEntitySet("Media", withNs("Medium"), [
+          { path: "copies", target: "Copies" },
+          { path: "reviews", target: "Reviews" },
+        ])
+        .addEntitySet("Copies", withNs("Copy"), [{ path: "medium", target: "Media" }])
+        .addEntitySet("Reviews", withNs("Review"))
+        .addSingleton("MainBranch", withNs("Medium"))
+        .addAction("checkOut", undefined, true, (builder) => builder.addParam("medium", withNs("Medium")))
+        .addFunction("newReleases", `Collection(${withNs("Medium")})`, false)
+        .addFunctionImport("NewReleases", withNs("newReleases"), "Media")
+        .addFunction("totalCount", ODataTypesV4.Int32, false)
+        .addFunctionImport("TotalCount", withNs("totalCount"));
+    }
+
+    async function generateWith(mode: CacheKeyMode) {
+      buildModel();
+      await doGenerate({ cacheKeys: { mode }, enablePrimitivePropertyServices: true });
+      return generatedText();
+    }
+
+    test("off: no cache-key expression is emitted anywhere", async () => {
+      const text = await generateWith(CacheKeyMode.off);
+
+      expect(text).not.toContain("rootState");
+      expect(text).not.toContain("hopState");
+      expect(text).not.toContain("withParams");
+      expect(text).not.toContain("cacheKeyState");
+      expect(text).not.toContain("CacheKeyNavHops");
+      expect(text).not.toContain("CACHE_KEY_NAV_HOPS");
+    });
+
+    test("root, hop, complex, primitive, stream, cast and operation hops all name themselves - never a type", async () => {
+      const text = await generateWith(CacheKeyMode.on);
+
+      // root: entity set getter on the main service - "Media", the entity SET's own name, never
+      // "Tester.Medium" (the type this used to, wrongly, be rooted at)
+      expect(text).toContain(
+        `rootState("Media", "list", { entitySetName: "Media", canonicalIdFn: (entity: unknown) => new QMediumId("Media").buildCanonicalId(entity), qEntityFn: () => QMedium })`,
+      );
+      // root: singleton getter - its own name directly, no params marker needed, no entitySetName (a
+      // singleton has no "list" form for `invalidates` to ever name)
+      expect(text).toContain(`rootState("MainBranch", "detail", { qEntityFn: () => QMedium })`);
+      // navigation hop with no Partner/ReferentialConstraint - irrelevant now, every navigation property
+      // is handled the same way regardless of what metadata backs it
+      expect(text).toContain(
+        `hopState(cacheKeyState, { name: "reviews", kind: "list", entitySetName: "Reviews", canonicalIdFn: (entity: unknown) => new QReviewId("Reviews").buildCanonicalId(entity), qEntityFn: () => QReview })`,
+      );
+      // contained: no entity set of its own
+      expect(text).toContain(`hopState(cacheKeyState, { name: "chapters", kind: "list", qEntityFn: () => QChapter })`);
+      // the old grade-A relation is just another hierarchical hop now, both directions, no re-rooting
+      expect(text).toContain(
+        `hopState(cacheKeyState, { name: "copies", kind: "list", entitySetName: "Copies", canonicalIdFn: (entity: unknown) => new QCopyId("Copies").buildCanonicalId(entity), qEntityFn: () => QCopy })`,
+      );
+      expect(text).toContain(
+        `hopState(cacheKeyState, { name: "medium", kind: "detail", entitySetName: "Media", canonicalIdFn: (entity: unknown) => new QMediumId("Media").buildCanonicalId(entity), qEntityFn: () => QMedium })`,
+      );
+      expect(text).not.toContain("reRoot");
+      // complex property: never a navigation property, no entity set, no Q-object factory of its own
+      expect(text).toContain(`hopState(cacheKeyState, { name: "details", kind: "detail" })`);
+      // primitive collection and primitive property: bare name, no kind - stays on its parent's resource
+      expect(text).toContain(`hopState(cacheKeyState, { name: "keywords" })`);
+      expect(text).toContain(`hopState(cacheKeyState, { name: "rating" })`);
+      // stream property: the property hop, then a further hop appending $value
+      expect(text).toContain(`hopState(hopState(cacheKeyState, { name: "scan" }), { name: "$value" })`);
+      // subtype cast: a restriction on the same resource, not a hop away from it - a genuine spec URL
+      // segment, so it stays a type here, unlike everything else
+      expect(text).toContain(`withParams(cacheKeyState, { cast: "${withNs("Book")}" })`);
+      // bound action: a hop off the resource it is bound to, unstructured return -> bare name
+      expect(text).toContain(`hopState(cacheKeyState, { name: "${withNs("checkOut")}" })`);
+      // unbound function with a declared EntitySet: still rooted at the *import's* own name ("NewReleases"),
+      // never the entity set's ("Media") - entitySetName/canonicalIdFn/qEntityFn are attached alongside it
+      // only so ResourceIdentityHandler can record the actual Media entities the response carries
+      expect(text).toContain(
+        `rootState("NewReleases", "list", { entitySetName: "Media", canonicalIdFn: (entity: unknown) => new QMediumId("Media").buildCanonicalId(entity), qEntityFn: () => QMedium })`,
+      );
+      // unbound function with no EntitySet: rooted at its own import name too, no sentinel needed
+      expect(text).toContain(`rootState("TotalCount", "detail")`);
+      expect(text).not.toContain("OPERATION_ROOT");
+      // no generated nav-hops table anywhere - removed along with type-rooted identity
+      expect(text).not.toContain("CacheKeyNavHops");
+      expect(text).not.toContain("CACHE_KEY_NAV_HOPS");
+    });
+
+    test("createEntityService forwards the cache-key state it is handed, without computing one", async () => {
+      const text = await generateWith(CacheKeyMode.on);
+
+      expect(text).toContain("new MediumService<V>(client, path, name, options, cacheKeyState);");
     });
   });
 


### PR DESCRIPTION
Fourth layer of the feat/cache-keys (#526) per-package stack, on top of
#530 (odata-service, merged).

- OptionModel.ts: cacheKeys option, CacheKeyMode collapsed to on|off.
- ServiceGenerator.ts: every generated root/hop names itself by entity
  set, singleton, or navigation/containment property - never a type.
  entitySetName/canonicalIdFn/qEntityFn are emitted wherever a resource
  has independent identity (never for a contained one). An unbound
  operation import always roots at its own OData name (never the
  operation's qualified name, never its declared result EntitySet's
  name either) - the canonical URL for a function/action import is
  always the service root plus the import's own name, confirmed against
  OData v4.01 Part 1 §11.5.4.1/§11.5.5.1. A bound operation is unchanged:
  a hop off the resource it hangs on, its own qualified name is a
  genuine URL segment. Invocation params are nested under their own
  key, never dropped, never colliding with a composable operation's own
  $select/$filter/... params.
- DataModelDigestion(V2/V4).ts: still digest Partner/ReferentialConstraint
  metadata (used elsewhere), but cache-key generation no longer consumes
  the grade it used to derive from them - a cache key is always the
  literal route taken, never re-rooted at a referentially-constrained
  target.
- No more generated NavHopsTable: the Q-object passed into expand()/
  expanding() already carries everything $expand enrichment needs
  directly (see #529).

Replaces #531, whose base branch (feat/cache-key-service) was deleted on
merge and closed the PR along with it. int-test/examples is next.