### PR TITLE
refactor(odata-service): replace getCacheKeyState() with narrow getEntitySetName()

### DIFF
--- a/packages/odata-service/src/StreamServiceBase.ts
+++ b/packages/odata-service/src/StreamServiceBase.ts
@@ -38,8 +38,9 @@ export abstract class StreamServiceBase<V extends ODataVersionV4 = "4.0"> {
     return this.__base.path;
   }
 
-  public getCacheKeyState() {
-    return this.__base.cacheKeyState;
+  /** The entity set this resource belongs to, by its own name - absent for a contained entity, a complex value, or a singleton. */
+  public getEntitySetName() {
+    return this.__base.cacheKeyState?.entitySetName;
   }
 
   /**

--- a/packages/odata-service/src/v2/CollectionServiceV2.ts
+++ b/packages/odata-service/src/v2/CollectionServiceV2.ts
@@ -38,8 +38,9 @@ export class CollectionServiceV2<
     return this.__base.path;
   }
 
-  public getCacheKeyState() {
-    return this.__base.cacheKeyState;
+  /** The entity set this resource belongs to, by its own name - absent for a contained entity, a complex value, or a singleton. */
+  public getEntitySetName() {
+    return this.__base.cacheKeyState?.entitySetName;
   }
 
   /**

--- a/packages/odata-service/src/v2/ComplexTypeServiceV2.ts
+++ b/packages/odata-service/src/v2/ComplexTypeServiceV2.ts
@@ -32,8 +32,9 @@ export class ComplexTypeServiceV2<T, UpdatableT, Q extends QueryObjectModel, AsV
     return this.__base.path;
   }
 
-  public getCacheKeyState() {
-    return this.__base.cacheKeyState;
+  /** The entity set this resource belongs to, by its own name - absent for a contained entity, a complex value, or a singleton. */
+  public getEntitySetName() {
+    return this.__base.cacheKeyState?.entitySetName;
   }
 
   public patch(model: Partial<UpdatableT>, queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void) {

--- a/packages/odata-service/src/v2/EntitySetServiceV2.ts
+++ b/packages/odata-service/src/v2/EntitySetServiceV2.ts
@@ -53,8 +53,9 @@ export abstract class EntitySetServiceV2<
     return this.__base.path;
   }
 
-  public getCacheKeyState() {
-    return this.__base.cacheKeyState;
+  /** The entity set this resource belongs to, by its own name - absent for a contained entity, a complex value, or a singleton. */
+  public getEntitySetName() {
+    return this.__base.cacheKeyState?.entitySetName;
   }
 
   /**

--- a/packages/odata-service/src/v2/EntityTypeServiceV2.ts
+++ b/packages/odata-service/src/v2/EntityTypeServiceV2.ts
@@ -32,8 +32,9 @@ export class EntityTypeServiceV2<T, UpdatableT, Q extends QueryObjectModel, AsV4
     return this.__base.path;
   }
 
-  public getCacheKeyState() {
-    return this.__base.cacheKeyState;
+  /** The entity set this resource belongs to, by its own name - absent for a contained entity, a complex value, or a singleton. */
+  public getEntitySetName() {
+    return this.__base.cacheKeyState?.entitySetName;
   }
 
   /**

--- a/packages/odata-service/src/v2/PrimitiveTypeServiceV2.ts
+++ b/packages/odata-service/src/v2/PrimitiveTypeServiceV2.ts
@@ -67,8 +67,9 @@ export class PrimitiveTypeServiceV2<T, AsV4 extends boolean = false> {
     return this.__base.path;
   }
 
-  public getCacheKeyState() {
-    return this.__base.cacheKeyState;
+  /** The entity set this resource belongs to, by its own name - absent for a contained entity, a complex value, or a singleton. */
+  public getEntitySetName() {
+    return this.__base.cacheKeyState?.entitySetName;
   }
 
   /**

--- a/packages/odata-service/src/v4/CollectionServiceV4.ts
+++ b/packages/odata-service/src/v4/CollectionServiceV4.ts
@@ -54,8 +54,9 @@ export class CollectionServiceV4<
     return this.__base.path;
   }
 
-  public getCacheKeyState() {
-    return this.__base.cacheKeyState;
+  /** The entity set this resource belongs to, by its own name - absent for a contained entity, a complex value, or a singleton. */
+  public getEntitySetName() {
+    return this.__base.cacheKeyState?.entitySetName;
   }
 
   /**

--- a/packages/odata-service/src/v4/EntitySetServiceV4.ts
+++ b/packages/odata-service/src/v4/EntitySetServiceV4.ts
@@ -61,8 +61,9 @@ export abstract class EntitySetServiceV4<
     return this.__base.path;
   }
 
-  public getCacheKeyState() {
-    return this.__base.cacheKeyState;
+  /** The entity set this resource belongs to, by its own name - absent for a contained entity, a complex value, or a singleton. */
+  public getEntitySetName() {
+    return this.__base.cacheKeyState?.entitySetName;
   }
 
   /**

--- a/packages/odata-service/src/v4/EntityTypeServiceV4.ts
+++ b/packages/odata-service/src/v4/EntityTypeServiceV4.ts
@@ -32,8 +32,9 @@ export class EntityTypeServiceV4<T, UpdatableT, Q extends QueryObjectModel, V ex
     return this.__base.path;
   }
 
-  public getCacheKeyState() {
-    return this.__base.cacheKeyState;
+  /** The entity set this resource belongs to, by its own name - absent for a contained entity, a complex value, or a singleton. */
+  public getEntitySetName() {
+    return this.__base.cacheKeyState?.entitySetName;
   }
 
   /**

--- a/packages/odata-service/src/v4/PrimitiveTypeServiceV4.ts
+++ b/packages/odata-service/src/v4/PrimitiveTypeServiceV4.ts
@@ -43,8 +43,9 @@ export class PrimitiveTypeServiceV4<T, V extends ODataVersionV4 = "4.0"> {
     return this.__base.path;
   }
 
-  public getCacheKeyState() {
-    return this.__base.cacheKeyState;
+  /** The entity set this resource belongs to, by its own name - absent for a contained entity, a complex value, or a singleton. */
+  public getEntitySetName() {
+    return this.__base.cacheKeyState?.entitySetName;
   }
 
   /**

--- a/packages/odata-service/test/cacheKey/ServiceThreading.test.ts
+++ b/packages/odata-service/test/cacheKey/ServiceThreading.test.ts
@@ -18,14 +18,24 @@ import { MockClient } from "../mock/MockClient";
 const MEDIUM = "Library.Catalog.Medium";
 const COPY = "Library.Catalog.Copy";
 
-type TestEntityService = EntityTypeServiceV4<TestModel, EditableTestModel, QTest, "4.0">;
+/**
+ * The real, published `EntityTypeServiceV4` no longer exposes its `CacheKeyState` (see the removed
+ * `getCacheKeyState()`, replaced by the narrow `getEntitySetName()`) - `steps`/`key` are internal wiring,
+ * asserted on here the same way `ServiceStateHelper`'s own tests reach protected internals: a test-local
+ * subclass, never shipped, with its own accessor onto `__base`.
+ */
+class TestEntityService extends EntityTypeServiceV4<TestModel, EditableTestModel, QTest, "4.0"> {
+  public getCacheKeyState() {
+    return this.__base.cacheKeyState;
+  }
+}
 
 /**
  * A minimal `EntitySetServiceV4` around a given id function, built here rather than via the shared
  * `TestCollectionService`/`TestCollectionServiceWithAlternateKey` fixtures: neither fixture's constructor
  * forwards a `cacheKeyState`, and reshaping them to do so would touch fixtures other tests already rely on.
- * `createEntityService` just needs to hand the state to *some* entity-type service, so a bare
- * `EntityTypeServiceV4` does the job without a fixture-specific subclass.
+ * `createEntityService` just needs to hand the state to *some* entity-type service, so `TestEntityService`
+ * does the job.
  */
 class TestSetService<EIdType> extends EntitySetServiceV4<
   TestModel,
@@ -51,7 +61,7 @@ class TestSetService<EIdType> extends EntitySetServiceV4<
     options: ODataServiceOptionsInternal<"4.0"> | undefined,
     cacheKeyState?: CacheKeyState,
   ): TestEntityService {
-    return new EntityTypeServiceV4(client, path, name, qTest, options, cacheKeyState);
+    return new TestEntityService(client, path, name, qTest, options, cacheKeyState);
   }
 }
 
