### PR TITLE
fix(odata-service): keep cache keys correct across addToQuery and hop-through invalidation

### DIFF
--- a/int-test/cap/test/v2/feature/CacheKeys.test.ts
+++ b/int-test/cap/test/v2/feature/CacheKeys.test.ts
@@ -72,7 +72,7 @@ describe("CAP Library: cache keys (V2)", () => {
     expect(touchesResource(["Loans", "list"], key)).toBe(false);
   });
 
-  test("invalidates on a write through a hop reaches the ancestor too", async () => {
+  test("invalidates on a write through a hop reaches the ancestor too - and the ancestor's own list form alongside it", async () => {
     const created = await LIBRARY_V2.Members(MEMBER_ID)
       .Reservations()
       .create({ Member_Id: MEMBER_ID, ReservedAt: "2026-05-02T10:00:00Z" })
@@ -82,6 +82,7 @@ describe("CAP Library: cache keys (V2)", () => {
 
     expect(created.invalidates).toEqual([
       ["Members", "detail", MEMBER_ID],
+      ["Members", "list"],
       ["Reservations", "list"],
     ]);
 

--- a/int-test/olingo-v2/test/feature/CacheKeys.test.ts
+++ b/int-test/olingo-v2/test/feature/CacheKeys.test.ts
@@ -53,6 +53,21 @@ describe("Olingo Library: cache keys", () => {
     ]);
   });
 
+  test("addToQuery changes the cache key with whatever it just restricted - not frozen at the query() call's own restrictions", async () => {
+    const base = LIBRARY.Books().query((builder, qBook) => builder.filter(qBook.Language.eq("de")));
+    const widened = base.addToQuery((builder) => builder.select("Title").top(1));
+
+    expect(widened.cacheKey).not.toEqual(base.cacheKey);
+
+    const [, , params] = widened.cacheKey as [string, string, { select: Array<string>; query: string }];
+    expect(params.select).toEqual(["Title"]);
+    expect(decodeURIComponent(params.query)).toContain("$filter=Language+eq+'de'");
+    expect(decodeURIComponent(params.query)).toContain("$top=1");
+
+    const result = await widened.execute();
+    expect(result.status).toBe(200);
+  });
+
   test("touchesResource reaches a hierarchical key by its own name", () => {
     const key = LIBRARY.Members(1).Loans().query().cacheKey!;
     expect(touchesResource(["Members", "detail", 1], key)).toBe(true);

--- a/packages/odata-service/src/cacheKey/BuildCacheKey.ts
+++ b/packages/odata-service/src/cacheKey/BuildCacheKey.ts
@@ -37,12 +37,15 @@ function mergeParams(
  * `resolveCrossRouteInvalidates`; empty, never computed here, for a client with no such store). Entries
  * another entry is a prefix of are dropped; what is left is coarsest first.
  *
- * Rule 2 is skipped where the resource has no entity set of its own - a contained entity, a complex value,
- * a singleton: nothing is ever registered under such a key. `deepEdit` hops read straight off
- * `state.params`, unlike every other params entry: they are not a restriction on the addressed resource
- * the way `filter`/`cast` are, so there is nothing to drop them for - they name additional, unrelated
- * entity sets this same write also touched, each with no key of its own yet since the entity is freshly
- * created.
+ * Rule 2 applies wherever a "detail" key goes stale and the entity set it belongs to is known - not just
+ * the addressed resource itself, but every ancestor hop too (rule 3): a list is a query *over* an entity
+ * set, so any of that set's members turning stale is reason enough to also invalidate the set's own bare
+ * list key, whichever hop the member was reached through. Skipped wherever the resource has no entity set
+ * of its own - a contained entity, a complex value, a singleton: nothing is ever registered under such a
+ * key. `deepEdit` hops read straight off `state.params`, unlike every other params entry: they are not a
+ * restriction on the addressed resource the way `filter`/`cast` are, so there is nothing to drop them for -
+ * they name additional, unrelated entity sets this same write also touched, each with no key of its own yet
+ * since the entity is freshly created.
  *
  * Deliberately does **not** enumerate the resource's children on its own: the ancestor entry covers them
  * by prefix for a hierarchical route, and `crossRouteKeys` is what reaches a route this write never took.
@@ -53,10 +56,15 @@ export function buildInvalidates(
 ): ReadonlyArray<ReadonlyArray<unknown>> {
   const deepEditHops = (state.params?.deepEdit as ReadonlyArray<string> | undefined) ?? [];
 
-  // ancestors in route order (coarsest first), then the resource itself, then its entity set, then
-  // whatever it deep-inserted into, then whatever another route to this same resource already has cached
+  const ancestorEntries = (state.ancestors ?? []).flatMap((ancestor) =>
+    ancestor.entitySetName ? [ancestor.key, [ancestor.entitySetName, "list"]] : [ancestor.key],
+  );
+
+  // ancestors in route order (coarsest first, each with its own list form alongside), then the resource
+  // itself, then its entity set, then whatever it deep-inserted into, then whatever another route to this
+  // same resource already has cached
   const candidates: Array<ReadonlyArray<unknown>> = [
-    ...(state.ancestors ?? []),
+    ...ancestorEntries,
     [state.name, ...state.steps],
     ...(state.entitySetName ? [[state.entitySetName, "list"]] : []),
     ...deepEditHops.map((entitySetName) => [entitySetName, "list"]),

--- a/packages/odata-service/src/cacheKey/CacheKeyState.ts
+++ b/packages/odata-service/src/cacheKey/CacheKeyState.ts
@@ -48,8 +48,14 @@ export interface CacheKeyState {
   readonly entitySetName?: string;
   /** See {@link CanonicalIdFn}. Present exactly where {@link entitySetName} is - a resource with no entity set of its own has no canonical id to build either. */
   readonly canonicalIdFn?: CanonicalIdFn;
-  /** Key of every hop from the root down to the parent, params already dropped. Feeds `invalidates`. */
-  readonly ancestors?: ReadonlyArray<ReadonlyArray<unknown>>;
+  /**
+   * Every hop from the root down to the parent, params already dropped, paired with the entity set each one
+   * belonged to at the time the route left it (absent under the same conditions {@link entitySetName} is).
+   * Feeds `invalidates`: a stale ancestor is not just itself invalidated, but - since it was fetched as a
+   * "detail" resource - its own bare list form too, on the same "a detail going stale means its list may no
+   * longer agree either" logic {@link entitySetName} already applies to the addressed resource itself.
+   */
+  readonly ancestors?: ReadonlyArray<{ readonly key: ReadonlyArray<unknown>; readonly entitySetName?: string }>;
   /**
    * The addressed resource's own key or id, exactly as given to `byId` - bare for a single primary key, an
    * object keyed by the model's own mapped property names otherwise. The same shape {@link CanonicalIdFn}
@@ -147,7 +153,10 @@ export function withParams(state: CacheKeyState, params: Readonly<Record<string,
  * taken, never re-rooted.
  */
 export function hopState(state: CacheKeyState, hop: HopDescriptor): CacheKeyState {
-  const ancestors = [...(state.ancestors ?? []), [state.name, ...state.steps]];
+  const ancestors = [
+    ...(state.ancestors ?? []),
+    { key: [state.name, ...state.steps], ...(state.entitySetName ? { entitySetName: state.entitySetName } : {}) },
+  ];
   const steps = hop.kind ? [...state.steps, hop.name, hop.kind] : [...state.steps, hop.name];
   const kindIndex = hop.kind ? steps.length - 1 : state.kindIndex;
 

--- a/packages/odata-service/src/request/UrlBuilderRequestCmdV2.ts
+++ b/packages/odata-service/src/request/UrlBuilderRequestCmdV2.ts
@@ -27,6 +27,12 @@ export class UrlBuilderRequestCmdV2<
   /**
    * Allow for URL manipulation by creating an entirely new RequestCmd.
    *
+   * `queryParams` is re-snapshotted off the resulting builder rather than carried over from `this.options`:
+   * it was itself only ever a snapshot of the builder at construction time (see the service methods that
+   * set it), so carrying the old one forward here would leave the new command's cache key blind to whatever
+   * `modFunction` just changed - a stale `$select`/`$expand` restriction next to a URL that no longer
+   * matches it.
+   *
    * @param modFunction the function to modify the URL
    */
   public addToQuery(modFunction: (urlBuilder: Builder, q: Q) => Builder) {
@@ -41,7 +47,7 @@ export class UrlBuilderRequestCmdV2<
       builder,
       this.q,
       this.data,
-      this.options,
+      { ...this.options, queryParams: builder.getCacheKeyParams() },
     );
   }
 }

--- a/packages/odata-service/src/request/UrlBuilderRequestCmdV4.ts
+++ b/packages/odata-service/src/request/UrlBuilderRequestCmdV4.ts
@@ -28,6 +28,12 @@ export class UrlBuilderRequestCmdV4<
   /**
    * Add to the existing query builder, thereby creating a clone.
    *
+   * `queryParams` is re-snapshotted off the resulting builder rather than carried over from `this.options`:
+   * it was itself only ever a snapshot of the builder at construction time (see the service methods that
+   * set it), so carrying the old one forward here would leave the new command's cache key blind to whatever
+   * `modFunction` just changed - a stale `$select`/`$expand` restriction next to a URL that no longer
+   * matches it.
+   *
    * @param modFunction the function to modify the URL
    * @returns
    */
@@ -43,7 +49,7 @@ export class UrlBuilderRequestCmdV4<
       builder,
       this.q,
       this.data,
-      this.options,
+      { ...this.options, queryParams: builder.getCacheKeyParams() },
     );
   }
 

--- a/packages/odata-service/src/request/UrlBuilderWriteRequestCmdV2.ts
+++ b/packages/odata-service/src/request/UrlBuilderWriteRequestCmdV2.ts
@@ -46,7 +46,10 @@ export class UrlBuilderWriteRequestCmdV2<
 
   /**
    * Overridden so the clone is a write command too: the inherited version names its own class, and would
-   * hand back a command that has silently forgotten the ETag just stated on this one.
+   * hand back a command that has silently forgotten the ETag just stated on this one. Unlike the inherited
+   * version, `queryParams` is carried over as-is rather than re-snapshotted off the new builder: a write
+   * never exposes a `cacheKey` at all (`RequestCmd.cacheKey` is `undefined` for any method but `GET`), so
+   * there is nothing here for a stale snapshot to mislead.
    */
   public addToQuery(modFunction: (urlBuilder: Builder, q: Q) => Builder) {
     if (!modFunction) {

--- a/packages/odata-service/src/request/UrlBuilderWriteRequestCmdV4.ts
+++ b/packages/odata-service/src/request/UrlBuilderWriteRequestCmdV4.ts
@@ -47,7 +47,10 @@ export class UrlBuilderWriteRequestCmdV4<
 
   /**
    * Overridden so the clone is a write command too: the inherited version names its own class, and would
-   * hand back a command that has silently forgotten the ETag just stated on this one.
+   * hand back a command that has silently forgotten the ETag just stated on this one. Unlike the inherited
+   * version, `queryParams` is carried over as-is rather than re-snapshotted off the new builder: a write
+   * never exposes a `cacheKey` at all (`RequestCmd.cacheKey` is `undefined` for any method but `GET`), so
+   * there is nothing here for a stale snapshot to mislead.
    */
   public addToQuery(modFunction: (urlBuilder: Builder, q: Q) => Builder) {
     if (!modFunction) {

--- a/packages/odata-service/test/cacheKey/BuildCacheKey.test.ts
+++ b/packages/odata-service/test/cacheKey/BuildCacheKey.test.ts
@@ -84,7 +84,7 @@ describe("buildInvalidates", () => {
     expect(buildInvalidates(state)).toContainEqual([MEDIA, "detail", 5]);
   });
 
-  test("a hierarchical write's own key is a prefix-redundant with its ancestor, and drops out - the ancestor and the entity-set list entry are what remain", () => {
+  test("a hierarchical write's own key is a prefix-redundant with its ancestor, and drops out - the ancestor, the ancestor's own list form, and the entity-set list entry are what remain", () => {
     const copies = hopState(withKey(rootState(MEDIA, "list", { entitySetName: MEDIA }), 5, { Id: 5 }), {
       name: "copies",
       kind: "list",
@@ -93,11 +93,12 @@ describe("buildInvalidates", () => {
     const key = { MediumId: 5, InventoryNumber: 7 };
     expect(buildInvalidates(withKey(copies, key, key))).toEqual([
       [MEDIA, "detail", 5],
+      [MEDIA, "list"],
       [COPIES, "list"],
     ]);
   });
 
-  test("a POST to a hierarchical collection: the own key without a key value is the ancestor plus the entity-set list", () => {
+  test("a POST to a hierarchical collection: the own key without a key value is the ancestor, the ancestor's own list form, plus the entity-set list", () => {
     const copies = hopState(withKey(rootState(MEDIA, "list", { entitySetName: MEDIA }), 5, { Id: 5 }), {
       name: "copies",
       kind: "list",
@@ -105,6 +106,7 @@ describe("buildInvalidates", () => {
     });
     expect(buildInvalidates(copies)).toEqual([
       [MEDIA, "detail", 5],
+      [MEDIA, "list"],
       [COPIES, "list"],
     ]);
   });
@@ -117,16 +119,20 @@ describe("buildInvalidates", () => {
     });
     expect(buildInvalidates(withKey(reservations, 9, { Id: 9 }))).toEqual([
       [MEMBERS, "detail", 42],
+      [MEMBERS, "list"],
       [RESERVATIONS, "list"],
     ]);
   });
 
-  test("a contained resource contributes no entity-set entry", () => {
+  test("a contained resource contributes no entity-set entry of its own, but its ancestor's list form still goes stale", () => {
     const chapters = hopState(withKey(rootState(MEDIA, "list", { entitySetName: MEDIA }), 1, { Id: 1 }), {
       name: "chapters",
       kind: "list",
     });
-    expect(buildInvalidates(withKey(chapters, 3, { Id: 3 }))).toEqual([[MEDIA, "detail", 1]]);
+    expect(buildInvalidates(withKey(chapters, 3, { Id: 3 }))).toEqual([
+      [MEDIA, "detail", 1],
+      [MEDIA, "list"],
+    ]);
   });
 
   test("two structurally equal key objects built independently compare as one entry", () => {
@@ -137,10 +143,23 @@ describe("buildInvalidates", () => {
       { MediumId: 5, InventoryNumber: 7 },
       { MediumId: 5, InventoryNumber: 7 },
     );
-    const withOtherOrder = { ...state, ancestors: [[COPIES, "detail", { InventoryNumber: 7, MediumId: 5 }]] };
+    const withOtherOrder = {
+      ...state,
+      ancestors: [{ key: [COPIES, "detail", { InventoryNumber: 7, MediumId: 5 }] }],
+    };
     expect(buildInvalidates(withOtherOrder as typeof state)).toEqual([
       [COPIES, "detail", { InventoryNumber: 7, MediumId: 5 }],
       [COPIES, "list"],
+    ]);
+  });
+
+  test("an ancestor with no entity set of its own (a contained resource, a complex value) contributes only its own key, never a list form", () => {
+    const state = withKey(rootState(MEDIA, "list", { entitySetName: MEDIA }), 5, { Id: 5 });
+    const withUnlistedAncestor = { ...state, ancestors: [{ key: ["SomeComplexValue", "detail"] }] };
+    expect(buildInvalidates(withUnlistedAncestor as typeof state)).toEqual([
+      ["SomeComplexValue", "detail"],
+      [MEDIA, "detail", 5],
+      [MEDIA, "list"],
     ]);
   });
 

--- a/packages/odata-service/test/cacheKey/CacheKeyState.test.ts
+++ b/packages/odata-service/test/cacheKey/CacheKeyState.test.ts
@@ -82,7 +82,7 @@ describe("CacheKeyState", () => {
 
     expect(state.name).toBe(MEDIA);
     expect(state.steps).toEqual(["detail", 5, "copies", "list"]);
-    expect(state.ancestors).toEqual([[MEDIA, "detail", 5]]);
+    expect(state.ancestors).toEqual([{ key: [MEDIA, "detail", 5] }]);
     expect(state.entitySetName).toBe(COPIES);
     expect(state.canonicalIdFn).toBe(canonicalIdOfCopies);
     expect(state.qEntityFn).toBe(qCopy);
@@ -92,7 +92,13 @@ describe("CacheKeyState", () => {
   test("an ancestor is pushed without its params object", () => {
     const parent = withParams(withKey(rootState(MEDIA, "list"), 5, { Id: 5 }), { cast: "Library.Catalog.Book" });
     const state = hopState(parent, { name: "copies", kind: "list", entitySetName: COPIES });
-    expect(state.ancestors).toEqual([[MEDIA, "detail", 5]]);
+    expect(state.ancestors).toEqual([{ key: [MEDIA, "detail", 5] }]);
+  });
+
+  test("an ancestor carries the entity set it belonged to, so a stale ancestor can invalidate that set's own list form too", () => {
+    const parent = withKey(rootState(MEDIA, "list", { entitySetName: MEDIA }), 5, { Id: 5 });
+    const state = hopState(parent, { name: "copies", kind: "list", entitySetName: COPIES });
+    expect(state.ancestors).toEqual([{ key: [MEDIA, "detail", 5], entitySetName: MEDIA }]);
   });
 
   test("a hop to a contained property has no entity set, so entitySetName and canonicalIdFn stay undefined", () => {
@@ -131,8 +137,8 @@ describe("CacheKeyState", () => {
       "detail",
     ]);
     expect(condition.ancestors).toEqual([
-      [MEDIA, "detail", 5],
-      [MEDIA, "detail", 5, "copies", "detail", { MediumId: 5, InventoryNumber: 7 }],
+      { key: [MEDIA, "detail", 5] },
+      { key: [MEDIA, "detail", 5, "copies", "detail", { MediumId: 5, InventoryNumber: 7 }], entitySetName: COPIES },
     ]);
   });
 

--- a/packages/odata-service/test/request/UrlBuilderRequestCmdV4.test.ts
+++ b/packages/odata-service/test/request/UrlBuilderRequestCmdV4.test.ts
@@ -3,7 +3,7 @@ import { ODataModelResponseV4 } from "@odata2ts/odata-core";
 import { CollectionQueryBuilderV4, createQueryBuilderV4 } from "@odata2ts/odata-query-builder";
 import { ModelResponseConverterV4 } from "@odata2ts/odata-query-objects";
 import { beforeEach, describe, expect, expectTypeOf, test } from "vitest";
-import { DEFAULT_HEADERS, UrlBuilderRequestCmdV4 } from "../../src";
+import { DEFAULT_HEADERS, rootState, UrlBuilderRequestCmdV4 } from "../../src";
 import { Feature, PersonModel } from "../fixture/PersonModel";
 import { QPersonV4, qPersonV4 } from "../fixture/v4/QPersonV4";
 import { MockClient } from "../mock/MockClient";
@@ -73,6 +73,20 @@ describe("UrlBuilderRequestCmdV4 tests", () => {
 
     expect(candidate.getUrl()).toBe(DEFAULT_URL);
     expect(newCandidate.getInfo()).toMatchObject({ ...candidate.getInfo(), url: DEFAULT_URL + "?$select=UserName" });
+  });
+
+  test("addToQuery updates the cache key with whatever the modification function just restricted - a stale queryParams snapshot from construction time must not survive it", () => {
+    const candidate = new UrlBuilderRequestCmdV4(client, ODataHttpMethods.Get, queryBuilder, qPersonV4, undefined, {
+      cacheKeyState: rootState("Person", "list"),
+      queryParams: queryBuilder.getCacheKeyParams(),
+    });
+    expect(candidate.cacheKey).toEqual(["Person", "list"]);
+
+    const withSelect = candidate.addToQuery((builder) => builder.select("userName"));
+    expect(withSelect.cacheKey).toEqual(["Person", "list", { select: ["UserName"] }]);
+
+    const withFilterToo = withSelect.addToQuery((builder, qPerson) => builder.filter(qPerson.age.gt("40")));
+    expect(withFilterToo.cacheKey).toEqual(["Person", "list", { select: ["UserName"], query: "%24filter=Age+gt+40" }]);
   });
 
   test("add to query multiple times", () => {


### PR DESCRIPTION
## Summary

- `addToQuery` cloned the query builder for the new command but kept reusing the `queryParams` snapshot taken at construction time, so a `select`/`expand`/`filter` added via `addToQuery` never showed up in `cacheKey`. Fixed by re-deriving `queryParams` from the modified builder in `UrlBuilderRequestCmdV4`/`V2`'s `addToQuery`. (Left the write-command overrides as-is: a write's `cacheKey` is always `undefined` regardless of method, and their builder type isn't guaranteed to expose `getCacheKeyParams`.)
- `buildInvalidates` only added an entity set's bare list key (`[entitySetName, "list"]`) for the *final* addressed resource, never for an ancestor hop. So a bound action routed through something with no entity set of its own - e.g. `Copies(1).checkOut()`, which hops through the operation's own name - dropped `["Copies", "list"]` from `invalidates`, even though `Copies(1)` itself is right there as an ancestor. Generalized the rule: `hopState` now records each ancestor's own `entitySetName` alongside its key, and `buildInvalidates` adds every ancestor's list form too, not just the addressed resource's own. This is a general fix (any hierarchical write benefits, not just bound actions), covered by new tests for both.

## Test plan

- [x] New unit tests in `CacheKeyState.test.ts` (ancestor carries its own `entitySetName`), `BuildCacheKey.test.ts` (ancestor list-form entries, including a contained-resource ancestor that contributes none), and `UrlBuilderRequestCmdV4.test.ts` (`addToQuery` chain updates `cacheKey`)
- [x] `packages/odata-service` full suite (509 tests)
- [x] `packages/odata2ts` full suite (778 tests, 3 skipped)
- [x] `tsc --noEmit` clean
- [x] `yarn check-format` clean