### PR TITLE
fix(odata-service): rename a statically-keyed hop's own segment to its entity set's name

### DIFF
--- a/int-test/asp-net/test/feature/CacheKeys.test.ts
+++ b/int-test/asp-net/test/feature/CacheKeys.test.ts
@@ -99,25 +99,18 @@ describe("ASP.NET Library: cache keys", () => {
     expect(result.status).toBe(200);
   });
 
-  test("canonicalKey names the resource by its entity set, not the hop's own (diverging) name - Publishers(1).Books(id)", () => {
+  test("a statically-keyed hop's own segment is renamed to its entity set's name, not the hop's own (diverging) name - Publishers(1).Books(id)", () => {
     // Publishers(1).Books(id): "Books" is the hop's own name, but it binds to entity set "Media" (not
-    // "Books"), and BOOK_DER_PROZESS is known the moment this request is constructed - no response needed.
-    // Shape only here: this server's controllers are hand-routed (EntitySetControllers.cs), and none of
-    // them implement a keyed GET through a to-many navigation property for *any* entity - not a
-    // cast/subtype-specific gap like Subtypes.test.ts's, just a route this particular server never wired
-    // up. The executed, end-to-end proof of the same mechanism (a write through the hop route
-    // deterministically invalidating the direct route, no prior read required) is int-test/cap's own
-    // CacheKeys.test.ts, against a server that does serve this shape.
+    // "Books" - no "Books" entity set exists in this model at all), and BOOK_DER_PROZESS is known the
+    // moment this request is constructed - withKey already renames the segment before any response.
+    // Shape only here: this server's controllers are hand-routed (EntitySetControllers.cs), and until
+    // test-server-asp-net's own nested-route fix (test-server-asp-net#38, merged, not yet released and
+    // pinned here) ships, they don't implement a keyed GET through a to-many navigation property for any
+    // entity. The executed, end-to-end proof of the same mechanism is int-test/cap's own CacheKeys.test.ts
+    // - though CAP's own model has no name-diverging to-many relationship to exercise, so neither server
+    // today proves this both executed *and* divergent at once; this becomes that proof once the pin bumps.
     const request = LIBRARY.Publishers(1).Books(BOOK_DER_PROZESS).query();
-    expect(request.cacheKey).toEqual([
-      "Publishers",
-      "detail",
-      1,
-      "Books",
-      "detail",
-      BOOK_DER_PROZESS,
-      { canonicalKey: ["Media", "detail", BOOK_DER_PROZESS] },
-    ]);
+    expect(request.cacheKey).toEqual(["Publishers", "detail", 1, "Media", "detail", BOOK_DER_PROZESS]);
     expect(touchesResource(["Media", "detail", BOOK_DER_PROZESS], request.cacheKey!)).toBe(true);
   });
 

--- a/int-test/asp-net/test/feature/CacheKeys.test.ts
+++ b/int-test/asp-net/test/feature/CacheKeys.test.ts
@@ -99,6 +99,28 @@ describe("ASP.NET Library: cache keys", () => {
     expect(result.status).toBe(200);
   });
 
+  test("canonicalKey names the resource by its entity set, not the hop's own (diverging) name - Publishers(1).Books(id)", () => {
+    // Publishers(1).Books(id): "Books" is the hop's own name, but it binds to entity set "Media" (not
+    // "Books"), and BOOK_DER_PROZESS is known the moment this request is constructed - no response needed.
+    // Shape only here: this server's controllers are hand-routed (EntitySetControllers.cs), and none of
+    // them implement a keyed GET through a to-many navigation property for *any* entity - not a
+    // cast/subtype-specific gap like Subtypes.test.ts's, just a route this particular server never wired
+    // up. The executed, end-to-end proof of the same mechanism (a write through the hop route
+    // deterministically invalidating the direct route, no prior read required) is int-test/cap's own
+    // CacheKeys.test.ts, against a server that does serve this shape.
+    const request = LIBRARY.Publishers(1).Books(BOOK_DER_PROZESS).query();
+    expect(request.cacheKey).toEqual([
+      "Publishers",
+      "detail",
+      1,
+      "Books",
+      "detail",
+      BOOK_DER_PROZESS,
+      { canonicalKey: ["Media", "detail", BOOK_DER_PROZESS] },
+    ]);
+    expect(touchesResource(["Media", "detail", BOOK_DER_PROZESS], request.cacheKey!)).toBe(true);
+  });
+
   test("a to-many hop: /Media(...)/Copies names itself by the navigation property, distinct from a hand-filtered route to the same entity set", async () => {
     const viaNavigation = LIBRARY.Media(BOOK_DER_PROZESS).Copies().query();
     const viaFilter = LIBRARY.Copies().query((builder, qCopy) => builder.filter(qCopy.MediumId.eq(BOOK_DER_PROZESS)));

--- a/int-test/cap/test/feature/CacheKeys.test.ts
+++ b/int-test/cap/test/feature/CacheKeys.test.ts
@@ -81,6 +81,34 @@ describe("CAP Library: cache keys (V4)", () => {
     );
   });
 
+  test("a statically-keyed hop's canonicalKey deterministically invalidates the direct route - no prior read required", async () => {
+    const request = LIBRARY.Publishers(1).Books(BOOK_DER_PROZESS).query();
+    expect(request.cacheKey).toEqual([
+      "Publishers",
+      "detail",
+      1,
+      "Books",
+      "detail",
+      BOOK_DER_PROZESS,
+      { canonicalKey: ["Books", "detail", BOOK_DER_PROZESS] },
+    ]);
+    expect(touchesResource(["Books", "detail", BOOK_DER_PROZESS], request.cacheKey!)).toBe(true);
+
+    const result = await request.execute();
+    expect(result.status).toBe(200);
+    expect(result.data.Title).toBe("Der Prozess");
+
+    // the deterministic proof: a write through the hop route invalidates the direct route's own key even
+    // though nothing was ever read via that direct route first - no ResourceIdentityHandler involved
+    const patched = await LIBRARY.Publishers(1).Books(BOOK_DER_PROZESS).patch({ Title: "Der Prozess" }).execute();
+    expect(patched.invalidates).toEqual(
+      expect.arrayContaining([
+        ["Books", "detail", BOOK_DER_PROZESS],
+        ["Books", "list"],
+      ]),
+    );
+  });
+
   test("Chapters/up_ - a binding declared through the contained Chapters collection - names its hop by the navigation property", async () => {
     // `up_`'s NavigationPropertyBinding is `Chapters/up_`, reached only by first following the contained
     // `Chapters` collection to `AudiobookChapter` - a real gap in DataModel.getNavPropBindingTarget this

--- a/int-test/cap/test/feature/CacheKeys.test.ts
+++ b/int-test/cap/test/feature/CacheKeys.test.ts
@@ -81,17 +81,9 @@ describe("CAP Library: cache keys (V4)", () => {
     );
   });
 
-  test("a statically-keyed hop's canonicalKey deterministically invalidates the direct route - no prior read required", async () => {
+  test("a statically-keyed hop's own segment is renamed to its entity set's name, deterministically invalidating the direct route - no prior read required. Not divergent in CAP's own model - Books really is the entity set here too - see int-test/asp-net for the case where the hop's own name and its entity set genuinely differ", async () => {
     const request = LIBRARY.Publishers(1).Books(BOOK_DER_PROZESS).query();
-    expect(request.cacheKey).toEqual([
-      "Publishers",
-      "detail",
-      1,
-      "Books",
-      "detail",
-      BOOK_DER_PROZESS,
-      { canonicalKey: ["Books", "detail", BOOK_DER_PROZESS] },
-    ]);
+    expect(request.cacheKey).toEqual(["Publishers", "detail", 1, "Books", "detail", BOOK_DER_PROZESS]);
     expect(touchesResource(["Books", "detail", BOOK_DER_PROZESS], request.cacheKey!)).toBe(true);
 
     const result = await request.execute();

--- a/packages/odata-service/src/cacheKey/BuildCacheKey.ts
+++ b/packages/odata-service/src/cacheKey/BuildCacheKey.ts
@@ -28,17 +28,25 @@ function mergeParams(
  * The keys a write makes stale.
  *
  * Six rules: the addressed resource's own key without its params object (a write invalidates the
- * resource however it was filtered, sorted or paged), its own `canonicalKey` where the hop that reached it
- * was statically keyed and diverges from its entity set's own name (deterministic - see `withKey` in
- * `CacheKeyState.ts` - so a write through this hop route also invalidates a direct route's cache entry
- * with no `ResourceIdentityHandler` involved), the resource's own entity set as a bare list key where it
- * belongs to one, the key of every ancestor hop - which is what catches a parent that was fetched with
- * `$expand` - a bare list-key entry per entity set the write's own payload deep-inserted into
- * (`state.params.deepEdit`, populated by `buildDeepEditHops` at the write's own call site), and whatever
- * hierarchical keys `crossRouteKeys` names - a route to this same resource the write's own route never
- * took, resolved via `ResourceIdentityHandler` from what an earlier response actually observed (see
- * `resolveCrossRouteInvalidates`; empty, never computed here, for a client with no such store). Entries
- * another entry is a prefix of are dropped; what is left is coarsest first.
+ * resource however it was filtered, sorted or paged), the same resource's own key in bare
+ * `[entitySetName, "detail", key]` form (see below - deterministic, so a write through a hop route also
+ * invalidates a direct route's cache entry with no `ResourceIdentityHandler` involved), the resource's own
+ * entity set as a bare list key where it belongs to one, the key of every ancestor hop - which is what
+ * catches a parent that was fetched with `$expand` - a bare list-key entry per entity set the write's own
+ * payload deep-inserted into (`state.params.deepEdit`, populated by `buildDeepEditHops` at the write's own
+ * call site), and whatever hierarchical keys `crossRouteKeys` names - a route to this same resource the
+ * write's own route never took, resolved via `ResourceIdentityHandler` from what an earlier response
+ * actually observed (see `resolveCrossRouteInvalidates`; empty, never computed here, for a client with no
+ * such store). Entries another entry is a prefix of are dropped; what is left is coarsest first.
+ *
+ * Rule 2 exists because a *longer* key can never be found by scanning a *shorter* one it was derived from:
+ * `withKey` already renames a statically-keyed hop's own segment to its entity set's name (`CacheKeyState.ts`),
+ * so `["Publishers","detail",1,"Media","detail",id]` already contains `["Media","detail",id]` as a plain,
+ * `touchesResource`-findable suffix - but the reverse direction (a *direct* write's own short key finding a
+ * *hop*-routed query's longer, cached one) needs that short form to exist as its own candidate here, not
+ * just as a substring of the resource's own (usually longer, and usually dropped as ancestor-redundant)
+ * rule-1 entry. At the root the two rules produce the identical entry and collapse into one via the same
+ * redundancy pass rule 4 already needs.
  *
  * Rule 3 applies wherever a "detail" key goes stale and the entity set it belongs to is known - not just
  * the addressed resource itself, but every ancestor hop too (rule 4): a list is a query *over* an entity
@@ -58,19 +66,22 @@ export function buildInvalidates(
   crossRouteKeys: ReadonlyArray<ReadonlyArray<unknown>> = [],
 ): ReadonlyArray<ReadonlyArray<unknown>> {
   const deepEditHops = (state.params?.deepEdit as ReadonlyArray<string> | undefined) ?? [];
-  const canonicalKey = state.params?.canonicalKey as ReadonlyArray<unknown> | undefined;
+  const keyedEntitySetForm =
+    state.entitySetName && state.key !== undefined
+      ? [state.entitySetName, "detail", state.steps[state.steps.length - 1]]
+      : undefined;
 
   const ancestorEntries = (state.ancestors ?? []).flatMap((ancestor) =>
     ancestor.entitySetName ? [ancestor.key, [ancestor.entitySetName, "list"]] : [ancestor.key],
   );
 
   // ancestors in route order (coarsest first, each with its own list form alongside), then the resource
-  // itself, its canonical form, then its entity set, then whatever it deep-inserted into, then whatever
-  // another route to this same resource already has cached
+  // itself, its bare entity-set-keyed form, then its entity set, then whatever it deep-inserted into, then
+  // whatever another route to this same resource already has cached
   const candidates: Array<ReadonlyArray<unknown>> = [
     ...ancestorEntries,
     [state.name, ...state.steps],
-    ...(canonicalKey ? [canonicalKey] : []),
+    ...(keyedEntitySetForm ? [keyedEntitySetForm] : []),
     ...(state.entitySetName ? [[state.entitySetName, "list"]] : []),
     ...deepEditHops.map((entitySetName) => [entitySetName, "list"]),
     ...crossRouteKeys,

--- a/packages/odata-service/src/cacheKey/BuildCacheKey.ts
+++ b/packages/odata-service/src/cacheKey/BuildCacheKey.ts
@@ -27,18 +27,21 @@ function mergeParams(
 /**
  * The keys a write makes stale.
  *
- * Five rules: the addressed resource's own key without its params object (a write invalidates the
- * resource however it was filtered, sorted or paged), the resource's own entity set as a bare list key
- * where it belongs to one, the key of every ancestor hop - which is what catches a parent that was
- * fetched with `$expand` - a bare list-key entry per entity set the write's own payload deep-inserted
- * into (`state.params.deepEdit`, populated by `buildDeepEditHops` at the write's own call site), and
- * whatever hierarchical keys `crossRouteKeys` names - a route to this same resource the write's own route
- * never took, resolved via `ResourceIdentityHandler` from what an earlier response actually observed (see
+ * Six rules: the addressed resource's own key without its params object (a write invalidates the
+ * resource however it was filtered, sorted or paged), its own `canonicalKey` where the hop that reached it
+ * was statically keyed and diverges from its entity set's own name (deterministic - see `withKey` in
+ * `CacheKeyState.ts` - so a write through this hop route also invalidates a direct route's cache entry
+ * with no `ResourceIdentityHandler` involved), the resource's own entity set as a bare list key where it
+ * belongs to one, the key of every ancestor hop - which is what catches a parent that was fetched with
+ * `$expand` - a bare list-key entry per entity set the write's own payload deep-inserted into
+ * (`state.params.deepEdit`, populated by `buildDeepEditHops` at the write's own call site), and whatever
+ * hierarchical keys `crossRouteKeys` names - a route to this same resource the write's own route never
+ * took, resolved via `ResourceIdentityHandler` from what an earlier response actually observed (see
  * `resolveCrossRouteInvalidates`; empty, never computed here, for a client with no such store). Entries
  * another entry is a prefix of are dropped; what is left is coarsest first.
  *
- * Rule 2 applies wherever a "detail" key goes stale and the entity set it belongs to is known - not just
- * the addressed resource itself, but every ancestor hop too (rule 3): a list is a query *over* an entity
+ * Rule 3 applies wherever a "detail" key goes stale and the entity set it belongs to is known - not just
+ * the addressed resource itself, but every ancestor hop too (rule 4): a list is a query *over* an entity
  * set, so any of that set's members turning stale is reason enough to also invalidate the set's own bare
  * list key, whichever hop the member was reached through. Skipped wherever the resource has no entity set
  * of its own - a contained entity, a complex value, a singleton: nothing is ever registered under such a
@@ -55,17 +58,19 @@ export function buildInvalidates(
   crossRouteKeys: ReadonlyArray<ReadonlyArray<unknown>> = [],
 ): ReadonlyArray<ReadonlyArray<unknown>> {
   const deepEditHops = (state.params?.deepEdit as ReadonlyArray<string> | undefined) ?? [];
+  const canonicalKey = state.params?.canonicalKey as ReadonlyArray<unknown> | undefined;
 
   const ancestorEntries = (state.ancestors ?? []).flatMap((ancestor) =>
     ancestor.entitySetName ? [ancestor.key, [ancestor.entitySetName, "list"]] : [ancestor.key],
   );
 
   // ancestors in route order (coarsest first, each with its own list form alongside), then the resource
-  // itself, then its entity set, then whatever it deep-inserted into, then whatever another route to this
-  // same resource already has cached
+  // itself, its canonical form, then its entity set, then whatever it deep-inserted into, then whatever
+  // another route to this same resource already has cached
   const candidates: Array<ReadonlyArray<unknown>> = [
     ...ancestorEntries,
     [state.name, ...state.steps],
+    ...(canonicalKey ? [canonicalKey] : []),
     ...(state.entitySetName ? [[state.entitySetName, "list"]] : []),
     ...deepEditHops.map((entitySetName) => [entitySetName, "list"]),
     ...crossRouteKeys,

--- a/packages/odata-service/src/cacheKey/CacheKeyState.ts
+++ b/packages/odata-service/src/cacheKey/CacheKeyState.ts
@@ -20,6 +20,14 @@ export type QEntityFn = () => new (prefix?: string, separator?: string) => Query
 export type CanonicalIdFn = (entity: unknown) => string | undefined;
 
 /**
+ * The array-shaped counterpart to a canonical id: `[entitySetName, "detail", key]` - exactly the `cacheKey`
+ * a direct route to the same resource would already have. Not the id *string* {@link CanonicalIdFn} builds
+ * for `ResourceIdentityHandler` - this is that same identity in `cacheKey`/`touchesResource`/`invalidates`
+ * form, for a resource a hop narrowed to a statically-known key. See `withKey`.
+ */
+export type CanonicalKey = readonly [entitySetName: string, kind: "detail", key: unknown];
+
+/**
  * What a generated service knows about the resource it addresses, in the form a cache key is built from.
  *
  * Threaded downwards through construction and never derived from a URL: the typed key value exists one call
@@ -38,7 +46,7 @@ export interface CacheKeyState {
    * collided two sibling navigations onto one key.
    */
   readonly kindIndex: number;
-  /** Restrictions contributed by the resource itself: cast, singleton, operation. */
+  /** Restrictions and identity forms contributed by the resource itself: cast, singleton, operation, {@link CanonicalKey} (`withKey`, for a statically-keyed hop). */
   readonly params?: Readonly<Record<string, unknown>>;
   /**
    * The entity set the addressed resource belongs to, by its own name - never a type. Feeds `invalidates`.
@@ -130,13 +138,28 @@ export function rootState(
  *
  * Rewrites the trailing kind marker rather than appending one, and pushes no ancestor: `byId` refines the
  * resource the route is at, it does not leave it.
+ *
+ * Also attaches {@link CanonicalKey} to `params` whenever this narrows a **hop**, not the root: `state.name`
+ * *is* the entity set's own name at the root already, so a root's own canonical form would just duplicate
+ * its own key for nothing. `stepKey` (the OData-named form already going into `steps`), not `id` (the
+ * caller's own, possibly TS-mapped form `key` stores) - `stepKey` is what makes `canonicalKey` byte-identical
+ * to what a direct route's own `cacheKey` produces, which is the entire point.
  */
 export function withKey(state: CacheKeyState, stepKey: unknown, id: unknown): CacheKeyState {
   const steps = [...state.steps];
   steps[state.kindIndex] = "detail";
   steps.push(stepKey);
 
-  return { ...state, steps, key: id };
+  const isHop = (state.ancestors?.length ?? 0) > 0;
+  const canonicalKey: CanonicalKey | undefined =
+    isHop && state.entitySetName ? [state.entitySetName, "detail", stepKey] : undefined;
+
+  return {
+    ...state,
+    steps,
+    key: id,
+    ...(canonicalKey ? { params: { ...state.params, canonicalKey } } : {}),
+  };
 }
 
 /** Adds a restriction the resource itself carries - a cast, a singleton marker, an operation. */

--- a/packages/odata-service/src/cacheKey/CacheKeyState.ts
+++ b/packages/odata-service/src/cacheKey/CacheKeyState.ts
@@ -20,14 +20,6 @@ export type QEntityFn = () => new (prefix?: string, separator?: string) => Query
 export type CanonicalIdFn = (entity: unknown) => string | undefined;
 
 /**
- * The array-shaped counterpart to a canonical id: `[entitySetName, "detail", key]` - exactly the `cacheKey`
- * a direct route to the same resource would already have. Not the id *string* {@link CanonicalIdFn} builds
- * for `ResourceIdentityHandler` - this is that same identity in `cacheKey`/`touchesResource`/`invalidates`
- * form, for a resource a hop narrowed to a statically-known key. See `withKey`.
- */
-export type CanonicalKey = readonly [entitySetName: string, kind: "detail", key: unknown];
-
-/**
  * What a generated service knows about the resource it addresses, in the form a cache key is built from.
  *
  * Threaded downwards through construction and never derived from a URL: the typed key value exists one call
@@ -46,7 +38,7 @@ export interface CacheKeyState {
    * collided two sibling navigations onto one key.
    */
   readonly kindIndex: number;
-  /** Restrictions and identity forms contributed by the resource itself: cast, singleton, operation, {@link CanonicalKey} (`withKey`, for a statically-keyed hop). */
+  /** Restrictions contributed by the resource itself: cast, singleton, operation. */
   readonly params?: Readonly<Record<string, unknown>>;
   /**
    * The entity set the addressed resource belongs to, by its own name - never a type. Feeds `invalidates`.
@@ -139,27 +131,29 @@ export function rootState(
  * Rewrites the trailing kind marker rather than appending one, and pushes no ancestor: `byId` refines the
  * resource the route is at, it does not leave it.
  *
- * Also attaches {@link CanonicalKey} to `params` whenever this narrows a **hop**, not the root: `state.name`
- * *is* the entity set's own name at the root already, so a root's own canonical form would just duplicate
- * its own key for nothing. `stepKey` (the OData-named form already going into `steps`), not `id` (the
- * caller's own, possibly TS-mapped form `key` stores) - `stepKey` is what makes `canonicalKey` byte-identical
- * to what a direct route's own `cacheKey` produces, which is the entire point.
+ * Where this narrows a **hop** (never the root, whose own name already *is* the entity set's) and the
+ * entity set is resolvable, the hop's own name in `steps` is *also* rewritten to that entity set's name -
+ * `Publishers(1).Books(id)` becomes `["Publishers","detail",1,"Media","detail",id]`, not
+ * `[...,"Books","detail",id]`. This is safe unconditionally, not just convenient: a declared key uniquely
+ * identifies an entity within its entity set by definition, so two routes narrowing to the *same*
+ * `(entitySetName, key)` pair are, by OData's own key semantics, the very same entity - there is no
+ * ambiguity a bare name could have resolved that a full key does not already settle on its own (unlike the
+ * hierarchical hop *name*, which is real and load-bearing precisely because it carries no key with it).
+ * The rewrite makes this hop's key byte-identical to what a direct route to the same entity already
+ * produces, so `touchesResource`'s existing plain scan finds one from the other with no special case; only
+ * `buildInvalidates` still needs a dedicated rule, since a *longer* key can never be found by scanning a
+ * *shorter* one it was derived from (see `BuildCacheKey.ts`).
  */
 export function withKey(state: CacheKeyState, stepKey: unknown, id: unknown): CacheKeyState {
   const steps = [...state.steps];
+  const isHop = state.kindIndex > 0;
+  if (isHop && state.entitySetName) {
+    steps[state.kindIndex - 1] = state.entitySetName;
+  }
   steps[state.kindIndex] = "detail";
   steps.push(stepKey);
 
-  const isHop = (state.ancestors?.length ?? 0) > 0;
-  const canonicalKey: CanonicalKey | undefined =
-    isHop && state.entitySetName ? [state.entitySetName, "detail", stepKey] : undefined;
-
-  return {
-    ...state,
-    steps,
-    key: id,
-    ...(canonicalKey ? { params: { ...state.params, canonicalKey } } : {}),
-  };
+  return { ...state, steps, key: id };
 }
 
 /** Adds a restriction the resource itself carries - a cast, a singleton marker, an operation. */

--- a/packages/odata-service/src/cacheKey/TouchesResource.ts
+++ b/packages/odata-service/src/cacheKey/TouchesResource.ts
@@ -3,18 +3,20 @@ import { sameElement } from "./KeyElementEquality";
 /**
  * Whether the given cache key touches the given `(name, kind, key?)` - exactly the shape of a root or an
  * `[entitySetName, "list"]` entry, wherever it occurs in the key, as a contiguous run - including inside an
- * `expand` entry of its params object (however deeply `expanding()` nested those) or a `canonicalKey` entry
- * (a statically-keyed hop's own identity in direct-route form - see `CacheKeyState.ts`).
+ * `expand` entry of its params object, however deeply `expanding()` nested those.
  *
  * A hierarchical key is rooted at the name the route started at, so a prefix match on a name reached
  * further down the route can never reach it - one array has one prefix. This is what makes such a key
  * reachable at all without a generated table alongside it: root and every hop already share this same
- * `(name, kind, key?)` shape, so a plain contiguous scan is all `invalidates` needs.
+ * `(name, kind, key?)` shape, so a plain contiguous scan is all `invalidates` needs. It is also what lets a
+ * statically-keyed hop be found by a direct route's own key with no special case at all: `withKey` renames
+ * such a hop's own segment to its entity set's name (see `CacheKeyState.ts`), so
+ * `Publishers(1).Books(id)`'s key already contains `["Media","detail",id]` as a plain, findable suffix.
  *
- * **`expand`/`canonicalKey` entries are searched too, recursively.** They live inside the trailing params
- * object, not as top-level elements, so a plain scan of `key` itself does not find them - a hop hidden two
- * objects deep is still exactly the same `(name, kind)` shape, so the very same matching logic applies to
- * it once found; only *finding* it needs an extra step, which is what this does.
+ * **`expand` entries are searched too, recursively.** They live inside the trailing params object, not as
+ * top-level elements, so a plain scan of `key` itself does not find them - a hop hidden two objects deep is
+ * still exactly the same `(name, kind)` shape, so the very same matching logic applies to it once found;
+ * only *finding* it needs an extra step, which is what this does.
  *
  * Kept library-neutral - it takes a key, not a cache-library query object:
  * `invalidateQueries({predicate: (q) => touchesResource(entry, q.queryKey)})`.
@@ -23,7 +25,7 @@ export function touchesResource(needle: ReadonlyArray<unknown>, key: ReadonlyArr
   if (isPrefixAt(needle, key, 0)) {
     return true;
   }
-  return structuredHopsOf(key).some((hop) => isPrefixAt(needle, hop, 0));
+  return expandHopsOf(key).some((hop) => isPrefixAt(needle, hop, 0));
 }
 
 function isPrefixAt(needle: ReadonlyArray<unknown>, haystack: ReadonlyArray<unknown>, start: number): boolean {
@@ -36,23 +38,18 @@ function isPrefixAt(needle: ReadonlyArray<unknown>, haystack: ReadonlyArray<unkn
 }
 
 /**
- * Every `(name, kind)` hop reachable through an `expand` entry, or a statically-keyed hop's own
- * `canonicalKey` entry, of any params object among `key`'s own elements - recursively for `expand`, since a
- * hop's own trailing element may carry further nested params with an `expand` of its own (index 2 for a
- * "list" hop, index 3 for a "detail" hop - which carries the "?" placeholder at index 2 instead, see
- * `ExpandHop` in odata-query-builder). A bare (unenriched) expand entry is just a rendered path string and
- * contributes nothing here - there is no name to find in it beyond what a plain scan of `key` already
- * covers. `canonicalKey` needs no recursion: it names the addressed resource itself, not a nested one.
+ * Every `(name, kind)` hop reachable through an `expand` entry of any params object among `key`'s own
+ * elements - recursively, since a hop's own trailing element may carry further nested params with an
+ * `expand` of its own (index 2 for a "list" hop, index 3 for a "detail" hop - which carries the "?"
+ * placeholder at index 2 instead, see `ExpandHop` in odata-query-builder). A bare (unenriched) expand entry
+ * is just a rendered path string and contributes nothing here - there is no name to find in it beyond what
+ * a plain scan of `key` already covers.
  */
-function structuredHopsOf(key: ReadonlyArray<unknown>): Array<ReadonlyArray<unknown>> {
+function expandHopsOf(key: ReadonlyArray<unknown>): Array<ReadonlyArray<unknown>> {
   const hops: Array<ReadonlyArray<unknown>> = [];
   for (const element of key) {
     if (typeof element === "object" && element !== null && !Array.isArray(element)) {
-      const params = element as Record<string, unknown>;
-      collectExpandHops(params, hops);
-      if (Array.isArray(params.canonicalKey)) {
-        hops.push(params.canonicalKey as ReadonlyArray<unknown>);
-      }
+      collectExpandHops(element as Record<string, unknown>, hops);
     }
   }
   return hops;

--- a/packages/odata-service/src/cacheKey/TouchesResource.ts
+++ b/packages/odata-service/src/cacheKey/TouchesResource.ts
@@ -3,17 +3,18 @@ import { sameElement } from "./KeyElementEquality";
 /**
  * Whether the given cache key touches the given `(name, kind, key?)` - exactly the shape of a root or an
  * `[entitySetName, "list"]` entry, wherever it occurs in the key, as a contiguous run - including inside an
- * `expand` entry of its params object, however deeply `expanding()` nested those.
+ * `expand` entry of its params object (however deeply `expanding()` nested those) or a `canonicalKey` entry
+ * (a statically-keyed hop's own identity in direct-route form - see `CacheKeyState.ts`).
  *
  * A hierarchical key is rooted at the name the route started at, so a prefix match on a name reached
  * further down the route can never reach it - one array has one prefix. This is what makes such a key
  * reachable at all without a generated table alongside it: root and every hop already share this same
  * `(name, kind, key?)` shape, so a plain contiguous scan is all `invalidates` needs.
  *
- * **`expand` entries are searched too, recursively.** They live inside the trailing params object, not as
- * top-level elements, so a plain scan of `key` itself does not find them - a hop hidden two objects deep is
- * still exactly the same `(name, kind)` shape, so the very same matching logic applies to it once found;
- * only *finding* it needs an extra step, which is what this does.
+ * **`expand`/`canonicalKey` entries are searched too, recursively.** They live inside the trailing params
+ * object, not as top-level elements, so a plain scan of `key` itself does not find them - a hop hidden two
+ * objects deep is still exactly the same `(name, kind)` shape, so the very same matching logic applies to
+ * it once found; only *finding* it needs an extra step, which is what this does.
  *
  * Kept library-neutral - it takes a key, not a cache-library query object:
  * `invalidateQueries({predicate: (q) => touchesResource(entry, q.queryKey)})`.
@@ -22,7 +23,7 @@ export function touchesResource(needle: ReadonlyArray<unknown>, key: ReadonlyArr
   if (isPrefixAt(needle, key, 0)) {
     return true;
   }
-  return expandHopsOf(key).some((hop) => isPrefixAt(needle, hop, 0));
+  return structuredHopsOf(key).some((hop) => isPrefixAt(needle, hop, 0));
 }
 
 function isPrefixAt(needle: ReadonlyArray<unknown>, haystack: ReadonlyArray<unknown>, start: number): boolean {
@@ -35,18 +36,23 @@ function isPrefixAt(needle: ReadonlyArray<unknown>, haystack: ReadonlyArray<unkn
 }
 
 /**
- * Every `(name, kind)` hop reachable through an `expand` entry of any params object among `key`'s own
- * elements - recursively, since a hop's own trailing element may carry further nested params with an
- * `expand` of its own (index 2 for a "list" hop, index 3 for a "detail" hop - which carries the "?"
- * placeholder at index 2 instead, see `ExpandHop` in odata-query-builder). A bare (unenriched) expand entry
- * is just a rendered path string and contributes nothing here - there is no name to find in it beyond what
- * a plain scan of `key` already covers.
+ * Every `(name, kind)` hop reachable through an `expand` entry, or a statically-keyed hop's own
+ * `canonicalKey` entry, of any params object among `key`'s own elements - recursively for `expand`, since a
+ * hop's own trailing element may carry further nested params with an `expand` of its own (index 2 for a
+ * "list" hop, index 3 for a "detail" hop - which carries the "?" placeholder at index 2 instead, see
+ * `ExpandHop` in odata-query-builder). A bare (unenriched) expand entry is just a rendered path string and
+ * contributes nothing here - there is no name to find in it beyond what a plain scan of `key` already
+ * covers. `canonicalKey` needs no recursion: it names the addressed resource itself, not a nested one.
  */
-function expandHopsOf(key: ReadonlyArray<unknown>): Array<ReadonlyArray<unknown>> {
+function structuredHopsOf(key: ReadonlyArray<unknown>): Array<ReadonlyArray<unknown>> {
   const hops: Array<ReadonlyArray<unknown>> = [];
   for (const element of key) {
     if (typeof element === "object" && element !== null && !Array.isArray(element)) {
-      collectExpandHops(element as Record<string, unknown>, hops);
+      const params = element as Record<string, unknown>;
+      collectExpandHops(params, hops);
+      if (Array.isArray(params.canonicalKey)) {
+        hops.push(params.canonicalKey as ReadonlyArray<unknown>);
+      }
     }
   }
   return hops;

--- a/packages/odata-service/test/cacheKey/BuildCacheKey.test.ts
+++ b/packages/odata-service/test/cacheKey/BuildCacheKey.test.ts
@@ -84,7 +84,7 @@ describe("buildInvalidates", () => {
     expect(buildInvalidates(state)).toContainEqual([MEDIA, "detail", 5]);
   });
 
-  test("a hierarchical write's own key is a prefix-redundant with its ancestor, and drops out - the ancestor, the ancestor's own list form, and the entity-set list entry are what remain", () => {
+  test("a hierarchical write's own key is a prefix-redundant with its ancestor, and drops out - the ancestor, the ancestor's own list form, the hop's own canonicalKey, and the entity-set list entry are what remain", () => {
     const copies = hopState(withKey(rootState(MEDIA, "list", { entitySetName: MEDIA }), 5, { Id: 5 }), {
       name: "copies",
       kind: "list",
@@ -94,6 +94,7 @@ describe("buildInvalidates", () => {
     expect(buildInvalidates(withKey(copies, key, key))).toEqual([
       [MEDIA, "detail", 5],
       [MEDIA, "list"],
+      [COPIES, "detail", key],
       [COPIES, "list"],
     ]);
   });
@@ -120,6 +121,7 @@ describe("buildInvalidates", () => {
     expect(buildInvalidates(withKey(reservations, 9, { Id: 9 }))).toEqual([
       [MEMBERS, "detail", 42],
       [MEMBERS, "list"],
+      [RESERVATIONS, "detail", 9],
       [RESERVATIONS, "list"],
     ]);
   });

--- a/packages/odata-service/test/cacheKey/CacheKeyState.test.ts
+++ b/packages/odata-service/test/cacheKey/CacheKeyState.test.ts
@@ -127,10 +127,11 @@ describe("CacheKeyState", () => {
     const condition = hopState(copy, { name: "condition", kind: "detail" });
 
     expect(condition.name).toBe(MEDIA);
+    // "Copies" (the entity set), not "copies" (the hop's own OData name) - withKey already renamed it
     expect(condition.steps).toEqual([
       "detail",
       5,
-      "copies",
+      COPIES,
       "detail",
       { MediumId: 5, InventoryNumber: 7 },
       "condition",
@@ -138,7 +139,7 @@ describe("CacheKeyState", () => {
     ]);
     expect(condition.ancestors).toEqual([
       { key: [MEDIA, "detail", 5] },
-      { key: [MEDIA, "detail", 5, "copies", "detail", { MediumId: 5, InventoryNumber: 7 }], entitySetName: COPIES },
+      { key: [MEDIA, "detail", 5, COPIES, "detail", { MediumId: 5, InventoryNumber: 7 }], entitySetName: COPIES },
     ]);
   });
 
@@ -154,20 +155,38 @@ describe("CacheKeyState", () => {
     expect(state.steps).toEqual(["detail", "x", "scan", "$value"]);
   });
 
-  test("withKey after a hop keeps the navigation property's own name", () => {
+  test("withKey after a hop renames the segment to the entity set's own name, not the navigation property's", () => {
     const parent = withKey(rootState(MEDIA, "list"), 5, { Id: 5 });
     const copies = hopState(parent, { name: "copies", kind: "list", entitySetName: COPIES });
     const state = withKey(copies, 7, { InventoryNumber: 7 });
-    expect(state.steps).toEqual(["detail", 5, "copies", "detail", 7]);
+    expect(state.steps).toEqual(["detail", 5, COPIES, "detail", 7]);
   });
 
-  test("two sibling navigations of the same target entity set do not collide - each keeps its own name", () => {
+  test("withKey after a hop with no entity set of its own (contained) keeps the navigation property's own name - there is nothing to rename it to", () => {
+    const parent = withKey(rootState(MEDIA, "list"), 1, { Id: 1 });
+    const chapters = hopState(parent, { name: CHAPTERS, kind: "list" });
+    const state = withKey(chapters, 1, { Id: 1 });
+    expect(state.steps).toEqual(["detail", 1, CHAPTERS, "detail", 1]);
+  });
+
+  test("two sibling navigations to the same target entity set converge once narrowed to the same key - a declared key identifies one entity, so this is the same resource, not a collision", () => {
     const parent = withKey(rootState(MEDIA, "list"), 5, { Id: 5 });
     const primary = withKey(hopState(parent, { name: "copies", kind: "list", entitySetName: COPIES }), 3, {
       InventoryNumber: 3,
     });
     const backup = withKey(hopState(parent, { name: "backupCopies", kind: "list", entitySetName: COPIES }), 3, {
       InventoryNumber: 3,
+    });
+    expect(primary.steps).toEqual(backup.steps);
+  });
+
+  test("two sibling navigations narrowed to genuinely different keys never converge", () => {
+    const parent = withKey(rootState(MEDIA, "list"), 5, { Id: 5 });
+    const primary = withKey(hopState(parent, { name: "copies", kind: "list", entitySetName: COPIES }), 3, {
+      InventoryNumber: 3,
+    });
+    const backup = withKey(hopState(parent, { name: "backupCopies", kind: "list", entitySetName: COPIES }), 9, {
+      InventoryNumber: 9,
     });
     expect(primary.steps).not.toEqual(backup.steps);
   });
@@ -185,46 +204,30 @@ describe("CacheKeyState", () => {
     expect(state.steps[state.kindIndex]).toBe("list");
   });
 
-  describe("withKey attaches canonicalKey for a statically-keyed hop", () => {
-    test("a root-level byId gets no canonicalKey - its own name already is the entity set's", () => {
+  describe("withKey's rename is gated on the same conditions the params-based design used to gate canonicalKey on", () => {
+    test("a root-level byId renames nothing - its own name already is the entity set's", () => {
       const state = withKey(rootState(MEDIA, "list", { entitySetName: MEDIA }), 5, { Id: 5 });
-      expect(state.params).toBeUndefined();
+      expect(state.steps).toEqual(["detail", 5]);
     });
 
-    test("a hop-level byId gets canonicalKey, shaped exactly like a direct route's own cacheKey", () => {
-      const media = withKey(rootState(MEDIA, "list"), 5, { Id: 5 });
-      const copies = hopState(media, { name: "copies", kind: "list", entitySetName: COPIES });
-      const state = withKey(copies, 3, { InventoryNumber: 3 });
-      expect(state.params).toEqual({ canonicalKey: [COPIES, "detail", 3] });
-    });
-
-    test("a composite key's canonicalKey carries the OData-named step form, not the raw id", () => {
+    test("a composite key renames the segment and stores the OData-named step form byte-identical to a direct route's own key, while state.key keeps the caller's own (possibly TS-mapped) id", () => {
       const media = withKey(rootState(MEDIA, "list"), 5, { Id: 5 });
       const copies = hopState(media, { name: "copies", kind: "list", entitySetName: COPIES });
       const stepKey = { MediumId: 5, InventoryNumber: 7 };
       const id = { mediumId: 5, inventoryNumber: 7 };
       const state = withKey(copies, stepKey, id);
-      expect(state.params).toEqual({ canonicalKey: [COPIES, "detail", stepKey] });
+      expect(state.steps).toEqual(["detail", 5, COPIES, "detail", stepKey]);
       expect(state.key).toBe(id);
     });
 
-    test("a hop-level byId with no entity set of its own (contained) gets no canonicalKey", () => {
-      const media = withKey(rootState(MEDIA, "list"), 1, { Id: 1 });
-      const chapters = hopState(media, { name: CHAPTERS, kind: "list" });
-      const state = withKey(chapters, 1, { Id: 1 });
-      expect(state.params).toBeUndefined();
-    });
-
-    test("canonicalKey merges alongside a restriction the hop already carries", () => {
+    test("the rename does not disturb a restriction the hop already carries in params", () => {
       const media = withKey(rootState(MEDIA, "list"), 5, { Id: 5 });
       const copies = withParams(hopState(media, { name: "copies", kind: "list", entitySetName: COPIES }), {
         cast: "Library.Catalog.SpecialCopy",
       });
       const state = withKey(copies, 3, { InventoryNumber: 3 });
-      expect(state.params).toEqual({
-        cast: "Library.Catalog.SpecialCopy",
-        canonicalKey: [COPIES, "detail", 3],
-      });
+      expect(state.steps).toEqual(["detail", 5, COPIES, "detail", 3]);
+      expect(state.params).toEqual({ cast: "Library.Catalog.SpecialCopy" });
     });
   });
 });

--- a/packages/odata-service/test/cacheKey/CacheKeyState.test.ts
+++ b/packages/odata-service/test/cacheKey/CacheKeyState.test.ts
@@ -184,4 +184,47 @@ describe("CacheKeyState", () => {
     expect(state.kindIndex).toBe(state.steps.length - 1);
     expect(state.steps[state.kindIndex]).toBe("list");
   });
+
+  describe("withKey attaches canonicalKey for a statically-keyed hop", () => {
+    test("a root-level byId gets no canonicalKey - its own name already is the entity set's", () => {
+      const state = withKey(rootState(MEDIA, "list", { entitySetName: MEDIA }), 5, { Id: 5 });
+      expect(state.params).toBeUndefined();
+    });
+
+    test("a hop-level byId gets canonicalKey, shaped exactly like a direct route's own cacheKey", () => {
+      const media = withKey(rootState(MEDIA, "list"), 5, { Id: 5 });
+      const copies = hopState(media, { name: "copies", kind: "list", entitySetName: COPIES });
+      const state = withKey(copies, 3, { InventoryNumber: 3 });
+      expect(state.params).toEqual({ canonicalKey: [COPIES, "detail", 3] });
+    });
+
+    test("a composite key's canonicalKey carries the OData-named step form, not the raw id", () => {
+      const media = withKey(rootState(MEDIA, "list"), 5, { Id: 5 });
+      const copies = hopState(media, { name: "copies", kind: "list", entitySetName: COPIES });
+      const stepKey = { MediumId: 5, InventoryNumber: 7 };
+      const id = { mediumId: 5, inventoryNumber: 7 };
+      const state = withKey(copies, stepKey, id);
+      expect(state.params).toEqual({ canonicalKey: [COPIES, "detail", stepKey] });
+      expect(state.key).toBe(id);
+    });
+
+    test("a hop-level byId with no entity set of its own (contained) gets no canonicalKey", () => {
+      const media = withKey(rootState(MEDIA, "list"), 1, { Id: 1 });
+      const chapters = hopState(media, { name: CHAPTERS, kind: "list" });
+      const state = withKey(chapters, 1, { Id: 1 });
+      expect(state.params).toBeUndefined();
+    });
+
+    test("canonicalKey merges alongside a restriction the hop already carries", () => {
+      const media = withKey(rootState(MEDIA, "list"), 5, { Id: 5 });
+      const copies = withParams(hopState(media, { name: "copies", kind: "list", entitySetName: COPIES }), {
+        cast: "Library.Catalog.SpecialCopy",
+      });
+      const state = withKey(copies, 3, { InventoryNumber: 3 });
+      expect(state.params).toEqual({
+        cast: "Library.Catalog.SpecialCopy",
+        canonicalKey: [COPIES, "detail", 3],
+      });
+    });
+  });
 });

--- a/packages/odata-service/test/cacheKey/TouchesResource.test.ts
+++ b/packages/odata-service/test/cacheKey/TouchesResource.test.ts
@@ -106,4 +106,22 @@ describe("touchesResource - expand entries, buried inside the trailing params ob
     const key = [MEDIA, "detail", 5];
     expect(touchesResource(["copies", "list"], key)).toBe(false);
   });
+
+  test("a statically-keyed hop's own canonicalKey entry is found the same way an expand hop is", () => {
+    // Publishers(1).Books(id) - "Books" is the hop's own name, "Media" its target's entity set
+    const key = [
+      "Publishers",
+      "detail",
+      1,
+      "Books",
+      "detail",
+      "1111...1",
+      { canonicalKey: ["Media", "detail", "1111...1"] },
+    ];
+    expect(touchesResource(["Media", "detail", "1111...1"], key)).toBe(true);
+    // a plain top-level scan for the hop's own hierarchical route still works too - canonicalKey is additive
+    expect(touchesResource(["Publishers", "detail", 1, "Books", "detail", "1111...1"], key)).toBe(true);
+    // a different id's canonical form does not match
+    expect(touchesResource(["Media", "detail", "2222...2"], key)).toBe(false);
+  });
 });

--- a/packages/odata-service/test/cacheKey/TouchesResource.test.ts
+++ b/packages/odata-service/test/cacheKey/TouchesResource.test.ts
@@ -107,21 +107,14 @@ describe("touchesResource - expand entries, buried inside the trailing params ob
     expect(touchesResource(["copies", "list"], key)).toBe(false);
   });
 
-  test("a statically-keyed hop's own canonicalKey entry is found the same way an expand hop is", () => {
-    // Publishers(1).Books(id) - "Books" is the hop's own name, "Media" its target's entity set
-    const key = [
-      "Publishers",
-      "detail",
-      1,
-      "Books",
-      "detail",
-      "1111...1",
-      { canonicalKey: ["Media", "detail", "1111...1"] },
-    ];
+  test("a statically-keyed hop's own key, already renamed to its entity set's name by withKey, is found by a plain top-level scan - no params object involved at all", () => {
+    // Publishers(1).Books(id): "Books" is the hop's own OData name, but withKey already renamed this
+    // segment to "Media" (its target's entity set) when the key was applied - see CacheKeyState.ts
+    const key = ["Publishers", "detail", 1, "Media", "detail", "1111...1"];
     expect(touchesResource(["Media", "detail", "1111...1"], key)).toBe(true);
-    // a plain top-level scan for the hop's own hierarchical route still works too - canonicalKey is additive
-    expect(touchesResource(["Publishers", "detail", 1, "Books", "detail", "1111...1"], key)).toBe(true);
-    // a different id's canonical form does not match
+    // the hop's own ancestor prefix is still findable too - the rename only touches its own segment
+    expect(touchesResource(["Publishers", "detail", 1], key)).toBe(true);
+    // a different id does not match
     expect(touchesResource(["Media", "detail", "2222...2"], key)).toBe(false);
   });
 });


### PR DESCRIPTION
A navigation hop narrowed by its own statically-known key (`Publishers(1).Books(id)`, where `Books` binds to
entity set `Media`, not `Books`) addresses the exact same resource a direct route reaches (`Media(id)`) - but
its hierarchical `cacheKey` used to name the hop by its own navigation-property name, so the two routes'
keys never matched each other structurally.

`entitySetName` and the key are both known the instant the request is *constructed* - no response required -
and a declared key uniquely identifies an entity within its entity set by definition: two routes narrowing to
the same `(entitySetName, key)` pair are, by OData's own key semantics, the same entity, unconditionally.
`withKey` now renames such a hop's own segment in `steps` directly, to its entity set's name, whenever it
narrows a non-root hop whose entity set is resolvable: `Publishers(1).Books(id)` becomes
`["Publishers","detail",1,"Media","detail",id]`, not `[...,"Books","detail",id]`.

- `touchesResource`'s existing plain scan finds the shared `["Media","detail",id]` suffix with no code
  change at all.
- `buildInvalidates` gets one added rule, for the one direction a contiguous scan can't cover on its own: a
  write through the *direct* route (`Media(id)`) needs the resource's own short `[entitySetName, "detail",
  key]` form as an explicit invalidation candidate, since a longer, hop-routed cache entry can't be found by
  scanning a shorter key it was derived from. The reverse direction needs no such rule - a write through the
  *hop* route already contains the short form as a plain, findable suffix once renamed.
- Omitted at the root (already named by entity set), for unkeyed/list hops, and for a `"detail"` hop reached
  without an inline key - none of those have a single, statically-known id to justify the substitution, and
  they keep depending on response-observed identity (`ResourceIdentityHandler`) for cross-route resolution
  as before.

Full design and rejected alternatives are recorded in `docs/adr/0003-statically-keyed-hop-renamed-to-its-entity-set.md`
in the workspace-root spec repo.

### Server coverage

- **cap**: executed against a real server, and here the hop's own name and its entity set happen to coincide
  (`Publishers.Books` → entity set `Books`), so this proves the write-invalidates-direct-route mechanism over
  a live HTTP round trip, but not the divergent-naming case.
- **asp-net**: `Publishers.Books` binds to entity set `Media` - the genuinely divergent case this feature
  exists for - correctly asserted in `CacheKeys.test.ts` (`["Publishers","detail",1,"Media","detail",id]`),
  computed client-side with no network call. Executing it end-to-end needs a keyed GET/PATCH route through
  this navigation property, added in
  [test-server-asp-net#38](https://github.com/odata2ts/test-server-asp-net/pull/38) (merged, releasing soon).
  Once released and this repo's `server-image.json` pin is bumped, this test converts from shape-only to
  executed, closing the coverage gap completely. Tracked as a direct follow-up to this PR.
- Unit-level tests (`CacheKeyState.test.ts`, `TouchesResource.test.ts`, `BuildCacheKey.test.ts`) exercise the
  divergent-naming case directly via mocked state in the meantime.

Full suites green: `odata-service` 532 tests, `odata2ts`, `odata-query-builder`, and all three server
int-tests (asp-net 160, cap 223, olingo-v2 137), workspace-wide `test-compile`.
