### PR TITLE
cacheKeys config: boolean, not an On/Off enum

### DIFF
--- a/int-test/asp-net/odata2ts.config.ts
+++ b/int-test/asp-net/odata2ts.config.ts
@@ -1,12 +1,4 @@
-import {
-  CacheKeyMode,
-  ConfigFileOptions,
-  EmitModes,
-  KeyProperties,
-  ManagedPropertyMode,
-  Modes,
-  TypeModel,
-} from "@odata2ts/odata2ts";
+import { ConfigFileOptions, EmitModes, KeyProperties, ManagedPropertyMode, Modes, TypeModel } from "@odata2ts/odata2ts";
 
 /** The running server to refresh from, or `undefined` to read the committed snapshot - see below. */
 const SOURCE_URL = process.env.LIBRARY_BASE_URL;
@@ -68,7 +60,7 @@ const config: ConfigFileOptions = {
       // this metadata reproduces the reference model exactly, which puts every hop shape into one client -
       // to-many and to-one navigation, grade-B/C-style relations, containment and a stream - so this is
       // where the cache-key shape itself is held against a real server; see test/feature/CacheKeys.test.ts.
-      cacheKeys: { mode: CacheKeyMode.on },
+      cacheKeys: true,
     },
     /**
      * The same model once more, targeting OData 4.01 instead of the default 4.0.

--- a/int-test/cap/odata2ts.config.ts
+++ b/int-test/cap/odata2ts.config.ts
@@ -1,5 +1,4 @@
 import {
-  CacheKeyMode,
   ConfigFileOptions,
   EmitModes,
   EnumSynthesis,
@@ -74,7 +73,7 @@ const config: ConfigFileOptions = {
       // Reservations) - since a cache key is now purely the route taken, named, that richer metadata makes
       // no difference to the key shape at all, only to what the generator could once have inferred from it.
       // See test/feature/CacheKeys.test.ts.
-      cacheKeys: { mode: CacheKeyMode.on },
+      cacheKeys: true,
     },
     /**
      * The V4 model with `unflattenComplexTypes`, which is what this whole server is the case for:
@@ -216,7 +215,7 @@ const config: ConfigFileOptions = {
         payloadResultsWrapping: false,
       },
       // on, against V2 metadata and its own V2 URL/filter-literal building - see test/v2/feature/CacheKeys.test.ts.
-      cacheKeys: { mode: CacheKeyMode.on },
+      cacheKeys: true,
     },
   },
 };

--- a/int-test/olingo-v2/odata2ts.config.ts
+++ b/int-test/olingo-v2/odata2ts.config.ts
@@ -1,12 +1,4 @@
-import {
-  CacheKeyMode,
-  ConfigFileOptions,
-  EmitModes,
-  KeyProperties,
-  ManagedPropertyMode,
-  Modes,
-  TypeModel,
-} from "@odata2ts/odata2ts";
+import { ConfigFileOptions, EmitModes, KeyProperties, ManagedPropertyMode, Modes, TypeModel } from "@odata2ts/odata2ts";
 
 /** The running server to refresh from, or `undefined` to read the committed snapshot - see below. */
 const SOURCE_URL = process.env.LIBRARY_BASE_URL;
