### PR TITLE
fix(odata-query-builder): name expand cache-key hops by entity set, not nav property

### DIFF
--- a/packages/odata-query-builder/src/CacheKeyParams.ts
+++ b/packages/odata-query-builder/src/CacheKeyParams.ts
@@ -1,10 +1,14 @@
 /**
- * An expand entry once its navigation property is known: the property's own OData name and kind - the same
- * `(name, kind)` shape a structured hop in the main key already uses. The optional 3rd slot, present only
- * when a nested `expanding()` builder ran for this property, carries *further* expand hops reachable
- * underneath it - nothing else. Identity for a nested query's own filter/select/orderBy/etc. is already
- * covered by the opaque `query` string `RequestCmd.cacheKey` attaches (see `QueryStringCapture.ts` in
- * odata-service); the only thing `touchesResource`/`buildDeepEditHops` ever read out of a nested expand
+ * An expand entry once its navigation property is known: the *target's own entity set name* (never the
+ * navigation property's own OData name, which need not match it) and kind - the same `(name, kind)` shape a
+ * structured hop in the main key already uses, and specifically the shape `[entitySetName, "list"]` a
+ * write's own `invalidates` registers under, so `touchesResource` can find this hop by scanning for that
+ * exact pair. A property reached through a contained (entity-set-less) navigation falls back to its own
+ * OData name, since there is no entity set for a write to ever invalidate by anyway. The optional 3rd slot,
+ * present only when a nested `expanding()` builder ran for this property, carries *further* expand hops
+ * reachable underneath it - nothing else. Identity for a nested query's own filter/select/orderBy/etc. is
+ * already covered by the opaque `query` string `RequestCmd.cacheKey` attaches (see `QueryStringCapture.ts`
+ * in odata-service); the only thing `touchesResource`/`buildDeepEditHops` ever read out of a nested expand
  * entry is more `(name, kind)` hops to keep recursing into.
  */
 export type ExpandHop = readonly [

--- a/packages/odata-query-builder/src/ODataQueryBuilder.ts
+++ b/packages/odata-query-builder/src/ODataQueryBuilder.ts
@@ -67,6 +67,13 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
    * `rawForm` is exactly what this same call also pushed into `expands` - needed to tell a direct entry
    * apart from a hoisted one reconciled back from `expands` after `build()` has folded
    * `hoistedExpandsBucket` into it, without depending on whether that fold has happened yet.
+   *
+   * `entitySetName` is the *target's* entity set name, read off the same nav property's own `getBinding()`
+   * (absent for a contained target, which has none) - this, not `path`, is what an `ExpandHop`'s own name
+   * must carry: `invalidates` (`buildInvalidates`, odata-service) registers a write under its bare
+   * `[entitySetName, "list"]` entry, and `touchesResource` finds an expand hop only by scanning for that
+   * exact shape - a nav property whose OData name differs from its target's entity set name (the common
+   * case) would otherwise never match, silently breaking invalidation through `$expand`.
    */
   private expandEntries:
     | Array<{
@@ -74,6 +81,7 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
         kind?: "list" | "detail";
         rawForm: string;
         nestedBuilder?: ODataQueryBuilder<any>;
+        entitySetName?: string;
       }>
     | undefined;
 
@@ -234,7 +242,8 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
               ? ("list" as const)
               : ("detail" as const)
             : undefined;
-          return { path, rawForm: path, kind };
+          const entitySetName = entityProp?.getBinding?.()?.getEntitySetName();
+          return { path, rawForm: path, kind, entitySetName };
         }),
       );
     }
@@ -294,6 +303,7 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
         rawForm: content,
         kind: entityProp.isCollectionType() ? "list" : "detail",
         nestedBuilder: nestedEngine,
