### PR TITLE
feat(odata2ts)!: make ts-nocheck opt-in and decouple it from debug

### DIFF
--- a/examples/main/odata2ts.config.ts
+++ b/examples/main/odata2ts.config.ts
@@ -22,8 +22,6 @@ const config: ConfigFileOptions = {
   mode: Modes.service,
   emitMode: EmitModes.ts,
   prettier: true,
-  // otherwise: ts-nocheck above every generated file
-  debug: true,
   services: {
     // Just the Trippin service with a bit of mapping
     trippin: {

--- a/int-test/cli/README.md
+++ b/int-test/cli/README.md
@@ -17,10 +17,10 @@ parsing, config-file discovery, precedence between the two, the service selectio
 messages all are. What an option does to the generated code is not - that is the business of the generator
 unit tests in `packages/odata2ts/test/generator` and of the compile gate in `int-test/config-variants`.
 
-The one deliberate exception is `debug`, in `config-file.test.ts`: it decides whether every emitted file
-opens with `@ts-nocheck`, and that is worth pinning here because it is the reason every other generating
-test configuration in this repository switches the option on. A type check over output which has exempted
-itself from type checking proves nothing.
+The one deliberate exception is `enableTsNoCheck`, in `config-file.test.ts`: it decides whether every
+emitted file opens with `@ts-nocheck`, and that is worth pinning here because a type check over output
+which has exempted itself from type checking proves nothing. The same test pins that `debug` has no
+effect on this - the two options used to be one switch and are now unrelated.
 
 ## The files
 

--- a/int-test/cli/test/config-file.test.ts
+++ b/int-test/cli/test/config-file.test.ts
@@ -88,17 +88,27 @@ describe("Config File Test", () => {
     expect(result.stderr).toContain("--output");
   });
 
-  test("debug decides whether the emitted code exempts itself from type checking", async () => {
-    // The one place `debug: false` is deliberate. Without the option every generated file opens with
-    // `@ts-nocheck`, which makes a type check over that output meaningless - the reason every other
-    // generating test configuration in this repository switches it on.
+  test("enableTsNoCheck decides whether the emitted code exempts itself from type checking", async () => {
+    // The one place `enableTsNoCheck: false` (the default) is deliberate. Without the option every
+    // generated file is type-checked, which is why no other generating test configuration in this
+    // repository needs to switch it on.
     await runCli(["-s", DUMMY_SOURCE, "-o", "build/quiet", "--service-name", "Quiet"], SINGLE_SERVICE);
     const quiet = await readFile(path.join(SINGLE_SERVICE, "build/quiet/QuietService.ts"), "utf-8");
-    expect(quiet).toContain("@ts-nocheck");
+    expect(quiet).not.toContain("@ts-nocheck");
 
-    await runCli(["-s", DUMMY_SOURCE, "-o", "build/loud", "--service-name", "Loud", "-d"], SINGLE_SERVICE);
+    await runCli(
+      ["-s", DUMMY_SOURCE, "-o", "build/loud", "--service-name", "Loud", "--enable-ts-no-check"],
+      SINGLE_SERVICE,
+    );
     const loud = await readFile(path.join(SINGLE_SERVICE, "build/loud/LoudService.ts"), "utf-8");
-    expect(loud).not.toContain("@ts-nocheck");
+    expect(loud).toContain("@ts-nocheck");
+  });
+
+  test("debug no longer has any effect on @ts-nocheck", async () => {
+    // debug and enableTsNoCheck were once the same switch; this pins that they are now unrelated.
+    await runCli(["-s", DUMMY_SOURCE, "-o", "build/debug-only", "--service-name", "DebugOnly", "-d"], SINGLE_SERVICE);
+    const debugOnly = await readFile(path.join(SINGLE_SERVICE, "build/debug-only/DebugOnlyService.ts"), "utf-8");
+    expect(debugOnly).not.toContain("@ts-nocheck");
   });
 });
 

--- a/int-test/config-variants/README.md
+++ b/int-test/config-variants/README.md
@@ -34,12 +34,10 @@ server under its OData name, whether a converter round-trips, whether a URL is o
 none of that is visible here. That is what `int-test/asp-net`, `int-test/cap` and `int-test/olingo-v2` are
 for.
 
-Two things are essential for the gate to be worth anything at all:
-
-- **`debug: true` in every variant.** Without it the generator writes `// @ts-nocheck` into every emitted
-  file, and a type check over such output happily confirms code which does not compile. That is not a
-  weaker gate, it is a worthless one.
-- **`src-generated` in the tsconfig's `include`**, so that generated files nobody imports get checked too.
+One thing is essential for the gate to be worth anything at all: **`src-generated` in the tsconfig's
+`include`**, so that generated files nobody imports get checked too. Generated files are type-checked by
+default (`enableTsNoCheck` defaults to `false`) - a `// @ts-nocheck`'d file would let a type check happily
+confirm code which does not compile, which is not a weaker gate, it is a worthless one.
 
 ## The variants
 

--- a/int-test/config-variants/odata2ts.config.ts
+++ b/int-test/config-variants/odata2ts.config.ts
@@ -22,13 +22,11 @@ import {
  * `tsc` over the result. No server, no Docker, no runtime: it plugs into the ordinary `yarn build` +
  * `yarn test-compile` of the repository root and therefore runs in the plain unit-test CI job.
  *
- * Two things are essential for it to be worth anything:
- *
- * - **`debug: true` everywhere.** Without it the generator writes `// @ts-nocheck` into every emitted file,
- *   and a type check over such output happily confirms code which does not compile. That is not a weaker
- *   gate, it is a worthless one.
- * - **`src-generated` is in the tsconfig's `include`** (see tsconfig.json), so files nobody imports are
- *   checked as well.
+ * One thing is essential for it to be worth anything: **`src-generated` is in the tsconfig's `include`**
+ * (see tsconfig.json), so files nobody imports are checked as well. Generated files are type-checked by
+ * default (`enableTsNoCheck` defaults to `false`) - if that ever stops being true, a type check over
+ * `// @ts-nocheck` output would happily confirm code which does not compile, which is not a weaker gate,
+ * it is a worthless one.
  *
  * The variants follow n+1 rather than 2^n: one variant per axis against the baseline, plus a single
  * "everything on" one to catch interactions. A real matrix would not only be expensive, it would be hard to
@@ -70,8 +68,6 @@ const RESOLVE_LOCATION_CLASH = [{ name: "Location_", mappedName: "ShelfLocation"
 const config: ConfigFileOptions = {
   emitMode: EmitModes.ts,
   prettier: true,
-  // mandatory, see above: without it every generated file carries `@ts-nocheck` and the gate proves nothing
-  debug: true,
   services: {
     /**
      * The baseline: plain defaults, so the other variants have something to be a variant *of*.

--- a/packages/odata2ts/src/OptionModel.ts
+++ b/packages/odata2ts/src/OptionModel.ts
@@ -355,6 +355,13 @@ export interface CliOptions {
    */
   debug?: boolean;
   /**
+   * Adds `// @ts-nocheck` to the top of every generated file, so a consuming project's `tsc` skips
+   * type-checking generated code. A performance optimization, not a correctness escape hatch: it does
+   * not affect {@link debug}, which is unrelated. Defaults to `false`, so generated code is
+   * type-checked by default; set to `true` to trade that safety for the faster build.
+   */
+  enableTsNoCheck?: boolean;
+  /**
    * Overrides the service name found in the source file.
    *
    * The service name is the basis for all file names and the name of the main OData client service

--- a/packages/odata2ts/src/app.ts
+++ b/packages/odata2ts/src/app.ts
@@ -96,7 +96,7 @@ export async function runApp(metadataJson: ODataEdmxModelBase<any>, options: Run
     usePrettier: options.prettier,
     tsConfigPath: options.tsconfig,
     bundledFileGeneration: options.bundledFileGeneration,
-    allowTypeChecking: options.debug,
+    allowTypeChecking: !options.enableTsNoCheck,
     odataVersionV4: options.v4.odataVersion,
   });
 

--- a/packages/odata2ts/src/cli/processCliArgs.ts
+++ b/packages/odata2ts/src/cli/processCliArgs.ts
@@ -78,6 +78,10 @@ export function processCliArgs(argv: Array<string>) {
       "Specify alternative to 'tsconfig.json' to use specific compilerOptions (applies if emitMode is not ts)",
     )
     .option("-d, --debug", "Verbose debug infos")
+    .option(
+      "--enable-ts-no-check",
+      "Add // @ts-nocheck to generated files, skipping downstream type checking for faster builds",
+    )
     .option("--service-name <serviceName>", "Give the service your own name")
     .addOption(
       new Option("--key-properties <mode>", "What an unannotated key property is taken to be")

--- a/packages/odata2ts/src/defaultConfig.ts
+++ b/packages/odata2ts/src/defaultConfig.ts
@@ -12,6 +12,7 @@ const defaultConfig: DefaultConfiguration = {
   mode: Modes.all,
   emitMode: EmitModes.js_dts,
   debug: false,
+  enableTsNoCheck: false,
   prettier: false,
   tsconfig: "tsconfig.json",
   converters: [],

--- a/packages/odata2ts/src/project/ProjectManager.ts
+++ b/packages/odata2ts/src/project/ProjectManager.ts
@@ -377,8 +377,8 @@ export class ProjectManager {
       return false;
     }
 
-    // barrels are trivially correct, so they are type checked regardless of the debug option: an ambiguous
-    // re-export is a real problem and should surface instead of being hidden behind @ts-nocheck
+    // barrels are trivially correct, so they are type checked regardless of the enableTsNoCheck option: an
+    // ambiguous re-export is a real problem and should surface instead of being hidden behind @ts-nocheck
     const fileHandler = this.createFile(INDEX_FILE_NAME, undefined, folderPath, true);
     fileHandler.getFile().addExportDeclarations(exportDeclarations);
 

--- a/packages/odata2ts/test/app.test.ts
+++ b/packages/odata2ts/test/app.test.ts
@@ -183,7 +183,7 @@ describe("App Test", () => {
       usePrettier: false,
       bundledFileGeneration: true,
       tsConfigPath: "tsconfig.json",
-      allowTypeChecking: false,
+      allowTypeChecking: true,
       odataVersionV4: "4.0",
     });
 
@@ -212,7 +212,7 @@ describe("App Test", () => {
       usePrettier: true,
       bundledFileGeneration: false,
       tsConfigPath: "test.json",
-      allowTypeChecking: false,
+      allowTypeChecking: true,
       odataVersionV4: "4.0",
     });
 
@@ -220,6 +220,20 @@ describe("App Test", () => {
     expect(Generator.generateModels).toHaveBeenCalled();
     expect(Generator.generateQueryObjects).toHaveBeenCalled();
     expect(Generator.generateServices).not.toHaveBeenCalled();
+  });
+
+  test("App: enableTsNoCheck controls allowTypeChecking, independent of debug", async () => {
+    // enableTsNoCheck alone turns type checking off
+    runOptions.enableTsNoCheck = true;
+    await doRunApp();
+    expect(createPmSpy.mock.calls[0][4]).toMatchObject({ allowTypeChecking: false });
+
+    // debug alone does not - the two options are unrelated
+    vi.clearAllMocks();
+    runOptions.enableTsNoCheck = false;
+    runOptions.debug = true;
+    await doRunApp();
+    expect(createPmSpy.mock.calls[0][4]).toMatchObject({ allowTypeChecking: true });
   });
 
   test("App: generate also services", async () => {

--- a/packages/odata2ts/test/cli/cli.test.ts
+++ b/packages/odata2ts/test/cli/cli.test.ts
@@ -269,6 +269,21 @@ describe("Cli Test", () => {
     await testDebug(false);
   });
 
+  async function testEnableTsNoCheck(enableTsNoCheck: boolean) {
+    const args = [...defaultArgs];
+    if (enableTsNoCheck) {
+      args.push("--enable-ts-no-check");
+    }
+    runOptions.enableTsNoCheck = enableTsNoCheck;
+
+    await testCli(args);
+  }
+
+  test("Test enableTsNoCheck option", async () => {
+    await testEnableTsNoCheck(true);
+    await testEnableTsNoCheck(false);
+  });
+
   async function testKeyProperties(keyProperties: KeyProperties | undefined) {
     const args = [...defaultArgs];
     if (keyProperties) {


### PR DESCRIPTION
- Add `enableTsNoCheck` (default `false`) as the sole switch for `// @ts-nocheck` on generated files, plus a matching `--enable-ts-no-check` CLI flag mirroring `-d/--debug`
- Fully decouple `debug` from ts-nocheck: it no longer has any effect on type checking, and keeps only its logging responsibilities (CLI opts, resolved config, metadata-download requests)
- BREAKING CHANGE: generated code is type-checked by default now; set `enableTsNoCheck: true` to restore the old unconditional `// @ts-nocheck` behavior
- Barrel/index-file exception (always type-checked) is unchanged
- Drop the now-unnecessary `debug: true` from `examples/main` and `int-test/config-variants` configs, and update their docs
- Add/update unit and E2E tests covering the new option and the debug decoupling