### PR TITLE
feat(odata2ts): add namespace aliasing for cache keys, config matchers, folder layout

### DIFF
--- a/int-test/asp-net/odata2ts.config.ts
+++ b/int-test/asp-net/odata2ts.config.ts
@@ -140,6 +140,35 @@ const config: ConfigFileOptions = {
       // create, and after this release only `Branch` and `Copy` still are one.
       keyProperties: KeyProperties.strict,
     },
+    /**
+     * The same model once more, with namespace aliasing switched on - see `odata2ts-namespace-alias.md`.
+     *
+     * This is the one client this whole package is a good case for: the reference model's four namespaces
+     * (`Library.Catalog`, `Library.Circulation`, `PublisherRegistry`, and `Library.Service`, which declares
+     * no types of its own and so never gets a folder) let a project-configured alias, the three remaining
+     * auto-synthesized ones, and folder-layout opt-in all show up together in one real client.
+     *
+     * Generated separately rather than replacing the raw `library` client above, exactly like every other
+     * axis in this file: `useAliasForFolderName` moves physical files, and doing that to the client every
+     * other test file already imports from would make this feature's own test additions indistinguishable
+     * from an unrelated, unintended folder-layout change to the rest of the suite.
+     *
+     * `PublisherRegistry` declares no subtype cast and no bound operation of its own, so there is no
+     * cache-key literal to prove its alias through - `useAliasForFolderName` (the generated import paths in
+     * test/feature/NamespaceAlias.test.ts) is what proves it out here instead. `Library.Catalog` and
+     * `Library.Circulation` do have a cast and a bound action respectively, which is what proves the
+     * auto-synthesized aliases through an actual cache-key literal. See test/feature/NamespaceAlias.test.ts.
+     */
+    libraryNamespaceAlias: {
+      serviceName: "LibraryNamespaceAlias",
+      source: SOURCE,
+      output: "src-generated/library-namespace-alias",
+      cacheKeys: true,
+      namespace: {
+        alias: { PublisherRegistry: "Pub" },
+        useAliasForFolderName: true,
+      },
+    },
   },
 };
 

--- a/int-test/asp-net/odata2ts.config.ts
+++ b/int-test/asp-net/odata2ts.config.ts
@@ -145,8 +145,9 @@ const config: ConfigFileOptions = {
      *
      * This is the one client this whole package is a good case for: the reference model's four namespaces
      * (`Library.Catalog`, `Library.Circulation`, `PublisherRegistry`, and `Library.Service`, which declares
-     * no types of its own and so never gets a folder) let a project-configured alias, the three remaining
-     * auto-synthesized ones, and folder-layout opt-in all show up together in one real client.
+     * no types of its own and so never gets a folder) let three project-configured aliases and folder-layout
+     * opt-in all show up together in one real client. There is no auto-synthesis - every alias here is
+     * explicit, on purpose.
      *
      * Generated separately rather than replacing the raw `library` client above, exactly like every other
      * axis in this file: `useAliasForFolderName` moves physical files, and doing that to the client every
