### PR TITLE
feat(odata2ts): add cacheKeys.namespace to disambiguate entity sets across services

### DIFF
--- a/int-test/asp-net/odata2ts.config.ts
+++ b/int-test/asp-net/odata2ts.config.ts
@@ -159,12 +159,17 @@ const config: ConfigFileOptions = {
      * test/feature/NamespaceAlias.test.ts) is what proves it out here instead. `Library.Catalog` and
      * `Library.Circulation` do have a cast and a bound action respectively, which is what proves the other
      * two aliases through an actual cache-key literal. See test/feature/NamespaceAlias.test.ts.
+     *
+     * `cacheKeys.namespace` is also on here, sharing this client rather than getting its own: it needs the
+     * exact same explicit aliases to prove itself against a real service anyway (an entity-set root's own
+     * name and every `entitySetName` prefixed with the owning type's alias), so there is nothing a separate
+     * client would add.
      */
     libraryNamespaceAlias: {
       serviceName: "LibraryNamespaceAlias",
       source: SOURCE,
       output: "src-generated/library-namespace-alias",
-      cacheKeys: true,
+      cacheKeys: { enabled: true, namespace: true },
       namespace: {
         alias: {
           "Library.Catalog": "Catalog",

--- a/int-test/asp-net/test/feature/NamespaceAlias.test.ts
+++ b/int-test/asp-net/test/feature/NamespaceAlias.test.ts
@@ -1,15 +1,21 @@
 import { afterAll, describe, expect, test } from "vitest";
-import { LIBRARY_NAMESPACE_ALIAS } from "../LibraryTestConstants.js";
+import { BOOK_DER_PROZESS, LIBRARY_NAMESPACE_ALIAS } from "../LibraryTestConstants.js";
 
 /**
- * `namespace.alias` (`odata2ts-namespace-alias.md`), against the one server whose reference model has all
- * four namespaces this feature cares about: `Library.Catalog` (aliased to `Catalog`), `Library.Circulation`
+ * `namespace.alias` and `cacheKeys.namespace`, against the one server whose reference model has all four
+ * namespaces this feature cares about: `Library.Catalog` (aliased to `Catalog`), `Library.Circulation`
  * (aliased to `Circulation`), `PublisherRegistry` (aliased to `Pub`), and `Library.Service` (which declares
  * no types of its own, so it never gets a folder and carries no cache-key literal either). Every alias here
  * is explicit, project-configured - there is no auto-synthesis.
  *
+ * `cacheKeys.namespace` shares this client rather than getting its own: it needs the exact same explicit
+ * aliases to prove itself against a real service (an entity-set root's own name and every `entitySetName`
+ * prefixed with the owning type's alias - see `OptionModel.ts`'s own doc comment on the option for the
+ * "same HttpClient across several generated clients" use case this exists for).
+ *
  * `LIBRARY_NAMESPACE_ALIAS` is a separate client from `LIBRARY` (see the config's own comment): every other
- * assertion in this package is unaffected by aliasing, and this is the one client where it is switched on.
+ * assertion in this package is unaffected by either option, and this is the one client where they are
+ * switched on.
  */
 describe("ASP.NET Library: namespace aliasing", () => {
   let memberId: number | undefined;
@@ -20,19 +26,19 @@ describe("ASP.NET Library: namespace aliasing", () => {
     }
   });
 
-  test("a subtype cast's cache-key literal carries the configured alias, not the raw namespace", async () => {
+  test("a subtype cast's cache-key literal carries the configured alias, not the raw namespace - and cacheKeys.namespace prefixes the root itself the same way", async () => {
     // the single-entity cast form (`Media(<id>)/Library.Catalog.Book`) is one of the things this server does
     // not serve (see the package README) - the collection form is, and is all a cast's own cache-key literal
     // needs to prove out anyway
     const request = LIBRARY_NAMESPACE_ALIAS.Media().asBookCollectionService().query();
-    expect(request.cacheKey).toEqual(["Media", "list", { cast: "Catalog.Book" }]);
+    expect(request.cacheKey).toEqual(["Catalog.Media", "list", { cast: "Catalog.Book" }]);
 
     const result = await request.execute();
     expect(result.status).toBe(200);
     expect(result.data.value.length).toBeGreaterThan(0);
   });
 
-  test("a bound operation's cache-key literal carries the configured alias too", async () => {
+  test("a bound operation's cache-key literal carries the configured alias too - entitySetName included, wherever a hop attaches one", async () => {
     // OutstandingBalance is a bound *function* (GET, read-only) - unlike the bound actions on this same
     // entity, calling it has no side effect on data other tests depend on
     const created = await LIBRARY_NAMESPACE_ALIAS.Members()
@@ -42,11 +48,19 @@ describe("ASP.NET Library: namespace aliasing", () => {
     memberId = created.data.Id;
 
     const request = LIBRARY_NAMESPACE_ALIAS.Members(memberId).OutstandingBalance();
-    expect(request.cacheKey).toEqual(["Members", "detail", memberId, "Circulation.OutstandingBalance"]);
+    expect(request.cacheKey).toEqual(["Circulation.Members", "detail", memberId, "Circulation.OutstandingBalance"]);
 
     const result = await request.execute();
     expect(result.status).toBe(200);
     expect(typeof result.data.value).toBe("number");
+  });
+
+  test("a hierarchical hop's own step name is never prefixed - only its entitySetName is", async () => {
+    const request = LIBRARY_NAMESPACE_ALIAS.Media(BOOK_DER_PROZESS).Copies().query();
+    expect(request.cacheKey).toEqual(["Catalog.Media", "detail", BOOK_DER_PROZESS, "Copies", "list"]);
+
+    const result = await request.execute();
+    expect(result.status).toBe(200);
   });
 
   test("PublisherRegistry's project-configured alias has no cast or bound operation to prove itself through a cache-key literal - useAliasForFolderName is what proves it instead: this very import only resolves if the generated folder is really named `pub`, not `publisher-registry`", async () => {

--- a/packages/odata2ts/src/OptionModel.ts
+++ b/packages/odata2ts/src/OptionModel.ts
@@ -245,11 +245,28 @@ export interface CacheKeysObjectOptions {
    * responses rather than a generation-time prediction. One behaviour, so a boolean is all this needs to be.
    */
   enabled: boolean;
+  /**
+   * Prefixes every entity-set-derived identifier a cache key carries - a root's own name (an entity set's
+   * or singleton's), and `entitySetName` wherever a hop attaches one - with that type's own effective
+   * namespace (its alias if it has one, its real namespace otherwise; see `NamespaceAliasResolver`).
+   *
+   * Off by default: within one generated client, a route's own name is already enough to identify a
+   * resource. Turn this on when a single cache - an `HttpClient.resourceIdentity`, or an app-level query
+   * cache keyed by `cacheKey` - is shared across *multiple* generated clients whose entity-set names might
+   * otherwise collide (`["Media", "list"]` from one service is indistinguishable from another's).
+   *
+   * Never reaches a hierarchical hop's own step name (a navigation property's odataName): that value is
+   * already nested inside an array rooted at a namespaced name, so it is never compared as a standalone
+   * identifier the way `entitySetName` is. Never reaches the raw name a `canonicalIdFn` bakes into
+   * generated code for `QId`/URL building either - that string is a real OData URL segment and must stay
+   * exactly the server's own name regardless of this option.
+   */
+  namespace?: boolean;
 }
 
 /**
  * `cacheKeys` in `ConfigFileOptions`: either the bare boolean directly, or the object form - which exists
- * only so a later option can join `enabled` under the same key without a breaking change.
+ * so `namespace` (and any future option) can join `enabled` under the same key without a breaking change.
  */
 export type CacheKeysOptions = boolean | CacheKeysObjectOptions;
 
@@ -259,6 +276,14 @@ export function resolveCacheKeysEnabled(options: CacheKeysOptions | undefined): 
     return options;
   }
   return options?.enabled ?? false;
+}
+
+/** Whether entity-set-derived cache-key identifiers carry their owning type's namespace - `false` for the bare boolean shorthand, since there is nowhere to state it. */
+export function resolveCacheKeysNamespace(options: CacheKeysOptions | undefined): boolean {
+  if (typeof options === "boolean") {
+    return false;
+  }
+  return options?.namespace ?? false;
 }
 
 /**

--- a/packages/odata2ts/src/data-model/DataModel.ts
+++ b/packages/odata2ts/src/data-model/DataModel.ts
@@ -109,6 +109,26 @@ export class DataModel {
   }
 
   /**
+   * The effective namespace of a fully qualified name, alone - the same alias resolution
+   * {@link getDisplayFqName} applies to a whole FQN, stopping short of the local name. Used to prefix an
+   * otherwise un-namespaced cache-key identifier (an entity set's or unbound operation's own name) with its
+   * owning type's namespace, gated by `cacheKeys.namespace` - see `ServiceGenerator`'s cache-key emission.
+   *
+   * Unlike {@link getDisplayFqName}, always returns *something* to prefix with: falls back to the real,
+   * un-aliased namespace (`fqName` minus its own local name) wherever none of the alias sources cover it,
+   * since - here - there is always a namespace, just not always an alias for it.
+   */
+  public getDisplayNamespace(fqName: string): string {
+    for (const ns of this.aliasedNamespacesLongestFirst) {
+      if (fqName.startsWith(ns + ".")) {
+        return this.namespace2Alias[ns];
+      }
+    }
+    const lastDot = fqName.lastIndexOf(".");
+    return lastDot < 0 ? fqName : fqName.slice(0, lastDot);
+  }
+
+  /**
    * OData version: 2.0 or 4.0.
    * @returns
    */

--- a/packages/odata2ts/src/defaultConfig.ts
+++ b/packages/odata2ts/src/defaultConfig.ts
@@ -119,7 +119,7 @@ const defaultConfig: DefaultConfiguration = {
   byTypeAndName: [],
   disableBindingProps: false,
   deepInsertProps: DeepInsertProps.all,
-  cacheKeys: { enabled: false },
+  cacheKeys: { enabled: false, namespace: false },
   namespace: { alias: {}, useAliasForFolderName: false },
 };
 

--- a/packages/odata2ts/src/generator/ServiceGenerator.ts
+++ b/packages/odata2ts/src/generator/ServiceGenerator.ts
@@ -26,7 +26,7 @@ import {
   SingletonType,
 } from "../data-model/DataTypeModel.js";
 import { NamingHelper } from "../data-model/NamingHelper.js";
-import { ConfigFileOptions, Modes, resolveCacheKeysEnabled } from "../OptionModel.js";
+import { ConfigFileOptions, Modes, resolveCacheKeysEnabled, resolveCacheKeysNamespace } from "../OptionModel.js";
 import { FileHandler } from "../project/FileHandler.js";
 import { ProjectManager } from "../project/ProjectManager.js";
 import { ClientApiImports, CoreImports, QueryObjectImports, ServiceImports } from "./import/ImportObjects.js";
@@ -64,6 +64,7 @@ class ServiceGenerator {
   ) {}
 
   private readonly cacheKeysEnabled = resolveCacheKeysEnabled(this.options.cacheKeys);
+  private readonly cacheKeysNamespace = resolveCacheKeysNamespace(this.options.cacheKeys);
 
   private isV4BigNumber() {
     return this.options.v4.bigNumberAsString && this.version === ODataVersions.V4;
@@ -102,6 +103,15 @@ class ServiceGenerator {
     return `(entity: unknown) => new ${qId}("${entitySetOdataName}").buildCanonicalId(entity)`;
   }
 
+  /**
+   * `name` (an entity set's or singleton's own odataName), prefixed with `entityType`'s own effective
+   * namespace when `cacheKeys.namespace` is on - see that option's own doc comment for what this guards
+   * against and what it deliberately never reaches (a hop's own step name, a canonicalIdFn's raw name).
+   */
+  private namespacedName(entityType: EntityType, name: string): string {
+    return this.cacheKeysNamespace ? `${this.dataModel.getDisplayNamespace(entityType.fqName)}.${name}` : name;
+  }
+
   /** The root of a route: an entity set or a singleton. An operation with no declared result set is the one root with no type to head with - built as a plain object literal instead, see `emitUnboundOperationRootExpr`. */
   private emitRootStateExpr(
     imports: ImportContainer,
@@ -114,15 +124,17 @@ class ServiceGenerator {
       return "";
     }
     const rootStateFn = imports.addServiceFunction("rootState");
+    const cacheKeyName = this.namespacedName(entityType, name);
     const optionsEntries = [
       options?.paramsSource ? `params: ${options.paramsSource}` : "",
-      options?.isEntitySet ? `entitySetName: "${name}"` : "",
+      options?.isEntitySet ? `entitySetName: "${cacheKeyName}"` : "",
+      // the canonicalIdFn's own name is a real OData URL segment - always the raw `name`, never `cacheKeyName`
       options?.isEntitySet ? `canonicalIdFn: ${this.canonicalIdFnExpr(imports, entityType, name)}` : "",
       `qEntityFn: ${this.qEntityFnExpr(imports, entityType)}`,
     ]
       .filter(Boolean)
       .join(", ");
-    return `${rootStateFn}("${name}", "${kind}", { ${optionsEntries} })`;
+    return `${rootStateFn}("${cacheKeyName}", "${kind}", { ${optionsEntries} })`;
   }
 
   /**
@@ -146,7 +158,11 @@ class ServiceGenerator {
 
     const kind = isCollection ? "list" : "detail";
     const targetSet = !contained ? this.dataModel.getNavPropBindingTarget(ownerFqName, navPropOdataName) : undefined;
-    const entitySetNameEntry = targetSet ? `, entitySetName: "${targetSet.odataName}"` : "";
+    // the hop's own step name (navPropOdataName) never carries this prefix - only entitySetName does, since
+    // that is the value reused as a bare, cross-route identifier (invalidates, response-observed identity)
+    const entitySetNameEntry = targetSet
+      ? `, entitySetName: "${this.namespacedName(targetSet.entityType, targetSet.odataName)}"`
+      : "";
     const canonicalIdFnEntry = targetSet
       ? `, canonicalIdFn: ${this.canonicalIdFnExpr(imports, targetSet.entityType, targetSet.odataName)}`
       : "";
@@ -205,6 +221,11 @@ class ServiceGenerator {
    * import does declare a result `EntitySet`, `entitySetName`/`canonicalIdFn`/`qEntityFn` are still attached
    * so `ResourceIdentityHandler` can record the real entities the response carries - a separate concern from
    * what the root's own identity in the key is.
+   *
+   * `cacheKeys.namespace`, when on, still prefixes the root's own name with the *operation's* namespace
+   * (`op.fqName`) - not because the root is rooted at the operation's qualified name (it isn't, see above),
+   * but for the same collision-avoidance reason every other root gets prefixed with its own type's
+   * namespace: two different services' import names can otherwise collide identically.
    */
   private emitUnboundOperationRootExpr(
     imports: ImportContainer,
@@ -222,6 +243,9 @@ class ServiceGenerator {
       : undefined;
     const rootStateFn = imports.addServiceFunction("rootState");
     const kind = op.returnType?.isCollection ? "list" : "detail";
+    const cacheKeyName = this.cacheKeysNamespace
+      ? `${this.dataModel.getDisplayNamespace(op.fqName)}.${importOdataName}`
+      : importOdataName;
     // nested under its own "params" key, never spread directly - a composable operation's cache key later
     // merges in real query params (select/filter/...) via buildCacheKey, and those must not collide with
     // the operation's own invocation arguments
@@ -230,15 +254,16 @@ class ServiceGenerator {
     if (entitySet) {
       const canonicalIdFnEntry = `canonicalIdFn: ${this.canonicalIdFnExpr(imports, entitySet.entityType, entitySet.odataName)}, `;
       const qEntityFnEntry = `qEntityFn: ${this.qEntityFnExpr(imports, entitySet.entityType)}`;
+      const namespacedEntitySetName = this.namespacedName(entitySet.entityType, entitySet.odataName);
       return (
-        `${rootStateFn}("${importOdataName}", "${kind}", ` +
-        `{ ${paramsEntry}entitySetName: "${entitySet.odataName}", ${canonicalIdFnEntry}${qEntityFnEntry} })`
+        `${rootStateFn}("${cacheKeyName}", "${kind}", ` +
+        `{ ${paramsEntry}entitySetName: "${namespacedEntitySetName}", ${canonicalIdFnEntry}${qEntityFnEntry} })`
       );
     }
 
     return hasParams
-      ? `${rootStateFn}("${importOdataName}", "${kind}", { params: { params } })`
-      : `${rootStateFn}("${importOdataName}", "${kind}")`;
+      ? `${rootStateFn}("${cacheKeyName}", "${kind}", { params: { params } })`
+      : `${rootStateFn}("${cacheKeyName}", "${kind}")`;
   }
 
   /**

--- a/packages/odata2ts/test/data-model/DataModel.test.ts
+++ b/packages/odata2ts/test/data-model/DataModel.test.ts
@@ -375,4 +375,38 @@ describe("Data Model Tests", function () {
       expect(dataModel.getDisplayFqName("Xxx")).toBe("Xxx");
     });
   });
+
+  describe("getDisplayNamespace", () => {
+    test("an unaliased namespace falls back to the real, raw namespace - there is always something to prefix with here", () => {
+      expect(dataModel.getDisplayNamespace(`${NS1}.Reservation`)).toBe(NS1);
+    });
+
+    test("an aliased namespace resolves to its alias", () => {
+      expect(dataModel.getDisplayNamespace(`${NS2}.Reservation`)).toBe(ALIAS_NS2);
+    });
+
+    test("a namespace aliased to the empty string resolves to the empty string, not the raw namespace", () => {
+      const withEmptyAlias = new DataModel([[NS1], [NS2, ""]], ODataVersion.V4);
+      expect(withEmptyAlias.getDisplayNamespace(`${NS2}.Reservation`)).toBe("");
+    });
+
+    test("a namespace nested inside another aliased one resolves against the longer, more specific match", () => {
+      const outer = "Library";
+      const inner = "Library.Circulation";
+      const nested = new DataModel(
+        [
+          [outer, "Lib"],
+          [inner, "Circ"],
+        ],
+        ODataVersion.V4,
+      );
+
+      expect(nested.getDisplayNamespace(`${inner}.Reservation`)).toBe("Circ");
+      expect(nested.getDisplayNamespace(`${outer}.Branch`)).toBe("Lib");
+    });
+
+    test("a name with no namespace at all (no dot) is returned unchanged - never a real input in practice", () => {
+      expect(dataModel.getDisplayNamespace("Xxx")).toBe("Xxx");
+    });
+  });
 });

--- a/packages/odata2ts/test/evaluateConfig.test.ts
+++ b/packages/odata2ts/test/evaluateConfig.test.ts
@@ -9,6 +9,7 @@ import {
   Modes,
   NamingStrategies,
   resolveCacheKeysEnabled,
+  resolveCacheKeysNamespace,
 } from "../src/index.js";
 
 describe("Config Evaluation Tests", () => {
@@ -328,9 +329,17 @@ describe("Config Evaluation Tests", () => {
       expect(resolveCacheKeysEnabled(false)).toBe(false);
     });
 
+    test("namespace: absent means off, the object form is passed through, the bare boolean shorthand has nowhere to state it so is always off", () => {
+      expect(resolveCacheKeysNamespace(undefined)).toBe(false);
+      expect(resolveCacheKeysNamespace({ enabled: true })).toBe(false);
+      expect(resolveCacheKeysNamespace({ enabled: true, namespace: true })).toBe(true);
+      expect(resolveCacheKeysNamespace({ enabled: true, namespace: false })).toBe(false);
+      expect(resolveCacheKeysNamespace(true)).toBe(false);
+    });
+
     test("the default is off, so a config saying nothing generates nothing", () => {
       const [only] = evaluateConfigOptions({}, { services: { a: { source: "a.xml", output: "a" } } });
-      expect(only.cacheKeys).toEqual({ enabled: false });
+      expect(only.cacheKeys).toEqual({ enabled: false, namespace: false });
       expect(resolveCacheKeysEnabled(only.cacheKeys)).toBe(false);
     });
 
@@ -350,12 +359,13 @@ describe("Config Evaluation Tests", () => {
     });
 
     test("a service overrides the default rather than merging with it", () => {
-      // deepmerge folds the default {enabled:false} under the service's own entry; the service must win
+      // deepmerge folds the default {enabled:false, namespace:false} under the service's own entry; the
+      // service's own enabled wins, namespace falls through unset from the default since it never overrode it
       const [only] = evaluateConfigOptions(
         {},
         { services: { a: { source: "a.xml", output: "a", cacheKeys: { enabled: true } } } },
       );
-      expect(only.cacheKeys).toEqual({ enabled: true });
+      expect(only.cacheKeys).toEqual({ enabled: true, namespace: false });
     });
   });
 });

--- a/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
@@ -371,6 +371,41 @@ describe("Service Generator Tests V4", () => {
         `rootState("Media", "list", { entitySetName: "Media", canonicalIdFn: (entity: unknown) => new QMediumId("Media").buildCanonicalId(entity), qEntityFn: () => QMedium })`,
       );
     });
+
+    test("cacheKeys.namespace prefixes every root and entitySetName with the owning type's namespace - never a hop's own step name, never a canonicalIdFn's raw name", async () => {
+      buildModel();
+      await doGenerate({
+        cacheKeys: { enabled: true, namespace: true },
+        enablePrimitivePropertyServices: true,
+      });
+      const text = generatedText();
+
+      // entity-set root: both the root's own name and entitySetName carry the prefix; canonicalIdFn's own
+      // "Media" - a real OData URL segment - does not
+      expect(text).toContain(
+        `rootState("Tester.Media", "list", { entitySetName: "Tester.Media", canonicalIdFn: (entity: unknown) => new QMediumId("Media").buildCanonicalId(entity), qEntityFn: () => QMedium })`,
+      );
+      // singleton root: prefixed the same way, even though it has no entitySetName to also prefix
+      expect(text).toContain(`rootState("Tester.MainBranch", "detail", { qEntityFn: () => QMedium })`);
+      // hierarchical hop: the hop's own step name ("reviews") is never prefixed - only entitySetName is,
+      // since that is the value reused as a bare, cross-route identifier
+      expect(text).toContain(
+        `hopState(cacheKeyState, { name: "reviews", kind: "list", entitySetName: "Tester.Reviews", canonicalIdFn: (entity: unknown) => new QReviewId("Reviews").buildCanonicalId(entity), qEntityFn: () => QReview })`,
+      );
+      // contained hop: no entitySetName to begin with, so nothing changes here regardless of the option
+      expect(text).toContain(`hopState(cacheKeyState, { name: "chapters", kind: "list", qEntityFn: () => QChapter })`);
+      // unbound function with a declared EntitySet: the import's own root name is prefixed via the
+      // *operation's* namespace, entitySetName via the entity type's - both happen to be "Tester" here
+      expect(text).toContain(
+        `rootState("Tester.NewReleases", "list", { entitySetName: "Tester.Media", canonicalIdFn: (entity: unknown) => new QMediumId("Media").buildCanonicalId(entity), qEntityFn: () => QMedium })`,
+      );
+      // unbound function with no EntitySet: the import's own root name is still prefixed
+      expect(text).toContain(`rootState("Tester.TotalCount", "detail")`);
+      // the cast and bound-operation literals are untouched by this option - they already carry their own
+      // namespace unconditionally (the existing namespace.alias feature), with nothing new to add
+      expect(text).toContain(`withParams(cacheKeyState, { cast: "${withNs("Book")}" })`);
+      expect(text).toContain(`hopState(cacheKeyState, { name: "${withNs("checkOut")}" })`);
+    });
   });
 
   test("Service Generator: Min Case", async () => {


### PR DESCRIPTION
## Summary

New `cacheKeys.namespace: boolean` option (default `false`, only reachable via the object form `cacheKeys: { enabled: true, namespace: true }`).

**Use case:** one `HttpClient` (and therefore one shared cache/`resourceIdentity`) consumes several different generated services. Without this option, two different services' entity sets sharing a name (`["Media", "list"]`) produce identical cache keys and collide.

When on, prefixes every **entity-set-derived** cache-key identifier with that type's own effective namespace (its alias if `namespace.alias`/a server-declared `<Schema Alias>` gives it one, its real namespace otherwise, via the existing `NamespaceAliasResolver`):

- A root's own name — an entity set's or a singleton's, or an unbound operation import's.
- `entitySetName`, wherever a hop attaches one (feeds `invalidates`' bare `[entitySetName, "list"]` entries and response-observed cross-route matching — the other place a bare, cross-service-comparable identifier shows up).

**Deliberately left alone:**
- A hierarchical hop's own step name (a navigation property's odataName, e.g. `"copies"` in `[..., "copies", "list"]`) — it's nested inside an array already rooted at a namespaced name, never compared as a standalone identifier.
- The raw name a `canonicalIdFn` bakes into generated code for `QId`/URL building (`new QCopyId("Copies")`) — that's a real OData URL segment and must stay exactly the server's own name regardless of this option.
- The cast/bound-operation literals — already namespace-qualified unconditionally by the existing `namespace.alias` feature, nothing new to add.

New `DataModel.getDisplayNamespace(fqName)` resolves just the namespace portion of a FQN through the same alias table `getDisplayFqName` already reads — unlike `getDisplayFqName`, it always has *something* to prefix with (falls back to the real namespace, never leaves the identifier bare).

## Test plan

- [x] `evaluateConfig.test.ts` — `resolveCacheKeysNamespace` resolution (absent/object-form/bare-boolean-shorthand-has-nowhere-to-state-it)
- [x] `DataModel.test.ts` — `getDisplayNamespace` (aliased/unaliased/empty-string-alias/nested/no-namespace-at-all)
- [x] `ServiceGenerator.test.ts` — golden-output test covering every root shape (entity set, singleton, unbound operation with/without a declared result set) and a hierarchical hop, confirming the hop's own step name and the `canonicalIdFn`'s raw name are untouched
- [x] Full monorepo build + test (`odata-query-objects`, `odata2ts`, `odata-query-builder`, `odata-service`) all pass, `yarn check-format` clean
- [x] `examples/main` smoke test unaffected
- [x] `int-test/asp-net`'s existing `libraryNamespaceAlias` client (real explicit aliases already configured there) now also turns on `cacheKeys.namespace`, regenerated and run against the live container: existing cast/bound-operation assertions updated for the now-prefixed root, plus a new assertion proving a hierarchical hop's own step name stays unprefixed while its `entitySetName` doesn't. All 155 tests pass against the live server; `int-test/cap` (219) unaffected.