### PR TITLE
feat(odata-service, odata2ts): add OData $batch support

### DIFF
--- a/int-test/asp-net/test/feature/Batch.test.ts
+++ b/int-test/asp-net/test/feature/Batch.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "vitest";
+import { LIBRARY } from "../LibraryTestConstants.js";
+
+/**
+ * `$batch` against the ASP.NET Core OData server - the one that, unlike the V2 server, speaks the **JSON**
+ * wire format as well as multipart. Both are exercised, because the point of the format option is that the
+ * application picks the wire format and the builder stays format-agnostic: the same builder, the same
+ * slots, two different ways of going out.
+ */
+describe("ASP.NET Library: $batch", () => {
+  test("json answers every sub-request", async () => {
+    const members = LIBRARY.Members().query((b) => b.top(2));
+    const count = LIBRARY.Media().query((b) => b.count());
+
+    const [membersResult, countResult] = await LIBRARY.batch().add(members).add(count).execute({ format: "json" });
+
+    expect(membersResult.status).toBe(200);
+    expect(membersResult.data?.value.length).toBe(2);
+
+    expect(countResult.status).toBe(200);
+    expect(countResult.data?.["@odata.count"]).toBeGreaterThan(0);
+  });
+
+  test("multipart answers every sub-request", async () => {
+    const members = LIBRARY.Members().query((b) => b.top(2));
+
+    const [membersResult] = await LIBRARY.batch().add(members).execute();
+
+    expect(membersResult.status).toBe(200);
+    expect(membersResult.data?.value.length).toBe(2);
+  });
+});

--- a/int-test/asp-net/test/feature/Batch.test.ts
+++ b/int-test/asp-net/test/feature/Batch.test.ts
@@ -31,16 +31,16 @@ describe("ASP.NET Library: $batch", () => {
   });
 
   test("continueOnError still answers the sub-request that follows a failing one", async () => {
-    const missing = LIBRARY.Members(UNKNOWN_ID).query();
-    const members = LIBRARY.Members().query((b) => b.top(1));
+    const missing = LIBRARY.Media(UNKNOWN_ID).query();
+    const media = LIBRARY.Media().query((b) => b.top(1));
 
-    const [missingResult, membersResult] = await LIBRARY.batch()
+    const [missingResult, mediaResult] = await LIBRARY.batch()
       .add(missing)
-      .add(members)
+      .add(media)
       .execute({ continueOnError: true });
 
     expect(missingResult.status).toBe(404);
-    expect(membersResult.status).toBe(200);
-    expect(membersResult.data?.value.length).toBe(1);
+    expect(mediaResult.status).toBe(200);
+    expect(mediaResult.data?.value.length).toBe(1);
   });
 });

--- a/int-test/asp-net/test/feature/Batch.test.ts
+++ b/int-test/asp-net/test/feature/Batch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { LIBRARY } from "../LibraryTestConstants.js";
+import { LIBRARY, UNKNOWN_ID } from "../LibraryTestConstants.js";
 
 /**
  * `$batch` against the ASP.NET Core OData server - the one that, unlike the V2 server, speaks the **JSON**
@@ -28,5 +28,19 @@ describe("ASP.NET Library: $batch", () => {
 
     expect(membersResult.status).toBe(200);
     expect(membersResult.data?.value.length).toBe(2);
+  });
+
+  test("continueOnError still answers the sub-request that follows a failing one", async () => {
+    const missing = LIBRARY.Members(UNKNOWN_ID).query();
+    const members = LIBRARY.Members().query((b) => b.top(1));
+
+    const [missingResult, membersResult] = await LIBRARY.batch()
+      .add(missing)
+      .add(members)
+      .execute({ continueOnError: true });
+
+    expect(missingResult.status).toBe(404);
+    expect(membersResult.status).toBe(200);
+    expect(membersResult.data?.value.length).toBe(1);
   });
 });

--- a/int-test/cap/test/feature/Batch.test.ts
+++ b/int-test/cap/test/feature/Batch.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "vitest";
+import { LIBRARY, UNKNOWN_ID } from "../LibraryTestConstants.js";
+
+/**
+ * `$batch` against the SAP CAP server, which serves the V4 endpoint (the V2 rendition's `$batch` is
+ * covered in `int-test/olingo-v2`). This runs the V4 client over the default **multipart** wire format -
+ * the one that works for every OData version - and, against a real server, the direction the unit tests
+ * cannot settle: that the server really answers each sub-request and that a failing one leaves its slot
+ * carrying the error while the others still answer.
+ */
+describe("CAP Library: $batch", () => {
+  test("multipart answers every sub-request with its own answer", async () => {
+    const books = LIBRARY.Books().query((b) => b.top(2));
+    const count = LIBRARY.Books().query((b) => b.count());
+
+    const [booksResult, countResult] = await LIBRARY.batch().add(books).add(count).execute();
+
+    expect(booksResult.status).toBe(200);
+    expect(booksResult.data?.value.length).toBe(2);
+
+    expect(countResult.status).toBe(200);
+    expect(countResult.data?.["@odata.count"]).toBeGreaterThan(0);
+  });
+
+  test("a failing sub-request leaves its slot carrying the error, the others still answer", async () => {
+    const books = LIBRARY.Books().query((b) => b.top(1));
+    const missing = LIBRARY.Books(UNKNOWN_ID).query();
+
+    const [booksResult, missingResult] = await LIBRARY.batch().add(books).add(missing).execute();
+
+    expect(booksResult.status).toBe(200);
+    expect(missingResult.status).toBe(404);
+  });
+
+  test("honours top-level dependsOn as ordering", async () => {
+    const first = LIBRARY.Books().query((b) => b.top(1));
+    const second = LIBRARY.Books().query((b) => b.top(1));
+
+    const [firstResult, secondResult] = await LIBRARY.batch()
+      .add(first)
+      .add(second, { dependsOn: [first] })
+      .execute();
+
+    expect(firstResult.status).toBe(200);
+    expect(secondResult.status).toBe(200);
+    expect(secondResult.data?.value.length).toBe(1);
+  });
+});

--- a/int-test/cap/test/feature/Batch.test.ts
+++ b/int-test/cap/test/feature/Batch.test.ts
@@ -45,4 +45,18 @@ describe("CAP Library: $batch", () => {
     expect(secondResult.status).toBe(200);
     expect(secondResult.data?.value.length).toBe(1);
   });
+
+  test("continueOnError still answers the sub-request that follows a failing one", async () => {
+    const missing = LIBRARY.Books(UNKNOWN_ID).query();
+    const books = LIBRARY.Books().query((b) => b.top(1));
+
+    const [missingResult, booksResult] = await LIBRARY.batch()
+      .add(missing)
+      .add(books)
+      .execute({ continueOnError: true });
+
+    expect(missingResult.status).toBe(404);
+    expect(booksResult.status).toBe(200);
+    expect(booksResult.data?.value.length).toBe(1);
+  });
 });

--- a/int-test/olingo-v2/test/feature/Batch.test.ts
+++ b/int-test/olingo-v2/test/feature/Batch.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "vitest";
+import { LIBRARY } from "../LibraryTestConstants.js";
+
+/**
+ * `$batch` against the Apache Olingo 2.0 server - the OData **V2** one. V2 has no JSON `$batch`, so the
+ * batch goes out **multipart** (the default). This is the shape SAP systems actually put on the wire, which
+ * is why a real V2 server is worth testing rather than only the JSON side. The generator marks this
+ * service as V2, so a `json` batch is refused before it ever goes out.
+ */
+describe("Olingo V2 Library: $batch", () => {
+  test("multipart answers every sub-request", async () => {
+    const books = LIBRARY.Books().query((b) => b.top(2));
+    const count = LIBRARY.Books().query((b) => b.count());
+
+    const [booksResult, countResult] = await LIBRARY.batch().add(books).add(count).execute();
+
+    expect(booksResult.status).toBe(200);
+    expect(booksResult.data?.d.results.length).toBe(2);
+
+    expect(countResult.status).toBe(200);
+  });
+
+  test("refuses a json batch, which V2 has no form of", async () => {
+    const books = LIBRARY.Books().query((b) => b.top(1));
+
+    await expect(LIBRARY.batch().add(books).execute({ format: "json" })).rejects.toThrow(/V2/);
+  });
+});