@@ -110,5 +120,39 @@ describe("byId produces the typed key, not the rendered predicate", () => {
 
     const state = service.byId({ name: "978-3" }).getCacheKeyState()!;
     expect(state.steps).toEqual(["detail", { NAME: "978-3" }]);
+  });
+});
+
+describe("getEntitySetName - the one narrow accessor a generated service exposes publicly", () => {
+  const client = new MockClient(false);
+
+  test("reflects the root's own entity set", () => {
+    const service = new TestSetService<TestModelId>(
+      client,
+      "/root",
+      "Media",
+      new QTestIdFunction("Media"),
+      rootState(MEDIUM, "list", { entitySetName: "Media" }),
+    );
+
+    expect(service.getEntitySetName()).toBe("Media");
+  });
+
+  test("is undefined where the route was never threaded with cache-key state at all", () => {
+    const service = new TestSetService<TestModelId>(client, "/root", "Media", new QTestIdFunction("Media"));
+
+    expect(service.getEntitySetName()).toBeUndefined();
+  });
+
+  test("survives byId() unchanged - narrowing to one entity does not leave its entity set", () => {
+    const service = new TestSetService<TestModelId>(
+      client,
+      "/root",
+      "Media",
+      new QTestIdFunction("Media"),
+      rootState(MEDIUM, "list", { entitySetName: "Media" }),
+    );
+
+    expect(service.byId("5").getEntitySetName()).toBe("Media");
   });
 });


### PR DESCRIPTION
- A full call-site audit found no reader of `getCacheKeyState()` outside three internal unit tests (`ServiceThreading.test.ts`) asserting on `steps`/`key` to verify the generator's own wiring - no generated code, example, or int-test ever called it, and no application code ever read anything but `entitySetName` off it.
- Replaced with one narrow accessor, `getEntitySetName(): string | undefined`, covering the one real use (a hand-rolled `invalidateQueries` call scoped by entity set) - absent for a contained entity, a complex value, or a singleton, exactly where `CacheKeyState.entitySetName` itself is.
- `steps`/`ancestors`/`kindIndex`/`qEntityFn`/`canonicalIdFn` are no longer reachable from any generated service's public surface; every generated service gains exactly one name in its own namespace, not a growing accessor a future bound operation or navigation property could someday collide with.
- The three internal tests that needed `steps`/`key` now reach them through a test-local subclass with its own accessor onto `__base` - the same pattern this package's other tests already use for protected internals, never through anything shipped.
- Verified against the full `odata-service` suite (526 tests), workspace-wide `test-compile`, and all three server int-test suites re-run after a full rebuild+regenerate (asp-net 159, cap 222, olingo-v2 137 - unaffected, confirming nothing outside `odata-service` referenced the removed method).
- Spec doc (`spec/odata2ts-cache-key.md`) updated separately with the audit findings and a new Decisions-and-rejected-alternatives entry.