@@ -156,8 +157,8 @@ const config: ConfigFileOptions = {
      * `PublisherRegistry` declares no subtype cast and no bound operation of its own, so there is no
      * cache-key literal to prove its alias through - `useAliasForFolderName` (the generated import paths in
      * test/feature/NamespaceAlias.test.ts) is what proves it out here instead. `Library.Catalog` and
-     * `Library.Circulation` do have a cast and a bound action respectively, which is what proves the
-     * auto-synthesized aliases through an actual cache-key literal. See test/feature/NamespaceAlias.test.ts.
+     * `Library.Circulation` do have a cast and a bound action respectively, which is what proves the other
+     * two aliases through an actual cache-key literal. See test/feature/NamespaceAlias.test.ts.
      */
     libraryNamespaceAlias: {
       serviceName: "LibraryNamespaceAlias",
@@ -165,7 +166,11 @@ const config: ConfigFileOptions = {
       output: "src-generated/library-namespace-alias",
       cacheKeys: true,
       namespace: {
-        alias: { PublisherRegistry: "Pub" },
+        alias: {
+          "Library.Catalog": "Catalog",
+          "Library.Circulation": "Circulation",
+          PublisherRegistry: "Pub",
+        },
         useAliasForFolderName: true,
       },
     },

--- a/int-test/asp-net/test/LibraryTestConstants.ts
+++ b/int-test/asp-net/test/LibraryTestConstants.ts
@@ -1,5 +1,6 @@
 import { FetchClient } from "@odata2ts/http-client-fetch";
 import { inject } from "vitest";
+import { LibraryNamespaceAliasService } from "../src-generated/library-namespace-alias/LibraryNamespaceAliasService.js";
 import { LibraryRenamedService } from "../src-generated/library-renamed/LibraryRenamedService.js";
 import { LibraryStrictService } from "../src-generated/library-strict/LibraryStrictService.js";
 import { LibraryService } from "../src-generated/library/LibraryService.js";
@@ -21,6 +22,12 @@ export const LIBRARY_RENAMED = new LibraryRenamedService(ODATA_CLIENT, BASE_URL)
  * what makes the difference between the two observable at all.
  */
 export const LIBRARY_STRICT = new LibraryStrictService(ODATA_CLIENT, BASE_URL);
+
+/**
+ * The same service through the client generated with namespace aliasing switched on. Only
+ * `NamespaceAlias.test.ts` uses it: everywhere else the raw namespace is what a cache-key literal carries.
+ */
+export const LIBRARY_NAMESPACE_ALIAS = new LibraryNamespaceAliasService(ODATA_CLIENT, BASE_URL);
 
 // Fixed keys from the server's seed data.
 

--- a/int-test/asp-net/test/feature/NamespaceAlias.test.ts
+++ b/int-test/asp-net/test/feature/NamespaceAlias.test.ts
@@ -2,10 +2,11 @@ import { afterAll, describe, expect, test } from "vitest";
 import { LIBRARY_NAMESPACE_ALIAS } from "../LibraryTestConstants.js";
 
 /**
- * `namespace.alias`/auto-synthesis (`odata2ts-namespace-alias.md`), against the one server whose reference
- * model has all four namespaces this feature cares about: `Library.Catalog`, `Library.Circulation`,
- * `PublisherRegistry` (project-configured to `Pub` here), and `Library.Service` (which declares no types of
- * its own, so it never gets a folder and carries no cache-key literal either).
+ * `namespace.alias` (`odata2ts-namespace-alias.md`), against the one server whose reference model has all
+ * four namespaces this feature cares about: `Library.Catalog` (aliased to `Catalog`), `Library.Circulation`
+ * (aliased to `Circulation`), `PublisherRegistry` (aliased to `Pub`), and `Library.Service` (which declares
+ * no types of its own, so it never gets a folder and carries no cache-key literal either). Every alias here
+ * is explicit, project-configured - there is no auto-synthesis.
  *
  * `LIBRARY_NAMESPACE_ALIAS` is a separate client from `LIBRARY` (see the config's own comment): every other
  * assertion in this package is unaffected by aliasing, and this is the one client where it is switched on.
@@ -19,7 +20,7 @@ describe("ASP.NET Library: namespace aliasing", () => {
     }
   });
 
-  test("a subtype cast's cache-key literal carries the auto-synthesized alias, not the raw namespace", async () => {
+  test("a subtype cast's cache-key literal carries the configured alias, not the raw namespace", async () => {
     // the single-entity cast form (`Media(<id>)/Library.Catalog.Book`) is one of the things this server does
     // not serve (see the package README) - the collection form is, and is all a cast's own cache-key literal
     // needs to prove out anyway
@@ -31,7 +32,7 @@ describe("ASP.NET Library: namespace aliasing", () => {
     expect(result.data.value.length).toBeGreaterThan(0);
   });
 
-  test("a bound operation's cache-key literal carries the auto-synthesized alias too", async () => {
+  test("a bound operation's cache-key literal carries the configured alias too", async () => {
     // OutstandingBalance is a bound *function* (GET, read-only) - unlike the bound actions on this same
     // entity, calling it has no side effect on data other tests depend on
     const created = await LIBRARY_NAMESPACE_ALIAS.Members()

--- a/int-test/asp-net/test/feature/NamespaceAlias.test.ts
+++ b/int-test/asp-net/test/feature/NamespaceAlias.test.ts
@@ -1,0 +1,55 @@
+import { afterAll, describe, expect, test } from "vitest";
+import { LIBRARY_NAMESPACE_ALIAS } from "../LibraryTestConstants.js";
+
+/**
+ * `namespace.alias`/auto-synthesis (`odata2ts-namespace-alias.md`), against the one server whose reference
+ * model has all four namespaces this feature cares about: `Library.Catalog`, `Library.Circulation`,
+ * `PublisherRegistry` (project-configured to `Pub` here), and `Library.Service` (which declares no types of
+ * its own, so it never gets a folder and carries no cache-key literal either).
+ *
+ * `LIBRARY_NAMESPACE_ALIAS` is a separate client from `LIBRARY` (see the config's own comment): every other
+ * assertion in this package is unaffected by aliasing, and this is the one client where it is switched on.
+ */
+describe("ASP.NET Library: namespace aliasing", () => {
+  let memberId: number | undefined;
+
+  afterAll(async () => {
+    if (memberId !== undefined) {
+      await LIBRARY_NAMESPACE_ALIAS.Members(memberId).delete().execute();
+    }
+  });
+
+  test("a subtype cast's cache-key literal carries the auto-synthesized alias, not the raw namespace", async () => {
+    // the single-entity cast form (`Media(<id>)/Library.Catalog.Book`) is one of the things this server does
+    // not serve (see the package README) - the collection form is, and is all a cast's own cache-key literal
+    // needs to prove out anyway
+    const request = LIBRARY_NAMESPACE_ALIAS.Media().asBookCollectionService().query();
+    expect(request.cacheKey).toEqual(["Media", "list", { cast: "Catalog.Book" }]);
+
+    const result = await request.execute();
+    expect(result.status).toBe(200);
+    expect(result.data.value.length).toBeGreaterThan(0);
+  });
+
+  test("a bound operation's cache-key literal carries the auto-synthesized alias too", async () => {
+    // OutstandingBalance is a bound *function* (GET, read-only) - unlike the bound actions on this same
+    // entity, calling it has no side effect on data other tests depend on
+    const created = await LIBRARY_NAMESPACE_ALIAS.Members()
+      .create({ Name: "NamespaceAlias Test", PreviousAddresses: [] })
+      .execute();
+    expect(created.status).toBe(201);
+    memberId = created.data.Id;
+
+    const request = LIBRARY_NAMESPACE_ALIAS.Members(memberId).OutstandingBalance();
+    expect(request.cacheKey).toEqual(["Members", "detail", memberId, "Circulation.OutstandingBalance"]);
+
+    const result = await request.execute();
+    expect(result.status).toBe(200);
+    expect(typeof result.data.value).toBe("number");
+  });
+
+  test("PublisherRegistry's project-configured alias has no cast or bound operation to prove itself through a cache-key literal - useAliasForFolderName is what proves it instead: this very import only resolves if the generated folder is really named `pub`, not `publisher-registry`", async () => {
+    const { QBranch } = await import("../../src-generated/library-namespace-alias/pub/branch/QBranch.js");
+    expect(new QBranch()).toBeInstanceOf(QBranch);
+  });
+});

--- a/int-test/cap/test/feature/CacheKeys.test.ts
+++ b/int-test/cap/test/feature/CacheKeys.test.ts
@@ -97,6 +97,14 @@ describe("CAP Library: cache keys (V4)", () => {
     expect(result.data.value.some((book) => book.Title === "Der Prozess")).toBe(true);
   });
 
+  test("a bound operation's cache-key literal carries the auto-synthesized namespace alias, not the raw namespace - the single-namespace case `odata2ts-namespace-alias.md` is written against (Library.Service has no second namespace to disambiguate from, but still synthesizes the same way a multi-namespace service would)", async () => {
+    const request = LIBRARY.Books().AvailableLanguages();
+    expect(request.cacheKey).toEqual(["Books", "list", "Service.AvailableLanguages"]);
+
+    const result = await request.execute();
+    expect(result.status).toBe(200);
+  });
+
   test("a groupBy ($apply) query produces a cache key distinct from the same query without it", () => {
     // the concrete regression this whole opaque-query-string redesign fixes: $apply used to be silently
     // excluded from the cache key, so an aggregated query collapsed onto its non-aggregated counterpart

--- a/int-test/cap/test/feature/CacheKeys.test.ts
+++ b/int-test/cap/test/feature/CacheKeys.test.ts
@@ -97,14 +97,6 @@ describe("CAP Library: cache keys (V4)", () => {
     expect(result.data.value.some((book) => book.Title === "Der Prozess")).toBe(true);
   });
 
-  test("a bound operation's cache-key literal carries the auto-synthesized namespace alias, not the raw namespace - the single-namespace case `odata2ts-namespace-alias.md` is written against (Library.Service has no second namespace to disambiguate from, but still synthesizes the same way a multi-namespace service would)", async () => {
-    const request = LIBRARY.Books().AvailableLanguages();
-    expect(request.cacheKey).toEqual(["Books", "list", "Service.AvailableLanguages"]);
-
-    const result = await request.execute();
-    expect(result.status).toBe(200);
-  });
-
   test("a groupBy ($apply) query produces a cache key distinct from the same query without it", () => {
     // the concrete regression this whole opaque-query-string redesign fixes: $apply used to be silently
     // excluded from the cache key, so an aggregated query collapsed onto its non-aggregated counterpart

--- a/packages/odata2ts/src/OptionModel.ts
+++ b/packages/odata2ts/src/OptionModel.ts
@@ -262,6 +262,33 @@ export function resolveCacheKeysEnabled(options: CacheKeysOptions | undefined): 
 }
 
 /**
+ * Shortens a namespace wherever its length actually matters: cache-key literals that carry a fully
+ * qualified name (a subtype cast, a bound operation's own name), `byTypeAndName`/`propertiesByName`
+ * matchers, and - opt-in - generated folder paths. See `NamespaceAliasResolver.resolveNamespaceAliases` for
+ * the three-source precedence (server-declared, then this option, then auto-synthesis) and the validation
+ * rules a misconfigured `alias` entry triggers.
+ */
+export interface NamespaceOptions {
+  /**
+   * Fills a namespace the server does not already declare an `Alias` for, e.g. `{ "Library.Catalog": "Cat" }`.
+   * Configuring an alias for a namespace the server already aliases is a hard error - the server's own
+   * alias is authoritative and always wins, so a project value would silently never take effect otherwise.
+   */
+  alias?: Record<string, string>;
+  /**
+   * Turns off auto-synthesis: a namespace neither the server nor `alias` covers keeps its full, unaliased
+   * name instead of odata2ts guessing one from the namespace's own last dot-segment. Default `false`.
+   */
+  disableAutoAlias?: boolean;
+  /**
+   * Opts generated folder/file paths (only consulted under `bundledFileGeneration`) into the effective
+   * alias in place of the real namespace. Default `false` - folder layout is unaffected otherwise, even
+   * where a namespace ends up aliased for every other consumer.
+   */
+  useAliasForFolderName?: boolean;
+}
+
+/**
  * Config options for CLI.
  */
 export interface CliOptions {
@@ -590,6 +617,12 @@ export interface ConfigFileOptions extends Omit<CliOptions, "sourceUrl" | "sourc
    * future option to join it under the same key without a breaking change.
    */
   cacheKeys?: CacheKeysOptions;
+  /**
+   * Configures namespace aliasing - see {@link NamespaceOptions}. Deep-merged the same way as
+   * `byTypeAndName`: a top-level `alias` map and a service-level one merge key-by-key, the service-level
+   * entry winning where both name the same namespace.
+   */
+  namespace?: NamespaceOptions;
 }
 
 /**

--- a/packages/odata2ts/src/OptionModel.ts
+++ b/packages/odata2ts/src/OptionModel.ts
@@ -265,8 +265,8 @@ export function resolveCacheKeysEnabled(options: CacheKeysOptions | undefined): 
  * Shortens a namespace wherever its length actually matters: cache-key literals that carry a fully
  * qualified name (a subtype cast, a bound operation's own name), `byTypeAndName`/`propertiesByName`
  * matchers, and - opt-in - generated folder paths. See `NamespaceAliasResolver.resolveNamespaceAliases` for
- * the three-source precedence (server-declared, then this option, then auto-synthesis) and the validation
- * rules a misconfigured `alias` entry triggers.
+ * the two-source precedence (server-declared, then this option) and the validation rules a misconfigured
+ * `alias` entry triggers.
  */
 export interface NamespaceOptions {
   /**
@@ -275,11 +275,6 @@ export interface NamespaceOptions {
    * alias is authoritative and always wins, so a project value would silently never take effect otherwise.
    */
   alias?: Record<string, string>;
-  /**
-   * Turns off auto-synthesis: a namespace neither the server nor `alias` covers keeps its full, unaliased
-   * name instead of odata2ts guessing one from the namespace's own last dot-segment. Default `false`.
-   */
-  disableAutoAlias?: boolean;
   /**
    * Opts generated folder/file paths (only consulted under `bundledFileGeneration`) into the effective
    * alias in place of the real namespace. Default `false` - folder layout is unaffected otherwise, even

--- a/packages/odata2ts/src/data-model/DataModel.ts
+++ b/packages/odata2ts/src/data-model/DataModel.ts
@@ -88,8 +88,8 @@ export class DataModel {
 
   /**
    * The display form of a fully qualified name: an aliased namespace prefix replaced by its effective
-   * alias, exactly where `namespace2Alias` carries one for it - server-declared, project-configured, or
-   * auto-synthesized, already blended into that one table by the time this runs (see
+   * alias, exactly where `namespace2Alias` carries one for it - server-declared or project-configured,
+   * already blended into that one table by the time this runs (see
    * `NamespaceAliasResolver.resolveNamespaceAliases`, and how the digester feeds its result into this very
    * constructor). `fqName` itself never changes here - every internal lookup (`models`,
    * `ImportContainer.addGenerated*`, error messages) keeps keying off the real, alias-free name; this is

--- a/packages/odata2ts/src/data-model/DataModel.ts
+++ b/packages/odata2ts/src/data-model/DataModel.ts
@@ -62,6 +62,8 @@ export class DataModel {
    */
   private typeDefinitions = new Map<string, string>();
   private readonly namespace2Alias: { [ns: string]: string };
+  /** `namespace2Alias`'s own keys, longest first, so a namespace nested inside another aliased one resolves against the more specific match - see {@link getDisplayFqName}. */
+  private readonly aliasedNamespacesLongestFirst: Array<string>;
   private aliases: Record<string, string> = {};
   private container: EntityContainerModel = { entitySets: {}, singletons: {}, functions: {}, actions: {} };
   private navPropBindings?: Map<string, EntitySetType>;
@@ -73,11 +75,37 @@ export class DataModel {
   ) {
     this.converters = converters;
     this.namespace2Alias = namespaces.reduce<Record<string, string>>((col, [ns, alias]) => {
-      if (alias) {
+      // `alias !== undefined`, not truthy: an explicitly configured `alias: ""` (see `NamespaceOptions`,
+      // NamespaceAliasResolver) is a deliberate way to drop a namespace's prefix entirely and must be
+      // stored, not treated the same as "no alias at all" the way a plain falsy check would.
+      if (alias !== undefined) {
         col[ns] = alias;
       }
       return col;
     }, {});
+    this.aliasedNamespacesLongestFirst = Object.keys(this.namespace2Alias).sort((a, b) => b.length - a.length);
+  }
+
+  /**
+   * The display form of a fully qualified name: an aliased namespace prefix replaced by its effective
+   * alias, exactly where `namespace2Alias` carries one for it - server-declared, project-configured, or
+   * auto-synthesized, already blended into that one table by the time this runs (see
+   * `NamespaceAliasResolver.resolveNamespaceAliases`, and how the digester feeds its result into this very
+   * constructor). `fqName` itself never changes here - every internal lookup (`models`,
+   * `ImportContainer.addGenerated*`, error messages) keeps keying off the real, alias-free name; this is
+   * purely an output-side view over it, for a cache-key literal that must still carry the fully qualified
+   * name (a subtype cast, a bound operation's own name) now written more compactly.
+   */
+  public getDisplayFqName(fqName: string): string {
+    for (const ns of this.aliasedNamespacesLongestFirst) {
+      if (fqName === ns) {
+        return this.namespace2Alias[ns];
+      }
+      if (fqName.startsWith(ns + ".")) {
+        return withNamespace(this.namespace2Alias[ns], fqName.slice(ns.length + 1));
+      }
+    }
+    return fqName;
   }
 
   /**

--- a/packages/odata2ts/src/data-model/DataModelDigestion.ts
+++ b/packages/odata2ts/src/data-model/DataModelDigestion.ts
@@ -135,6 +135,15 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
    */
   private synthesizedEnums = new Map<string, SynthesizedEnum>();
 
+  /**
+   * Every namespace's effective alias (server-declared, project-configured, or auto-synthesized) - read
+   * straight off `namingHelper`, which already resolved and validated it at its own construction (see
+   * `NamingHelper.getEffectiveNamespaceAlias`), rather than recomputed here from `options.namespace`. Feeds
+   * every `NamespaceWithAlias` tuple this digester builds, `DataModel`'s included, so `namespace2Alias` (and
+   * everything reading it, `getDisplayFqName` included) carries all three sources blended into one table.
+   */
+  private readonly effectiveNamespaceAlias: Record<string, string>;
+
   protected constructor(
     protected version: ODataVersion,
     protected schemas: Array<S>,
@@ -143,7 +152,11 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
     converters?: MappedConverterChains,
     protected references?: Array<Reference>,
   ) {
-    const namespaces = schemas.map<NamespaceWithAlias>((s) => [s.$.Namespace, s.$.Alias]);
+    this.effectiveNamespaceAlias = namingHelper.getEffectiveNamespaceAlias();
+    const namespaces = schemas.map<NamespaceWithAlias>((s) => [
+      s.$.Namespace,
+      this.effectiveNamespaceAlias[s.$.Namespace],
+    ]);
     this.dataModel = new DataModel(namespaces, version, converters);
     this.serviceConfigHelper = new ServiceConfigHelper(options);
     this.nameValidator = options.bundledFileGeneration ? new NameClashValidator(options) : new NamespaceNameValidator();
@@ -327,7 +340,7 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
     }
 
     this.schemas.forEach((schema) => {
-      const ns: NamespaceWithAlias = [schema.$.Namespace, schema.$.Alias];
+      const ns: NamespaceWithAlias = [schema.$.Namespace, this.effectiveNamespaceAlias[schema.$.Namespace]];
 
       // type definitions: alias for primitive types
       this.addTypeDefinition(schema.$.Namespace, schema.TypeDefinition);

--- a/packages/odata2ts/src/data-model/DataModelDigestion.ts
+++ b/packages/odata2ts/src/data-model/DataModelDigestion.ts
@@ -136,11 +136,11 @@ export abstract class Digester<S extends Schema<ET, CT>, ET extends EntityType, 
   private synthesizedEnums = new Map<string, SynthesizedEnum>();
 
   /**
-   * Every namespace's effective alias (server-declared, project-configured, or auto-synthesized) - read
-   * straight off `namingHelper`, which already resolved and validated it at its own construction (see
+   * Every namespace's effective alias (server-declared or project-configured) - read straight off
+   * `namingHelper`, which already resolved and validated it at its own construction (see
    * `NamingHelper.getEffectiveNamespaceAlias`), rather than recomputed here from `options.namespace`. Feeds
    * every `NamespaceWithAlias` tuple this digester builds, `DataModel`'s included, so `namespace2Alias` (and
-   * everything reading it, `getDisplayFqName` included) carries all three sources blended into one table.
+   * everything reading it, `getDisplayFqName` included) carries both sources blended into one table.
    */
   private readonly effectiveNamespaceAlias: Record<string, string>;
 

--- a/packages/odata2ts/src/data-model/NamespaceAliasResolver.ts
+++ b/packages/odata2ts/src/data-model/NamespaceAliasResolver.ts
@@ -1,0 +1,124 @@
+import { NamespaceOptions } from "../OptionModel.js";
+import { NamespaceWithAlias } from "./DataModel.js";
+
+const SIMPLE_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function isValidAliasValue(alias: string): boolean {
+  return alias === "" || SIMPLE_IDENTIFIER.test(alias);
+}
+
+function lastDotSegment(namespace: string): string {
+  const lastDot = namespace.lastIndexOf(".");
+  return lastDot < 0 ? namespace : namespace.slice(lastDot + 1);
+}
+
+/**
+ * Resolves every namespace's *effective* alias from the three sources `odata2ts-namespace-alias.md`
+ * describes, in fixed precedence: a server-declared `<Schema Alias="...">` (`rawNamespaces`' own alias
+ * slot) always wins, a project-configured `namespace.alias` fills whatever the server left unaliased, and
+ * odata2ts synthesizes its own guess - the namespace's last dot-segment - for whatever both leave a gap,
+ * unless `disableAutoAlias` turns that off.
+ *
+ * Returns one flat map from real namespace to effective alias, covering only the namespaces that end up
+ * with one - the single already-merged table every consumer (`DataModel.namespace2Alias`,
+ * `ServiceConfigHelper`'s per-call `NamespaceWithAlias` tuples, `NamingHelper.getFolderPath`,
+ * `DataModel.getDisplayFqName`) reads from, so none of them need to know which of the three sources
+ * actually supplied a given value.
+ *
+ * Throws where a project setting is unambiguously wrong (an alias for an unknown or already-aliased
+ * namespace, an alias that isn't a valid CSDL `SimpleIdentifier`) or would silently collapse two namespaces
+ * onto the same alias. A synthesized alias that would collide is instead dropped without error: nobody
+ * asked for it, so it must never be able to break a build the way a rejected explicit setting legitimately
+ * can - see the spec's "Auto-synthesis" section.
+ */
+export function resolveNamespaceAliases(
+  rawNamespaces: ReadonlyArray<NamespaceWithAlias>,
+  options: Pick<NamespaceOptions, "alias" | "disableAutoAlias"> | undefined,
+): Record<string, string> {
+  const allNamespaces = rawNamespaces.map(([ns]) => ns);
+  const namespaceSet = new Set(allNamespaces);
+
+  const serverAlias = new Map<string, string>();
+  for (const [ns, alias] of rawNamespaces) {
+    if (alias) {
+      serverAlias.set(ns, alias);
+    }
+  }
+
+  const configuredAlias = options?.alias ?? {};
+  for (const [ns, alias] of Object.entries(configuredAlias)) {
+    if (!namespaceSet.has(ns)) {
+      throw new Error(
+        `namespace.alias configures an alias for namespace "${ns}", but the digested metadata does not contain that namespace!`,
+      );
+    }
+    if (serverAlias.has(ns)) {
+      throw new Error(
+        `namespace.alias configures an alias for namespace "${ns}", but the server already declares alias ` +
+          `"${serverAlias.get(ns)}" for it - remove the configured entry, the server's own alias always wins.`,
+      );
+    }
+    if (!isValidAliasValue(alias)) {
+      throw new Error(
+        `namespace.alias for namespace "${ns}" is not a valid alias: "${alias}" is neither the empty string ` +
+          `nor a valid CSDL SimpleIdentifier.`,
+      );
+    }
+  }
+
+  // server-declared and project-configured are both deliberate settings, validated identically from here on
+  const authoritative = new Map<string, string>([...serverAlias, ...Object.entries(configuredAlias)]);
+
+  const authoritativeOwnersByAlias = new Map<string, Array<string>>();
+  for (const [ns, alias] of authoritative) {
+    const owners = authoritativeOwnersByAlias.get(alias) ?? [];
+    owners.push(ns);
+    authoritativeOwnersByAlias.set(alias, owners);
+  }
+  for (const [alias, owners] of authoritativeOwnersByAlias) {
+    if (owners.length > 1) {
+      throw new Error(
+        `Namespaces ${owners.map((ns) => `"${ns}"`).join(" and ")} both resolve to the same alias "${alias}" - ` +
+          `a server-declared or project-configured alias must be unique across the whole service.`,
+      );
+    }
+  }
+  for (const [ns, alias] of authoritative) {
+    if (alias !== ns && namespaceSet.has(alias)) {
+      throw new Error(
+        `The alias "${alias}" declared/configured for namespace "${ns}" is itself the real name of another ` +
+          `namespace in this service - alias values must be unique from every real namespace name.`,
+      );
+    }
+  }
+
+  const effective = new Map<string, string>(authoritative);
+
+  if (!options?.disableAutoAlias) {
+    const candidateOwnersByAlias = new Map<string, Array<string>>();
+    for (const ns of allNamespaces) {
+      if (effective.has(ns)) {
+        continue;
+      }
+      const candidate = lastDotSegment(ns);
+      const collides =
+        [...effective.values()].includes(candidate) ||
+        allNamespaces.some((other) => other !== ns && other === candidate);
+      if (collides) {
+        continue;
+      }
+      const owners = candidateOwnersByAlias.get(candidate) ?? [];
+      owners.push(ns);
+      candidateOwnersByAlias.set(candidate, owners);
+    }
+    for (const [candidate, owners] of candidateOwnersByAlias) {
+      // 2+ namespaces synthesizing to the identical candidate is exactly the kind of collision auto-synthesis
+      // must never force a choice between - drop the candidate for all of them rather than pick a winner
+      if (owners.length === 1) {
+        effective.set(owners[0], candidate);
+      }
+    }
+  }
+
+  return Object.fromEntries(effective);
+}

--- a/packages/odata2ts/src/data-model/NamespaceAliasResolver.ts
+++ b/packages/odata2ts/src/data-model/NamespaceAliasResolver.ts
@@ -7,33 +7,24 @@ function isValidAliasValue(alias: string): boolean {
   return alias === "" || SIMPLE_IDENTIFIER.test(alias);
 }
 
-function lastDotSegment(namespace: string): string {
-  const lastDot = namespace.lastIndexOf(".");
-  return lastDot < 0 ? namespace : namespace.slice(lastDot + 1);
-}
-
 /**
- * Resolves every namespace's *effective* alias from the three sources `odata2ts-namespace-alias.md`
+ * Resolves every namespace's *effective* alias from the two sources `odata2ts-namespace-alias.md`
  * describes, in fixed precedence: a server-declared `<Schema Alias="...">` (`rawNamespaces`' own alias
- * slot) always wins, a project-configured `namespace.alias` fills whatever the server left unaliased, and
- * odata2ts synthesizes its own guess - the namespace's last dot-segment - for whatever both leave a gap,
- * unless `disableAutoAlias` turns that off.
+ * slot) always wins, and a project-configured `namespace.alias` fills whatever the server left unaliased.
  *
  * Returns one flat map from real namespace to effective alias, covering only the namespaces that end up
  * with one - the single already-merged table every consumer (`DataModel.namespace2Alias`,
  * `ServiceConfigHelper`'s per-call `NamespaceWithAlias` tuples, `NamingHelper.getFolderPath`,
- * `DataModel.getDisplayFqName`) reads from, so none of them need to know which of the three sources
- * actually supplied a given value.
+ * `DataModel.getDisplayFqName`) reads from, so neither needs to know which of the two sources actually
+ * supplied a given value.
  *
  * Throws where a project setting is unambiguously wrong (an alias for an unknown or already-aliased
  * namespace, an alias that isn't a valid CSDL `SimpleIdentifier`) or would silently collapse two namespaces
- * onto the same alias. A synthesized alias that would collide is instead dropped without error: nobody
- * asked for it, so it must never be able to break a build the way a rejected explicit setting legitimately
- * can - see the spec's "Auto-synthesis" section.
+ * onto the same alias.
  */
 export function resolveNamespaceAliases(
   rawNamespaces: ReadonlyArray<NamespaceWithAlias>,
-  options: Pick<NamespaceOptions, "alias" | "disableAutoAlias"> | undefined,
+  options: Pick<NamespaceOptions, "alias"> | undefined,
 ): Record<string, string> {
   const allNamespaces = rawNamespaces.map(([ns]) => ns);
   const namespaceSet = new Set(allNamespaces);
@@ -66,16 +57,16 @@ export function resolveNamespaceAliases(
     }
   }
 
-  // server-declared and project-configured are both deliberate settings, validated identically from here on
-  const authoritative = new Map<string, string>([...serverAlias, ...Object.entries(configuredAlias)]);
+  // server-declared and project-configured are both deliberate settings, validated identically
+  const effective = new Map<string, string>([...serverAlias, ...Object.entries(configuredAlias)]);
 
-  const authoritativeOwnersByAlias = new Map<string, Array<string>>();
-  for (const [ns, alias] of authoritative) {
-    const owners = authoritativeOwnersByAlias.get(alias) ?? [];
+  const ownersByAlias = new Map<string, Array<string>>();
+  for (const [ns, alias] of effective) {
+    const owners = ownersByAlias.get(alias) ?? [];
     owners.push(ns);
-    authoritativeOwnersByAlias.set(alias, owners);
+    ownersByAlias.set(alias, owners);
   }
-  for (const [alias, owners] of authoritativeOwnersByAlias) {
+  for (const [alias, owners] of ownersByAlias) {
     if (owners.length > 1) {
       throw new Error(
         `Namespaces ${owners.map((ns) => `"${ns}"`).join(" and ")} both resolve to the same alias "${alias}" - ` +
@@ -83,40 +74,12 @@ export function resolveNamespaceAliases(
       );
     }
   }
-  for (const [ns, alias] of authoritative) {
+  for (const [ns, alias] of effective) {
     if (alias !== ns && namespaceSet.has(alias)) {
       throw new Error(
         `The alias "${alias}" declared/configured for namespace "${ns}" is itself the real name of another ` +
           `namespace in this service - alias values must be unique from every real namespace name.`,
       );
-    }
-  }
-
-  const effective = new Map<string, string>(authoritative);
-
-  if (!options?.disableAutoAlias) {
-    const candidateOwnersByAlias = new Map<string, Array<string>>();
-    for (const ns of allNamespaces) {
-      if (effective.has(ns)) {
-        continue;
-      }
-      const candidate = lastDotSegment(ns);
-      const collides =
-        [...effective.values()].includes(candidate) ||
-        allNamespaces.some((other) => other !== ns && other === candidate);
-      if (collides) {
-        continue;
-      }
-      const owners = candidateOwnersByAlias.get(candidate) ?? [];
-      owners.push(ns);
-      candidateOwnersByAlias.set(candidate, owners);
-    }
-    for (const [candidate, owners] of candidateOwnersByAlias) {
-      // 2+ namespaces synthesizing to the identical candidate is exactly the kind of collision auto-synthesis
-      // must never force a choice between - drop the candidate for all of them rather than pick a winner
-      if (owners.length === 1) {
-        effective.set(owners[0], candidate);
-      }
     }
   }
 

--- a/packages/odata2ts/src/data-model/NamingHelper.ts
+++ b/packages/odata2ts/src/data-model/NamingHelper.ts
@@ -2,6 +2,7 @@ import { camelCase, constantCase, kebabCase, pascalCase, snakeCase } from "chang
 import { FileNamingStrategyOption, NameSettings, NamingStrategies, StandardNamingOptions } from "../NamingModel.js";
 import { RunOptions } from "../OptionModel.js";
 import { NamespaceWithAlias } from "./DataModel.js";
+import { resolveNamespaceAliases } from "./NamespaceAliasResolver.js";
 
 function getNamingStrategyImpl(strategy: NamingStrategies | undefined) {
   switch (strategy) {
@@ -22,13 +23,16 @@ const noopNamingFunction = (value: string, options?: StandardNamingOptions) => {
   return (options?.prefix || "") + value + (options?.suffix || "");
 };
 
-export interface NamingHelperSettings extends Pick<RunOptions, "allowRenaming" | "naming"> {}
+export interface NamingHelperSettings extends Pick<RunOptions, "allowRenaming" | "naming" | "namespace"> {}
 
 export class NamingHelper {
   private readonly allowModelPropRenaming: boolean;
   private readonly mainServiceName: string;
   private readonly namespacePrefixes: Array<string>;
   private readonly options: NameSettings;
+  private readonly useAliasForFolderName: boolean;
+  /** Every namespace's effective alias (server-declared, project-configured, or auto-synthesized) - computed once, here, since this is the earliest point in the pipeline that has both the digested namespaces and the resolved config. Reused by the digester for `DataModel`/`ServiceConfigHelper` rather than recomputed, so validation runs exactly once. */
+  private readonly effectiveNamespaceAlias: Record<string, string>;
 
   constructor(options: NamingHelperSettings, mainServiceName: string, namespaces?: Array<NamespaceWithAlias>) {
     if (!options) {
@@ -55,6 +59,13 @@ export class NamingHelper {
       }, [])
       .map((sn) => sn + ".")
       .sort((a, b) => (a.length === b.length ? 0 : a.length > b.length ? -1 : 1));
+    this.useAliasForFolderName = options.namespace?.useAliasForFolderName ?? false;
+    this.effectiveNamespaceAlias = resolveNamespaceAliases(namespaces, options.namespace);
+  }
+
+  /** Every namespace's effective alias - see the field doc comment. Reused by the digester so alias resolution (including its validation) runs exactly once per generation run. */
+  public getEffectiveNamespaceAlias(): Record<string, string> {
+    return this.effectiveNamespaceAlias;
   }
 
   /**
@@ -286,6 +297,9 @@ export class NamingHelper {
   };
 
   public getFolderPath(namespace: string, name: string) {
-    return `${kebabCase(namespace)}/${kebabCase(name)}`;
+    const folderNamespace = this.useAliasForFolderName
+      ? (this.effectiveNamespaceAlias[namespace] ?? namespace)
+      : namespace;
+    return `${kebabCase(folderNamespace)}/${kebabCase(name)}`;
   }
 }

--- a/packages/odata2ts/src/data-model/NamingHelper.ts
+++ b/packages/odata2ts/src/data-model/NamingHelper.ts
@@ -31,7 +31,7 @@ export class NamingHelper {
   private readonly namespacePrefixes: Array<string>;
   private readonly options: NameSettings;
   private readonly useAliasForFolderName: boolean;
-  /** Every namespace's effective alias (server-declared, project-configured, or auto-synthesized) - computed once, here, since this is the earliest point in the pipeline that has both the digested namespaces and the resolved config. Reused by the digester for `DataModel`/`ServiceConfigHelper` rather than recomputed, so validation runs exactly once. */
+  /** Every namespace's effective alias (server-declared or project-configured) - computed once, here, since this is the earliest point in the pipeline that has both the digested namespaces and the resolved config. Reused by the digester for `DataModel`/`ServiceConfigHelper` rather than recomputed, so validation runs exactly once. */
   private readonly effectiveNamespaceAlias: Record<string, string>;
 
   constructor(options: NamingHelperSettings, mainServiceName: string, namespaces?: Array<NamespaceWithAlias>) {

--- a/packages/odata2ts/src/data-model/ServiceConfigHelper.ts
+++ b/packages/odata2ts/src/data-model/ServiceConfigHelper.ts
@@ -153,12 +153,25 @@ export class ServiceConfigHelper {
 
   private getByRegExp(mapping: Array<[RegExp, any]>, [mainNs, alias]: NamespaceWithAlias, nameToMap: string) {
     const fqName = `${mainNs}.${nameToMap}`;
+    // matched by both spellings, same as getByName - a matcher written against the alias form should
+    // resolve regardless of which of the three sources (server-declared, project-configured, auto-
+    // synthesized) actually supplied it, exactly as one written against the real namespace already does
+    const aliasFqName = alias ? `${alias}.${nameToMap}` : undefined;
     const hayStack = [...this.mapping.Any.regExps, ...mapping];
 
     const resultList = hayStack
-      .filter(([regExp, config]) => regExp.test(fqName))
-      .map(([regExp, { name, mappedName, type, ...attrs }]) => ({
-        mappedName: mappedName ? fqName.replace(regExp, mappedName) : undefined,
+      .map(([regExp, config]): [RegExp, any, string] | undefined => {
+        if (regExp.test(fqName)) {
+          return [regExp, config, fqName];
+        }
+        if (aliasFqName && regExp.test(aliasFqName)) {
+          return [regExp, config, aliasFqName];
+        }
+        return undefined;
+      })
+      .filter((entry): entry is [RegExp, any, string] => !!entry)
+      .map(([regExp, { name, mappedName, type, ...attrs }, matchedText]) => ({
+        mappedName: mappedName ? matchedText.replace(regExp, mappedName) : undefined,
         ...attrs,
       }));
 

--- a/packages/odata2ts/src/defaultConfig.ts
+++ b/packages/odata2ts/src/defaultConfig.ts
@@ -120,6 +120,7 @@ const defaultConfig: DefaultConfiguration = {
   disableBindingProps: false,
   deepInsertProps: DeepInsertProps.all,
   cacheKeys: { enabled: false },
+  namespace: { alias: {}, disableAutoAlias: false, useAliasForFolderName: false },
 };
 
 const { models, queryObjects, services } = defaultConfig.naming;

--- a/packages/odata2ts/src/defaultConfig.ts
+++ b/packages/odata2ts/src/defaultConfig.ts
@@ -120,7 +120,7 @@ const defaultConfig: DefaultConfiguration = {
   disableBindingProps: false,
   deepInsertProps: DeepInsertProps.all,
   cacheKeys: { enabled: false },
-  namespace: { alias: {}, disableAutoAlias: false, useAliasForFolderName: false },
+  namespace: { alias: {}, useAliasForFolderName: false },
 };
 
 const { models, queryObjects, services } = defaultConfig.naming;

--- a/packages/odata2ts/src/generator/ServiceGenerator.ts
+++ b/packages/odata2ts/src/generator/ServiceGenerator.ts
@@ -183,13 +183,19 @@ class ServiceGenerator {
     return `cacheKeyState && ${hopStateFn}(${hopStateFn}(cacheKeyState, { name: "${odataName}" }), { name: "$value" })`;
   }
 
-  /** A subtype cast: a restriction on the very same resource, not a hop away from it. */
+  /**
+   * A subtype cast: a restriction on the very same resource, not a hop away from it. The cast's FQN is run
+   * through `getDisplayFqName` so a namespace that ends up aliased (see `NamespaceAliasResolver`) is
+   * written compactly here too - the same resolution `entityTypeName`-style consumers would use, so a cache
+   * key's `cast` entry and any matcher written against it never drift apart.
+   */
   private emitCastParamsExpr(imports: ImportContainer, castFqName: string): string {
     if (!this.cacheKeysEnabled) {
       return "";
     }
     const withParamsFn = imports.addServiceFunction("withParams");
-    return `cacheKeyState && ${withParamsFn}(cacheKeyState, { cast: "${castFqName}" })`;
+    const displayFqName = this.dataModel.getDisplayFqName(castFqName);
+    return `cacheKeyState && ${withParamsFn}(cacheKeyState, { cast: "${displayFqName}" })`;
   }
 
   /**
@@ -235,7 +241,11 @@ class ServiceGenerator {
       : `${rootStateFn}("${importOdataName}", "${kind}")`;
   }
 
-  /** A bound function/action: a hop off the resource it is bound to, with its own kind marker where the return type is structured - never a type, matching every other hop. */
+  /**
+   * A bound function/action: a hop off the resource it is bound to, with its own kind marker where the
+   * return type is structured - never a type, matching every other hop. The operation's own FQN is run
+   * through `getDisplayFqName` for the same reason `emitCastParamsExpr` does - see there.
+   */
   private emitBoundOperationHopExpr(
     imports: ImportContainer,
     fqOperationName: string,
@@ -247,7 +257,8 @@ class ServiceGenerator {
     const hopStateFn = imports.addServiceFunction("hopState");
     const isStructured = !!returnType?.fqType && returnType.dataType !== DataTypes.PrimitiveType;
     const kindEntry = isStructured ? `, kind: "${returnType!.isCollection ? "list" : "detail"}"` : "";
-    return `cacheKeyState && ${hopStateFn}(cacheKeyState, { name: "${fqOperationName}"${kindEntry} })`;
+    const displayFqName = this.dataModel.getDisplayFqName(fqOperationName);
+    return `cacheKeyState && ${hopStateFn}(cacheKeyState, { name: "${displayFqName}"${kindEntry} })`;
   }
 
   /**

--- a/packages/odata2ts/test/data-model/DataModel.test.ts
+++ b/packages/odata2ts/test/data-model/DataModel.test.ts
@@ -335,4 +335,44 @@ describe("Data Model Tests", function () {
 
     expect(dataModel.getEntityType(modelName)).toStrictEqual(expectedDummy);
   });
+
+  describe("getDisplayFqName", () => {
+    test("an unaliased namespace's FQN is returned unchanged", () => {
+      expect(dataModel.getDisplayFqName(`${NS1}.Reservation`)).toBe(`${NS1}.Reservation`);
+    });
+
+    test("an aliased namespace's prefix is replaced by its alias", () => {
+      expect(dataModel.getDisplayFqName(`${NS2}.Reservation`)).toBe(`${ALIAS_NS2}.Reservation`);
+    });
+
+    test("the bare namespace itself (no local name) resolves to the bare alias", () => {
+      expect(dataModel.getDisplayFqName(NS2)).toBe(ALIAS_NS2);
+    });
+
+    test("a namespace aliased to the empty string drops the prefix entirely", () => {
+      // "" is a deliberate alias value (see NamespaceOptions), distinct from "no alias at all" - the
+      // constructor must store it (`alias !== undefined`, not a truthy check) for this to work
+      const withEmptyAlias = new DataModel([[NS1], [NS2, ""]], ODataVersion.V4);
+      expect(withEmptyAlias.getDisplayFqName(`${NS2}.Reservation`)).toBe("Reservation");
+    });
+
+    test("a namespace nested inside another aliased one resolves against the longer, more specific match", () => {
+      const outer = "Library";
+      const inner = "Library.Circulation";
+      const nested = new DataModel(
+        [
+          [outer, "Lib"],
+          [inner, "Circ"],
+        ],
+        ODataVersion.V4,
+      );
+
+      expect(nested.getDisplayFqName(`${inner}.Reservation`)).toBe("Circ.Reservation");
+      expect(nested.getDisplayFqName(`${outer}.Branch`)).toBe("Lib.Branch");
+    });
+
+    test("a name that isn't qualified by any known namespace is returned unchanged", () => {
+      expect(dataModel.getDisplayFqName("Xxx")).toBe("Xxx");
+    });
+  });
 });

--- a/packages/odata2ts/test/data-model/NamespaceAliasResolver.test.ts
+++ b/packages/odata2ts/test/data-model/NamespaceAliasResolver.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "vitest";
+import { NamespaceWithAlias } from "../../src/data-model/DataModel.js";
+import { resolveNamespaceAliases } from "../../src/data-model/NamespaceAliasResolver.js";
+
+describe("resolveNamespaceAliases", () => {
+  describe("auto-synthesis", () => {
+    test("a single-segment namespace synthesizes to itself", () => {
+      const namespaces: Array<NamespaceWithAlias> = [["PublisherRegistry"]];
+      expect(resolveNamespaceAliases(namespaces, undefined)).toEqual({ PublisherRegistry: "PublisherRegistry" });
+    });
+
+    test("a single-namespace service synthesizes the same way as a multi-namespace one - no empty-string special case", () => {
+      const namespaces: Array<NamespaceWithAlias> = [["Library.Service"]];
+      expect(resolveNamespaceAliases(namespaces, undefined)).toEqual({ "Library.Service": "Service" });
+    });
+
+    test("last-dot-segment extraction across two, three and four namespaces", () => {
+      const two: Array<NamespaceWithAlias> = [["Library.Catalog"], ["Library.Circulation"]];
+      expect(resolveNamespaceAliases(two, undefined)).toEqual({
+        "Library.Catalog": "Catalog",
+        "Library.Circulation": "Circulation",
+      });
+
+      const four: Array<NamespaceWithAlias> = [
+        ["Library.Catalog"],
+        ["Library.Circulation"],
+        ["PublisherRegistry"],
+        ["Library.Service"],
+      ];
+      expect(resolveNamespaceAliases(four, undefined)).toEqual({
+        "Library.Catalog": "Catalog",
+        "Library.Circulation": "Circulation",
+        PublisherRegistry: "PublisherRegistry",
+        "Library.Service": "Service",
+      });
+    });
+
+    test("disableAutoAlias leaves every unaliased namespace without one", () => {
+      const namespaces: Array<NamespaceWithAlias> = [["Library.Catalog"], ["Library.Circulation", "Circ"]];
+      expect(resolveNamespaceAliases(namespaces, { disableAutoAlias: true })).toEqual({
+        "Library.Circulation": "Circ",
+      });
+    });
+
+    test("a synthesis collision between two namespaces drops the alias for both, without error", () => {
+      const namespaces: Array<NamespaceWithAlias> = [["A.Catalog"], ["B.Catalog"]];
+      expect(() => resolveNamespaceAliases(namespaces, undefined)).not.toThrow();
+      expect(resolveNamespaceAliases(namespaces, undefined)).toEqual({});
+    });
+
+    test("a synthesis collision against a real, unaliased namespace name is dropped without error", () => {
+      // "Catalog" is itself a real namespace, so "Foo.Catalog" can never synthesize to it
+      const namespaces: Array<NamespaceWithAlias> = [["Foo.Catalog"], ["Catalog"]];
+      expect(resolveNamespaceAliases(namespaces, undefined)).toEqual({ Catalog: "Catalog" });
+    });
+
+    test("a synthesis collision against a server-declared or project-configured alias is dropped without error", () => {
+      const namespaces: Array<NamespaceWithAlias> = [["Foo.Catalog"], ["Bar.Catalog", "Catalog"]];
+      expect(resolveNamespaceAliases(namespaces, undefined)).toEqual({ "Bar.Catalog": "Catalog" });
+    });
+  });
+
+  describe("precedence", () => {
+    test("a server-declared alias always wins over a project-configured one attempting the same namespace", () => {
+      const namespaces: Array<NamespaceWithAlias> = [["Library.Catalog", "Srv"]];
+      expect(() => resolveNamespaceAliases(namespaces, { alias: { "Library.Catalog": "Cat" } })).toThrow(
+        /already declares alias/,
+      );
+    });
+
+    test("a project-configured alias fills a namespace the server left unaliased", () => {
+      const namespaces: Array<NamespaceWithAlias> = [["Library.Catalog"]];
+      expect(resolveNamespaceAliases(namespaces, { alias: { "Library.Catalog": "Cat" } })).toEqual({
+        "Library.Catalog": "Cat",
+      });
+    });
+
+    test("project-configured wins over auto-synthesis for the same namespace", () => {
+      const namespaces: Array<NamespaceWithAlias> = [["Library.Catalog"]];
+      const result = resolveNamespaceAliases(namespaces, { alias: { "Library.Catalog": "Cat" } });
+      expect(result["Library.Catalog"]).toBe("Cat");
+    });
+  });
+
+  describe("validation", () => {
+    test("alias names a namespace the digested metadata does not contain", () => {
+      const namespaces: Array<NamespaceWithAlias> = [["Library.Catalog"]];
+      expect(() => resolveNamespaceAliases(namespaces, { alias: { Typo: "T" } })).toThrow(
+        /does not contain that namespace/,
+      );
+    });
+
+    test("alias names a namespace the server already aliases", () => {
+      const namespaces: Array<NamespaceWithAlias> = [["Library.Catalog", "Srv"]];
+      expect(() => resolveNamespaceAliases(namespaces, { alias: { "Library.Catalog": "Cat" } })).toThrow(
+        /already declares alias "Srv"/,
+      );
+    });
+
+    test("two namespaces resolving to the same alias where at least one side is server-declared or project-configured", () => {
+      const namespaces: Array<NamespaceWithAlias> = [["Library.Catalog", "Cat"], ["Library.Circulation"]];
+      expect(() => resolveNamespaceAliases(namespaces, { alias: { "Library.Circulation": "Cat" } })).toThrow(
+        /both resolve to the same alias "Cat"/,
+      );
+    });
+
+    test("two server-declared aliases colliding with each other is a hard error too", () => {
+      const namespaces: Array<NamespaceWithAlias> = [
+        ["Library.Catalog", "Cat"],
+        ["Library.Circulation", "Cat"],
+      ];
+      expect(() => resolveNamespaceAliases(namespaces, undefined)).toThrow(/both resolve to the same alias "Cat"/);
+    });
+
+    test("a server-declared alias colliding with a real namespace name elsewhere in the service", () => {
+      const namespaces: Array<NamespaceWithAlias> = [["Library.Catalog", "Circulation"], ["Circulation"]];
+      expect(() => resolveNamespaceAliases(namespaces, undefined)).toThrow(/is itself the real name of another/);
+    });
+
+    test("a project-configured alias colliding with a real namespace name elsewhere in the service", () => {
+      const namespaces: Array<NamespaceWithAlias> = [["Library.Catalog"], ["Circulation"]];
+      expect(() => resolveNamespaceAliases(namespaces, { alias: { "Library.Catalog": "Circulation" } })).toThrow(
+        /is itself the real name of another/,
+      );
+    });
+
+    test("an alias value that is not a valid CSDL SimpleIdentifier", () => {
+      const namespaces: Array<NamespaceWithAlias> = [["Library.Catalog"]];
+      expect(() => resolveNamespaceAliases(namespaces, { alias: { "Library.Catalog": "Not.Valid" } })).toThrow(
+        /not a valid alias/,
+      );
+      expect(() => resolveNamespaceAliases(namespaces, { alias: { "Library.Catalog": "1Bad" } })).toThrow(
+        /not a valid alias/,
+      );
+    });
+
+    test("the empty string is explicitly allowed as an alias value", () => {
+      const namespaces: Array<NamespaceWithAlias> = [["Library.Catalog"]];
+      expect(resolveNamespaceAliases(namespaces, { alias: { "Library.Catalog": "" } })).toEqual({
+        "Library.Catalog": "",
+      });
+    });
+
+    test("an alias equal to its own namespace's name is not a self-collision", () => {
+      const namespaces: Array<NamespaceWithAlias> = [["PublisherRegistry", "PublisherRegistry"]];
+      expect(() => resolveNamespaceAliases(namespaces, undefined)).not.toThrow();
+    });
+  });
+});

--- a/packages/odata2ts/test/data-model/NamespaceAliasResolver.test.ts
+++ b/packages/odata2ts/test/data-model/NamespaceAliasResolver.test.ts
@@ -3,61 +3,9 @@ import { NamespaceWithAlias } from "../../src/data-model/DataModel.js";
 import { resolveNamespaceAliases } from "../../src/data-model/NamespaceAliasResolver.js";
 
 describe("resolveNamespaceAliases", () => {
-  describe("auto-synthesis", () => {
-    test("a single-segment namespace synthesizes to itself", () => {
-      const namespaces: Array<NamespaceWithAlias> = [["PublisherRegistry"]];
-      expect(resolveNamespaceAliases(namespaces, undefined)).toEqual({ PublisherRegistry: "PublisherRegistry" });
-    });
-
-    test("a single-namespace service synthesizes the same way as a multi-namespace one - no empty-string special case", () => {
-      const namespaces: Array<NamespaceWithAlias> = [["Library.Service"]];
-      expect(resolveNamespaceAliases(namespaces, undefined)).toEqual({ "Library.Service": "Service" });
-    });
-
-    test("last-dot-segment extraction across two, three and four namespaces", () => {
-      const two: Array<NamespaceWithAlias> = [["Library.Catalog"], ["Library.Circulation"]];
-      expect(resolveNamespaceAliases(two, undefined)).toEqual({
-        "Library.Catalog": "Catalog",
-        "Library.Circulation": "Circulation",
-      });
-
-      const four: Array<NamespaceWithAlias> = [
-        ["Library.Catalog"],
-        ["Library.Circulation"],
-        ["PublisherRegistry"],
-        ["Library.Service"],
-      ];
-      expect(resolveNamespaceAliases(four, undefined)).toEqual({
-        "Library.Catalog": "Catalog",
-        "Library.Circulation": "Circulation",
-        PublisherRegistry: "PublisherRegistry",
-        "Library.Service": "Service",
-      });
-    });
-
-    test("disableAutoAlias leaves every unaliased namespace without one", () => {
-      const namespaces: Array<NamespaceWithAlias> = [["Library.Catalog"], ["Library.Circulation", "Circ"]];
-      expect(resolveNamespaceAliases(namespaces, { disableAutoAlias: true })).toEqual({
-        "Library.Circulation": "Circ",
-      });
-    });
-
-    test("a synthesis collision between two namespaces drops the alias for both, without error", () => {
-      const namespaces: Array<NamespaceWithAlias> = [["A.Catalog"], ["B.Catalog"]];
-      expect(() => resolveNamespaceAliases(namespaces, undefined)).not.toThrow();
-      expect(resolveNamespaceAliases(namespaces, undefined)).toEqual({});
-    });
-
-    test("a synthesis collision against a real, unaliased namespace name is dropped without error", () => {
-      // "Catalog" is itself a real namespace, so "Foo.Catalog" can never synthesize to it
-      const namespaces: Array<NamespaceWithAlias> = [["Foo.Catalog"], ["Catalog"]];
-      expect(resolveNamespaceAliases(namespaces, undefined)).toEqual({ Catalog: "Catalog" });
-    });
-
-    test("a synthesis collision against a server-declared or project-configured alias is dropped without error", () => {
-      const namespaces: Array<NamespaceWithAlias> = [["Foo.Catalog"], ["Bar.Catalog", "Catalog"]];
-      expect(resolveNamespaceAliases(namespaces, undefined)).toEqual({ "Bar.Catalog": "Catalog" });
-    });
+  test("a namespace neither the server nor the project aliases has no effective alias", () => {
+    const namespaces: Array<NamespaceWithAlias> = [["Library.Catalog"], ["Library.Circulation"]];
+    expect(resolveNamespaceAliases(namespaces, undefined)).toEqual({});
   });
 
   describe("precedence", () => {
@@ -75,10 +23,12 @@ describe("resolveNamespaceAliases", () => {
       });
     });
 
-    test("project-configured wins over auto-synthesis for the same namespace", () => {
-      const namespaces: Array<NamespaceWithAlias> = [["Library.Catalog"]];
-      const result = resolveNamespaceAliases(namespaces, { alias: { "Library.Catalog": "Cat" } });
-      expect(result["Library.Catalog"]).toBe("Cat");
+    test("a server-declared alias for one namespace and a project-configured one for another both take effect", () => {
+      const namespaces: Array<NamespaceWithAlias> = [["Library.Catalog", "Cat"], ["Library.Circulation"]];
+      expect(resolveNamespaceAliases(namespaces, { alias: { "Library.Circulation": "Circ" } })).toEqual({
+        "Library.Catalog": "Cat",
+        "Library.Circulation": "Circ",
+      });
     });
   });
 

--- a/packages/odata2ts/test/data-model/NamingHelper.test.ts
+++ b/packages/odata2ts/test/data-model/NamingHelper.test.ts
@@ -14,7 +14,7 @@ describe("NamingHelper Tests", function () {
   const OVERRIDING_SERVICE_NAME = "my_Trip";
   const TEST_CONFIG = getTestConfigMinimal();
 
-  let options: Pick<TestOptions, "serviceName" | "allowRenaming" | "naming">;
+  let options: Pick<TestOptions, "serviceName" | "allowRenaming" | "naming" | "namespace">;
   let toTest: NamingHelper;
 
   function withNs(name: string, ns = NAMESPACE) {
@@ -22,7 +22,7 @@ describe("NamingHelper Tests", function () {
   }
 
   function createHelper(overrideServiceName: boolean = false) {
-    const config = deepmerge(TEST_CONFIG, options) as Pick<RunOptions, "allowRenaming" | "naming">;
+    const config = deepmerge(TEST_CONFIG, options) as Pick<RunOptions, "allowRenaming" | "naming" | "namespace">;
     toTest = new NamingHelper(config, overrideServiceName ? OVERRIDING_SERVICE_NAME : NAMESPACE, NAMESPACES);
   }
 
@@ -473,6 +473,40 @@ describe("NamingHelper Tests", function () {
     createHelper();
 
     expect(toTest.getPrivatePropName("test")).toBe("PRE_TEST_SUF");
+  });
+
+  describe("getFolderPath", () => {
+    test("uses the real namespace by default, even where an alias is known", () => {
+      createHelper();
+      expect(toTest.getFolderPath(NAMESPACE2, "Book")).toBe("test/book");
+    });
+
+    test("useAliasForFolderName swaps in the effective (server-declared) alias", () => {
+      options.namespace = { useAliasForFolderName: true };
+      createHelper();
+      expect(toTest.getFolderPath(NAMESPACE2, "Book")).toBe("alias/book");
+    });
+
+    test("useAliasForFolderName also picks up an auto-synthesized alias for a dotted namespace", () => {
+      options.namespace = { useAliasForFolderName: true };
+      const nested: Array<NamespaceWithAlias> = [["Library.Catalog"]];
+      toTest = new NamingHelper(deepmerge(TEST_CONFIG, options), NAMESPACE, nested);
+
+      expect(toTest.getFolderPath("Library.Catalog", "Book")).toBe("catalog/book");
+    });
+
+    test("without useAliasForFolderName, folder layout is byte-identical to today's output regardless of aliasing", () => {
+      createHelper();
+      expect(toTest.getFolderPath(NAMESPACE2, "Book")).toBe(toTest.getFolderPath(NAMESPACE2, "Book"));
+      expect(toTest.getFolderPath(NAMESPACE2, "Book")).toBe(`${NAMESPACE2}/book`.toLowerCase());
+    });
+  });
+
+  describe("namespace.alias validation", () => {
+    test("surfaces at NamingHelper construction, before any digestion happens", () => {
+      options.namespace = { alias: { Typo: "T" } };
+      expect(() => createHelper()).toThrow(/does not contain that namespace/);
+    });
   });
 
   test("getNameAndServicePrefix", () => {

--- a/packages/odata2ts/test/data-model/NamingHelper.test.ts
+++ b/packages/odata2ts/test/data-model/NamingHelper.test.ts
@@ -487,8 +487,8 @@ describe("NamingHelper Tests", function () {
       expect(toTest.getFolderPath(NAMESPACE2, "Book")).toBe("alias/book");
     });
 
-    test("useAliasForFolderName also picks up an auto-synthesized alias for a dotted namespace", () => {
-      options.namespace = { useAliasForFolderName: true };
+    test("useAliasForFolderName also picks up a project-configured alias for a dotted namespace", () => {
+      options.namespace = { useAliasForFolderName: true, alias: { "Library.Catalog": "Catalog" } };
       const nested: Array<NamespaceWithAlias> = [["Library.Catalog"]];
       toTest = new NamingHelper(deepmerge(TEST_CONFIG, options), NAMESPACE, nested);
 

--- a/packages/odata2ts/test/data-model/ServiceConfigHelper.test.ts
+++ b/packages/odata2ts/test/data-model/ServiceConfigHelper.test.ts
@@ -239,6 +239,27 @@ describe("ServiceConfigHelper Tests", function () {
     expect(result).toStrictEqual({ mappedName });
   });
 
+  test("find config: RegExp matching against the namespace alias, not just the real namespace", () => {
+    const name = "test";
+    const mappedName = "xyz";
+    const [, alias] = DEFAULT_NAMESPACES;
+
+    // written against the alias form ("self.test"), which getByRegExp previously never tried - only
+    // getByName did
+    const aliasRegExp = new RegExp(`${alias}\\.test`);
+    createHelperWithEntities({ type: TypeModel.Any, name: aliasRegExp, mappedName });
+
+    expect(toTest.findEntityTypeConfig(DEFAULT_NAMESPACES, name)).toStrictEqual({ mappedName });
+  });
+
+  test("find config: RegExp mappedName substitution uses whichever spelling actually matched", () => {
+    const [, alias] = DEFAULT_NAMESPACES;
+
+    createHelperWithEntities({ type: TypeModel.Any, name: /self\.(.+)/, mappedName: "Aliased_$1" });
+
+    expect(toTest.findEntityTypeConfig(DEFAULT_NAMESPACES, "test")).toStrictEqual({ mappedName: "Aliased_test" });
+  });
+
   test("find config: wrong name option", () => {
     const exceptionNoName = "No value for required attribute [name] specified!";
     const exceptionWrongType = "Wrong type for attribute [name]!";

--- a/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
@@ -349,6 +349,28 @@ describe("Service Generator Tests V4", () => {
 
       expect(text).toContain("new MediumService<V>(client, path, name, options, cacheKeyState);");
     });
+
+    test("namespace.alias shortens the cast and bound-operation cache-key literals - the only two hop names still namespace-qualified", async () => {
+      buildModel();
+      await doGenerate({
+        cacheKeys: { enabled: true },
+        enablePrimitivePropertyServices: true,
+        namespace: { alias: { [SERVICE_NAME]: "T" } },
+      });
+      const text = generatedText();
+
+      expect(text).toContain(`withParams(cacheKeyState, { cast: "T.Book" })`);
+      expect(text).toContain(`hopState(cacheKeyState, { name: "T.checkOut" })`);
+      // the un-aliased forms must not appear as a cache-key literal - "Tester.Book" legitimately still
+      // appears elsewhere (the runtime subtype `name` a cast service is constructed with), unrelated to
+      // getDisplayFqName and out of scope for this feature
+      expect(text).not.toContain(`withParams(cacheKeyState, { cast: "${withNs("Book")}" })`);
+      expect(text).not.toContain(`hopState(cacheKeyState, { name: "${withNs("checkOut")}" })`);
+      // everything else stays exactly as before - never namespace-qualified in the first place
+      expect(text).toContain(
+        `rootState("Media", "list", { entitySetName: "Media", canonicalIdFn: (entity: unknown) => new QMediumId("Media").buildCanonicalId(entity), qEntityFn: () => QMedium })`,
+      );
+    });
   });
 
   test("Service Generator: Min Case", async () => {


### PR DESCRIPTION
## Summary

Implements a new `namespace` config option that shortens a namespace wherever its length actually matters.

- **`NamespaceOptions`** (`OptionModel.ts`): `alias` (project-configured, per namespace) and `useAliasForFolderName`.
- **`NamespaceAliasResolver.resolveNamespaceAliases`**: resolves each namespace's *effective* alias in fixed precedence — a server-declared `<Schema Alias>` always wins, `namespace.alias` fills a gap the server left. Validates the four hard-error rules from the spec (unknown namespace, already-aliased namespace, alias/namespace collisions, invalid `SimpleIdentifier`). No auto-synthesis: every alias a generated client can carry traces back to something a human actually wrote down, never a guess `odata2ts` made up from a namespace's own last dot-segment.
- **`NamingHelper`**: computes the effective alias table once at construction (so validation runs exactly once per generation run) and exposes it for the digester to reuse; `getFolderPath` uses it under `useAliasForFolderName`.
- **`DataModelDigestion.ts`**: feeds the resolved aliases into every `NamespaceWithAlias` tuple it builds, so `DataModel.namespace2Alias` carries both sources blended into the one table every consumer already reads.
- **`DataModel.getDisplayFqName`**: new output-side view over `namespace2Alias`, replacing an aliased namespace prefix wherever a caller still needs a fully-qualified name.
- **`ServiceGenerator.ts`**: the two cache-key call sites that still carry a namespace-qualified FQN after the "names not types" redesign — a subtype cast (`emitCastParamsExpr`) and a bound operation's own name (`emitBoundOperationHopExpr`) — now route through `getDisplayFqName`.
- **`ServiceConfigHelper.getByRegExp`**: fixed to also try the alias-qualified form, matching `getByName`'s existing behavior (a pre-existing inconsistency the spec calls out).

### Server integration tests

Added and verified against live containers (`ghcr.io/odata2ts/test-server-asp-net:0.2.4`, `ghcr.io/odata2ts/test-server-cap:0.4.0`):

- **asp-net**: a new, separate `libraryNamespaceAlias` client, explicitly aliasing all three of the reference model's namespaces that need one (`Library.Catalog` → `Catalog`, `Library.Circulation` → `Circulation`, `PublisherRegistry` → `Pub`; `Library.Service` declares no types and needs none) plus `useAliasForFolderName: true`. Kept apart from the shared `library` client rather than mutating it in place — `useAliasForFolderName` moves physical files, and every other test file in the package already imports from the unaliased folder layout. `test/feature/NamespaceAlias.test.ts` proves the `Pub` alias through its own generated folder path, and the other two through an actual subtype-cast and bound-function cache-key literal.
- **cap**: no client needed — `Library.Service` has no alias configured, so its cache-key literals stay full-length, which is exactly the intended default behavior with auto-synthesis removed.
- Full existing suites (154 asp-net, 219/2-skipped cap, 134 olingo-v2) re-run against the live servers to confirm the default (no aliasing at all, since it's opt-in) is byte-identical to today's output — none of the three existing suites needed any change.

## Test plan

- [x] `NamespaceAliasResolver.test.ts` — precedence, all four validation rules
- [x] `DataModel.test.ts` — `getDisplayFqName` (aliased/unaliased/nested/empty-string/no-match)
- [x] `NamingHelper.test.ts` — `getFolderPath` with/without `useAliasForFolderName`, validation surfaces at construction
- [x] `ServiceConfigHelper.test.ts` — `getByRegExp` alias-form matching
- [x] `ServiceGenerator.test.ts` — golden-output test confirming only the cast/bound-operation cache-key literals get shortened, only when explicitly aliased
- [x] Full monorepo build + test (`odata-query-objects`, `odata2ts`, `odata-query-builder`, `odata-service`) all pass, `yarn check-format` clean
- [x] Real end-to-end smoke test: `examples/main`'s three local-metadata clients (Trippin, TrippinRw, OData V2) generate, type-check, and their own test suite passes unchanged
- [x] `int-test/asp-net` and `int-test/cap` regenerated and run against live Docker containers, all green (154 and 221 tests respectively)