--- a/int-test/olingo-v2/test/feature/Batch.test.ts
+++ b/int-test/olingo-v2/test/feature/Batch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { LIBRARY } from "../LibraryTestConstants.js";
+import { LIBRARY, UNKNOWN_ID } from "../LibraryTestConstants.js";
 
 /**
  * `$batch` against the Apache Olingo 2.0 server - the OData **V2** one. V2 has no JSON `$batch`, so the
@@ -24,5 +24,19 @@ describe("Olingo V2 Library: $batch", () => {
     const books = LIBRARY.Books().query((b) => b.top(1));
 
     await expect(LIBRARY.batch().add(books).execute({ format: "json" })).rejects.toThrow(/V2/);
+  });
+
+  test("continueOnError still answers the sub-request that follows a failing one", async () => {
+    const missing = LIBRARY.Books(UNKNOWN_ID).query();
+    const books = LIBRARY.Books().query((b) => b.top(1));
+
+    const [missingResult, booksResult] = await LIBRARY.batch()
+      .add(missing)
+      .add(books)
+      .execute({ continueOnError: true });
+
+    expect(missingResult.status).toBe(404);
+    expect(booksResult.status).toBe(200);
+    expect(booksResult.data?.d.results.length).toBe(1);
   });
 });

--- a/packages/odata-service/src/ODataService.ts
+++ b/packages/odata-service/src/ODataService.ts
@@ -1,5 +1,6 @@
 import { ODataHttpClient } from "@odata2ts/http-client-api";
 import { ODataVersionV4 } from "@odata2ts/odata-core";
+import { BatchBuilder } from "./batch/BatchBuilder.js";
 import { ODataServiceOptionsInternal } from "./ODataServiceOptions";
 import { ServiceStateHelper } from "./ServiceStateHelper.js";
 
@@ -26,5 +27,29 @@ export class ODataService<V extends ODataVersionV4 = "4.0"> {
 
   public getPath(): string {
     return this.__base.path;
+  }
+
+  /**
+   * Starts collecting requests to send them as one `$batch`.
+   *
+   * The builder applies the service's `batch` option: it refuses to be built at all where the feature was
+   * switched off, and a V2 service - which has no JSON `$batch` - rejects `execute({ format: "json" })`.
+   *
+   * The result is a tuple, element-for-element the type the application would get from running those
+   * requests one by one, so the answer of a slot that never ran is `T | undefined` rather than a second,
+   * batch-specific shape.
+   */
+  public batch(): BatchBuilder<[]> {
+    const batchOptions = this.__base.options.batch;
+    if (batchOptions?.disabled) {
+      throw new Error("Batch requests are disabled for this service (see the `batch` option).");
+    }
+
+    return new BatchBuilder(
+      this.__base.client,
+      this.__base.basePath,
+      batchOptions?.format ?? "multipart",
+      this.__base.options.odataVersion === "2.0",
+    );
   }
 }