@@ -70,7 +62,7 @@ const config: ConfigFileOptions = {
       output: "src-generated/library",
       // on, the counterpart of int-test/cap's V2 client: the two V2 servers answer the same model, so
       // running both is what tells a V2 quirk apart from a difference between the servers themselves.
-      cacheKeys: { mode: CacheKeyMode.on },
+      cacheKeys: true,
     },
     /**
      * The same model a third time, with renaming switched on - the V2 half of what
@@ -130,7 +122,7 @@ const config: ConfigFileOptions = {
       // bigint, which JSON.stringify refuses. Decision 1 of the cache-key plan (OData-side, pre-render
       // values via convertTo) exists specifically because of this converter, so this is where it is held
       // against a real server rather than only against a fixture.
-      cacheKeys: { mode: CacheKeyMode.on },
+      cacheKeys: true,
     },
     /**
      * The same model a fourth time, with `v2ResponseAsV4` switched on: every response is reshaped as its

--- a/packages/odata2ts/src/OptionModel.ts
+++ b/packages/odata2ts/src/OptionModel.ts
@@ -232,32 +232,33 @@ export enum EnumSynthesis {
   allowedValuesAndSymbolicName = "allowedValuesAndSymbolicName",
 }
 
-/**
- * How a generated client builds `RequestCmd.cacheKey` - see the docs on `cacheKeys`.
- *
- * Purely hierarchical, always: the key is the literal, named route taken to reach a response, never
- * re-rooted at a resource's own type - that used to be a second mode (`typeFlattening`), and is now what
- * `ResourceIdentityHandler` does at runtime instead, from actual responses rather than a generation-time
- * prediction. One behaviour, so a binary switch is all `mode` needs to be.
- */
-export enum CacheKeyMode {
-  /** Generate `cacheKey`/`invalidates` on every `RequestCmd`. */
-  on = "on",
-  /** Nothing is generated - identical to omitting `cacheKeys` entirely. */
-  off = "off",
-}
-
-export interface CacheKeysOptions {
+export interface CacheKeysObjectOptions {
   /**
-   * Required: naming the object is not itself a decision, and a silently defaulted mode would make
-   * whether a generated key exists at all depend on a value nobody wrote down.
+   * Required: naming the object is not itself a decision, and a silently defaulted value would make
+   * whether a generated key exists at all depend on a value nobody wrote down. Use the bare boolean shorthand
+   * (`cacheKeys: true`/`false`) where the object's only purpose would be carrying this one flag.
+   *
+   * Generates `cacheKey`/`invalidates` on every `RequestCmd` when `true`; `false` emits nothing - identical
+   * to omitting `cacheKeys` entirely. Purely hierarchical, always: the key is the literal, named route taken
+   * to reach a response, never re-rooted at a resource's own type - that used to be a second mode
+   * (`typeFlattening`), and is now what `ResourceIdentityHandler` does at runtime instead, from actual
+   * responses rather than a generation-time prediction. One behaviour, so a boolean is all this needs to be.
    */
-  mode: CacheKeyMode;
+  enabled: boolean;
 }
 
-/** The mode actually in force - `off` where the whole `cacheKeys` object was never configured. */
-export function resolveCacheKeyMode(options: CacheKeysOptions | undefined): CacheKeyMode {
-  return options?.mode ?? CacheKeyMode.off;
+/**
+ * `cacheKeys` in `ConfigFileOptions`: either the bare boolean directly, or the object form - which exists
+ * only so a later option can join `enabled` under the same key without a breaking change.
+ */
+export type CacheKeysOptions = boolean | CacheKeysObjectOptions;
+
+/** Whether cache keys are in force - `false` where the whole `cacheKeys` option was never configured. */
+export function resolveCacheKeysEnabled(options: CacheKeysOptions | undefined): boolean {
+  if (typeof options === "boolean") {
+    return options;
+  }
+  return options?.enabled ?? false;
 }
 
 /**
@@ -585,9 +586,8 @@ export interface ConfigFileOptions extends Omit<CliOptions, "sourceUrl" | "sourc
    * addresses, for a cache built on top of the generated client (TanStack Query is the motivating case,
    * hence the array shape).
    *
-   * Off by default. An object rather than a bare string, because the shape has to have room for the
-   * further switches this will attract - which properties become key segments, whether operations are
-   * keyed at all - without a second top-level option.
+   * Off by default. `true`/`false` is the common case; the `{ enabled }` object form exists only for a
+   * future option to join it under the same key without a breaking change.
    */
   cacheKeys?: CacheKeysOptions;
 }

--- a/packages/odata2ts/src/defaultConfig.ts
+++ b/packages/odata2ts/src/defaultConfig.ts
@@ -1,14 +1,6 @@
 import deepmerge from "deepmerge";
 import { NameSettings, NamingStrategies } from "./NamingModel.js";
-import {
-  CacheKeyMode,
-  DeepInsertProps,
-  EmitModes,
-  KeyProperties,
-  ManagedPropertyMode,
-  Modes,
-  RunOptions,
-} from "./OptionModel.js";
+import { DeepInsertProps, EmitModes, KeyProperties, ManagedPropertyMode, Modes, RunOptions } from "./OptionModel.js";
 
 export type DefaultConfiguration = Omit<RunOptions, "sourceUrl" | "source" | "output" | "serviceName">;
 /**
@@ -127,7 +119,7 @@ const defaultConfig: DefaultConfiguration = {
   byTypeAndName: [],
   disableBindingProps: false,
   deepInsertProps: DeepInsertProps.all,
-  cacheKeys: { mode: CacheKeyMode.off },
+  cacheKeys: { enabled: false },
 };
 
 const { models, queryObjects, services } = defaultConfig.naming;

--- a/packages/odata2ts/src/generator/ServiceGenerator.ts
+++ b/packages/odata2ts/src/generator/ServiceGenerator.ts
@@ -26,7 +26,7 @@ import {
   SingletonType,
 } from "../data-model/DataTypeModel.js";
 import { NamingHelper } from "../data-model/NamingHelper.js";
-import { CacheKeyMode, ConfigFileOptions, Modes, resolveCacheKeyMode } from "../OptionModel.js";
+import { ConfigFileOptions, Modes, resolveCacheKeysEnabled } from "../OptionModel.js";
 import { FileHandler } from "../project/FileHandler.js";
 import { ProjectManager } from "../project/ProjectManager.js";
 import { ClientApiImports, CoreImports, QueryObjectImports, ServiceImports } from "./import/ImportObjects.js";
@@ -63,7 +63,7 @@ class ServiceGenerator {
     private options: ServiceGeneratorOptions = { v2: {}, v4: {} },
   ) {}
 
-  private readonly cacheKeyMode = resolveCacheKeyMode(this.options.cacheKeys);
+  private readonly cacheKeysEnabled = resolveCacheKeysEnabled(this.options.cacheKeys);
 
   private isV4BigNumber() {
     return this.options.v4.bigNumberAsString && this.version === ODataVersions.V4;
@@ -110,7 +110,7 @@ class ServiceGenerator {
     entityType: EntityType,
     options?: { paramsSource?: string; isEntitySet?: boolean },
   ): string {
-    if (this.cacheKeyMode === CacheKeyMode.off) {
+    if (!this.cacheKeysEnabled) {
       return "";
     }
     const rootStateFn = imports.addServiceFunction("rootState");
@@ -140,7 +140,7 @@ class ServiceGenerator {
     isCollection: boolean,
     contained: boolean,
   ): string {
-    if (this.cacheKeyMode === CacheKeyMode.off) {
+    if (!this.cacheKeysEnabled) {
       return "";
     }
 
@@ -158,7 +158,7 @@ class ServiceGenerator {
 
   /** A complex property hop: the same shape as a navigation hop, minus any entity-set identity - a complex value is never a navigation property and belongs to no entity set. */
   private emitComplexHopExpr(imports: ImportContainer, isCollection: boolean, name: string): string {
-    if (this.cacheKeyMode === CacheKeyMode.off) {
+    if (!this.cacheKeysEnabled) {
       return "";
     }
     const hopStateFn = imports.addServiceFunction("hopState");
@@ -167,7 +167,7 @@ class ServiceGenerator {
 
   /** A primitive property, primitive collection or stream property hop: bare name, no kind - stays on its parent's resource. */
   private emitBareHopExpr(imports: ImportContainer, name: string): string {
-    if (this.cacheKeyMode === CacheKeyMode.off) {
+    if (!this.cacheKeysEnabled) {
       return "";
     }
     const hopStateFn = imports.addServiceFunction("hopState");
@@ -176,7 +176,7 @@ class ServiceGenerator {
 
   /** A stream property's raw value: the property hop, then a further hop appending `$value`. */
   private emitStreamHopExpr(imports: ImportContainer, odataName: string): string {
-    if (this.cacheKeyMode === CacheKeyMode.off) {
+    if (!this.cacheKeysEnabled) {
       return "";
     }
     const hopStateFn = imports.addServiceFunction("hopState");
@@ -185,7 +185,7 @@ class ServiceGenerator {
 
   /** A subtype cast: a restriction on the very same resource, not a hop away from it. */
   private emitCastParamsExpr(imports: ImportContainer, castFqName: string): string {
-    if (this.cacheKeyMode === CacheKeyMode.off) {
+    if (!this.cacheKeysEnabled) {
       return "";
     }
     const withParamsFn = imports.addServiceFunction("withParams");
@@ -207,7 +207,7 @@ class ServiceGenerator {
     entitySetOdataName: string | undefined,
     hasParams: boolean,
   ): string {
-    if (this.cacheKeyMode === CacheKeyMode.off) {
+    if (!this.cacheKeysEnabled) {
       return "";
     }
 
@@ -241,7 +241,7 @@ class ServiceGenerator {
     fqOperationName: string,
     returnType: ReturnTypeModel | undefined,
   ): string {
-    if (this.cacheKeyMode === CacheKeyMode.off) {
+    if (!this.cacheKeysEnabled) {
       return "";
     }
     const hopStateFn = imports.addServiceFunction("hopState");
@@ -658,7 +658,7 @@ class ServiceGenerator {
             // a getter elsewhere constructs this very class as a hop off its own state (see emitNavHopExpr
             // et al.) - without this parameter that hop's cache-key state would have nowhere to go, and the
             // base class's own trailing parameter would sit unreachable behind a narrower constructor
-            ...(this.cacheKeyMode !== CacheKeyMode.off
+            ...(this.cacheKeysEnabled
               ? [
                   {
                     name: "cacheKeyState",
@@ -669,7 +669,7 @@ class ServiceGenerator {
               : []),
           ],
           statements: [
-            `super(client, basePath, name, ${qObjectName}, ${this.getServiceRuntimeOptions(model, isComplexType)}${this.cacheKeyMode !== CacheKeyMode.off ? ", cacheKeyState" : ""});`,
+            `super(client, basePath, name, ${qObjectName}, ${this.getServiceRuntimeOptions(model, isComplexType)}${this.cacheKeysEnabled ? ", cacheKeyState" : ""});`,
           ],
         },
       ],
@@ -1027,7 +1027,7 @@ class ServiceGenerator {
             // emitNavHopExpr et al.) - without this parameter that hop's cache-key state would have
             // nowhere to go, and the base class's own trailing parameter would sit unreachable behind a
             // narrower constructor
-            ...(this.cacheKeyMode !== CacheKeyMode.off
+            ...(this.cacheKeysEnabled
               ? [
                   {
                     name: "cacheKeyState",
@@ -1038,7 +1038,7 @@ class ServiceGenerator {
               : []),
           ],
           statements: [
-            `super(client, basePath, name, ${qObjectName}, new ${qIdFunctionName}(name), ${this.getServiceRuntimeOptions(model)}${this.cacheKeyMode !== CacheKeyMode.off ? ", cacheKeyState" : ""});`,
+            `super(client, basePath, name, ${qObjectName}, new ${qIdFunctionName}(name), ${this.getServiceRuntimeOptions(model)}${this.cacheKeysEnabled ? ", cacheKeyState" : ""});`,
           ],
         },
       ],
@@ -1055,7 +1055,7 @@ class ServiceGenerator {
             { name: "options", type: `${serviceOptions}${this.getServiceVersionArg()} | undefined` },
             // this base class's own `byId` computes the entity's cache-key state (see EntitySetServiceV4/V2);
             // this override only has to forward it, never compute it itself
-            ...(this.cacheKeyMode !== CacheKeyMode.off
+            ...(this.cacheKeysEnabled
               ? [
                   {
                     name: "cacheKeyState",
@@ -1066,7 +1066,7 @@ class ServiceGenerator {
               : []),
           ],
           statements: [
-            `return new ${entityServiceName}${this.getServiceVersionArg()}(client, path, name, options${this.cacheKeyMode !== CacheKeyMode.off ? ", cacheKeyState" : ""});`,
+            `return new ${entityServiceName}${this.getServiceVersionArg()}(client, path, name, options${this.cacheKeysEnabled ? ", cacheKeyState" : ""});`,
           ],
         },
       ],

--- a/packages/odata2ts/test/evaluateConfig.test.ts
+++ b/packages/odata2ts/test/evaluateConfig.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { evaluateConfigOptions } from "../src/evaluateConfig.js";
 import {
-  CacheKeyMode,
   CliOptions,
   ConfigFileOptions,
   DeepInsertProps,
@@ -9,7 +8,7 @@ import {
   getDefaultConfig,
   Modes,
   NamingStrategies,
-  resolveCacheKeyMode,
+  resolveCacheKeysEnabled,
 } from "../src/index.js";
 
 describe("Config Evaluation Tests", () => {
@@ -316,42 +315,47 @@ describe("Config Evaluation Tests", () => {
 
   describe("cacheKeys option", () => {
     test("absent means off", () => {
-      expect(resolveCacheKeyMode(undefined)).toBe(CacheKeyMode.off);
+      expect(resolveCacheKeysEnabled(undefined)).toBe(false);
     });
 
-    test("a named mode is passed through", () => {
-      expect(resolveCacheKeyMode({ mode: CacheKeyMode.on })).toBe(CacheKeyMode.on);
-      expect(resolveCacheKeyMode({ mode: CacheKeyMode.off })).toBe(CacheKeyMode.off);
+    test("the object form is passed through", () => {
+      expect(resolveCacheKeysEnabled({ enabled: true })).toBe(true);
+      expect(resolveCacheKeysEnabled({ enabled: false })).toBe(false);
+    });
+
+    test("the bare boolean shorthand works too", () => {
+      expect(resolveCacheKeysEnabled(true)).toBe(true);
+      expect(resolveCacheKeysEnabled(false)).toBe(false);
     });
 
     test("the default is off, so a config saying nothing generates nothing", () => {
       const [only] = evaluateConfigOptions({}, { services: { a: { source: "a.xml", output: "a" } } });
-      expect(only.cacheKeys).toEqual({ mode: CacheKeyMode.off });
-      expect(resolveCacheKeyMode(only.cacheKeys)).toBe(CacheKeyMode.off);
+      expect(only.cacheKeys).toEqual({ enabled: false });
+      expect(resolveCacheKeysEnabled(only.cacheKeys)).toBe(false);
     });
 
     test("it is a per-service option, overridable from the base settings", () => {
       const [first, second] = evaluateConfigOptions(
         {},
         {
-          cacheKeys: { mode: CacheKeyMode.on },
+          cacheKeys: true,
           services: {
             a: { source: "a.xml", output: "a" },
-            b: { source: "b.xml", output: "b", cacheKeys: { mode: CacheKeyMode.off } },
+            b: { source: "b.xml", output: "b", cacheKeys: false },
           },
         },
       );
-      expect(first.cacheKeys).toEqual({ mode: CacheKeyMode.on });
-      expect(second.cacheKeys).toEqual({ mode: CacheKeyMode.off });
+      expect(first.cacheKeys).toEqual(true);
+      expect(second.cacheKeys).toEqual(false);
     });
 
     test("a service overrides the default rather than merging with it", () => {
-      // deepmerge folds the default {mode:"off"} under the service's own entry; the service must win
+      // deepmerge folds the default {enabled:false} under the service's own entry; the service must win
       const [only] = evaluateConfigOptions(
         {},
-        { services: { a: { source: "a.xml", output: "a", cacheKeys: { mode: CacheKeyMode.on } } } },
+        { services: { a: { source: "a.xml", output: "a", cacheKeys: { enabled: true } } } },
       );
-      expect(only.cacheKeys).toEqual({ mode: CacheKeyMode.on });
+      expect(only.cacheKeys).toEqual({ enabled: true });
     });
   });
 });

--- a/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
@@ -5,7 +5,6 @@ import { beforeAll, beforeEach, describe, expect, test } from "vitest";
 import { digest } from "../../../src/data-model/DataModelDigestionV4.js";
 import { NamingHelper } from "../../../src/data-model/NamingHelper.js";
 import {
-  CacheKeyMode,
   ConfigFileOptions,
   EmitModes,
   KeyProperties,
@@ -188,9 +187,19 @@ describe("Service Generator Tests V4", () => {
     test("a collection getter roots the key at the entity set's own name, not its type, when the feature is on", async () => {
       addEntity();
 
-      await doGenerate({ cacheKeys: { mode: CacheKeyMode.on } });
+      await doGenerate({ cacheKeys: { enabled: true } });
 
       // "Ents" - the entity set's own name - never the entity type's FQ name ("Tester.TestEntity")
+      expect(generatedText()).toContain(
+        `rootState("Ents", "list", { entitySetName: "Ents", canonicalIdFn: (entity: unknown) => new QTestEntityId("Ents").buildCanonicalId(entity), qEntityFn: () => QTestEntity })`,
+      );
+    });
+
+    test("the bare boolean shorthand works identically to the object form", async () => {
+      addEntity();
+
+      await doGenerate({ cacheKeys: true });
+
       expect(generatedText()).toContain(
         `rootState("Ents", "list", { entitySetName: "Ents", canonicalIdFn: (entity: unknown) => new QTestEntityId("Ents").buildCanonicalId(entity), qEntityFn: () => QTestEntity })`,
       );
@@ -205,10 +214,10 @@ describe("Service Generator Tests V4", () => {
       expect(generatedText()).not.toContain("cacheKeyState");
     });
 
-    test("nothing is emitted under mode: off - identical to cacheKeys being absent", async () => {
+    test("nothing is emitted under enabled: false - identical to cacheKeys being absent", async () => {
       addEntity();
 
-      await doGenerate({ cacheKeys: { mode: CacheKeyMode.off } });
+      await doGenerate({ cacheKeys: { enabled: false } });
 
       expect(generatedText()).not.toContain("rootState");
       expect(generatedText()).not.toContain("cacheKeyState");
@@ -266,14 +275,14 @@ describe("Service Generator Tests V4", () => {
         .addFunctionImport("TotalCount", withNs("totalCount"));
     }
 
-    async function generateWith(mode: CacheKeyMode) {
+    async function generateWith(enabled: boolean) {
       buildModel();
-      await doGenerate({ cacheKeys: { mode }, enablePrimitivePropertyServices: true });
+      await doGenerate({ cacheKeys: { enabled }, enablePrimitivePropertyServices: true });
       return generatedText();
     }
 
     test("off: no cache-key expression is emitted anywhere", async () => {
-      const text = await generateWith(CacheKeyMode.off);
+      const text = await generateWith(false);
 
       expect(text).not.toContain("rootState");
       expect(text).not.toContain("hopState");
@@ -284,7 +293,7 @@ describe("Service Generator Tests V4", () => {
     });
 
     test("root, hop, complex, primitive, stream, cast and operation hops all name themselves - never a type", async () => {
-      const text = await generateWith(CacheKeyMode.on);
+      const text = await generateWith(true);
 
       // root: entity set getter on the main service - "Media", the entity SET's own name, never
       // "Tester.Medium" (the type this used to, wrongly, be rooted at)
@@ -336,7 +345,7 @@ describe("Service Generator Tests V4", () => {
     });
 
     test("createEntityService forwards the cache-key state it is handed, without computing one", async () => {
-      const text = await generateWith(CacheKeyMode.on);
+      const text = await generateWith(true);
 
       expect(text).toContain("new MediumService<V>(client, path, name, options, cacheKeyState);");
     });


### PR DESCRIPTION
## Summary
- `CacheKeysOptions`/`CacheKeyMode` collapsed: `cacheKeys` now takes a plain `boolean` (`cacheKeys: true`), or the object form `{ enabled: boolean }` for a future option to join it under the same key without a breaking change.
- `enabled` is required within the object form — a partial `cacheKeys: {}` remains a compile error, same guarantee the old required `mode` gave.
- `ServiceGenerator` resolves this once (`resolveCacheKeysEnabled` / `cacheKeysEnabled`) and every emission site now checks the boolean directly instead of comparing against an enum value.
- Int-test configs (asp-net, cap, olingo-v2) switched to the `cacheKeys: true` shorthand.
- `spec/odata2ts-cache-key.md` updated to match (separate commit in the workspace root repo).

## Test plan
- [x] `yarn vitest run` in `packages/odata2ts` (742 passed)
- [x] Full dependency-chain test run (`odata-query-objects`, `odata2ts`, `odata-query-builder`, `odata-service`) — all green
- [x] `tsc --noEmit` on `int-test/asp-net`, `int-test/cap`, `int-test/olingo-v2` against the new `cacheKeys: true` shorthand
- [x] `yarn check-format`