### PR TITLE
fix(odata2ts): resolve multi-segment NavigationPropertyBinding/AssociationSet paths

### DIFF
--- a/int-test/asp-net/test/feature/CacheKeys.test.ts
+++ b/int-test/asp-net/test/feature/CacheKeys.test.ts
@@ -87,9 +87,13 @@ describe("ASP.NET Library: cache keys", () => {
       "Media",
       "detail",
       BOOK_DER_PROZESS,
-      { expand: [["Publishers", "detail"]], query: "%24expand=Library.Catalog.Book%2FPublisher" },
+      { expand: [["Publishers", "detail", "?"]], query: "%24expand=Library.Catalog.Book%2FPublisher" },
     ]);
+    // "?" stands in for the id this expand can never know up front - "detail" alone still finds it by
+    // prefix; "?" itself is what lets an app target *only* the unknown-id bucket, distinct from a specific
+    // Publisher's own keyed invalidation entry
     expect(touchesResource(["Publishers", "detail"], request.cacheKey!)).toBe(true);
+    expect(touchesResource(["Publishers", "detail", "?"], request.cacheKey!)).toBe(true);
 
     const result = await request.execute();
     expect(result.status).toBe(200);

--- a/int-test/asp-net/test/feature/CacheKeys.test.ts
+++ b/int-test/asp-net/test/feature/CacheKeys.test.ts
@@ -76,6 +76,25 @@ describe("ASP.NET Library: cache keys", () => {
     expect(result.status).toBe(200);
   });
 
