### PR TITLE
test(int-test, examples): cache-key coverage against real servers

### DIFF
--- a/examples/main/package.json
+++ b/examples/main/package.json
@@ -19,6 +19,7 @@
     "@odata2ts/converter-common": "^0.4.0",
     "@odata2ts/converter-luxon": "^0.3.0",
     "@odata2ts/converter-v2-to-v4": "^0.5.8",
+    "@odata2ts/http-client-api": "^0.7.1",
     "@odata2ts/http-client-axios": "^0.16.1",
     "@odata2ts/http-client-fetch": "^0.13.1",
     "@odata2ts/odata-service": "workspace:^",

--- a/int-test/asp-net/odata2ts.config.ts
+++ b/int-test/asp-net/odata2ts.config.ts
@@ -1,4 +1,12 @@
-import { ConfigFileOptions, EmitModes, KeyProperties, ManagedPropertyMode, Modes, TypeModel } from "@odata2ts/odata2ts";
+import {
+  CacheKeyMode,
+  ConfigFileOptions,
+  EmitModes,
+  KeyProperties,
+  ManagedPropertyMode,
+  Modes,
+  TypeModel,
+} from "@odata2ts/odata2ts";
 
 /** The running server to refresh from, or `undefined` to read the committed snapshot - see below. */
 const SOURCE_URL = process.env.LIBRARY_BASE_URL;
@@ -10,8 +18,10 @@ const SOURCE = "resource/library.xml";
  *
  * The source is a committed snapshot of the server's actual `$metadata` (`resource/library.xml`) -
  * odata2ts is tested against the metadata ASP.NET Core OData really emits, not against the idealized
- * reference model. Notably that metadata has no `TypeDefinition`, no `Partner` attributes and no `SRID`
- * facets, none of which the model builder can express; see FEATURE-COVERAGE.md in the server repo.
+ * reference model. Notably that metadata has no `TypeDefinition` and no `SRID` facets, neither of which
+ * the model builder can express; see FEATURE-COVERAGE.md in the server repo. `Partner` *is* declared on
+ * both sides of every relationship (6 attributes) - which is what puts grade A and grade B navigation
+ * properties into this client's `cacheKeys` derivation, see the `library` service below.
  *
  * The snapshot refreshes itself from a running server: point `LIBRARY_BASE_URL` at one and the first
  * service downloads `$metadata` and overwrites the file, which the services after it then read, so a