+        entitySetName: entityProp.getBinding?.()?.getEntitySetName(),
       });
     }
     if (hoistedExpands.length) {
@@ -483,8 +493,9 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
    * The `$expand`/`$select`/`$filter`/`$search` structure this builder's resource needs a cache key to
    * carry - not the query's full identity, which `RequestCmd.cacheKey` (odata-service) captures separately
    * as one opaque string for everything else off the actual request. `$expand` stays hop-shaped because
-   * invalidation reach (`touchesResource`, `buildDeepEditHops`) needs to find a navigation property by
-   * name; `$select` stays a plain sorted array for a currently-nonexistent future consumer; `$filter`/
+   * invalidation reach (`touchesResource`, `buildDeepEditHops`) needs to find a hop by its target's *entity
+   * set* name - the same name a write's own `invalidates` registers under, which a bare navigation-property
+   * name need not match; `$select` stays a plain sorted array for a currently-nonexistent future consumer; `$filter`/
    * `$search` are rendered canonically here (sorted, `$filter` also safely grouped - see
    * `CacheKeyParams.ts`) so that call-site clause ordering converges, but `RequestCmd.cacheKey` folds that
    * canonical text into the same opaque string as everything else rather than exposing it as its own
@@ -502,15 +513,18 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
     // expand()/expanding()/addExpands() are the only ways to populate `expands`, and every one of them
     // also pushes onto expandEntries in the same call - so expandEntries alone is a complete, structured
     // account of every *direct* expand target on this builder. `kind`'s presence is what marks a real hop:
-    // `path` is already the property's own odataName, read straight off its Q-object wrapper at the point
-    // expand()/expanding() was called - no generated table, no type, needed to enrich it further.
+    // `path` (used for sorting, and as the entry itself where there is no `entitySetName` to prefer) is the
+    // property's own odataName, read straight off its Q-object wrapper at the point expand()/expanding() was
+    // called; the hop's own name, though, prefers `entitySetName` - see the `entitySetName` doc comment on
+    // `expandEntries` above for why a bare nav-property name cannot serve as that name.
     const expandItems: Array<{ sortKey: string; entry: string | ExpandHop }> = entries.map(
-      ({ path, kind, nestedBuilder }) => {
+      ({ path, kind, nestedBuilder, entitySetName }) => {
         if (!kind) {
           return { sortKey: path, entry: path };
         }
         const nested = nestedBuilder?.getCacheKeyParams();
-        const expandHop: ExpandHop = nested?.expand ? [path, kind, { expand: nested.expand }] : [path, kind];
+        const name = entitySetName ?? path;
+        const expandHop: ExpandHop = nested?.expand ? [name, kind, { expand: nested.expand }] : [name, kind];
         return { sortKey: path, entry: expandHop };
       },
     );

--- a/packages/odata-query-builder/test/CacheKeyParams.test.ts
+++ b/packages/odata-query-builder/test/CacheKeyParams.test.ts
@@ -1,7 +1,40 @@
+import {
+  QBinding,
+  QEntityCollectionPath,
+  QId,
+  QNumberParam,
+  QNumberPath,
+  QParamModel,
+  QueryObject,
+} from "@odata2ts/odata-query-objects";
 import { beforeEach, describe, expect, test } from "vitest";
 import { createExpandingQueryBuilderV4 } from "../src";
 import { ODataQueryBuilder } from "../src/ODataQueryBuilder";
 import { QPerson, qPerson } from "./fixture/types/QSimplePersonModel";
+
+/**
+ * The nav property's own OData name ("copies") deliberately differs in case from its target's entity set
+ * name ("Copies") - the exact shape a real service produces, and the one an expand hop's name must resolve
+ * against (via `getBinding()`), not the nav property's own name (`getPath()`).
+ */
+class QCopy extends QueryObject {
+  public readonly id = new QNumberPath(this.withPrefix("Id"));
+}
+
+class QCopyId extends QId<number> {
+  getParams(): Array<QParamModel<any, any>> {
+    return [new QNumberParam("Id", "id")];
+  }
+}
+
+class QMedia extends QueryObject {
+  public readonly id = new QNumberPath(this.withPrefix("Id"));
+  public readonly copies = new QEntityCollectionPath(
+    this.withPrefix("copies"),
+    () => QCopy,
+    new QBinding(() => new QCopyId("Copies"), "4.0"),
+  );
+}
 
 describe("CacheKeyParams", () => {
   let builder: ODataQueryBuilder<QPerson>;
@@ -100,6 +133,18 @@ describe("CacheKeyParams", () => {
       expect(builder.getCacheKeyParams()).toEqual({
         expand: [["friends", "list", { expand: [["bestFriend", "detail"]] }]],
       });
+    });
+
+    test("expand() names a bound hop by its target's entity set, not the nav property's own OData name - so a write's `[entitySetName, 'list']` invalidates entry can find it", () => {
+      const media = new ODataQueryBuilder("Media", new QMedia());
+      media.expand(["copies"]);
+      expect(media.getCacheKeyParams()).toEqual({ expand: [["Copies", "list"]] });
+    });
+
+    test("expanding() enriches a bound hop the same way as a bare expand()", () => {
+      const media = new ODataQueryBuilder("Media", new QMedia());
+      media.expanding(createExpandingQueryBuilderV4, "copies", () => {});
+      expect(media.getCacheKeyParams()).toEqual({ expand: [["Copies", "list"]] });
     });
   });
 


### PR DESCRIPTION
## Summary

- `$expand` cache-key hops were named after the navigation property's own OData name (`getPath()`), not the target's entity set name.
- `touchesResource`/`buildInvalidates` match an expand hop against a write's bare `[entitySetName, "list"]` invalidation entry, so a nav property whose OData name differs from its target's entity set (e.g. `copies` → `Copies`) could never be invalidated: a write to a `Copy` would never invalidate a query that expanded it.
- Fixed by reading the target's entity set name off the same `QBinding.getEntitySetName()` a hierarchical hop already uses, falling back to the property's own OData name only where it has none (a contained navigation property).

## Test plan

- [x] Added regression tests in `packages/odata-query-builder/test/CacheKeyParams.test.ts` covering both `expand()` and `expanding()` against a bound nav property whose name differs from its entity set name
- [x] Full monorepo build + test (`odata-query-objects`, `odata2ts`, `odata-query-builder`, `odata-service`) all pass
- [x] `yarn check-format` clean