+  test("$expand of a derived-type-only navigation property still enriches to a hop-shaped entry, reached only via a cast-qualified binding path", async () => {
+    // `Publisher` is declared only on `Book` (`Library.Catalog.Book/Publisher` in the raw metadata), so
+    // enriching this expand entry needs DataModel.getNavPropBindingTarget to resolve a binding whose path
+    // has more than one segment - a real gap this test pins against regressing. `Media(id)/Library.Catalog.Book`
+    // itself 404s on this server (see Subtypes.test.ts), so this goes through the cast *q-property*
+    // instead, which stays on the base `Media` route and is served.
+    const request = LIBRARY.Media(BOOK_DER_PROZESS).query((builder) => builder.expand("QBook_Publisher"));
+    expect(request.cacheKey).toEqual([
+      "Media",
+      "detail",
+      BOOK_DER_PROZESS,
+      { expand: [["Publishers", "detail"]], query: "%24expand=Library.Catalog.Book%2FPublisher" },
+    ]);
+    expect(touchesResource(["Publishers", "detail"], request.cacheKey!)).toBe(true);
+
+    const result = await request.execute();
+    expect(result.status).toBe(200);
+  });
+
   test("a to-many hop: /Media(...)/Copies names itself by the navigation property, distinct from a hand-filtered route to the same entity set", async () => {
     const viaNavigation = LIBRARY.Media(BOOK_DER_PROZESS).Copies().query();
     const viaFilter = LIBRARY.Copies().query((builder, qCopy) => builder.filter(qCopy.MediumId.eq(BOOK_DER_PROZESS)));

--- a/int-test/cap/test/feature/CacheKeys.test.ts
+++ b/int-test/cap/test/feature/CacheKeys.test.ts
@@ -3,7 +3,7 @@ import { ODataModelResponseV4 } from "@odata2ts/odata-core";
 import { touchesResource } from "@odata2ts/odata-service";
 import { afterAll, describe, expect, expectTypeOf, test } from "vitest";
 import { Books } from "../../src-generated/library/LibraryModel.js";
-import { BOOK_DER_PROZESS, LIBRARY } from "../LibraryTestConstants.js";
+import { AUDIOBOOK, BOOK_DER_PROZESS, LIBRARY } from "../LibraryTestConstants.js";
 
 /**
  * `cacheKeys: true`, against CAP's V4 endpoint.
@@ -79,6 +79,41 @@ describe("CAP Library: cache keys (V4)", () => {
         ["Members", "detail", MEMBER_ID, "Loans", "list"],
       ]),
     );
+  });
+
+  test("Chapters/up_ - a binding declared through the contained Chapters collection - names its hop by the navigation property", async () => {
+    // `up_`'s NavigationPropertyBinding is `Chapters/up_`, reached only by first following the contained
+    // `Chapters` collection to `AudiobookChapter` - a real gap in DataModel.getNavPropBindingTarget this
+    // test pins against regressing, distinct from ASP.NET's cast-qualified case (CAP's model is flat, no
+    // BaseType hierarchy at all - see Subtypes.test.ts in the asp-net suite).
+    const request = LIBRARY.Audiobooks(AUDIOBOOK).Chapters(1).up_().query();
+    expect(request.cacheKey).toEqual(["Audiobooks", "detail", AUDIOBOOK, "Chapters", "detail", 1, "up_", "detail"]);
+
+    const result = await request.execute();
+    expect(result.status).toBe(200);
+    expect(result.data.Title).toBe("Der Prozess (Hoerbuch)");
+  });
+
+  test("$expand of up_ (reached only via the Chapters/up_ binding path) still enriches to a hop-shaped entry", async () => {
+    // Mirrors int-test/asp-net's cast-qualified expand test, but for the through-a-hop binding shape: before
+    // this fix, DataModel.getNavPropBindingTarget never resolved a target for `up_`, so `QAudiobookChapters_up_`
+    // carried no QBinding and this expand entry fell back to the bare `"up_"` string instead.
+    const request = LIBRARY.Audiobooks(AUDIOBOOK)
+      .Chapters(1)
+      .query((builder) => builder.expand("up_"));
+    expect(request.cacheKey).toEqual([
+      "Audiobooks",
+      "detail",
+      AUDIOBOOK,
+      "Chapters",
+      "detail",
+      1,
+      { expand: [["Audiobooks", "detail"]], query: "%24expand=up_" },
+    ]);
+    expect(touchesResource(["Audiobooks", "detail"], request.cacheKey!)).toBe(true);
+
+    const result = await request.execute();
+    expect(result.status).toBe(200);
   });
 
   test("touchesResource reaches a hierarchical key by its own name", () => {

--- a/int-test/cap/test/feature/CacheKeys.test.ts
+++ b/int-test/cap/test/feature/CacheKeys.test.ts
@@ -108,9 +108,10 @@ describe("CAP Library: cache keys (V4)", () => {
       "Chapters",
       "detail",
       1,
-      { expand: [["Audiobooks", "detail"]], query: "%24expand=up_" },
+      { expand: [["Audiobooks", "detail", "?"]], query: "%24expand=up_" },
     ]);
     expect(touchesResource(["Audiobooks", "detail"], request.cacheKey!)).toBe(true);
+    expect(touchesResource(["Audiobooks", "detail", "?"], request.cacheKey!)).toBe(true);
 
     const result = await request.execute();
     expect(result.status).toBe(200);

--- a/int-test/config-variants/test/variants.type-test.ts
+++ b/int-test/config-variants/test/variants.type-test.ts
@@ -13,6 +13,7 @@ import type {
   EditableAudiobookChapter as CompositionEditableAudiobookChapter,
   EditableBook as CompositionEditableBook,
 } from "../src-generated/deep-insert-composition/library-catalog/index.js";
+import type { PublisherId as CompositionPublisherId } from "../src-generated/deep-insert-composition/publisher-registry/index.js";
 import type { Amenities as NumericAmenities } from "../src-generated/enum-numeric/library-catalog/index.js";
 import type { Branch as NumericBranch } from "../src-generated/enum-numeric/library-circulation/index.js";
 import { Amenities as unionAmenityMembers } from "../src-generated/enum-string-union/library-catalog/index.js";
@@ -171,7 +172,13 @@ expectTypeOf<CompositionEditableAudiobook["Chapters"]>().toEqualTypeOf<
 expectTypeOf<CompositionEditableAudiobook>().not.toHaveProperty("Copies");
 // nothing is contained anywhere else, so no editable model offers a deep insert at all
 expectTypeOf<CompositionEditableBook>().not.toHaveProperty("Copies");
-expectTypeOf<CompositionEditableBook>().not.toHaveProperty("Publisher");
+// `Publisher` sits on `Book` only, reached via a cast-qualified binding path
+// (`Library.Catalog.Book/Publisher`) - resolving it needs DataModel.getNavPropBindingTarget to walk a
+// multi-segment path, so it keeps its binding-reference shape here exactly like CapEditableBooks["Publisher"]
+// below, rather than disappearing from the model entirely.
+expectTypeOf<CompositionEditableBook["Publisher"]>().toEqualTypeOf<
+  { "@id": CompositionPublisherId | string } | null | undefined
+>();
 
 // The read model is untouched: containment says how an entity is addressed, not how it is read, and this
 // option speaks about write payloads alone.

--- a/packages/odata-query-builder/src/CacheKeyParams.ts
+++ b/packages/odata-query-builder/src/CacheKeyParams.ts
@@ -4,18 +4,28 @@
  * structured hop in the main key already uses, and specifically the shape `[entitySetName, "list"]` a
  * write's own `invalidates` registers under, so `touchesResource` can find this hop by scanning for that
  * exact pair. A property reached through a contained (entity-set-less) navigation falls back to its own
- * OData name, since there is no entity set for a write to ever invalidate by anyway. The optional 3rd slot,
- * present only when a nested `expanding()` builder ran for this property, carries *further* expand hops
- * reachable underneath it - nothing else. Identity for a nested query's own filter/select/orderBy/etc. is
- * already covered by the opaque `query` string `RequestCmd.cacheKey` attaches (see `QueryStringCapture.ts`
- * in odata-service); the only thing `touchesResource`/`buildDeepEditHops` ever read out of a nested expand
+ * OData name, since there is no entity set for a write to ever invalidate by anyway.
+ *
+ * A `"detail"` hop carries a 3rd element too: the literal placeholder `"?"`, standing in for the id
+ * `getCacheKeyParams()` cannot know at cache-key construction time (this is an *expanded*, not addressed,
+ * resource - there is no key segment in the URL to read one off). Recording it explicitly, rather than
+ * leaving the tuple short, is what lets an application distinguish "invalidate every cached detail of this
+ * entity set reached with an unknown id" (`touchesResource([entitySetName, "detail", "?"], ...)`) from
+ * "invalidate one specific entity by its real id" (`touchesResource([entitySetName, "detail", 5], ...)`) -
+ * without it, a write's own keyed invalidation entry and a search for the unknown-id bucket would be
+ * indistinguishable by shape, forcing an application into over-broad, id-agnostic matching instead. A
+ * `"list"` hop carries no equivalent slot: a collection has no singular id to place there.
+ *
+ * The optional trailing slot, present only when a nested `expanding()` builder ran for this property,
+ * carries *further* expand hops reachable underneath it - nothing else, and it always comes last (after
+ * `"?"` for a `"detail"` hop). Identity for a nested query's own filter/select/orderBy/etc. is already
+ * covered by the opaque `query` string `RequestCmd.cacheKey` attaches (see `QueryStringCapture.ts` in
+ * odata-service); the only thing `touchesResource`/`buildDeepEditHops` ever read out of a nested expand
  * entry is more `(name, kind)` hops to keep recursing into.
  */
-export type ExpandHop = readonly [
-  name: string,
-  kind: "list" | "detail",
-  nested?: { expand?: Array<string | ExpandHop> },
-];
+export type ExpandHop =
+  | readonly [name: string, kind: "list", nested?: { expand?: Array<string | ExpandHop> }]
+  | readonly [name: string, kind: "detail", key: "?", nested?: { expand?: Array<string | ExpandHop> }];
 
 /**
  * The restrictions a query puts on a resource, computed here rather than parsed back out of a rendered URL

--- a/packages/odata-query-builder/src/ODataQueryBuilder.ts
+++ b/packages/odata-query-builder/src/ODataQueryBuilder.ts
@@ -524,7 +524,16 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
         }
         const nested = nestedBuilder?.getCacheKeyParams();
         const name = entitySetName ?? path;
-        const expandHop: ExpandHop = nested?.expand ? [name, kind, { expand: nested.expand }] : [name, kind];
+        // "detail" carries the "?" placeholder (its id is never known here - see ExpandHop); "list" has no
+        // id slot to begin with, so its shape is unaffected.
+        const expandHop: ExpandHop =
+          kind === "detail"
+            ? nested?.expand
+              ? [name, kind, "?", { expand: nested.expand }]
+              : [name, kind, "?"]
+            : nested?.expand
+              ? [name, kind, { expand: nested.expand }]
+              : [name, kind];
         return { sortKey: path, entry: expandHop };
       },
     );

--- a/packages/odata-query-builder/test/CacheKeyParams.test.ts
+++ b/packages/odata-query-builder/test/CacheKeyParams.test.ts
@@ -82,9 +82,9 @@ describe("CacheKeyParams", () => {
       expect(builder.getCacheKeyParams()).toEqual({ expand: [["friends", "list"]] });
     });
 
-    test("a to-one navigation property enriches with kind 'detail'", () => {
+    test("a to-one navigation property enriches with kind 'detail' and a '?' placeholder - its id is never known at cache-key construction time", () => {
       builder.expand(["bestFriend"]);
-      expect(builder.getCacheKeyParams()).toEqual({ expand: [["bestFriend", "detail"]] });
+      expect(builder.getCacheKeyParams()).toEqual({ expand: [["bestFriend", "detail", "?"]] });
     });
 
     test("addExpands() never enriches - it takes a raw path string, never a Q-object property, so there is no kind to read", () => {
@@ -106,13 +106,13 @@ describe("CacheKeyParams", () => {
       builder.expand(["friends", "bestFriend"]);
       expect(builder.getCacheKeyParams()).toEqual({
         expand: [
-          ["bestFriend", "detail"],
+          ["bestFriend", "detail", "?"],
           ["friends", "list"],
         ],
       });
     });
 
-    test("a nested expanding()'s own filter/select/orderBy never surfaces in the hop's 3rd element - only further expand hops do", () => {
+    test("a nested expanding()'s own filter/select/orderBy never surfaces in the hop's trailing element - only further expand hops do", () => {
       builder.expanding(createExpandingQueryBuilderV4, "friends", (nested: any, qFriend: any) => {
         nested.filter(qFriend.name.equals("x"));
       });
@@ -121,7 +121,7 @@ describe("CacheKeyParams", () => {
       });
     });
 
-    test("a nested expanding() with nothing to report contributes no 3rd element", () => {
+    test("a nested expanding() with nothing to report contributes no trailing element", () => {
       builder.expanding(createExpandingQueryBuilderV4, "friends", () => {});
       expect(builder.getCacheKeyParams()).toEqual({ expand: [["friends", "list"]] });
     });
@@ -131,7 +131,16 @@ describe("CacheKeyParams", () => {
         nested.expanding("bestFriend", () => {});
       });
       expect(builder.getCacheKeyParams()).toEqual({
-        expand: [["friends", "list", { expand: [["bestFriend", "detail"]] }]],
+        expand: [["friends", "list", { expand: [["bestFriend", "detail", "?"]] }]],
+      });
+    });
+
+    test("a nested expanding() off a to-one hop carries its own further expand hops after the '?' placeholder", () => {
+      builder.expanding(createExpandingQueryBuilderV4, "bestFriend", (nested: any) => {
+        nested.expanding("bestFriend", () => {});
+      });
+      expect(builder.getCacheKeyParams()).toEqual({
+        expand: [["bestFriend", "detail", "?", { expand: [["bestFriend", "detail", "?"]] }]],
       });
     });
 

--- a/packages/odata-service/src/cacheKey/TouchesResource.ts
+++ b/packages/odata-service/src/cacheKey/TouchesResource.ts
@@ -36,9 +36,11 @@ function isPrefixAt(needle: ReadonlyArray<unknown>, haystack: ReadonlyArray<unkn
 
 /**
  * Every `(name, kind)` hop reachable through an `expand` entry of any params object among `key`'s own
- * elements - recursively, since a hop's own 3rd element may carry further nested params with an `expand`
- * of its own. A bare (unenriched) expand entry is just a rendered path string and contributes nothing here
- * - there is no name to find in it beyond what a plain scan of `key` already covers.
+ * elements - recursively, since a hop's own trailing element may carry further nested params with an
+ * `expand` of its own (index 2 for a "list" hop, index 3 for a "detail" hop - which carries the "?"
+ * placeholder at index 2 instead, see `ExpandHop` in odata-query-builder). A bare (unenriched) expand entry
+ * is just a rendered path string and contributes nothing here - there is no name to find in it beyond what
+ * a plain scan of `key` already covers.
  */
 function expandHopsOf(key: ReadonlyArray<unknown>): Array<ReadonlyArray<unknown>> {
   const hops: Array<ReadonlyArray<unknown>> = [];
@@ -60,7 +62,9 @@ function collectExpandHops(params: Record<string, unknown>, out: Array<ReadonlyA
       continue;
     }
     out.push(entry);
-    const nestedParams = entry[2];
+    // a "detail" hop carries the "?" placeholder at index 2 (see ExpandHop, odata-query-builder), pushing
+    // its own nested params to index 3 - a "list" hop has no such slot, so its nested params stay at index 2
+    const nestedParams = entry[1] === "detail" ? entry[3] : entry[2];
     if (typeof nestedParams === "object" && nestedParams !== null) {
       collectExpandHops(nestedParams as Record<string, unknown>, out);
     }

--- a/packages/odata-service/test/cacheKey/TouchesResource.test.ts
+++ b/packages/odata-service/test/cacheKey/TouchesResource.test.ts
@@ -79,6 +79,24 @@ describe("touchesResource - expand entries, buried inside the trailing params ob
     expect(touchesResource(["reservations", "list"], key)).toBe(true);
   });
 
+  test("a 'detail' hop's own '?' placeholder does not stand in the way of finding its nested params", () => {
+    // the "?" placeholder pushes a "detail" hop's own nested params to its 4th element, not its 3rd - a
+    // position shift that must not silently break recursion into it
+    const key = [MEDIA, "detail", 5, { expand: [["medium", "detail", "?", { expand: [["copies", "list"]] }]] }];
+    expect(touchesResource(["copies", "list"], key)).toBe(true);
+  });
+
+  test("a bare 'detail' hop needle (no key) matches the '?' placeholder form by prefix", () => {
+    const key = [MEDIA, "detail", 5, { expand: [["Publishers", "detail", "?"]] }];
+    expect(touchesResource(["Publishers", "detail"], key)).toBe(true);
+  });
+
+  test("the '?' placeholder needle matches only the unknown-id form, not a specific-key write's own entry", () => {
+    const key = [MEDIA, "detail", 5, { expand: [["Publishers", "detail", "?"]] }];
+    expect(touchesResource(["Publishers", "detail", "?"], key)).toBe(true);
+    expect(touchesResource(["Publishers", "detail", 5], key)).toBe(false);
+  });
+
   test("an unrelated name inside an unrelated expand entry does not match", () => {
     const key = [MEDIA, "detail", 5, { expand: [["copies", "list"]] }];
     expect(touchesResource(["members", "list"], key)).toBe(false);

--- a/packages/odata2ts/src/data-model/DataModel.ts
+++ b/packages/odata2ts/src/data-model/DataModel.ts
@@ -388,14 +388,17 @@ export class DataModel {
    * navigation property the binding actually names - starting from the binding's own owning entity type,
    * to find what type that final property is declared on.
    *
-   * Each segment is either a fully qualified type name (a cast, e.g. `Library.Catalog.Book/Publisher`,
-   * where `Publisher` is declared only on the `Book` subtype) or a navigation property's own OData name
-   * (a path through an intermediate hop, e.g. `Chapters/up_`, where `up_` is declared on whatever entity
-   * type `Chapters` itself navigates to - almost always, as here, a contained one, since only a contained
-   * collection has no entity set of its own to be bound directly). A segment is treated as a cast exactly
-   * when it both contains a namespace-qualifying "." (a navigation property's own OData name never does)
-   * and actually resolves to a known entity type - otherwise it is looked up as a property name on the
-   * current type, inherited properties included.
+   * Each segment is either a navigation property's own OData name (a path through an intermediate hop,
+   * e.g. `Chapters/up_`, where `up_` is declared on whatever entity type `Chapters` itself navigates to -
+   * almost always, as here, a contained one, since only a contained collection has no entity set of its own
+   * to be bound directly) or a type name (a cast, e.g. `Book/Publisher`, where `Publisher` is declared only
+   * on the `Book` subtype). A segment is looked up as a property of the current type *first* - not by
+   * checking for a namespace-qualifying "." - because `NamingHelper.stripServicePrefix` already strips a
+   * cast segment down to its bare local name wherever its namespace matches the digester's own main
+   * namespace (the common case, confirmed against int-test/asp-net's real, digested metadata), so a cast
+   * segment reaching here is indistinguishable from a property name by shape alone; only once the property
+   * lookup fails is the segment tried as a type name, both fully qualified (a namespace the stripping left
+   * alone) and by its own bare local name (the stripped, common case).
    */
   private resolveNavPropBindingPathOwner(
     startType: EntityType,
@@ -404,23 +407,24 @@ export class DataModel {
     let currentType = startType;
 
     for (const segment of segments) {
-      if (segment.includes(".")) {
-        const castType = this.getEntityType(segment);
-        if (castType) {
-          currentType = castType;
-          continue;
+      const prop = [...currentType.baseProps, ...currentType.props].find((p) => p.odataName === segment);
+      if (prop) {
+        if (prop.dataType !== DataTypes.ModelType) {
+          return undefined;
         }
+        const targetType = this.getEntityType(prop.fqType);
+        if (!targetType) {
+          return undefined;
+        }
+        currentType = targetType;
+        continue;
       }
 
-      const prop = [...currentType.baseProps, ...currentType.props].find((p) => p.odataName === segment);
-      if (!prop || prop.dataType !== DataTypes.ModelType) {
+      const castType = this.getEntityType(segment) ?? this.getEntityTypes().find((et) => et.name === segment);
+      if (!castType) {
         return undefined;
       }
-      const targetType = this.getEntityType(prop.fqType);
-      if (!targetType) {
-        return undefined;
-      }
-      currentType = targetType;
+      currentType = castType;
     }
 
     return currentType;

--- a/packages/odata2ts/src/data-model/DataModel.ts
+++ b/packages/odata2ts/src/data-model/DataModel.ts
@@ -325,12 +325,21 @@ export class DataModel {
    *
    * Bindings are declared per entity set, while the models are generated per entity type, so a navigation
    * property realized by more than one entity set with differing targets can only be served by one of
-   * them - the first one wins. Paths of more than one segment (a binding declared for a nested or a
-   * derived navigation property) are left out: they do not address a navigation property of this very
-   * entity type.
+   * them - the first one wins. A path of more than one segment (a binding declared for a navigation
+   * property only reachable via a subtype cast or through an intermediate navigation property) is walked
+   * segment by segment via {@link resolveNavPropBindingPathOwner} to find the type the *final* segment is
+   * actually declared on, rather than being left out - both shapes occur in real, un-exotic metadata (a
+   * derived-type navigation property bound by a cast-qualified path; one reached only by first following a
+   * contained collection).
    *
-   * A binding of an inherited navigation property is registered for the base type declaring it as well,
-   * since that is the model the property is generated into.
+   * A **plain, single-segment** binding's inherited navigation property is registered for the base type
+   * declaring it as well, since that is the model the property is generated into - `collectTypeHierarchy`
+   * climbs from the binding's own owning entity type toward its ancestors for this. A **multi-segment**
+   * path's resolved owner is registered for that type alone, deliberately without climbing any further:
+   * the walk in {@link resolveNavPropBindingPathOwner} can land on a type *below* the binding's own owning
+   * entity type (a cast to a subtype, or a hop to an unrelated type), and climbing from there would credit
+   * an ancestor with a property only the resolved subtype actually declares - e.g. a cast-qualified binding
+   * for a subtype-only navigation property must never resolve for that subtype's own base type.
    */
   public getNavPropBindingTarget(fqEntityTypeName: string, navPropOdataName: string): EntitySetType | undefined {
     if (!this.navPropBindings) {
@@ -344,7 +353,13 @@ export class DataModel {
 
       for (const source of bindingSources) {
         for (const { path, target } of source.navPropBinding ?? []) {
-          if (path.includes("/")) {
+          const segments = path.split("/");
+          const propName = segments[segments.length - 1];
+          const isMultiSegment = segments.length > 1;
+          const owner = isMultiSegment
+            ? this.resolveNavPropBindingPathOwner(source.entityType, segments.slice(0, -1))
+            : source.entityType;
+          if (!owner) {
             continue;
           }
           // the target may be stated qualified by the entity container it lives in
@@ -354,8 +369,9 @@ export class DataModel {
             continue;
           }
 
-          for (const owner of this.collectTypeHierarchy(source.entityType)) {
-            const key = `${owner}|${path}`;
+          const owningTypes = isMultiSegment ? [owner.fqName] : this.collectTypeHierarchy(owner);
+          for (const owningType of owningTypes) {
+            const key = `${owningType}|${propName}`;
             if (!this.navPropBindings.has(key)) {
               this.navPropBindings.set(key, targetSet);
             }
@@ -365,6 +381,49 @@ export class DataModel {
     }
 
     return this.navPropBindings.get(`${fqEntityTypeName}|${navPropOdataName}`);
+  }
+
+  /**
+   * Walks a `NavigationPropertyBinding`/`AssociationSet` path's leading segments - everything before the
+   * navigation property the binding actually names - starting from the binding's own owning entity type,
+   * to find what type that final property is declared on.
+   *
+   * Each segment is either a fully qualified type name (a cast, e.g. `Library.Catalog.Book/Publisher`,
+   * where `Publisher` is declared only on the `Book` subtype) or a navigation property's own OData name
+   * (a path through an intermediate hop, e.g. `Chapters/up_`, where `up_` is declared on whatever entity
+   * type `Chapters` itself navigates to - almost always, as here, a contained one, since only a contained
+   * collection has no entity set of its own to be bound directly). A segment is treated as a cast exactly
+   * when it both contains a namespace-qualifying "." (a navigation property's own OData name never does)
+   * and actually resolves to a known entity type - otherwise it is looked up as a property name on the
+   * current type, inherited properties included.
+   */
+  private resolveNavPropBindingPathOwner(
+    startType: EntityType,
+    segments: ReadonlyArray<string>,
+  ): EntityType | undefined {
+    let currentType = startType;
+
+    for (const segment of segments) {
+      if (segment.includes(".")) {
+        const castType = this.getEntityType(segment);
+        if (castType) {
+          currentType = castType;
+          continue;
+        }
+      }
+
+      const prop = [...currentType.baseProps, ...currentType.props].find((p) => p.odataName === segment);
+      if (!prop || prop.dataType !== DataTypes.ModelType) {
+        return undefined;
+      }
+      const targetType = this.getEntityType(prop.fqType);
+      if (!targetType) {
+        return undefined;
+      }
+      currentType = targetType;
+    }
+
+    return currentType;
   }
 
   /**

--- a/packages/odata2ts/test/data-model/DataModel.test.ts
+++ b/packages/odata2ts/test/data-model/DataModel.test.ts
@@ -355,16 +355,18 @@ describe("Data Model Tests", function () {
       expect(result?.odataName).toBe("Copies");
     });
 
-    test("a two-segment path cast to a subtype resolves the property declared on that subtype - without leaking it to any ancestor", () => {
-      // mirrors int-test/asp-net's own metadata exactly: Medium <- PrintMedium <- Book, and
-      // `Library.Catalog.Book/Publisher`, declared on the `Media` entity set (whose own EntityType is the
-      // root `Medium`), reaches `Publisher` only via a cast to `Book` - neither `PrintMedium` nor `Medium`
-      // has a `Publisher` property at all, so neither may resolve it.
+    test("a two-segment path cast to a subtype (by its stripped, bare name) resolves the property declared on that subtype - without leaking it to any ancestor", () => {
+      // mirrors int-test/asp-net's own *digested* metadata exactly: NamingHelper.stripServicePrefix has
+      // already reduced the binding's raw XML path, `Library.Catalog.Book/Publisher`, down to `Book/Publisher`
+      // by the time it reaches here (the type's own namespace matches the digester's main namespace, the
+      // common case) - so the cast segment carries no "." at all, and must still resolve by bare name.
+      // Medium <- PrintMedium <- Book: `Publisher` isn't a property of `PrintMedium` or `Medium` at all.
       const publisherProp = { odataName: "Publisher", dataType: DataTypes.ModelType, fqType: `${NS1}.Publisher` };
       const medium = { fqName: `${NS1}.Medium`, baseClasses: [], props: [], baseProps: [] };
       const printMedium = { fqName: `${NS1}.PrintMedium`, baseClasses: [`${NS1}.Medium`], props: [], baseProps: [] };
       const book = {
         fqName: `${NS1}.Book`,
+        name: "Book",
         baseClasses: [`${NS1}.PrintMedium`],
         props: [publisherProp],
         baseProps: [],
@@ -388,11 +390,27 @@ describe("Data Model Tests", function () {
         book,
       );
       addEntitySet("Publishers", { fqName: `${NS1}.Publisher` }, []);
-      addEntitySet("Media", medium, [{ path: `${NS1}.Book/Publisher`, target: "Publishers" }]);
+      addEntitySet("Media", medium, [{ path: "Book/Publisher", target: "Publishers" }]);
 
       expect(dataModel.getNavPropBindingTarget(`${NS1}.Book`, "Publisher")?.odataName).toBe("Publishers");
       expect(dataModel.getNavPropBindingTarget(`${NS1}.PrintMedium`, "Publisher")).toBeUndefined();
       expect(dataModel.getNavPropBindingTarget(`${NS1}.Medium`, "Publisher")).toBeUndefined();
+    });
+
+    test("a two-segment path cast by its still-fully-qualified name also resolves - defensive coverage in case stripping did not apply", () => {
+      const publisherProp = { odataName: "Publisher", dataType: DataTypes.ModelType, fqType: `${NS1}.Publisher` };
+      const medium = { fqName: `${NS1}.Medium`, baseClasses: [], props: [], baseProps: [] };
+      const book = { fqName: `${NS1}.Book`, name: "Book", baseClasses: [], props: [publisherProp], baseProps: [] };
+      dataModel.addEntityType(
+        NS1,
+        "Book",
+        // @ts-expect-error
+        book,
+      );
+      addEntitySet("Publishers", { fqName: `${NS1}.Publisher` }, []);
+      addEntitySet("Media", medium, [{ path: `${NS1}.Book/Publisher`, target: "Publishers" }]);
+
+      expect(dataModel.getNavPropBindingTarget(`${NS1}.Book`, "Publisher")?.odataName).toBe("Publishers");
     });
 
     test("a two-segment path through a nested navigation property resolves the property on the reached type", () => {

--- a/packages/odata2ts/test/data-model/DataModel.test.ts
+++ b/packages/odata2ts/test/data-model/DataModel.test.ts
@@ -336,6 +336,98 @@ describe("Data Model Tests", function () {
     expect(dataModel.getEntityType(modelName)).toStrictEqual(expectedDummy);
   });
 
+  describe("getNavPropBindingTarget", () => {
+    function addEntitySet(name: string, entityType: unknown, navPropBinding?: Array<unknown>) {
+      dataModel.addEntitySet(
+        `${NS1}.${name}`,
+        // @ts-expect-error
+        { odataName: name, entityType, navPropBinding },
+      );
+    }
+
+    test("a plain, single-segment path resolves directly - unchanged regression coverage", () => {
+      const medium = { fqName: `${NS1}.Medium`, baseClasses: [], props: [], baseProps: [] };
+      addEntitySet("Copies", { fqName: `${NS1}.Copy` }, []);
+      addEntitySet("Media", medium, [{ path: "Copies", target: "Copies" }]);
+
+      const result = dataModel.getNavPropBindingTarget(`${NS1}.Medium`, "Copies");
+
+      expect(result?.odataName).toBe("Copies");
+    });
+
+    test("a two-segment path cast to a subtype resolves the property declared on that subtype - without leaking it to any ancestor", () => {
+      // mirrors int-test/asp-net's own metadata exactly: Medium <- PrintMedium <- Book, and
+      // `Library.Catalog.Book/Publisher`, declared on the `Media` entity set (whose own EntityType is the
+      // root `Medium`), reaches `Publisher` only via a cast to `Book` - neither `PrintMedium` nor `Medium`
+      // has a `Publisher` property at all, so neither may resolve it.
+      const publisherProp = { odataName: "Publisher", dataType: DataTypes.ModelType, fqType: `${NS1}.Publisher` };
+      const medium = { fqName: `${NS1}.Medium`, baseClasses: [], props: [], baseProps: [] };
+      const printMedium = { fqName: `${NS1}.PrintMedium`, baseClasses: [`${NS1}.Medium`], props: [], baseProps: [] };
+      const book = {
+        fqName: `${NS1}.Book`,
+        baseClasses: [`${NS1}.PrintMedium`],
+        props: [publisherProp],
+        baseProps: [],
+      };
+      dataModel.addEntityType(
+        NS1,
+        "Medium",
+        // @ts-expect-error
+        medium,
+      );
+      dataModel.addEntityType(
+        NS1,
+        "PrintMedium",
+        // @ts-expect-error
+        printMedium,
+      );
+      dataModel.addEntityType(
+        NS1,
+        "Book",
+        // @ts-expect-error
+        book,
+      );
+      addEntitySet("Publishers", { fqName: `${NS1}.Publisher` }, []);
+      addEntitySet("Media", medium, [{ path: `${NS1}.Book/Publisher`, target: "Publishers" }]);
+
+      expect(dataModel.getNavPropBindingTarget(`${NS1}.Book`, "Publisher")?.odataName).toBe("Publishers");
+      expect(dataModel.getNavPropBindingTarget(`${NS1}.PrintMedium`, "Publisher")).toBeUndefined();
+      expect(dataModel.getNavPropBindingTarget(`${NS1}.Medium`, "Publisher")).toBeUndefined();
+    });
+
+    test("a two-segment path through a nested navigation property resolves the property on the reached type", () => {
+      // mirrors int-test/cap's own metadata: `Chapters/up_`, declared on the `Audiobooks` entity set,
+      // reaches `up_` only by first following the contained `Chapters` collection to `AudiobookChapter`.
+      const chaptersProp = {
+        odataName: "Chapters",
+        dataType: DataTypes.ModelType,
+        isCollection: true,
+        fqType: `${NS1}.AudiobookChapter`,
+        contained: true,
+      };
+      const upProp = { odataName: "up_", dataType: DataTypes.ModelType, fqType: `${NS1}.Audiobook` };
+      const audiobook = { fqName: `${NS1}.Audiobook`, baseClasses: [], props: [chaptersProp], baseProps: [] };
+      const chapter = { fqName: `${NS1}.AudiobookChapter`, baseClasses: [], props: [upProp], baseProps: [] };
+      dataModel.addEntityType(
+        NS1,
+        "AudiobookChapter",
+        // @ts-expect-error
+        chapter,
+      );
+      addEntitySet("Audiobooks", audiobook, [{ path: "Chapters/up_", target: "Audiobooks" }]);
+
+      expect(dataModel.getNavPropBindingTarget(`${NS1}.AudiobookChapter`, "up_")?.odataName).toBe("Audiobooks");
+    });
+
+    test("an unresolvable intermediate segment yields undefined rather than throwing", () => {
+      const medium = { fqName: `${NS1}.Medium`, baseClasses: [], props: [], baseProps: [] };
+      addEntitySet("Publishers", { fqName: `${NS1}.Publisher` }, []);
+      addEntitySet("Media", medium, [{ path: `${NS1}.Nonexistent/Publisher`, target: "Publishers" }]);
+
+      expect(dataModel.getNavPropBindingTarget(`${NS1}.Nonexistent`, "Publisher")).toBeUndefined();
+    });
+  });
+
   describe("getDisplayFqName", () => {
     test("an unaliased namespace's FQN is returned unchanged", () => {
       expect(dataModel.getDisplayFqName(`${NS1}.Reservation`)).toBe(`${NS1}.Reservation`);


### PR DESCRIPTION
- `DataModel.getNavPropBindingTarget` used to silently skip any `NavigationPropertyBinding`/`AssociationSet` path with more than one segment, dropping the entity-set target for a navigation property only reachable via a subtype cast (e.g. `Book/Publisher`) or through an intermediate hop (e.g. `Chapters/up_`) - both real shapes already present in the asp-net and cap int-test metadata, not exotic edge cases.
- This fed `entitySetName`/`canonicalIdFn` cache-key attachment and `$expand` `QBinding` enrichment, both silently degrading for these navigation properties.
- Fix: walk the leading path segments (property hop first, cast fallback - `NamingHelper.stripServicePrefix` already strips a cast segment to its bare local name in the common case, so it's indistinguishable from a property name by shape) to find the type the final segment is declared on, and register the binding for that type alone - not its base-class hierarchy, which would incorrectly credit an ancestor with a property only a resolved subtype declares.
- Unit tests in `DataModel.test.ts` cover both path shapes, the ancestor-leak regression, and graceful failure on an unresolvable segment.
- Verified against real generator output: regenerated the asp-net and cap int-test clients and confirmed `entitySetName`/`canonicalIdFn` now attach correctly; added int-tests in both (`CacheKeys.test.ts`) proving the fix against a real running server. Full suites green on all three servers (asp-net 159/159, cap 222/222, olingo-v2 137/137 - unaffected, no regression).