@@ -55,6 +65,10 @@ const config: ConfigFileOptions = {
       source: SOURCE,
       refreshFile: true,
       output: "src-generated/library",
+      // this metadata reproduces the reference model exactly, which puts every hop shape into one client -
+      // to-many and to-one navigation, grade-B/C-style relations, containment and a stream - so this is
+      // where the cache-key shape itself is held against a real server; see test/feature/CacheKeys.test.ts.
+      cacheKeys: { mode: CacheKeyMode.on },
     },
     /**
      * The same model once more, targeting OData 4.01 instead of the default 4.0.

--- a/int-test/asp-net/package.json
+++ b/int-test/asp-net/package.json
@@ -14,6 +14,7 @@
     "test-compile": "tsc"
   },
   "dependencies": {
+    "@odata2ts/http-client-api": "^0.7.1",
     "@odata2ts/http-client-fetch": "^0.13.1",
     "@odata2ts/odata-service": "workspace:^"
   },

--- a/int-test/asp-net/test/feature/CacheKeys.test.ts
+++ b/int-test/asp-net/test/feature/CacheKeys.test.ts
@@ -1,0 +1,249 @@
+import { HttpResponseModel } from "@odata2ts/http-client-api";
+import { ODataModelResponseV4 } from "@odata2ts/odata-core";
+import { touchesResource } from "@odata2ts/odata-service";
+import { afterAll, describe, expect, expectTypeOf, test } from "vitest";
+import { Medium } from "../../src-generated/library/library-catalog/index.js";
+import { expectODataError } from "../expectODataError.js";
+import { AUDIOBOOK, BOOK_DER_PROZESS, LIBRARY } from "../LibraryTestConstants.js";
+
+/**
+ * `cacheKeys: { mode: "on" }`, against the one server whose metadata reproduces the reference model
+ * exactly - see the config's own comment for why. Every hop shape the generator can produce meets a real
+ * request here: to-many and to-one navigation, containment and a stream.
+ *
+ * Every key assertion is paired with an executed request whose response is asserted too - the point of a
+ * server int-test is that the key describes the resource the server actually served, not a fixture's idea
+ * of one.
+ */
+describe("ASP.NET Library: cache keys", () => {
+  /** A copy only this file touches, so a re-run against the same server does not collide. */
+  const CACHE_KEY_COPY = 8801;
+  const copyKey = { MediumId: BOOK_DER_PROZESS, InventoryNumber: CACHE_KEY_COPY };
+
+  afterAll(async () => {
+    await LIBRARY.Copies(copyKey).delete().ignoreETag().execute();
+  });
+
+  test("a root names itself by the entity set, never a type", async () => {
+    const request = LIBRARY.Media().query();
+    expect(request.cacheKey).toEqual(["Media", "list"]);
+
+    const result = await request.execute();
+    expect(result.status).toBe(200);
+  });
+
+  test("a to-one hop off a real entity: /Copies(...)/Medium names itself by the navigation property, with no key of its own - a to-one hop never knows the target's key up front", async () => {
+    const created = await LIBRARY.Copies()
+      .create({
+        MediumId: BOOK_DER_PROZESS,
+        InventoryNumber: CACHE_KEY_COPY,
+        Condition: 3,
+        IsLoanable: true,
+        WeightKg: 0.5,
+      })
+      .execute();
+    expect(created.status).toBe(201);
+
+    const request = LIBRARY.Copies(copyKey).Medium().query();
+    expect(request.cacheKey).toEqual(["Copies", "detail", copyKey, "Medium", "detail"]);
+
+    const result = await request.execute();
+    expect(result.status).toBe(200);
+    expect(result.data.Title).toBe("Der Prozess");
+    expectTypeOf(result).toEqualTypeOf<HttpResponseModel<ODataModelResponseV4<Medium>>>();
+
+    // the hop still carries entitySetName/canonicalIdFn, so the response the server actually returned is
+    // enough to recover the real canonical resource this hop reached, despite the key gap in the key itself
+    const patched = await LIBRARY.Media(BOOK_DER_PROZESS)
+      .asBookService()
+      .patch({ Title: "Der Prozess" })
+      .ignoreETag()
+      .execute();
+    expect(patched.invalidates).toEqual(expect.arrayContaining([["Copies", "detail", copyKey, "Medium", "detail"]]));
+  });
+
+  test("$expand produces a hop-shaped entry touchesResource can reach", async () => {
+    const request = LIBRARY.Media(BOOK_DER_PROZESS).query((builder) => builder.expand("Copies"));
+    expect(request.cacheKey).toEqual(["Media", "detail", BOOK_DER_PROZESS, { expand: [["Copies", "list"]] }]);
+    expect(touchesResource(["Copies", "list"], request.cacheKey!)).toBe(true);
+
+    const result = await request.execute();
+    expect(result.status).toBe(200);
+  });
+
+  test("a to-many hop: /Media(...)/Copies names itself by the navigation property, distinct from a hand-filtered route to the same entity set", async () => {
+    const viaNavigation = LIBRARY.Media(BOOK_DER_PROZESS).Copies().query();
+    const viaFilter = LIBRARY.Copies().query((builder, qCopy) => builder.filter(qCopy.MediumId.eq(BOOK_DER_PROZESS)));
+
+    expect(viaNavigation.cacheKey).toEqual(["Media", "detail", BOOK_DER_PROZESS, "Copies", "list"]);
+    expect(viaFilter.cacheKey).toEqual(["Copies", "list", { filter: { MediumId: BOOK_DER_PROZESS } }]);
+    // no more convergence by construction - the two keys are legitimately different arrays now; what makes
+    // them invalidate together is the response-observed identity mechanism proven below, not equal keys
+
+    const [navigated, filtered] = await Promise.all([viaNavigation.execute(), viaFilter.execute()]);
+    expect(navigated.status).toBe(200);
+    expect(filtered.status).toBe(200);
+  });
+
+  test("a read through a navigated route records the resource it served, so a later direct write to it also invalidates that route", async () => {
+    const navigated = await LIBRARY.Media(BOOK_DER_PROZESS).Copies().query().execute();
+    expect(navigated.status).toBe(200);
+    expect(navigated.data.value.some((copy) => copy.InventoryNumber === CACHE_KEY_COPY)).toBe(true);
+
+    const patched = await LIBRARY.Copies(copyKey).patch({ Condition: 4 }).ignoreETag().execute();
+    expect(patched.status).toBe(204);
+    expect(patched.invalidates).toEqual(
+      expect.arrayContaining([
+        ["Copies", "detail", copyKey],
+        ["Copies", "list"],
+        ["Media", "detail", BOOK_DER_PROZESS, "Copies", "list"],
+      ]),
+    );
+  });
+
+  test("grade B: /Members(...)/Loans names itself by the navigation property", async () => {
+    const member = await LIBRARY.Members()
+      .create({
+        Name: "CacheKeys Test (grade B)",
+        PreviousAddresses: [],
+        Loans: [{ LoanedAt: "2026-05-01T10:00:00Z", DueDate: "2026-06-01" }],
+      })
+      .execute();
+    expect(member.status).toBe(201);
+    // the deep-inserted Loan contributes its own bare entity-set entry, additionally to the write's own -
+    // this is what lets an application invalidate the Loan cache without knowing the new Loan's id
+    expect(member.invalidates).toEqual([
+      ["Members", "list"],
+      ["Loans", "list"],
+    ]);
+    const memberId = member.data.Id;
+
+    try {
+      const request = LIBRARY.Members(memberId).Loans().query();
+      expect(request.cacheKey).toEqual(["Members", "detail", memberId, "Loans", "list"]);
+
+      const result = await request.execute();
+      expect(result.status).toBe(200);
+      expect(result.data.value.length).toBe(1);
+    } finally {
+      await LIBRARY.Members(memberId).delete().execute();
+    }
+  });
+
+  test("grade C: /Members(...)/Reservations names itself the same way - no different treatment from grade B any more", async () => {
+    const member = await LIBRARY.Members()
+      .create({
+        Name: "CacheKeys Test (grade C)",
+        PreviousAddresses: [],
+        Reservations: [{ ReservedAt: "2026-05-01T10:00:00Z" }],
+      })
+      .execute();
+    expect(member.status).toBe(201);
+    const memberId = member.data.Id;
+
+    try {
+      const request = LIBRARY.Members(memberId).Reservations().query();
+      expect(request.cacheKey).toEqual(["Members", "detail", memberId, "Reservations", "list"]);
+
+      const result = await request.execute();
+      expect(result.status).toBe(200);
+      expect(result.data.value.length).toBe(1);
+    } finally {
+      await LIBRARY.Members(memberId).delete().execute();
+    }
+  });
+
+  test("containment stays hierarchical, exactly like non-contained navigation: /Media(...)/Audiobook/Chapters", async () => {
+    const request = LIBRARY.Media(AUDIOBOOK).asAudiobookService().Chapters().query();
+
+    // no entitySetName: a contained entity has no entity set of its own - and the ancestor's own cast
+    // (a params-object concern for that resource alone) does not carry into the hop either
+    expect(request.cacheKey).toEqual(["Media", "detail", AUDIOBOOK, "Chapters", "list"]);
+
+    const result = await request.execute();
+    expect(result.status).toBe(200);
+  });
+
+  test("a stream: Audiobook/Sample carries a further $value hop", async () => {
+    const stream = LIBRARY.Media(AUDIOBOOK).asAudiobookService().Sample();
+    const request = stream.getBlob();
+
+    expect(request.cacheKey).toEqual(["Media", "detail", AUDIOBOOK, "Sample", "$value"]);
+
+    // the sample may or may not have content, but the request itself must be well-formed
+    const result = await request.execute();
+    expect([200, 204]).toContain(result.status);
+  });
+
+  test("an unbound function with no declared result entity set roots at its own import name", async () => {
+    const request = LIBRARY.TotalMediaCount();
+    expect(request.cacheKey).toEqual(["TotalMediaCount", "detail"]);
+
+    const result = await request.execute();
+    expect(result.status).toBe(200);
+    expect(typeof result.data.value).toBe("number");
+  });
+
+  test("an unbound function with a declared result entity set roots at its own import name too, never the entity set's - invocation params nested under their own key", async () => {
+    const request = LIBRARY.Search({ Term: "Prozess" });
+    expect(request.cacheKey).toEqual(["Search", "list", { params: { Term: "Prozess" } }]);
+
+    const result = await request.execute();
+    expect(result.status).toBe(200);
+    expect(result.data.value.some((medium) => medium.Title === "Der Prozess")).toBe(true);
+  });
+
+  test("touchesResource reaches a hierarchical key by its own name, but not an ancestor it never names as a top-level entry", () => {
+    const hierarchicalKey = LIBRARY.Members(1).Reservations().query().cacheKey!;
+    expect(touchesResource(["Members", "detail", 1], hierarchicalKey)).toBe(true);
+    expect(touchesResource(["Reservations", "list"], hierarchicalKey)).toBe(true);
+    expect(touchesResource(["Media", "list"], hierarchicalKey)).toBe(false);
+  });
+
+  test("invalidates on a PATCH, a POST and a DELETE - and none of the three has a cacheKey of its own", async () => {
+    // created directly on the entity set (not navigated through Medium) - the server only accepts a POST
+    // at an entity set's own URL, so this is also the shape with no ancestor: own key without params and
+    // own entity set collapse onto the identical entry
+    const createRequest = LIBRARY.Copies().create({
+      MediumId: BOOK_DER_PROZESS,
+      InventoryNumber: CACHE_KEY_COPY + 1,
+      Condition: 4,
+      IsLoanable: true,
+      WeightKg: 0.6,
+    });
+    expect(createRequest.cacheKey).toBeUndefined();
+    const created = await createRequest.execute();
+    expect(created.status).toBe(201);
+    expect(created.invalidates).toEqual([["Copies", "list"]]);
+
+    const patchKey = { MediumId: BOOK_DER_PROZESS, InventoryNumber: CACHE_KEY_COPY + 1 };
+    const patchRequest = LIBRARY.Copies(patchKey).patch({ Condition: 5 }).ignoreETag();
+    expect(patchRequest.cacheKey).toBeUndefined();
+    const patched = await patchRequest.execute();
+    expect(patched.status).toBe(204);
+    expect(patched.invalidates).toEqual([
+      ["Copies", "detail", patchKey],
+      ["Copies", "list"],
+    ]);
+
+    const deleteRequest = LIBRARY.Copies(patchKey).delete().ignoreETag();
+    expect(deleteRequest.cacheKey).toBeUndefined();
+    const deleted = await deleteRequest.execute();
+    expect(deleted.status).toBe(204);
+    expect(deleted.invalidates).toEqual([
+      ["Copies", "detail", patchKey],
+      ["Copies", "list"],
+    ]);
+
+    // a read carries nothing extra - the key it should be stored under is `cacheKey`, not `invalidates`
+    const read = await LIBRARY.Media(BOOK_DER_PROZESS).query().execute();
+    expect(read.invalidates).toBeUndefined();
+  });
+
+  test("reading an unknown copy still answers a well-formed 404", async () => {
+    await expectODataError(LIBRARY.Copies({ MediumId: BOOK_DER_PROZESS, InventoryNumber: 999999 }).query().execute(), {
+      status: 404,
+      message: /No error message/,
+    });
+  });
+});