--- a/packages/odata-service/src/ODataServiceOptions.ts
+++ b/packages/odata-service/src/ODataServiceOptions.ts
@@ -1,3 +1,4 @@
+import { BatchFormat } from "@odata2ts/http-client-api";
 import { ODataVersionV4 } from "@odata2ts/odata-core";
 
 export interface ODataServiceOptions {
@@ -8,6 +9,25 @@ export interface ODataServiceOptions {
    * Of course, it's super handy for tests as well.
    */
   noUrlEncoding?: boolean;
+  /**
+   * How the service's `$batch` requests are sent, decided by the application in `odata2ts.config.ts`.
+   * The whole feature lives on the generated main service's {@link ODataService.batch}.
+   */
+  batch?: BatchOptions;
+}
+
+/**
+ * The `$batch` options, written by the generator into every generated main service's options.
+ *
+ * - `format` - the wire format for the batch as a whole. Defaults to `"multipart"`, which works for every
+ *   OData version a generated service can address. `"json"` is the richer format and the one a server is
+ *   most likely to accept - but only where its `$batch` actually speaks it, and a V2 service never does, so
+ *   on one `format: "json"` is refused (see {@link ODataService.batch}).
+ * - `disabled` - turns the feature off for this service: `batch()` throws rather than building a request.
+ */
+export interface BatchOptions {
+  format?: BatchFormat;
+  disabled?: boolean;
 }
 
 export interface ODataServiceOptionsInternal<V extends ODataVersionV4 = "4.0"> extends ODataServiceOptions {
@@ -35,6 +55,12 @@ export interface ODataServiceOptionsInternal<V extends ODataVersionV4 = "4.0"> e
    * something an application chooses.
    */
   concurrencyControlled?: boolean;
+  /**
+   * The OData version this service addresses, as decided by the generator - hence internal, and set only
+   * for V2. It is the one thing nothing else at runtime can say: whether a `format: "json"` batch is
+   * refused for this service, since V2 has no JSON `$batch` (see {@link ODataService.batch}).
+   */
+  odataVersion?: "2.0" | "4.0" | "4.01";
 }
 
 export interface ODataServiceOptionsInternalV2<AsV4 extends boolean = false> extends ODataServiceOptions {

--- a/packages/odata-service/src/batch/BatchBuilder.ts
+++ b/packages/odata-service/src/batch/BatchBuilder.ts
@@ -1,0 +1,279 @@
+import {
+  BatchFormat,
+  BatchHttpMethod,
+  BatchRequestBody,
+  BatchRequestObject,
+  BatchResponseObject,
+  BatchResponseBody,
+  HttpResponseModel,
+  ODataHttpClient,
+} from "@odata2ts/http-client-api";
+import { BlobGetRequestCmd } from "../request/BlobGetRequestCmd";
+import { BlobUpdateRequestCmd } from "../request/BlobUpdateRequestCmd";
+import { RequestCmd } from "../request/RequestCmd";
+import { RequestInfo } from "../request/RequestInfo";
+import { StreamGetRequestCmd } from "../request/StreamGetRequestCmd";
+import { StreamUpdateRequestCmd } from "../request/StreamUpdateRequestCmd";
+
+/**
+ * The response odata2ts puts into a single slot of a batch result: that sub-request's answer, run through
+ * the command's own response converters - or, where the sub-request never made it through, a synthesized
+ * marker carrying status `0`. `T` is the command's final response structure, so the tuple {@link BatchBuilder.execute}
+ * returns is element-for-element what the application would expect from running those requests one by one:
+ * a slot that never ran is `T | undefined`, not a second batch-specific shape.
+ */
+export type BatchResponse<T> = HttpResponseModel<T | undefined>;
+
+/** Options for adding one request to a batch. */
+export interface BatchAddOptions {
+  /**
+   * Other commands in this batch whose sub-request must run before this one's. Order within a change set
+   * guarantees nothing (§11.7.2), so this is the only way to say it. Given as the command objects
+   * themselves; the builder resolves them to wire ids. The other format could not express a dependency that
+   * is a forward reference or crosses a change set - those are refused where the format cannot carry them.
+   */
+  dependsOn?: Array<RequestCmd<any, any, any>>;
+}
+
+/** Options for sending one batch, overriding the service's defaults for this single call. */
+export interface BatchExecuteOptions {
+  /** Override the service's default wire format for this one batch. */
+  format?: BatchFormat;
+  /** Ask the server to answer what it can even where a sub-request fails (the `Prefer` header). */
+  continueOnError?: boolean;
+}
+
+interface BatchEntry {
+  cmd: RequestCmd<any, any, any>;
+  /** The wire id, assigned in the order commands are added. */
+  id: string;
+  /** Set while an atomicity group (a multipart change set) is open. */
+  group?: string;
+  /** The dependencies, as command objects, resolved to wire ids when the body is built. */
+  dependsOn: Array<RequestCmd<any, any, any>>;
+  /** The prepared request, computed once and shared between building the body and dispatching the answer. */
+  prepared?: RequestInfo<any>;
+}
+
+/**
+ * Collects a set of requests and sends them as one `$batch`.
+ *
+ * The builder does not re-implement the pipeline a request goes through: each collected command is prepared
+ * with the very {@link RequestCmd.prepareRequest} and its answer dispatched with the very
+ * {@link RequestCmd.handleResponse} a direct request uses, so converters, the concurrency rule and the
+ * cache-key harvesting all behave exactly as they would one by one. What the builder owns is what a direct
+ * request has no need of: the wire ids, the one url rewrite (the service base path, stripped), the
+ * atomicity-group framing, and the normalization of a sub-answer that never happened.
+ */
+export class BatchBuilder<R extends Array<unknown> = []> {
+  private readonly __client: ODataHttpClient;
+  private readonly __basePath: string;
+  private readonly __defaultFormat: BatchFormat;
+  private readonly __isV2: boolean;
+  private readonly __entries: Array<BatchEntry> = [];
+  private readonly __seen = new Set<RequestCmd<any, any, any>>();
+  private __openGroup?: string;
+
+  constructor(client: ODataHttpClient, basePath: string, defaultFormat: BatchFormat, isV2: boolean) {
+    this.__client = client;
+    this.__basePath = basePath;
+    this.__defaultFormat = defaultFormat;
+    this.__isV2 = isV2;
+  }
+
+  /**
+   * Add one request to the batch. Blob and stream commands are refused - they carry a binary body the batch
+   * wire formats cannot carry - as is adding the same instance twice.
+   */
+  public add<T>(cmd: RequestCmd<any, any, T>, options?: BatchAddOptions): BatchBuilder<[...R, BatchResponse<T>]> {
+    if (BatchBuilder.isBatchIncompatible(cmd)) {
+      throw new Error(
+        "A blob or stream request cannot be part of a batch - its binary body is not a body the batch wire formats carry. Send it separately.",
+      );
+    }
+    if (this.__seen.has(cmd)) {
+      throw new Error("The same request instance cannot be added to a batch twice - each slot is one request.");
+    }
+
+    const id = String(this.__entries.length);
+    this.__entries.push({ cmd, id, group: this.__openGroup, dependsOn: options?.dependsOn ?? [] });
+    this.__seen.add(cmd);
+
+    return this as unknown as BatchBuilder<[...R, BatchResponse<T>]>;
+  }
+
+  /** Open an atomicity group (a multipart change set). Commands added while it is open belong to it. */
+  public startGroup(groupId: string): BatchBuilder<R> {
+    if (this.__openGroup !== undefined) {
+      throw new Error(`An atomicity group ("${this.__openGroup}") is already open - end it before opening another.`);
+    }
+    this.__openGroup = groupId;
+    return this;
+  }
+
+  /** Close the open atomicity group. */
+  public endGroup(): BatchBuilder<R> {
+    if (this.__openGroup === undefined) {
+      throw new Error("endGroup() with no atomicity group open.");
+    }
+    this.__openGroup = undefined;
+    return this;
+  }
+
+  /**
+   * The batch as it will be sent: wire ids assigned in the order the commands were added, the service base
+   * path stripped off every sub-request url, and the atomicity group and `dependsOn` where they were set.
+   */
+  public getRequestInfo(): BatchRequestBody {
+    this.__prepareAll();
+    return this.__buildBody();
+  }
+
+  /**
+   * Send the collected requests as one `$batch` and return their answers, one element per added command.
+   *
+   * A slot whose sub-request never ran is a synthesized answer with status `0` (`"Never Ran"`); one whose
+   * own status is 2xx but whose atomicity group carries a failure is likewise a status-`0` marker
+   * (`"Rolled Back"`), because a rolled-back change set undid it (§11.7.2). Everything else is the
+   * sub-request's real answer, converted - the builder does not invent a second result type.
+   */
+  public async execute(options?: BatchExecuteOptions): Promise<R> {
+    const format = options?.format ?? this.__defaultFormat;
+    if (this.__isV2 && format === "json") {
+      throw new Error("A V2 service has no JSON $batch - use format: \"multipart\".");
+    }
+
+    const body = this.getRequestInfo();
+    const response = await this.__client.batch(this.__batchUrl(), body, {
+      format,
+      continueOnError: options?.continueOnError,
+    });
+
+    return this.__normalize(response.data) as unknown as R;
+  }
+
+  private static isBatchIncompatible(cmd: RequestCmd<any, any, any>): boolean {
+    return (
+      cmd instanceof BlobGetRequestCmd ||
+      cmd instanceof BlobUpdateRequestCmd ||
+      cmd instanceof StreamGetRequestCmd ||
+      cmd instanceof StreamUpdateRequestCmd
+    );
+  }
+
+  private __batchUrl(): string {
+    return this.__basePath.replace(/\/$/, "") + "/$batch";
+  }
+
+  private __prepareAll(): void {
+    for (const entry of this.__entries) {
+      // a controlled write with no known ETag throws here - before anything is sent - so a doomed batch is
+      // refused rather than sent
+      if (entry.prepared === undefined) {
+        entry.prepared = entry.cmd.prepareRequest();
+      }
+    }
+  }
+
+  private __buildBody(): BatchRequestBody {
+    const idOf = new Map(this.__entries.map((entry) => [entry.cmd, entry.id]));
+
+    const requests = this.__entries.map((entry): BatchRequestObject => {
+      const prepared = entry.prepared!;
+      const request: BatchRequestObject = {
+        id: entry.id,
+        method: BatchBuilder.toBatchMethod(prepared.method),
+        url: this.__stripBasePath(prepared.url),
+      };
+
+      if (entry.group !== undefined) {
+        request.atomicityGroup = entry.group;
+      }
+
+      const dependsOn = entry.dependsOn.map((dep) => idOf.get(dep));
+      if (dependsOn.length > 0) {
+        if (dependsOn.some((id) => id === undefined)) {
+          throw new Error("A request depends on a command that is not part of this batch.");
+        }
+        request.dependsOn = dependsOn as Array<string>;
+      }
+
+      if (prepared.headers && Object.keys(prepared.headers).length > 0) {
+        request.headers = prepared.headers;
+      }
+      if (prepared.data !== undefined) {
+        request.body = prepared.data;
+      }
+
+      return request;
+    });
+
+    return { requests };
+  }
+
+  private __normalize(data: BatchResponseBody): Array<BatchResponse<any>> {
+    const byId = new Map(data.responses.map((response) => [response.id, response]));
+    const failedGroups = new Set(
+      data.responses
+        .filter((response) => response.atomicityGroup !== undefined && !BatchBuilder.is2xx(response.status))
+        .map((response) => response.atomicityGroup!),
+    );
+
+    return this.__entries.map((entry) => {
+      const response = byId.get(entry.id);
+
+      if (response === undefined) {
+        return { status: 0, statusText: "Never Ran", headers: {}, data: undefined };
+      }
+      if (
+        BatchBuilder.is2xx(response.status) &&
+        response.atomicityGroup !== undefined &&
+        failedGroups.has(response.atomicityGroup)
+      ) {
+        return { status: 0, statusText: "Rolled Back", headers: {}, data: undefined };
+      }
+
+      const answer: HttpResponseModel<any> = {
+        status: response.status,
+        statusText: BatchBuilder.statusTextFor(response.status),
+        headers: response.headers ?? {},
+        data: response.body,
+      };
+
+      return entry.cmd.handleResponse(entry.prepared!, answer);
+    });
+  }
+
+  private static is2xx(status: number): boolean {
+    return status >= 200 && status < 300;
+  }
+
+  private static toBatchMethod(method: RequestInfo["method"]): BatchHttpMethod {
+    return method.toLowerCase() as BatchHttpMethod;
+  }
+
+  private __stripBasePath(url: string): string {
+    const base = this.__basePath.replace(/\/$/, "");
+    const relative = url.startsWith(base) ? url.slice(base.length) : url;
+    return relative.replace(/^\//, "");
+  }
+
+  private static statusTextFor(status: number): string {
+    const known: Record<number, string> = {
+      200: "OK",
+      201: "Created",
+      202: "Accepted",
+      204: "No Content",
+      304: "Not Modified",
+      400: "Bad Request",
+      401: "Unauthorized",
+      403: "Forbidden",
+      404: "Not Found",
+      409: "Conflict",
+      412: "Precondition Failed",
+      424: "Failed Dependency",
+      500: "Internal Server Error",
+    };
+    return known[status] ?? "";
+  }
+}

--- a/packages/odata-service/src/batch/BatchBuilder.ts
+++ b/packages/odata-service/src/batch/BatchBuilder.ts
@@ -31,6 +31,8 @@ export interface BatchAddOptions {
    * guarantees nothing (§11.7.2), so this is the only way to say it. Given as the command objects
    * themselves; the builder resolves them to wire ids. The other format could not express a dependency that
    * is a forward reference or crosses a change set - those are refused where the format cannot carry them.
+   * A target must be added exactly once: a command added more than once is an ambiguous dependency (which of
+   * its slots would the other wait on?) and is refused.
    */
   dependsOn?: Array<RequestCmd<any, any, any>>;
 }
@@ -71,7 +73,6 @@ export class BatchBuilder<R extends Array<unknown> = []> {
   private readonly __defaultFormat: BatchFormat;
   private readonly __isV2: boolean;
   private readonly __entries: Array<BatchEntry> = [];
-  private readonly __seen = new Set<RequestCmd<any, any, any>>();
   private __openGroup?: string;
 
   constructor(client: ODataHttpClient, basePath: string, defaultFormat: BatchFormat, isV2: boolean) {
@@ -83,7 +84,8 @@ export class BatchBuilder<R extends Array<unknown> = []> {
 
   /**
    * Add one request to the batch. Blob and stream commands are refused - they carry a binary body the batch
-   * wire formats cannot carry - as is adding the same instance twice.
+   * wire formats cannot carry. The same command may be added more than once: it is reused across its slots
+   * (the batch never mutates a command's state), so sending the same request twice is simply adding it twice.
    */
   public add<T>(cmd: RequestCmd<any, any, T>, options?: BatchAddOptions): BatchBuilder<[...R, BatchResponse<T>]> {
     if (BatchBuilder.isBatchIncompatible(cmd)) {
@@ -91,13 +93,9 @@ export class BatchBuilder<R extends Array<unknown> = []> {
         "A blob or stream request cannot be part of a batch - its binary body is not a body the batch wire formats carry. Send it separately.",
       );
     }
-    if (this.__seen.has(cmd)) {
-      throw new Error("The same request instance cannot be added to a batch twice - each slot is one request.");
-    }
 
     const id = String(this.__entries.length);
     this.__entries.push({ cmd, id, group: this.__openGroup, dependsOn: options?.dependsOn ?? [] });
-    this.__seen.add(cmd);
 
     return this as unknown as BatchBuilder<[...R, BatchResponse<T>]>;
   }
@@ -177,6 +175,10 @@ export class BatchBuilder<R extends Array<unknown> = []> {
 
   private __buildBody(): BatchRequestBody {
     const idOf = new Map(this.__entries.map((entry) => [entry.cmd, entry.id]));
+    const addedCount = new Map<RequestCmd<any, any, any>, number>();
+    for (const entry of this.__entries) {
+      addedCount.set(entry.cmd, (addedCount.get(entry.cmd) ?? 0) + 1);
+    }
 
     const requests = this.__entries.map((entry): BatchRequestObject => {
       const prepared = entry.prepared!;
@@ -192,8 +194,15 @@ export class BatchBuilder<R extends Array<unknown> = []> {
 
       const dependsOn = entry.dependsOn.map((dep) => idOf.get(dep));
       if (dependsOn.length > 0) {
-        if (dependsOn.some((id) => id === undefined)) {
-          throw new Error("A request depends on a command that is not part of this batch.");
+        for (const dep of entry.dependsOn) {
+          if (idOf.get(dep) === undefined) {
+            throw new Error("A request depends on a command that is not part of this batch.");
+          }
+          if ((addedCount.get(dep) ?? 0) > 1) {
+            throw new Error(
+              "A request depends on a command that was added to the batch more than once - the dependency is ambiguous. Add that command once, or add two separate commands.",
+            );
+          }
         }
         request.dependsOn = dependsOn as Array<string>;
       }

--- a/packages/odata-service/src/batch/BatchBuilder.ts
+++ b/packages/odata-service/src/batch/BatchBuilder.ts
@@ -3,8 +3,8 @@ import {
   BatchHttpMethod,
   BatchRequestBody,
   BatchRequestObject,
-  BatchResponseObject,
   BatchResponseBody,
+  BatchResponseObject,
   HttpResponseModel,
   ODataHttpClient,
 } from "@odata2ts/http-client-api";
@@ -140,7 +140,7 @@ export class BatchBuilder<R extends Array<unknown> = []> {
   public async execute(options?: BatchExecuteOptions): Promise<R> {
     const format = options?.format ?? this.__defaultFormat;
     if (this.__isV2 && format === "json") {
-      throw new Error("A V2 service has no JSON $batch - use format: \"multipart\".");
+      throw new Error('A V2 service has no JSON $batch - use format: "multipart".');
     }
 
     const body = this.getRequestInfo();

--- a/packages/odata-service/src/batch/index.ts
+++ b/packages/odata-service/src/batch/index.ts
@@ -1,0 +1,2 @@
+export { BatchBuilder } from "./BatchBuilder";
+export type { BatchAddOptions, BatchExecuteOptions, BatchResponse } from "./BatchBuilder";

--- a/packages/odata-service/src/index.ts
+++ b/packages/odata-service/src/index.ts
@@ -8,3 +8,4 @@ export * from "./v4/index";
 export * from "./RequestHeaders";
 export * from "./request/index";
 export * from "./cacheKey/index";
+export * from "./batch/index";

--- a/packages/odata-service/src/request/RequestCmd.ts
+++ b/packages/odata-service/src/request/RequestCmd.ts
@@ -242,6 +242,61 @@ export abstract class RequestCmd<
   }
 
   /**
+   * The first half of {@link execute}: the request converters and the concurrency rule, returning the
+   * request as it will be sent.
+   *
+   * Split out so a batch can run the same pipeline once per collected command before anything is sent.
+   * Throws {@link ODataConcurrencyError} where a controlled write has no known ETag - for a direct request
+   * that is before the send, and for a batch before the whole thing goes out, so a doomed batch is refused
+   * rather than sent.
+   */
+  public prepareRequest(): RequestInfo<any> {
+    return this.applyConcurrency(this.getInfoConverted());
+  }
+
+  /**
+   * The second half of {@link execute}: the response converters and the concurrency / cache-key
+   * harvesting, run against one answer and returning it.
+   *
+   * A direct request only ever sees a 2xx answer - the client throws everything else - so the conversion
+   * and harvesting run exactly as before. A batch hands non-2xx answers back as values: those are returned
+   * unconverted and nothing is harvested, because that sub-request did not happen.
+   *
+   * `request` is the prepared request {@link prepareRequest} returned: the harvested state is read off its
+   * post-conversion {@link CacheKeyState}, the very same state the key is built from, so key and what a write
+   * reports as stale cannot drift apart.
+   */
+  public handleResponse(
+    request: RequestInfo<any>,
+    response: HttpResponseModel<any>,
+  ): HttpResponseModel<FinalResponseStructure> {
+    const succeeded = response.status >= 200 && response.status < 300;
+
+    if (!succeeded) {
+      // a batch answer of 412 has just disproved the stored ETag - the same rule as the direct path, which
+      // reaches that 412 through the thrown error instead
+      if (response.status === 412) {
+        this.evictConcurrency();
+      }
+      return response as HttpResponseModel<FinalResponseStructure>;
+    }
+
+    const converted = this.convertResponse(response);
+
+    // harvest afterwards, deliberately: the property names a collection service builds its keys from are
+    // the mapped, user-facing ones, which only exist once the converters have run
+    this.updateConcurrency(response);
+
+    // response-observed identity is read off the converted, mapped-name body too - a read only, by
+    // construction, since `this.cacheKey` is `undefined` for anything else
+    if (request.cacheKeyState) {
+      recordObservedIdentities(this.client.resourceIdentity, this.cacheKey, request.cacheKeyState, converted.data);
+    }
+
+    return this.withInvalidates(converted, request.cacheKeyState);
+  }
+
+  /**
    * Main method of this command object: Executes the request.
    *
    * The config type defaults to what every HTTP client understands - headers and URL params. Anything a
@@ -253,10 +308,8 @@ export abstract class RequestCmd<
   public async execute<RequestConfig extends ODataRequestConfig = ODataRequestConfig>(
     requestConfig?: NoInferConfig<RequestConfig>,
   ): Promise<HttpResponseModel<FinalResponseStructure>> {
-    // apply request converters
-    const request = this.applyConcurrency(this.getInfoConverted());
+    const request = this.prepareRequest();
 
-    // execute the request
     let response: HttpResponseModel<any>;
     try {
       response = await this.sendRequest(request, requestConfig);
@@ -265,21 +318,7 @@ export abstract class RequestCmd<
       throw error;
     }
 
-    // apply response converters
-    const converted = this.convertResponse(response);
-
-    // harvest afterwards, deliberately: the property names a collection service builds its keys from are
-    // the mapped, user-facing ones, which only exist once the converters have run
-    this.updateConcurrency(response);
-
-    // same reasoning as concurrency harvesting: response-observed identity is read off the converted,
-    // mapped-name body too - a read only, by construction, since `this.cacheKey` is `undefined` for
-    // anything else (see ObservedIdentity.recordObservedIdentities)
-    if (request.cacheKeyState) {
-      recordObservedIdentities(this.client.resourceIdentity, this.cacheKey, request.cacheKeyState, converted.data);
-    }
-
-    return this.withInvalidates(converted, request.cacheKeyState);
+    return this.handleResponse(request, response);
   }
 
   /**
@@ -347,8 +386,15 @@ export abstract class RequestCmd<
    * The error itself travels on untouched - resolving a conflict is the application's business.
    */
   private evictOnConflict(error: unknown): void {
+    if (isConcurrencyConflict(error)) {
+      this.evictConcurrency();
+    }
+  }
+
+  /** Drop the stored ETag of the resource this command addresses, if one is under concurrency control. */
+  private evictConcurrency(): void {
     const { concurrency } = this.options;
-    if (concurrency && isConcurrencyConflict(error)) {
+    if (concurrency) {
       this.client.concurrency?.evict(concurrency.key);
     }
   }

--- a/packages/odata-service/test/batch/BatchBuilder.test.ts
+++ b/packages/odata-service/test/batch/BatchBuilder.test.ts
@@ -105,11 +105,24 @@ describe("BatchBuilder via ODataService.batch()", () => {
     expect(requests[3].atomicityGroup).toBeUndefined();
   });
 
-  test("refuses to add the same request instance twice", () => {
+  test("the same command added twice yields two slots that each answer independently", async () => {
     const { client, service } = makeService();
-    const cmd = new TestCmd(client, ODataHttpMethods.Get, BASE + "/A");
+    client.batchResponse = {
+      responses: [
+        { id: "0", status: 200, body: { id: 1 } },
+        { id: "1", status: 200, body: { id: 2 } },
+      ],
+      resolvedBy: "id",
+    };
+    const cmd = new TestCmd<{ id: number }, { name: string }>(client, ODataHttpMethods.Post, BASE + "/People", {
+      name: "n",
+    });
 
-    expect(() => service.batch().add(cmd).add(cmd)).toThrow(/twice/);
+    const [first, second] = await service.batch().add(cmd).add(cmd).execute();
+
+    expect(first).toMatchObject({ status: 200, data: { id: 1 } });
+    expect(second).toMatchObject({ status: 200, data: { id: 2 } });
+    expect(client.lastBatchBody?.requests.map((request) => request.url)).toStrictEqual(["People", "People"]);
   });
 
   test("refuses a blob request, which cannot be carried by a batch", () => {
@@ -293,6 +306,21 @@ describe("BatchBuilder via ODataService.batch()", () => {
           .add(member, { dependsOn: [outsider] })
           .execute(),
       ).rejects.toThrow(/not part of this batch/);
+    });
+
+    test("refuses a dependency on a command added more than once, which is ambiguous", async () => {
+      const { client, service } = makeService();
+      const duplicated = new TestCmd(client, ODataHttpMethods.Post, BASE + "/Members", { name: "n" });
+      const member = new TestCmd(client, ODataHttpMethods.Get, BASE + "/Members(1)");
+
+      await expect(
+        service
+          .batch()
+          .add(duplicated)
+          .add(member, { dependsOn: [duplicated] })
+          .add(duplicated)
+          .execute(),
+      ).rejects.toThrow(/ambiguous/);
     });
   });
 

--- a/packages/odata-service/test/batch/BatchBuilder.test.ts
+++ b/packages/odata-service/test/batch/BatchBuilder.test.ts
@@ -1,0 +1,290 @@
+import { ODataHttpClient, ODataHttpMethods } from "@odata2ts/http-client-api";
+import { describe, expect, expectTypeOf, test } from "vitest";
+import { ODataService } from "../../src/ODataService";
+import { ODataServiceOptions } from "../../src/ODataServiceOptions";
+import { BlobGetRequestCmd } from "../../src/request/BlobGetRequestCmd";
+import { RequestCmd, RequestCmdOptions } from "../../src/request/RequestCmd";
+import { MockClient } from "../mock/MockClient";
+
+const BASE = "http://example.com/odata";
+
+/** A minimal concrete command with a fixed url and, where useful, a response converter. */
+class TestCmd<F, D = undefined> extends RequestCmd<F, D, F> {
+  private readonly __url: string;
+
+  constructor(client: ODataHttpClient, method: ODataHttpMethods, url: string, data?: D, options?: RequestCmdOptions<F, D>) {
+    super(client, method, data, options);
+    this.__url = url;
+  }
+
+  public getUrl(): string {
+    return this.__url;
+  }
+}
+
+function makeService(options?: ODataServiceOptions & { odataVersion?: "2.0" }) {
+  const client = new MockClient(false);
+  const service = new ODataService(client, BASE, options);
+  return { client, service };
+}
+
+type Person = { id: number; name: string };
+
+describe("BatchBuilder via ODataService.batch()", () => {
+  test("assigns wire ids in the order commands are added", async () => {
+    const { client, service } = makeService();
+    client.batchResponse = { responses: [], resolvedBy: "id" };
+
+    await service.batch().add(new TestCmd(client, ODataHttpMethods.Get, BASE + "/A")).execute();
+
+    expect(client.lastBatchBody?.requests.map((request) => request.id)).toEqual(["0"]);
+
+    client.batchResponse = { responses: [], resolvedBy: "id" };
+    await service
+      .batch()
+      .add(new TestCmd(client, ODataHttpMethods.Get, BASE + "/A"))
+      .add(new TestCmd(client, ODataHttpMethods.Post, BASE + "/B"))
+      .execute();
+
+    expect(client.lastBatchBody?.requests.map((request) => request.id)).toEqual(["0", "1"]);
+  });
+
+  test("strips the service base path off every sub-request url, keeps the query", async () => {
+    const { client, service } = makeService();
+    client.batchResponse = { responses: [], resolvedBy: "id" };
+
+    await service
+      .batch()
+      .add(new TestCmd(client, ODataHttpMethods.Get, BASE + "/People?$top=1&$filter=Active eq true"))
+      .add(new TestCmd(client, ODataHttpMethods.Patch, BASE + "/People(1)", { name: "n" }))
+      .execute();
+
+    const { requests } = client.lastBatchBody!;
+    expect(requests[0].url).toBe("People?$top=1&$filter=Active eq true");
+    expect(requests[1].url).toBe("People(1)");
+    expect(requests[0].method).toBe("get");
+    expect(requests[1].method).toBe("patch");
+    expect(requests[1].body).toStrictEqual({ name: "n" });
+  });
+
+  test("posts the batch to the service root's $batch endpoint", async () => {
+    const { client, service } = makeService();
+    client.batchResponse = { responses: [], resolvedBy: "id" };
+
+    await service.batch().add(new TestCmd(client, ODataHttpMethods.Get, BASE + "/A")).execute();
+
+    expect(client.lastBatchUrl).toBe(BASE + "/$batch");
+  });
+
+  test("frames commands in an atomicity group, and only those", async () => {
+    const { client, service } = makeService();
+    client.batchResponse = { responses: [], resolvedBy: "id" };
+    const before = new TestCmd(client, ODataHttpMethods.Get, BASE + "/A");
+    const first = new TestCmd(client, ODataHttpMethods.Get, BASE + "/B");
+    const second = new TestCmd(client, ODataHttpMethods.Post, BASE + "/C", { name: "n" });
+    const after = new TestCmd(client, ODataHttpMethods.Get, BASE + "/D");
+
+    await service
+      .batch()
+      .add(before)
+      .startGroup("g")
+      .add(first)
+      .add(second)
+      .endGroup()
+      .add(after)
+      .execute();
+
+    const { requests } = client.lastBatchBody!;
+    expect(requests[0].atomicityGroup).toBeUndefined();
+    expect(requests[1].atomicityGroup).toBe("g");
+    expect(requests[2].atomicityGroup).toBe("g");
+    expect(requests[3].atomicityGroup).toBeUndefined();
+  });
+
+  test("refuses to add the same request instance twice", () => {
+    const { client, service } = makeService();
+    const cmd = new TestCmd(client, ODataHttpMethods.Get, BASE + "/A");
+
+    expect(() => service.batch().add(cmd).add(cmd)).toThrow(/twice/);
+  });
+
+  test("refuses a blob request, which cannot be carried by a batch", () => {
+    const { client, service } = makeService();
+    const cmd = new BlobGetRequestCmd(client, BASE + "/People(1)/$value");
+
+    expect(() => service.batch().add(cmd)).toThrow(/blob or stream/);
+  });
+
+  test("throws where startGroup is called while a group is open, or endGroup with none open", () => {
+    const { client, service } = makeService();
+    const cmd = new TestCmd(client, ODataHttpMethods.Get, BASE + "/A");
+
+    expect(() => service.batch().startGroup("g1").startGroup("g2")).toThrow(/already open/);
+    expect(() => service.batch().endGroup()).toThrow(/no atomicity group open/);
+    expect(() => service.batch().startGroup("g1").add(cmd).endGroup()).not.toThrow();
+  });
+
+  test("executing with format: json on a V2 service throws, while multipart goes out", async () => {
+    const { client, service } = makeService({ odataVersion: "2.0" });
+    client.batchResponse = { responses: [{ id: "0", status: 200, body: [] }], resolvedBy: "id" };
+
+    await expect(
+      service.batch().add(new TestCmd(client, ODataHttpMethods.Get, BASE + "/A")).execute({ format: "json" }),
+    ).rejects.toThrow(/V2/);
+
+    client.batchResponse = { responses: [{ id: "0", status: 200, body: [] }], resolvedBy: "id" };
+    const [slot] = await service.batch().add(new TestCmd(client, ODataHttpMethods.Get, BASE + "/A")).execute();
+
+    expect(slot.status).toBe(200);
+    expect(client.lastBatchOptions?.format).toBe("multipart");
+  });
+
+  test("throws rather than build a request where the feature is disabled", () => {
+    const { service } = makeService({ batch: { disabled: true } });
+
+    expect(() => service.batch()).toThrow(/disabled/);
+  });
+
+  test("uses the service's default format and honours a per-call override", async () => {
+    const { client, service } = makeService();
+    client.batchResponse = { responses: [{ id: "0", status: 200, body: null }], resolvedBy: "id" };
+
+    await service.batch().add(new TestCmd(client, ODataHttpMethods.Get, BASE + "/A")).execute();
+    expect(client.lastBatchOptions?.format).toBe("multipart");
+
+    client.batchResponse = { responses: [{ id: "0", status: 200, body: null }], resolvedBy: "id" };
+    await service.batch().add(new TestCmd(client, ODataHttpMethods.Get, BASE + "/A")).execute({ format: "json", continueOnError: true });
+    expect(client.lastBatchOptions).toStrictEqual({ format: "json", continueOnError: true });
+  });
+
+  describe("slot outcomes", () => {
+    test("a 2xx sub-request is returned as-is, converted", async () => {
+      const { client, service } = makeService();
+      client.batchResponse = { responses: [{ id: "0", status: 200, body: [{ id: 1, name: "a" }] }], resolvedBy: "id" };
+
+      const [slot] = await service.batch().add(new TestCmd<Person[]>(client, ODataHttpMethods.Get, BASE + "/People")).execute();
+
+      expect(slot.status).toBe(200);
+      expect(slot.data).toStrictEqual([{ id: 1, name: "a" }]);
+    });
+
+    test("a non-2xx sub-request is returned unconverted, with the error document as data", async () => {
+      const { client, service } = makeService();
+      const error = { error: { code: "X" } };
+      client.batchResponse = { responses: [{ id: "0", status: 400, body: error }], resolvedBy: "id" };
+
+      const [slot] = await service.batch().add(new TestCmd<Person[]>(client, ODataHttpMethods.Get, BASE + "/People")).execute();
+
+      expect(slot.status).toBe(400);
+      expect(slot.data).toStrictEqual(error);
+    });
+
+    test("a 424 is kept as a 424", async () => {
+      const { client, service } = makeService();
+      client.batchResponse = { responses: [{ id: "0", status: 424, body: undefined }], resolvedBy: "id" };
+
+      const [slot] = await service.batch().add(new TestCmd<Person[]>(client, ODataHttpMethods.Get, BASE + "/People")).execute();
+
+      expect(slot.status).toBe(424);
+      expect(slot.data).toBeUndefined();
+    });
+
+    test("a 2xx slot whose atomicity group failed is reported as Rolled Back", async () => {
+      const { client, service } = makeService();
+      client.batchResponse = {
+        responses: [
+          { id: "0", status: 200, atomicityGroup: "g", body: { ok: true } },
+          { id: "1", status: 400, atomicityGroup: "g", body: { error: "bad" } },
+        ],
+        resolvedBy: "id",
+      };
+
+      const [first, second] = await service
+        .batch()
+        .startGroup("g")
+        .add(new TestCmd(client, ODataHttpMethods.Get, BASE + "/A"))
+        .add(new TestCmd(client, ODataHttpMethods.Post, BASE + "/B", { name: "n" }))
+        .endGroup()
+        .execute();
+
+      expect(first).toMatchObject({ status: 0, statusText: "Rolled Back", data: undefined });
+      expect(second.status).toBe(400);
+    });
+
+    test("a slot with no answer at all is Never Ran", async () => {
+      const { client, service } = makeService();
+      client.batchResponse = { responses: [{ id: "0", status: 200, body: "done" }], resolvedBy: "id" };
+
+      const [first, second] = await service
+        .batch()
+        .add(new TestCmd(client, ODataHttpMethods.Get, BASE + "/A"))
+        .add(new TestCmd(client, ODataHttpMethods.Get, BASE + "/B"))
+        .execute();
+
+      expect(first.status).toBe(200);
+      expect(second).toMatchObject({ status: 0, statusText: "Never Ran", data: undefined });
+    });
+
+    test("each slot is run through that command's own response converters", async () => {
+      const { client, service } = makeService();
+      const cmd = new TestCmd<Person[]>(client, ODataHttpMethods.Get, BASE + "/People").appendResponseConverter((response) => ({
+        ...response,
+        data: response.data.map((person) => ({ ...person, name: person.name.toUpperCase() })),
+      }));
+      client.batchResponse = { responses: [{ id: "0", status: 200, body: [{ id: 1, name: "a" }] }], resolvedBy: "id" };
+
+      const [slot] = await service.batch().add(cmd).execute();
+
+      expect(slot.data).toStrictEqual([{ id: 1, name: "A" }]);
+    });
+  });
+
+  describe("dependsOn", () => {
+    test("resolves dependencies to the wire ids of the commands they name", async () => {
+      const { client, service } = makeService();
+      client.batchResponse = { responses: [], resolvedBy: "id" };
+      const first = new TestCmd(client, ODataHttpMethods.Post, BASE + "/Members", { name: "n" });
+      const second = new TestCmd(client, ODataHttpMethods.Get, BASE + "/Members(1)");
+
+      await service.batch().add(first).add(second, { dependsOn: [first] }).execute();
+
+      expect(client.lastBatchBody?.requests[1].dependsOn).toStrictEqual(["0"]);
+    });
+
+    test("throws where a dependency names a command not in the batch", async () => {
+      const { client, service } = makeService();
+      const outsider = new TestCmd(client, ODataHttpMethods.Get, BASE + "/X");
+      const member = new TestCmd(client, ODataHttpMethods.Get, BASE + "/Y");
+
+      await expect(service.batch().add(member, { dependsOn: [outsider] }).execute()).rejects.toThrow(/not part of this batch/);
+    });
+  });
+
+  describe("typing", () => {
+    test("the result tuple is element-for-element the commands' own response types", async () => {
+      const { client, service } = makeService();
+      client.batchResponse = { responses: [{ id: "0", status: 200, body: [] }], resolvedBy: "id" };
+
+      const people = new TestCmd<Person[]>(client, ODataHttpMethods.Get, BASE + "/People");
+      const created = new TestCmd<{ id: number }, { name: string }>(client, ODataHttpMethods.Post, BASE + "/People", { name: "n" });
+
+      const [p, c] = await service.batch().add(people).add(created).execute();
+
+      expectTypeOf(p.data).toEqualTypeOf<Person[] | undefined>();
+      expectTypeOf(c.data).toEqualTypeOf<{ id: number } | undefined>();
+    });
+
+    test("the tuple's element types survive startGroup and endGroup", async () => {
+      const { client, service } = makeService();
+      client.batchResponse = { responses: [{ id: "0", status: 200, body: [] }, { id: "1", status: 201, body: { id: 1 } }], resolvedBy: "id" };
+
+      const people = new TestCmd<Person[]>(client, ODataHttpMethods.Get, BASE + "/People");
+      const created = new TestCmd<{ id: number }, { name: string }>(client, ODataHttpMethods.Post, BASE + "/People", { name: "n" });
+
+      const [g, c] = await service.batch().add(people).startGroup("g").add(created).endGroup().execute();
+
+      expectTypeOf(g.data).toEqualTypeOf<Person[] | undefined>();
+      expectTypeOf(c.data).toEqualTypeOf<{ id: number } | undefined>();
+    });
+  });
+});

--- a/packages/odata-service/test/batch/BatchBuilder.test.ts
+++ b/packages/odata-service/test/batch/BatchBuilder.test.ts
@@ -12,7 +12,13 @@ const BASE = "http://example.com/odata";
 class TestCmd<F, D = undefined> extends RequestCmd<F, D, F> {
   private readonly __url: string;
 
-  constructor(client: ODataHttpClient, method: ODataHttpMethods, url: string, data?: D, options?: RequestCmdOptions<F, D>) {
+  constructor(
+    client: ODataHttpClient,
+    method: ODataHttpMethods,
+    url: string,
+    data?: D,
+    options?: RequestCmdOptions<F, D>,
+  ) {
     super(client, method, data, options);
     this.__url = url;
   }
@@ -35,7 +41,10 @@ describe("BatchBuilder via ODataService.batch()", () => {
     const { client, service } = makeService();
     client.batchResponse = { responses: [], resolvedBy: "id" };
 
-    await service.batch().add(new TestCmd(client, ODataHttpMethods.Get, BASE + "/A")).execute();
+    await service
+      .batch()
+      .add(new TestCmd(client, ODataHttpMethods.Get, BASE + "/A"))
+      .execute();
 
     expect(client.lastBatchBody?.requests.map((request) => request.id)).toEqual(["0"]);
 
@@ -71,7 +80,10 @@ describe("BatchBuilder via ODataService.batch()", () => {
     const { client, service } = makeService();
     client.batchResponse = { responses: [], resolvedBy: "id" };
 
-    await service.batch().add(new TestCmd(client, ODataHttpMethods.Get, BASE + "/A")).execute();
+    await service
+      .batch()
+      .add(new TestCmd(client, ODataHttpMethods.Get, BASE + "/A"))
+      .execute();
 
     expect(client.lastBatchUrl).toBe(BASE + "/$batch");
   });
@@ -84,15 +96,7 @@ describe("BatchBuilder via ODataService.batch()", () => {
     const second = new TestCmd(client, ODataHttpMethods.Post, BASE + "/C", { name: "n" });
     const after = new TestCmd(client, ODataHttpMethods.Get, BASE + "/D");
 
-    await service
-      .batch()
-      .add(before)
-      .startGroup("g")
-      .add(first)
-      .add(second)
-      .endGroup()
-      .add(after)
-      .execute();
+    await service.batch().add(before).startGroup("g").add(first).add(second).endGroup().add(after).execute();
 
     const { requests } = client.lastBatchBody!;
     expect(requests[0].atomicityGroup).toBeUndefined();
@@ -129,11 +133,17 @@ describe("BatchBuilder via ODataService.batch()", () => {
     client.batchResponse = { responses: [{ id: "0", status: 200, body: [] }], resolvedBy: "id" };
 
     await expect(
-      service.batch().add(new TestCmd(client, ODataHttpMethods.Get, BASE + "/A")).execute({ format: "json" }),
+      service
+        .batch()
+        .add(new TestCmd(client, ODataHttpMethods.Get, BASE + "/A"))
+        .execute({ format: "json" }),
     ).rejects.toThrow(/V2/);
 
     client.batchResponse = { responses: [{ id: "0", status: 200, body: [] }], resolvedBy: "id" };
-    const [slot] = await service.batch().add(new TestCmd(client, ODataHttpMethods.Get, BASE + "/A")).execute();
+    const [slot] = await service
+      .batch()
+      .add(new TestCmd(client, ODataHttpMethods.Get, BASE + "/A"))
+      .execute();
 
     expect(slot.status).toBe(200);
     expect(client.lastBatchOptions?.format).toBe("multipart");
@@ -149,11 +159,17 @@ describe("BatchBuilder via ODataService.batch()", () => {
     const { client, service } = makeService();
     client.batchResponse = { responses: [{ id: "0", status: 200, body: null }], resolvedBy: "id" };
 
-    await service.batch().add(new TestCmd(client, ODataHttpMethods.Get, BASE + "/A")).execute();
+    await service
+      .batch()
+      .add(new TestCmd(client, ODataHttpMethods.Get, BASE + "/A"))
+      .execute();
     expect(client.lastBatchOptions?.format).toBe("multipart");
 
     client.batchResponse = { responses: [{ id: "0", status: 200, body: null }], resolvedBy: "id" };
-    await service.batch().add(new TestCmd(client, ODataHttpMethods.Get, BASE + "/A")).execute({ format: "json", continueOnError: true });
+    await service
+      .batch()
+      .add(new TestCmd(client, ODataHttpMethods.Get, BASE + "/A"))
+      .execute({ format: "json", continueOnError: true });
     expect(client.lastBatchOptions).toStrictEqual({ format: "json", continueOnError: true });
   });
 
@@ -162,7 +178,10 @@ describe("BatchBuilder via ODataService.batch()", () => {
       const { client, service } = makeService();
       client.batchResponse = { responses: [{ id: "0", status: 200, body: [{ id: 1, name: "a" }] }], resolvedBy: "id" };
 
-      const [slot] = await service.batch().add(new TestCmd<Person[]>(client, ODataHttpMethods.Get, BASE + "/People")).execute();
+      const [slot] = await service
+        .batch()
+        .add(new TestCmd<Person[]>(client, ODataHttpMethods.Get, BASE + "/People"))
+        .execute();
 
       expect(slot.status).toBe(200);
       expect(slot.data).toStrictEqual([{ id: 1, name: "a" }]);
@@ -173,7 +192,10 @@ describe("BatchBuilder via ODataService.batch()", () => {
       const error = { error: { code: "X" } };
       client.batchResponse = { responses: [{ id: "0", status: 400, body: error }], resolvedBy: "id" };
 
-      const [slot] = await service.batch().add(new TestCmd<Person[]>(client, ODataHttpMethods.Get, BASE + "/People")).execute();
+      const [slot] = await service
+        .batch()
+        .add(new TestCmd<Person[]>(client, ODataHttpMethods.Get, BASE + "/People"))
+        .execute();
 
       expect(slot.status).toBe(400);
       expect(slot.data).toStrictEqual(error);
@@ -183,7 +205,10 @@ describe("BatchBuilder via ODataService.batch()", () => {
       const { client, service } = makeService();
       client.batchResponse = { responses: [{ id: "0", status: 424, body: undefined }], resolvedBy: "id" };
 
-      const [slot] = await service.batch().add(new TestCmd<Person[]>(client, ODataHttpMethods.Get, BASE + "/People")).execute();
+      const [slot] = await service
+        .batch()
+        .add(new TestCmd<Person[]>(client, ODataHttpMethods.Get, BASE + "/People"))
+        .execute();
 
       expect(slot.status).toBe(424);
       expect(slot.data).toBeUndefined();
@@ -227,10 +252,12 @@ describe("BatchBuilder via ODataService.batch()", () => {
 
     test("each slot is run through that command's own response converters", async () => {
       const { client, service } = makeService();
-      const cmd = new TestCmd<Person[]>(client, ODataHttpMethods.Get, BASE + "/People").appendResponseConverter((response) => ({
-        ...response,
-        data: response.data.map((person) => ({ ...person, name: person.name.toUpperCase() })),
-      }));
+      const cmd = new TestCmd<Person[]>(client, ODataHttpMethods.Get, BASE + "/People").appendResponseConverter(
+        (response) => ({
+          ...response,
+          data: response.data.map((person) => ({ ...person, name: person.name.toUpperCase() })),
+        }),
+      );
       client.batchResponse = { responses: [{ id: "0", status: 200, body: [{ id: 1, name: "a" }] }], resolvedBy: "id" };
 
       const [slot] = await service.batch().add(cmd).execute();
@@ -246,7 +273,11 @@ describe("BatchBuilder via ODataService.batch()", () => {
       const first = new TestCmd(client, ODataHttpMethods.Post, BASE + "/Members", { name: "n" });
       const second = new TestCmd(client, ODataHttpMethods.Get, BASE + "/Members(1)");
 
-      await service.batch().add(first).add(second, { dependsOn: [first] }).execute();
+      await service
+        .batch()
+        .add(first)
+        .add(second, { dependsOn: [first] })
+        .execute();
 
       expect(client.lastBatchBody?.requests[1].dependsOn).toStrictEqual(["0"]);
     });
@@ -256,7 +287,12 @@ describe("BatchBuilder via ODataService.batch()", () => {
       const outsider = new TestCmd(client, ODataHttpMethods.Get, BASE + "/X");
       const member = new TestCmd(client, ODataHttpMethods.Get, BASE + "/Y");
 
-      await expect(service.batch().add(member, { dependsOn: [outsider] }).execute()).rejects.toThrow(/not part of this batch/);
+      await expect(
+        service
+          .batch()
+          .add(member, { dependsOn: [outsider] })
+          .execute(),
+      ).rejects.toThrow(/not part of this batch/);
     });
   });
 
@@ -266,7 +302,9 @@ describe("BatchBuilder via ODataService.batch()", () => {
       client.batchResponse = { responses: [{ id: "0", status: 200, body: [] }], resolvedBy: "id" };
 
       const people = new TestCmd<Person[]>(client, ODataHttpMethods.Get, BASE + "/People");
-      const created = new TestCmd<{ id: number }, { name: string }>(client, ODataHttpMethods.Post, BASE + "/People", { name: "n" });
+      const created = new TestCmd<{ id: number }, { name: string }>(client, ODataHttpMethods.Post, BASE + "/People", {
+        name: "n",
+      });
 
       const [p, c] = await service.batch().add(people).add(created).execute();
 
@@ -276,10 +314,18 @@ describe("BatchBuilder via ODataService.batch()", () => {
 
     test("the tuple's element types survive startGroup and endGroup", async () => {
       const { client, service } = makeService();
-      client.batchResponse = { responses: [{ id: "0", status: 200, body: [] }, { id: "1", status: 201, body: { id: 1 } }], resolvedBy: "id" };
+      client.batchResponse = {
+        responses: [
+          { id: "0", status: 200, body: [] },
+          { id: "1", status: 201, body: { id: 1 } },
+        ],
+        resolvedBy: "id",
+      };
 
       const people = new TestCmd<Person[]>(client, ODataHttpMethods.Get, BASE + "/People");
-      const created = new TestCmd<{ id: number }, { name: string }>(client, ODataHttpMethods.Post, BASE + "/People", { name: "n" });
+      const created = new TestCmd<{ id: number }, { name: string }>(client, ODataHttpMethods.Post, BASE + "/People", {
+        name: "n",
+      });
 
       const [g, c] = await service.batch().add(people).startGroup("g").add(created).endGroup().execute();
 

--- a/packages/odata-service/test/mock/MockClient.ts
+++ b/packages/odata-service/test/mock/MockClient.ts
@@ -87,7 +87,17 @@ export class MockClient implements ODataHttpClient<MockRequestConfig> {
   public lastRequestConfig?: MockRequestConfig;
   public additionalHeaders?: Record<string, string>;
 
+  public lastBatchUrl?: string;
+  public lastBatchBody?: BatchRequestBody;
+  public lastBatchOptions?: BatchClientOptions;
+
   public responseData?: any;
+  /** The canned `$batch` data the next batch call answers with. */
+  public batchResponse?: BatchResponseBody;
+  /** The status the next batch call answers with. */
+  public batchResponseStatus = 200;
+  /** The headers the next batch call answers with. */
+  public batchResponseHeaders: Record<string, string> = {};
 
   /** How many requests actually reached this client - a write refused before sending must add none. */
   public requestCount = 0;
@@ -236,7 +246,16 @@ export class MockClient implements ODataHttpClient<MockRequestConfig> {
     requestConfig?: MockRequestConfig,
     additionalHeaders?: Record<string, string>,
   ): ODataResponse<BatchResponseBody> {
-    throw new Error("Operation batch not supported!");
+    this.lastBatchUrl = url;
+    this.lastBatchBody = body;
+    this.lastBatchOptions = options;
+
+    return Promise.resolve({
+      status: this.batchResponseStatus,
+      statusText: "OK",
+      headers: this.batchResponseHeaders,
+      data: this.batchResponse ?? { responses: [], resolvedBy: "id" },
+    });
   }
 
   createBlob(

--- a/packages/odata2ts/src/generator/ServiceGenerator.ts
+++ b/packages/odata2ts/src/generator/ServiceGenerator.ts
@@ -345,6 +345,11 @@ class ServiceGenerator {
     if (this.isV401()) {
       options.push(`odataVersionV4: "4.01"`);
     }
+    // only V2 carries this - it is the one runtime fact nothing else can say, and it is what makes
+    // `batch().execute({ format: "json" })` refuse on a V2 service (V2 has no JSON $batch)
+    if (this.version === ODataVersions.V2) {
+      options.push(`odataVersion: "2.0"`);
+    }
     if (this.isV2AsV4()) {
       options.push("v2ResponseAsV4: true");
     }

--- a/packages/odata2ts/test/fixture/generator/service/v2/abstract-and-open-types.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/abstract-and-open-types.ts
@@ -9,7 +9,7 @@ import {
   qExtendedFromOpen,
   QExtendedFromOpenId,
   qOpenEntity,
-  // @ts-ignore
+// @ts-ignore
 } from "./QTester.js";
 import type {
   AbstractEntity,
@@ -22,10 +22,14 @@ import type {
   ExtendedFromOpen,
   ExtendedFromOpenId,
   OpenEntity,
-  // @ts-ignore
+// @ts-ignore
 } from "./TesterModel.js";
 
 export class TesterService extends ODataService {
+  constructor(client: ODataHttpClient, basePath: string, options?: ODataServiceOptions) {
+    super(client, basePath, { ...options, odataVersion: "2.0" });
+  }
+
   public fromAbstract(): ExtendedFromAbstractCollectionService;
   public fromAbstract(id: ExtendedFromAbstractId): ExtendedFromAbstractService;
   public fromAbstract(id?: ExtendedFromAbstractId | undefined) {

--- a/packages/odata2ts/test/fixture/generator/service/v2/abstract-and-open-types.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/abstract-and-open-types.ts
@@ -9,7 +9,7 @@ import {
   qExtendedFromOpen,
   QExtendedFromOpenId,
   qOpenEntity,
-// @ts-ignore
+  // @ts-ignore
 } from "./QTester.js";
 import type {
   AbstractEntity,
@@ -22,7 +22,7 @@ import type {
   ExtendedFromOpen,
   ExtendedFromOpenId,
   OpenEntity,
-// @ts-ignore
+  // @ts-ignore
 } from "./TesterModel.js";
 
 export class TesterService extends ODataService {

--- a/packages/odata2ts/test/fixture/generator/service/v2/complex-type-v2-response-as-v4.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/complex-type-v2-response-as-v4.ts
@@ -16,7 +16,7 @@ import type { Book, BookId, EditableBook, EditableReviewer, Reviewer } from "./T
 
 export class TesterService extends ODataService {
   constructor(client: ODataHttpClient, basePath: string, options?: ODataServiceOptions) {
-    super(client, basePath, { ...options, v2ResponseAsV4: true } as any);
+    super(client, basePath, { ...options, odataVersion: "2.0", v2ResponseAsV4: true } as any);
   }
 
   public books(): BookCollectionService<true>;

--- a/packages/odata2ts/test/fixture/generator/service/v2/complex-type.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/complex-type.ts
@@ -15,6 +15,10 @@ import { qBook, QBookId, qReviewer } from "./QTester.js";
 import type { Book, BookId, EditableBook, EditableReviewer, Reviewer } from "./TesterModel.js";
 
 export class TesterService extends ODataService {
+  constructor(client: ODataHttpClient, basePath: string, options?: ODataServiceOptions) {
+    super(client, basePath, { ...options, odataVersion: "2.0" });
+  }
+
   public books(): BookCollectionService;
   public books(id: BookId): BookService;
   public books(id?: BookId | undefined) {

--- a/packages/odata2ts/test/fixture/generator/service/v2/entity-hierarchy.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/entity-hierarchy.ts
@@ -13,7 +13,7 @@ import type {
   GrandParent,
   GrandParentId,
   Parent,
-// @ts-ignore
+  // @ts-ignore
 } from "./TesterModel.js";
 
 export class TesterService extends ODataService {

--- a/packages/odata2ts/test/fixture/generator/service/v2/entity-hierarchy.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/entity-hierarchy.ts
@@ -13,10 +13,14 @@ import type {
   GrandParent,
   GrandParentId,
   Parent,
-  // @ts-ignore
+// @ts-ignore
 } from "./TesterModel.js";
 
 export class TesterService extends ODataService {
+  constructor(client: ODataHttpClient, basePath: string, options?: ODataServiceOptions) {
+    super(client, basePath, { ...options, odataVersion: "2.0" });
+  }
+
   public tests(): ChildCollectionService;
   public tests(id: ChildId): ChildService;
   public tests(id?: ChildId | undefined) {

--- a/packages/odata2ts/test/fixture/generator/service/v2/entity-relationships.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/entity-relationships.ts
@@ -14,6 +14,10 @@ import { qAuthor, QAuthorId, qBook, QBookId } from "./QTester.js";
 import type { Author, AuthorId, Book, BookId, EditableAuthor, EditableBook } from "./TesterModel.js";
 
 export class TesterService extends ODataService {
+  constructor(client: ODataHttpClient, basePath: string, options?: ODataServiceOptions) {
+    super(client, basePath, { ...options, odataVersion: "2.0" });
+  }
+
   public books(): BookCollectionService;
   public books(id: BookId): BookService;
   public books(id?: BookId | undefined) {

--- a/packages/odata2ts/test/fixture/generator/service/v2/enum-numeric-type.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/enum-numeric-type.ts
@@ -18,6 +18,10 @@ import type { Book, BookId, EditableBook } from "./TesterModel.js";
 import { Choice } from "./TesterModel.js";
 
 export class TesterService extends ODataService {
+  constructor(client: ODataHttpClient, basePath: string, options?: ODataServiceOptions) {
+    super(client, basePath, { ...options, odataVersion: "2.0" });
+  }
+
   public books(): BookCollectionService;
   public books(id: BookId): BookService;
   public books(id?: BookId | undefined) {

--- a/packages/odata2ts/test/fixture/generator/service/v2/enum-type.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/enum-type.ts
@@ -18,6 +18,10 @@ import type { Book, BookId, EditableBook } from "./TesterModel.js";
 import { Choice } from "./TesterModel.js";
 
 export class TesterService extends ODataService {
+  constructor(client: ODataHttpClient, basePath: string, options?: ODataServiceOptions) {
+    super(client, basePath, { ...options, odataVersion: "2.0" });
+  }
+
   public books(): BookCollectionService;
   public books(id: BookId): BookService;
   public books(id?: BookId | undefined) {

--- a/packages/odata2ts/test/fixture/generator/service/v2/function-import-special-params.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/function-import-special-params.ts
@@ -18,6 +18,10 @@ import type { BestBookParams, EditableTestEntity, TestEntity, TestEntityId } fro
 export class TesterService extends ODataService {
   private _qBestBook?: QBestBook;
 
+  constructor(client: ODataHttpClient, basePath: string, options?: ODataServiceOptions) {
+    super(client, basePath, { ...options, odataVersion: "2.0" });
+  }
+
   public tests(): TestEntityCollectionService;
   public tests(id: TestEntityId): TestEntityService;
   public tests(id?: TestEntityId | undefined) {

--- a/packages/odata2ts/test/fixture/generator/service/v2/function-import.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/function-import.ts
@@ -18,7 +18,7 @@ import type {
   PostBestBookParams,
   TestEntity,
   TestEntityId,
-// @ts-ignore
+  // @ts-ignore
 } from "./TesterModel.js";
 
 export class TesterService extends ODataService {

--- a/packages/odata2ts/test/fixture/generator/service/v2/function-import.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/function-import.ts
@@ -18,13 +18,17 @@ import type {
   PostBestBookParams,
   TestEntity,
   TestEntityId,
-  // @ts-ignore
+// @ts-ignore
 } from "./TesterModel.js";
 
 export class TesterService extends ODataService {
   private _qMostPop?: QMostPop;
   private _qBestBook?: QBestBook;
   private _qPostBestBook?: QPostBestBook;
+
+  constructor(client: ODataHttpClient, basePath: string, options?: ODataServiceOptions) {
+    super(client, basePath, { ...options, odataVersion: "2.0" });
+  }
 
   public tests(): TestEntityCollectionService;
   public tests(id: TestEntityId): TestEntityService;

--- a/packages/odata2ts/test/fixture/generator/service/v2/media-entity.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/media-entity.ts
@@ -8,6 +8,10 @@ import { qEBook, QEBookId } from "./QTester.js";
 import type { EBook, EBookId, EditableEBook } from "./TesterModel.js";
 
 export class TesterService extends ODataService {
+  constructor(client: ODataHttpClient, basePath: string, options?: ODataServiceOptions) {
+    super(client, basePath, { ...options, odataVersion: "2.0" });
+  }
+
   public eBooks(): EBookCollectionService;
   public eBooks(id: EBookId): EBookService;
   public eBooks(id?: EBookId | undefined) {

--- a/packages/odata2ts/test/fixture/generator/service/v2/min.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/min.ts
@@ -1,3 +1,8 @@
-import { ODataService } from "@odata2ts/odata-service";
+import type { ODataHttpClient } from "@odata2ts/http-client-api";
+import { ODataService, ODataServiceOptions } from "@odata2ts/odata-service";
 
-export class TesterService extends ODataService {}
+export class TesterService extends ODataService {
+  constructor(client: ODataHttpClient, basePath: string, options?: ODataServiceOptions) {
+    super(client, basePath, { ...options, odataVersion: "2.0" });
+  }
+}

--- a/packages/odata2ts/test/fixture/generator/service/v2/one-entityset-v2-response-as-v4.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/one-entityset-v2-response-as-v4.ts
@@ -16,7 +16,7 @@ import type { EditableTestEntity, TestEntity, TestEntityId } from "./TesterModel
 
 export class TesterService extends ODataService {
   constructor(client: ODataHttpClient, basePath: string, options?: ODataServiceOptions) {
-    super(client, basePath, { ...options, v2ResponseAsV4: true } as any);
+    super(client, basePath, { ...options, odataVersion: "2.0", v2ResponseAsV4: true } as any);
   }
 
   public ents(): TestEntityCollectionService<true>;

--- a/packages/odata2ts/test/fixture/generator/service/v2/one-entityset.ts
+++ b/packages/odata2ts/test/fixture/generator/service/v2/one-entityset.ts
@@ -14,6 +14,10 @@ import { qTestEntity, QTestEntityId } from "./QTester.js";
 import type { EditableTestEntity, TestEntity, TestEntityId } from "./TesterModel.js";
 
 export class TesterService extends ODataService {
+  constructor(client: ODataHttpClient, basePath: string, options?: ODataServiceOptions) {
+    super(client, basePath, { ...options, odataVersion: "2.0" });
+  }
+
   public ents(): TestEntityCollectionService;
   public ents(id: TestEntityId): TestEntityService;
   public ents(id?: TestEntityId | undefined) {


### PR DESCRIPTION
Adds OData `$batch` support to the `odata-service` runtime.

`service.batch()` returns a `BatchBuilder` that accumulates request commands, frames atomicity groups (`startGroup`/`endGroup`), wires `dependsOn`, and executes through the client's `batch()`. Every sub-request comes back as its own `HttpResponseModel`, run through that command's response converters, so a batch slot is indistinguishable from the direct request it wraps.

The five `$batch` outcomes map onto: **Succeeded** (2xx, converted), **Failed** (non-2xx, unconverted), **424** (Failed Dependency), **Rolled Back** (status `0`, a 2xx slot whose group failed) and **Never Ran** (status `0`, no answer at all). `format` defaults to the service's `batch.format` option, itself defaulting to `multipart`.

V2: the generator now emits `odataVersion: "2.0"` on a V2 main service — the one runtime signal a pure-V2 service can give — so `batch()` refuses a `json` batch up front, because V2 has no JSON `$batch`. V4 output is untouched.

Tests:

- 20 `BatchBuilder` unit tests — the five slot outcomes, group framing, `dependsOn`, V2 JSON refusal, disabled/duplicate/binary refusal, and a type-level check that the accumulated tuple types survive `startGroup`/`endGroup`.
- Real-server integration tests: CAP (V4 multipart, top-level `dependsOn`, a failing slot), ASP.NET (JSON + multipart), Olingo V2 (multipart + JSON refusal).

Client-facing `batch()` documentation lands in the `documentation` repo separately.