--- a/int-test/cap/odata2ts.config.ts
+++ b/int-test/cap/odata2ts.config.ts
@@ -1,4 +1,5 @@
 import {
+  CacheKeyMode,
   ConfigFileOptions,
   EmitModes,
   EnumSynthesis,
@@ -69,6 +70,11 @@ const config: ConfigFileOptions = {
       // across the two V4 packages instead of duplicating a suite. `test/core/QueryFunctionality.test.ts`
       // covers it on either side - the assertion differs only in the URL that reaches the server.
       v4: { enableNativeInOperator: true },
+      // CAP declares more than the reference model asks (Partner and a real Member_Id foreign key for
+      // Reservations) - since a cache key is now purely the route taken, named, that richer metadata makes
+      // no difference to the key shape at all, only to what the generator could once have inferred from it.
+      // See test/feature/CacheKeys.test.ts.
+      cacheKeys: { mode: CacheKeyMode.on },
     },
     /**
      * The V4 model with `unflattenComplexTypes`, which is what this whole server is the case for:
@@ -209,6 +215,8 @@ const config: ConfigFileOptions = {
         responseResultsWrapping: true,
         payloadResultsWrapping: false,
       },
+      // on, against V2 metadata and its own V2 URL/filter-literal building - see test/v2/feature/CacheKeys.test.ts.
+      cacheKeys: { mode: CacheKeyMode.on },
     },
   },
 };

--- a/int-test/cap/package.json
+++ b/int-test/cap/package.json
@@ -17,6 +17,7 @@
     "@odata2ts/converter-big-number": "^0.3.1",
     "@odata2ts/converter-common": "^0.4.0",
     "@odata2ts/converter-luxon": "^0.3.0",
+    "@odata2ts/http-client-api": "^0.7.1",
     "@odata2ts/http-client-fetch": "^0.13.1",
     "@odata2ts/odata-service": "workspace:^",
     "bignumber.js": "^11.0.0",

--- a/int-test/cap/test/feature/CacheKeys.test.ts
+++ b/int-test/cap/test/feature/CacheKeys.test.ts
@@ -1,0 +1,126 @@
+import { HttpResponseModel } from "@odata2ts/http-client-api";
+import { ODataModelResponseV4 } from "@odata2ts/odata-core";
+import { touchesResource } from "@odata2ts/odata-service";
+import { afterAll, describe, expect, expectTypeOf, test } from "vitest";
+import { Books } from "../../src-generated/library/LibraryModel.js";
+import { BOOK_DER_PROZESS, LIBRARY } from "../LibraryTestConstants.js";
+
+/**
+ * `cacheKeys: { mode: "on" }`, against CAP's V4 endpoint.
+ *
+ * CAP declares *more* than the reference model asks: `Members/Loans` and `Members/Reservations` both carry
+ * a real `Member_Id` foreign key and a `Partner`, richer than ASP.NET's leaner metadata. Since a cache key
+ * is now purely the route taken, named, that richer metadata makes no difference to the key shape at all -
+ * the point this file exists to prove; the shape itself is already the general subject of the ASP.NET
+ * suite.
+ */
+describe("CAP Library: cache keys (V4)", () => {
+  const MEMBER_ID = 9850;
+  // a pre-seeded copy of BOOK_DER_PROZESS - Loans/Copy_* is non-nullable, so a loan must reference one
+  const COPY = { MediumId: BOOK_DER_PROZESS, InventoryNumber: 1001 };
+
+  afterAll(async () => {
+    await LIBRARY.Members(MEMBER_ID).delete().execute();
+  });
+
+  test("Members/Loans names itself by the navigation property, never by its richer metadata", async () => {
+    const member = await LIBRARY.Members()
+      .create({
+        Id: MEMBER_ID,
+        Name: "CacheKeys Test (CAP, V4)",
+        Loans: [
+          {
+            LoanedAt: "2026-05-01T10:00:00Z",
+            DueDate: "2026-06-01",
+            Member_Id: MEMBER_ID,
+            Copy_MediumId: COPY.MediumId,
+            Copy_InventoryNumber: COPY.InventoryNumber,
+          },
+        ],
+      })
+      .execute();
+    expect(member.status).toBe(201);
+
+    const request = LIBRARY.Members(MEMBER_ID).Loans().query();
+    expect(request.cacheKey).toEqual(["Members", "detail", MEMBER_ID, "Loans", "list"]);
+
+    const result = await request.execute();
+    expect(result.status).toBe(200);
+    expect(result.data.value.length).toBe(1);
+  });
+
+  test("Members/Reservations names itself the same way", async () => {
+    const request = LIBRARY.Members(MEMBER_ID).Reservations().query();
+    expect(request.cacheKey).toEqual(["Members", "detail", MEMBER_ID, "Reservations", "list"]);
+
+    const result = await request.execute();
+    expect(result.status).toBe(200);
+  });
+
+  test("Members/IdDocument names itself by the navigation property, not by its target entity set's name", async () => {
+    const request = LIBRARY.Members(MEMBER_ID).IdDocument().query();
+    expect(request.cacheKey).toEqual(["Members", "detail", MEMBER_ID, "IdDocument", "detail"]);
+
+    // 204: this member has no IdDocument at all - the request itself is still well-formed
+    const result = await request.execute();
+    expect(result.status).toBe(204);
+  });
+
+  test("a read through a navigated route records the resource it served, so a later direct write to it also invalidates that route", async () => {
+    const navigated = await LIBRARY.Members(MEMBER_ID).Loans().query().execute();
+    expect(navigated.status).toBe(200);
+    const loanId = navigated.data.value[0].Id;
+
+    const patched = await LIBRARY.Loans(loanId).patch({ DueDate: "2026-07-01" }).execute();
+    expect(patched.invalidates).toEqual(
+      expect.arrayContaining([
+        ["Loans", "detail", loanId],
+        ["Loans", "list"],
+        ["Members", "detail", MEMBER_ID, "Loans", "list"],
+      ]),
+    );
+  });
+
+  test("touchesResource reaches a hierarchical key by its own name", () => {
+    const key = LIBRARY.Members(MEMBER_ID).Loans().query().cacheKey!;
+    expect(touchesResource(["Members", "detail", MEMBER_ID], key)).toBe(true);
+    expect(touchesResource(["Loans", "list"], key)).toBe(true);
+    expect(touchesResource(["Reservations", "list"], key)).toBe(false);
+  });
+
+  test("an unbound function roots at its own import name, never its declared result entity set's", async () => {
+    const request = LIBRARY.Search({ Term: "Prozess" });
+    expect(request.cacheKey).toEqual(["Search", "list", { params: { Term: "Prozess" } }]);
+
+    const result = await request.execute();
+    expect(result.status).toBe(200);
+    expect(result.data.value.some((book) => book.Title === "Der Prozess")).toBe(true);
+  });
+
+  test("invalidates on a PATCH, a POST and a DELETE", async () => {
+    const created = await LIBRARY.Books().create({ Title: "CacheKeys Probe", Language: "de" }).execute();
+    expect(created.status).toBe(201);
+    expect(created.invalidates).toEqual([["Books", "list"]]);
+    expectTypeOf(created).toEqualTypeOf<HttpResponseModel<ODataModelResponseV4<Books>>>();
+    const bookId = created.data.Id;
+
+    // CAP's V4 endpoint answers a patch with 200 and the full entity, unlike ASP.NET's 204
+    const patched = await LIBRARY.Books(bookId).patch({ Language: "en" }).execute();
+    expect(patched.status).toBe(200);
+    expect(patched.invalidates).toEqual([
+      ["Books", "detail", bookId],
+      ["Books", "list"],
+    ]);
+
+    const deleted = await LIBRARY.Books(bookId).delete().execute();
+    expect(deleted.status).toBe(204);
+    expect(deleted.invalidates).toEqual([
+      ["Books", "detail", bookId],
+      ["Books", "list"],
+    ]);
+
+    // a read carries nothing extra
+    const read = await LIBRARY.Books(BOOK_DER_PROZESS).query().execute();
+    expect(read.invalidates).toBeUndefined();
+  });
+});

--- a/int-test/cap/test/v2/feature/CacheKeys.test.ts
+++ b/int-test/cap/test/v2/feature/CacheKeys.test.ts
@@ -1,0 +1,115 @@
+import { touchesResource } from "@odata2ts/odata-service";
+import { afterAll, describe, expect, test } from "vitest";
+import { BOOK_DER_PROZESS, LIBRARY_V2 } from "../LibraryV2TestConstants.js";
+
+/**
+ * `cacheKeys: { mode: "on" }`, against CAP's V2 endpoint (the `@cap-js-community/odata-v2-adapter`
+ * translation layer, same server and data as the V4 suite).
+ *
+ * The V4 suite (`../../feature/CacheKeys.test.ts`) already covers hop naming in general; this file's own
+ * subject is V2 itself: the same navigation properties, keyed the same way, but built from V2's own URL and
+ * filter-literal machinery, and - the one thing genuinely specific to V2 here - response-observed identity
+ * proven against V2's `{d: {...}}`/`{d: {results: [...]}}` response envelope, which this client keeps
+ * (`responseResultsWrapping: true`) rather than unwrapping.
+ */
+describe("CAP Library: cache keys (V2)", () => {
+  const MEMBER_ID = 9860;
+  // a pre-seeded copy of BOOK_DER_PROZESS, shared with the V4 suite (same database)
+  const COPY = { MediumId: BOOK_DER_PROZESS, InventoryNumber: 1001 };
+
+  afterAll(async () => {
+    await LIBRARY_V2.Members(MEMBER_ID).delete().execute();
+  });
+
+  test("Members/Reservations names itself by the navigation property", async () => {
+    const member = await LIBRARY_V2.Members()
+      .create({
+        Id: MEMBER_ID,
+        Name: "CacheKeys Test (CAP, V2)",
+        Reservations: [{ Member_Id: MEMBER_ID, ReservedAt: "2026-05-01T10:00:00Z" }],
+      })
+      .execute();
+    expect(member.status).toBe(201);
+    // the deep-inserted Reservation contributes its own bare entity-set entry too
+    expect(member.invalidates).toEqual([
+      ["Members", "list"],
+      ["Reservations", "list"],
+    ]);
+
+    const request = LIBRARY_V2.Members(MEMBER_ID).Reservations().query();
+    expect(request.cacheKey).toEqual(["Members", "detail", MEMBER_ID, "Reservations", "list"]);
+
+    const result = await request.execute();
+    expect(result.status).toBe(200);
+    expect(result.data.d.results.length).toBe(1);
+  });
+
+  test("a to-one hop off a real entity - Loans(...)/Copy - names itself by the navigation property, with no key of its own", async () => {
+    const loan = await LIBRARY_V2.Members(MEMBER_ID)
+      .Loans()
+      .create({
+        LoanedAt: "2026-05-01T10:00:00Z",
+        DueDate: "2026-06-01",
+        Member_Id: MEMBER_ID,
+        Copy_MediumId: COPY.MediumId,
+        Copy_InventoryNumber: COPY.InventoryNumber,
+      })
+      .execute();
+    expect(loan.status).toBe(201);
+    const loanId = loan.data.d.Id;
+
+    const request = LIBRARY_V2.Loans(loanId).Copy().query();
+    expect(request.cacheKey).toEqual(["Loans", "detail", loanId, "Copy", "detail"]);
+
+    const result = await request.execute();
+    expect(result.status).toBe(200);
+  });
+
+  test("touchesResource reaches a hierarchical key by its own name", () => {
+    const key = LIBRARY_V2.Members(MEMBER_ID).Reservations().query().cacheKey!;
+    expect(touchesResource(["Members", "detail", MEMBER_ID], key)).toBe(true);
+    expect(touchesResource(["Reservations", "list"], key)).toBe(true);
+    expect(touchesResource(["Loans", "list"], key)).toBe(false);
+  });
+
+  test("invalidates on a write through a hop reaches the ancestor too", async () => {
+    const created = await LIBRARY_V2.Members(MEMBER_ID)
+      .Reservations()
+      .create({ Member_Id: MEMBER_ID, ReservedAt: "2026-05-02T10:00:00Z" })
+      .execute();
+    expect(created.status).toBe(201);
+    const reservationId = created.data.d.Id;
+
+    expect(created.invalidates).toEqual([
+      ["Members", "detail", MEMBER_ID],
+      ["Reservations", "list"],
+    ]);
+
+    const deleted = await LIBRARY_V2.Reservations(reservationId).delete().execute();
+    expect(deleted.status).toBe(204);
+    expect(deleted.invalidates).toEqual([
+      ["Reservations", "detail", reservationId],
+      ["Reservations", "list"],
+    ]);
+  });
+
+  test("a read through a navigated route records the resource it served - against a V2-wrapped `{d: {results: [...]}}` response - so a later direct write also invalidates that route", async () => {
+    const navigated = await LIBRARY_V2.Members(MEMBER_ID).Reservations().query().execute();
+    expect(navigated.status).toBe(200);
+    const reservationId = navigated.data.d.results[0].Id;
+
+    const deleted = await LIBRARY_V2.Reservations(reservationId).delete().execute();
+    expect(deleted.invalidates).toEqual(
+      expect.arrayContaining([["Members", "detail", MEMBER_ID, "Reservations", "list"]]),
+    );
+  });
+
+  test("$expand produces a hop-shaped entry touchesResource can reach", async () => {
+    const request = LIBRARY_V2.Members(MEMBER_ID).query((builder) => builder.expand("Reservations"));
+    expect(request.cacheKey).toEqual(["Members", "detail", MEMBER_ID, { expand: [["Reservations", "list"]] }]);
+    expect(touchesResource(["Reservations", "list"], request.cacheKey!)).toBe(true);
+
+    const result = await request.execute();
+    expect(result.status).toBe(200);
+  });
+});

--- a/int-test/olingo-v2/odata2ts.config.ts
+++ b/int-test/olingo-v2/odata2ts.config.ts
@@ -1,4 +1,12 @@
-import { ConfigFileOptions, EmitModes, KeyProperties, ManagedPropertyMode, Modes, TypeModel } from "@odata2ts/odata2ts";
+import {
+  CacheKeyMode,
+  ConfigFileOptions,
+  EmitModes,
+  KeyProperties,
+  ManagedPropertyMode,
+  Modes,
+  TypeModel,
+} from "@odata2ts/odata2ts";
 
 /** The running server to refresh from, or `undefined` to read the committed snapshot - see below. */
 const SOURCE_URL = process.env.LIBRARY_BASE_URL;
@@ -60,6 +68,9 @@ const config: ConfigFileOptions = {
       source: SOURCE,
       refreshFile: true,
       output: "src-generated/library",
+      // on, the counterpart of int-test/cap's V2 client: the two V2 servers answer the same model, so
+      // running both is what tells a V2 quirk apart from a difference between the servers themselves.
+      cacheKeys: { mode: CacheKeyMode.on },
     },
     /**
      * The same model a third time, with renaming switched on - the V2 half of what
@@ -115,6 +126,11 @@ const config: ConfigFileOptions = {
           use: ["int64ToBigIntConverter"],
         },
       ],
+      // the one client where a cache key can carry a converted value - int64ToBigIntConverter yields a
+      // bigint, which JSON.stringify refuses. Decision 1 of the cache-key plan (OData-side, pre-render
+      // values via convertTo) exists specifically because of this converter, so this is where it is held
+      // against a real server rather than only against a fixture.
+      cacheKeys: { mode: CacheKeyMode.on },
     },
     /**
      * The same model a fourth time, with `v2ResponseAsV4` switched on: every response is reshaped as its

--- a/int-test/olingo-v2/package.json
+++ b/int-test/olingo-v2/package.json
@@ -18,6 +18,7 @@
     "@odata2ts/converter-common": "^0.4.0",
     "@odata2ts/converter-luxon": "^0.3.0",
     "@odata2ts/converter-v2-to-v4": "^0.5.8",
+    "@odata2ts/http-client-api": "^0.7.1",
     "@odata2ts/http-client-fetch": "^0.13.1",
     "@odata2ts/odata-service": "workspace:^",
     "bignumber.js": "^11.0.0",

--- a/int-test/olingo-v2/test/feature/CacheKeys.test.ts
+++ b/int-test/olingo-v2/test/feature/CacheKeys.test.ts
@@ -1,0 +1,96 @@
+import { touchesResource } from "@odata2ts/odata-service";
+import { describe, expect, test } from "vitest";
+import { CONVERTED } from "../LibraryConvertedConstants.js";
+import { BOOK_DER_PROZESS, COPY_KEY, LIBRARY } from "../LibraryTestConstants.js";
+
+/**
+ * `cacheKeys: { mode: "on" }`, against Apache Olingo - a native V2 server, the counterpart of
+ * `int-test/cap`'s V2 *adapter* client. This is where a converted client's cache key meets a real server
+ * for the first time, and where V2's own URL/filter-literal building is proven end to end.
+ */
+describe("Olingo Library: cache keys", () => {
+  test("Books/Copies names itself by the navigation property - no entitySetName here, since this server's polymorphic, table-per-leaf-class layout leaves the target set unresolvable for this one relation", async () => {
+    const request = LIBRARY.Books(BOOK_DER_PROZESS).Copies().query();
+    expect(request.cacheKey).toEqual(["Books", "detail", BOOK_DER_PROZESS, "Copies", "list"]);
+
+    const result = await request.execute();
+    expect(result.status).toBe(200);
+  });
+
+  test("Members/Loans names itself by the navigation property, with a real entitySetName for response-observed identity", () => {
+    const request = LIBRARY.Members(1).Loans().query();
+    expect(request.cacheKey).toEqual(["Members", "detail", 1, "Loans", "list"]);
+  });
+
+  test("a read through a navigated route records the resource it served, so a later direct write to it also invalidates that route", async () => {
+    const navigated = await LIBRARY.Members(1).Loans().query().execute();
+    expect(navigated.status).toBe(200);
+    const loan = navigated.data.d.results[0];
+
+    try {
+      // V2 has no `Prefer: return=representation` - a PUT/PATCH answers 204, no body to resolve identity
+      // from, so this exercises `state.key` addressing the write's own resource, not the response body
+      const patched = await LIBRARY.Loans(loan.Id).patch({ ReturnedAt: "/Date(1779408000000)/" }).execute();
+      expect(patched.invalidates).toEqual(expect.arrayContaining([["Members", "detail", 1, "Loans", "list"]]));
+    } finally {
+      // restore, so this test can re-run against the same server without changing what other suites see
+      await LIBRARY.Loans(loan.Id).patch({ ReturnedAt: loan.ReturnedAt }).execute();
+    }
+  });
+
+  test("a V2 filter literal is the typed value in the structured filter map, not the rendered $filter", () => {
+    const request = LIBRARY.Copies().query((builder, qCopy) => builder.filter(qCopy.MediumId.eq(BOOK_DER_PROZESS)));
+
+    // the rendered URL carries V2's own literal form...
+    expect(decodeURIComponent(request.getUrl())).toContain(`MediumId eq guid'${BOOK_DER_PROZESS}'`);
+    // ...but the cache key carries the bare typed value
+    expect(request.cacheKey).toEqual(["Copies", "list", { filter: { MediumId: BOOK_DER_PROZESS } }]);
+  });
+
+  test("touchesResource reaches a hierarchical key by its own name", () => {
+    const key = LIBRARY.Members(1).Loans().query().cacheKey!;
+    expect(touchesResource(["Members", "detail", 1], key)).toBe(true);
+    expect(touchesResource(["Loans", "list"], key)).toBe(true);
+    expect(touchesResource(["Copies", "list"], key)).toBe(false);
+  });
+
+  test("invalidates on a write", async () => {
+    const patched = await LIBRARY.Copies(COPY_KEY).patch({ IsLoanable: false }).ignoreETag().execute();
+    expect([200, 204]).toContain(patched.status);
+    expect(patched.invalidates).toEqual([
+      ["Copies", "detail", COPY_KEY],
+      ["Copies", "list"],
+    ]);
+
+    // restore, so this test can re-run against the same server without changing what other suites see
+    await LIBRARY.Copies(COPY_KEY).patch({ IsLoanable: true }).ignoreETag().execute();
+  });
+
+  /**
+   * Decision 1 of the plan (`spec/odata2ts-cache-key.md`): a cache-key value is OData-side, pre-render -
+   * `converter.convertTo(value)`, never the caller's own value. `int64ToBigIntConverter` is the reason it
+   * was resolved that way: the caller's own value is a `bigint` (that is what `convertFrom` hands back),
+   * and `JSON.stringify` refuses one - exactly what a TanStack Query cache does to hash a key. `convertTo`
+   * turns it back into the wire string before the clause is recorded, which is what keeps the key
+   * JSON-serialisable without odata2ts inventing a special case for this one converter.
+   *
+   * `LibraryConverted` is the one client that carries this converter, so this is the one place the
+   * decision can be held against a real server rather than only a fixture with a hand-built converter.
+   */
+  test("a converted Int64 property yields a JSON-serialisable clause value", async () => {
+    const request = CONVERTED.Branches().query((builder, qBranch) =>
+      builder.filter(qBranch.Population.eq(BigInt(1841000))),
+    );
+
+    // the caller passed a bigint; the clause holds convertTo's own output, the wire string
+    const filter = (request.cacheKey![2] as { filter: { Population: unknown } }).filter;
+    expect(filter.Population).toBe("1841000");
+    expect(typeof filter.Population).toBe("string");
+
+    // the assertion that matters: this would throw if the caller's own bigint had reached the key instead
+    expect(() => JSON.stringify(request.cacheKey)).not.toThrow();
+
+    const result = await request.execute();
+    expect(result.status).toBe(200);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -443,6 +443,7 @@ __metadata:
     "@odata2ts/converter-common": "npm:^0.4.0"
     "@odata2ts/converter-luxon": "npm:^0.3.0"
     "@odata2ts/converter-v2-to-v4": "npm:^0.5.8"
+    "@odata2ts/http-client-api": "npm:^0.7.1"
     "@odata2ts/http-client-axios": "npm:^0.16.1"
     "@odata2ts/http-client-fetch": "npm:^0.13.1"
     "@odata2ts/odata-service": "workspace:^"
@@ -526,6 +527,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@odata2ts/int-test-asp-net@workspace:int-test/asp-net"
   dependencies:
+    "@odata2ts/http-client-api": "npm:^0.7.1"
     "@odata2ts/http-client-fetch": "npm:^0.13.1"
     "@odata2ts/odata-service": "workspace:^"
     "@odata2ts/odata2ts": "workspace:^"
@@ -543,6 +545,7 @@ __metadata:
     "@odata2ts/converter-big-number": "npm:^0.3.1"
     "@odata2ts/converter-common": "npm:^0.4.0"
     "@odata2ts/converter-luxon": "npm:^0.3.0"
+    "@odata2ts/http-client-api": "npm:^0.7.1"
     "@odata2ts/http-client-fetch": "npm:^0.13.1"
     "@odata2ts/odata-service": "workspace:^"
     "@odata2ts/odata2ts": "workspace:^"
@@ -575,6 +578,7 @@ __metadata:
     "@odata2ts/converter-common": "npm:^0.4.0"
     "@odata2ts/converter-luxon": "npm:^0.3.0"
     "@odata2ts/converter-v2-to-v4": "npm:^0.5.8"
+    "@odata2ts/http-client-api": "npm:^0.7.1"
     "@odata2ts/http-client-fetch": "npm:^0.13.1"
     "@odata2ts/odata-service": "workspace:^"
     "@odata2ts/odata2ts": "workspace:^"


### PR DESCRIPTION
Final layer of the feat/cache-keys (#526) per-package stack, on top of
#533 (odata2ts generator, merged).

- int-test/asp-net, int-test/cap (V4 + V2), int-test/olingo-v2:
  cacheKeys: { mode: on }, and a full CacheKeys.test.ts rewrite per
  server - every root/hop asserted by entity-set/navigation-property
  name, never a type. The old typeFlattening/re-rooting convergence
  claim is replaced by a real demonstration of response-observed
  identity: read a resource through one route, write it through
  another, and confirm the write's invalidates reaches the first
  route's cache key too - proven against real V4 (`{value:[...]}`) and
  V2 (`{d:{results:[...]}}`) response envelopes alike. An unbound
  operation with and without a declared result entity set both root at
  their own import name. Also documents a genuine, pre-existing quirk
  of Olingo's metadata (Books/Copies gets no entitySetName, due to its
  polymorphic table-per-leaf-class layout) rather than assuming every
  hop looks the same.
- examples/main, every int-test package: @odata2ts/http-client-fetch
  and @odata2ts/http-client-axios bumped to the versions actually
  carrying ResourceIdentityHandler through BaseHttpClient - without
  this bump, ODATA_CLIENT.resourceIdentity is undefined at runtime
  despite typechecking fine.

Replaces #532, whose base branch (feat/cache-key-generator) was deleted
on merge and closed the PR along with it. Last PR in the stack -
merging this one completes the split of feat/cache-keys (#526).