### PR TITLE
feat(odata-service): extend the statically-keyed hop rename to ancestors in buildInvalidates

### DIFF
--- a/int-test/asp-net/server-image.json
+++ b/int-test/asp-net/server-image.json
@@ -1,4 +1,4 @@
 {
   "image": "ghcr.io/odata2ts/test-server-asp-net",
-  "version": "0.4.0"
+  "version": "0.5.0"
 }

--- a/int-test/asp-net/test/feature/CacheKeys.test.ts
+++ b/int-test/asp-net/test/feature/CacheKeys.test.ts
@@ -130,6 +130,61 @@ describe("ASP.NET Library: cache keys", () => {
     );
   });
 
+  test("a write three hops deep, through an ancestor whose own name diverges from its entity set, still deterministically invalidates a direct route to that ancestor - Publishers(1).Books(id).Copies(...)", async () => {
+    // the deferred follow-up to the previous test, closed in ADR-0003: "Books" (the ancestor hop, not the
+    // addressed resource here) diverges from its entity set "Media" too - the addressed Copy needs no
+    // divergence of its own to prove this, only its ancestor does
+    const ancestorCopyKey = { MediumId: BOOK_DER_PROZESS, InventoryNumber: CACHE_KEY_COPY + 1 };
+    const created = await LIBRARY.Copies()
+      .create({
+        MediumId: BOOK_DER_PROZESS,
+        InventoryNumber: CACHE_KEY_COPY + 1,
+        Condition: 3,
+        IsLoanable: true,
+        WeightKg: 0.5,
+      })
+      .execute();
+    expect(created.status).toBe(201);
+
+    try {
+      const request = LIBRARY.Publishers(1).Books(BOOK_DER_PROZESS).Copies(ancestorCopyKey).query();
+      expect(request.cacheKey).toEqual([
+        "Publishers",
+        "detail",
+        1,
+        "Media",
+        "detail",
+        BOOK_DER_PROZESS,
+        "Copies",
+        "detail",
+        ancestorCopyKey,
+      ]);
+      expect(touchesResource(["Media", "detail", BOOK_DER_PROZESS], request.cacheKey!)).toBe(true);
+
+      const result = await request.execute();
+      expect(result.status).toBe(200);
+      expect(result.data.InventoryNumber).toBe(CACHE_KEY_COPY + 1);
+
+      // the deterministic proof: a write three hops deep invalidates the ancestor's own direct Media(id)
+      // route too, not just the ancestor's full, hierarchical (and much longer) key
+      const patched = await LIBRARY.Publishers(1)
+        .Books(BOOK_DER_PROZESS)
+        .Copies(ancestorCopyKey)
+        .patch({ Condition: 4 })
+        .ignoreETag()
+        .execute();
+      expect(patched.status).toBe(204);
+      expect(patched.invalidates).toEqual(
+        expect.arrayContaining([
+          ["Media", "detail", BOOK_DER_PROZESS],
+          ["Media", "list"],
+        ]),
+      );
+    } finally {
+      await LIBRARY.Copies(ancestorCopyKey).delete().ignoreETag().execute();
+    }
+  });
+
   test("a to-many hop: /Media(...)/Copies names itself by the navigation property, distinct from a hand-filtered route to the same entity set", async () => {
     const viaNavigation = LIBRARY.Media(BOOK_DER_PROZESS).Copies().query();
     const viaFilter = LIBRARY.Copies().query((builder, qCopy) => builder.filter(qCopy.MediumId.eq(BOOK_DER_PROZESS)));

--- a/packages/odata-service/src/cacheKey/BuildCacheKey.ts
+++ b/packages/odata-service/src/cacheKey/BuildCacheKey.ts
@@ -1,4 +1,4 @@
-import { CacheKeyState } from "./CacheKeyState";
+import { CacheKeyState, keyedEntitySetFormOf } from "./CacheKeyState";
 import { sameElement } from "./KeyElementEquality";
 
 /**
@@ -27,14 +27,16 @@ function mergeParams(
 /**
  * The keys a write makes stale.
  *
- * Six rules: the addressed resource's own key without its params object (a write invalidates the
- * resource however it was filtered, sorted or paged), the same resource's own key in bare
+ * Six rules: (1) the addressed resource's own key without its params object (a write invalidates the
+ * resource however it was filtered, sorted or paged); (2) the same resource's own key in bare
  * `[entitySetName, "detail", key]` form (see below - deterministic, so a write through a hop route also
- * invalidates a direct route's cache entry with no `ResourceIdentityHandler` involved), the resource's own
- * entity set as a bare list key where it belongs to one, the key of every ancestor hop - which is what
- * catches a parent that was fetched with `$expand` - a bare list-key entry per entity set the write's own
- * payload deep-inserted into (`state.params.deepEdit`, populated by `buildDeepEditHops` at the write's own
- * call site), and whatever hierarchical keys `crossRouteKeys` names - a route to this same resource the
+ * invalidates a direct route's cache entry with no `ResourceIdentityHandler` involved); (3) the resource's
+ * own entity set as a bare list key where it belongs to one; (4) every ancestor hop's own key - which is
+ * what catches a parent that was fetched with `$expand` - each paired with its own bare list form, and,
+ * exactly like rule 2, its own bare `[entitySetName, "detail", key]` form where that ancestor was itself
+ * narrowed by a key of its own; (5) a bare list-key entry per entity set the write's own payload
+ * deep-inserted into (`state.params.deepEdit`, populated by `buildDeepEditHops` at the write's own call
+ * site); and (6) whatever hierarchical keys `crossRouteKeys` names - a route to this same resource the
  * write's own route never took, resolved via `ResourceIdentityHandler` from what an earlier response
  * actually observed (see `resolveCrossRouteInvalidates`; empty, never computed here, for a client with no
  * such store). Entries another entry is a prefix of are dropped; what is left is coarsest first.
@@ -48,15 +50,24 @@ function mergeParams(
  * rule-1 entry. At the root the two rules produce the identical entry and collapse into one via the same
  * redundancy pass rule 4 already needs.
  *
- * Rule 3 applies wherever a "detail" key goes stale and the entity set it belongs to is known - not just
- * the addressed resource itself, but every ancestor hop too (rule 4): a list is a query *over* an entity
- * set, so any of that set's members turning stale is reason enough to also invalidate the set's own bare
- * list key, whichever hop the member was reached through. Skipped wherever the resource has no entity set
- * of its own - a contained entity, a complex value, a singleton: nothing is ever registered under such a
- * key. `deepEdit` hops read straight off `state.params`, unlike every other params entry: they are not a
- * restriction on the addressed resource the way `filter`/`cast` are, so there is nothing to drop them for -
- * they name additional, unrelated entity sets this same write also touched, each with no key of its own yet
- * since the entity is freshly created.
+ * Rule 4's own short-form addition exists for the identical reason, one level up: an ancestor's own full
+ * key (`ancestor.key`) is itself hierarchical - prefixed by *its* ancestors in turn - so scanning it alone
+ * can never find a direct route's shorter, cached key either, even once that ancestor's own hop segment has
+ * been renamed to its entity set's name. A write three hops deep, through an ancestor whose own name
+ * diverges from its entity set (`Publishers(1).Books(id).Copies(...)`, where `Books` binds to `Media`),
+ * needs `["Media","detail",id]` as its own candidate to still invalidate a *direct* `Media(id)` route's
+ * cached query - `ancestor.key` alone (`["Publishers","detail",1,"Media","detail",id]`) cannot reach it.
+ * `CacheKeyState.hopState` precomputes this short form per ancestor for exactly this rule to consume.
+ *
+ * Rule 3 (and rule 4's own list form) applies wherever a "detail" key goes stale and the entity set it
+ * belongs to is known - not just the addressed resource itself, but every ancestor hop too: a list is a
+ * query *over* an entity set, so any of that set's members turning stale is reason enough to also invalidate
+ * the set's own bare list key, whichever hop the member was reached through. Skipped wherever the resource
+ * has no entity set of its own - a contained entity, a complex value, a singleton: nothing is ever
+ * registered under such a key. `deepEdit` hops read straight off `state.params`, unlike every other params
+ * entry: they are not a restriction on the addressed resource the way `filter`/`cast` are, so there is
+ * nothing to drop them for - they name additional, unrelated entity sets this same write also touched, each
+ * with no key of its own yet since the entity is freshly created.
  *
  * Deliberately does **not** enumerate the resource's children on its own: the ancestor entry covers them
  * by prefix for a hierarchical route, and `crossRouteKeys` is what reaches a route this write never took.
@@ -66,14 +77,13 @@ export function buildInvalidates(
   crossRouteKeys: ReadonlyArray<ReadonlyArray<unknown>> = [],
 ): ReadonlyArray<ReadonlyArray<unknown>> {
   const deepEditHops = (state.params?.deepEdit as ReadonlyArray<string> | undefined) ?? [];
-  const keyedEntitySetForm =
-    state.entitySetName && state.key !== undefined
-      ? [state.entitySetName, "detail", state.steps[state.steps.length - 1]]
-      : undefined;
+  const keyedEntitySetForm = keyedEntitySetFormOf(state);
 
-  const ancestorEntries = (state.ancestors ?? []).flatMap((ancestor) =>
-    ancestor.entitySetName ? [ancestor.key, [ancestor.entitySetName, "list"]] : [ancestor.key],
-  );
+  const ancestorEntries = (state.ancestors ?? []).flatMap((ancestor) => [
+    ancestor.key,
+    ...(ancestor.entitySetName ? [[ancestor.entitySetName, "list"]] : []),
+    ...(ancestor.keyedEntitySetForm ? [ancestor.keyedEntitySetForm] : []),
+  ]);
 
   // ancestors in route order (coarsest first, each with its own list form alongside), then the resource
   // itself, its bare entity-set-keyed form, then its entity set, then whatever it deep-inserted into, then

--- a/packages/odata-service/src/cacheKey/CacheKeyState.ts
+++ b/packages/odata-service/src/cacheKey/CacheKeyState.ts
@@ -54,8 +54,17 @@ export interface CacheKeyState {
    * Feeds `invalidates`: a stale ancestor is not just itself invalidated, but - since it was fetched as a
    * "detail" resource - its own bare list form too, on the same "a detail going stale means its list may no
    * longer agree either" logic {@link entitySetName} already applies to the addressed resource itself.
+   * Where that ancestor was itself narrowed by its own key, `keyedEntitySetForm` carries its bare
+   * `[entitySetName, "detail", key]` form too - the same short-form rule the addressed resource gets in
+   * `buildInvalidates`, needed for the identical reason: an ancestor's *own* full key here is hierarchical
+   * (prefixed by its own ancestors in turn), so it can never be found by scanning a direct route's shorter,
+   * cached key on its own.
    */
-  readonly ancestors?: ReadonlyArray<{ readonly key: ReadonlyArray<unknown>; readonly entitySetName?: string }>;
+  readonly ancestors?: ReadonlyArray<{
+    readonly key: ReadonlyArray<unknown>;
+    readonly entitySetName?: string;
+    readonly keyedEntitySetForm?: ReadonlyArray<unknown>;
+  }>;
   /**
    * The addressed resource's own key or id, exactly as given to `byId` - bare for a single primary key, an
    * object keyed by the model's own mapped property names otherwise. The same shape {@link CanonicalIdFn}
@@ -162,6 +171,22 @@ export function withParams(state: CacheKeyState, params: Readonly<Record<string,
 }
 
 /**
+ * A state's own bare `[entitySetName, "detail", key]` form, where it has been narrowed by its own key and
+ * has an entity set to name it by - the same short form `withKey`'s own rename already makes this state's
+ * `steps` end in, pulled out standalone for `buildInvalidates` to use as an invalidation candidate in its
+ * own right (see `BuildCacheKey.ts`'s rule 2): a state's full key is hierarchical, prefixed by every
+ * ancestor above it, so it can never be found by scanning a direct route's shorter, cached key on its own -
+ * only this bare form can. Shared between `hopState` (which precomputes it per ancestor, on the state a hop
+ * departs) and `buildInvalidates` (which computes it once more for the write's own addressed resource), so
+ * the one rule for deriving it cannot drift between the two call sites.
+ */
+export function keyedEntitySetFormOf(state: CacheKeyState): ReadonlyArray<unknown> | undefined {
+  return state.entitySetName && state.key !== undefined
+    ? [state.entitySetName, "detail", state.steps[state.steps.length - 1]]
+    : undefined;
+}
+
+/**
  * Follows one traversal step.
  *
  * The route leaves the current resource here, so its key - params dropped - is pushed onto `ancestors`. The
@@ -170,9 +195,14 @@ export function withParams(state: CacheKeyState, params: Readonly<Record<string,
  * taken, never re-rooted.
  */
 export function hopState(state: CacheKeyState, hop: HopDescriptor): CacheKeyState {
+  const keyedEntitySetForm = keyedEntitySetFormOf(state);
   const ancestors = [
     ...(state.ancestors ?? []),
-    { key: [state.name, ...state.steps], ...(state.entitySetName ? { entitySetName: state.entitySetName } : {}) },
+    {
+      key: [state.name, ...state.steps],
+      ...(state.entitySetName ? { entitySetName: state.entitySetName } : {}),
+      ...(keyedEntitySetForm ? { keyedEntitySetForm } : {}),
+    },
   ];
   const steps = hop.kind ? [...state.steps, hop.name, hop.kind] : [...state.steps, hop.name];
   const kindIndex = hop.kind ? steps.length - 1 : state.kindIndex;

--- a/packages/odata-service/test/cacheKey/BuildCacheKey.test.ts
+++ b/packages/odata-service/test/cacheKey/BuildCacheKey.test.ts
@@ -84,7 +84,7 @@ describe("buildInvalidates", () => {
     expect(buildInvalidates(state)).toContainEqual([MEDIA, "detail", 5]);
   });
 
-  test("a hierarchical write's own key is a prefix-redundant with its ancestor, and drops out - the ancestor, the ancestor's own list form, the hop's own canonicalKey, and the entity-set list entry are what remain", () => {
+  test("a hierarchical write's own key is a prefix-redundant with its ancestor, and drops out - the ancestor, the ancestor's own list form, the hop's own bare entity-set-keyed form, and the entity-set list entry are what remain", () => {
     const copies = hopState(withKey(rootState(MEDIA, "list", { entitySetName: MEDIA }), 5, { Id: 5 }), {
       name: "copies",
       kind: "list",
@@ -108,6 +108,30 @@ describe("buildInvalidates", () => {
     expect(buildInvalidates(copies)).toEqual([
       [MEDIA, "detail", 5],
       [MEDIA, "list"],
+      [COPIES, "list"],
+    ]);
+  });
+
+  test("a write three hops deep, through an ancestor whose own name diverges from its entity set, still deterministically invalidates a direct route to that ancestor - not just the ancestor's own (longer, hierarchical) key", () => {
+    // Publishers(1).Books(5).copies(...): "books" is the hop's own name, but it binds to entity set MEDIA
+    // (not "books") - the deferred follow-up this test pins: an ancestor's own hierarchical key
+    // (["Publishers","detail",1,MEDIA,"detail",5]) can never be found by scanning a *direct* Media(5)
+    // route's shorter, cached key on its own - only its own bare [MEDIA,"detail",5] form can, exactly the
+    // same reasoning rule 2 already applies to the addressed resource itself
+    const PUBLISHERS = "Publishers";
+    const publishers = withKey(rootState(PUBLISHERS, "list", { entitySetName: PUBLISHERS }), 1, { Id: 1 });
+    const books = withKey(hopState(publishers, { name: "books", kind: "list", entitySetName: MEDIA }), 5, {
+      Id: 5,
+    });
+    const copyKey = { MediumId: 5, InventoryNumber: 7 };
+    const copies = withKey(hopState(books, { name: "copies", kind: "list", entitySetName: COPIES }), copyKey, copyKey);
+
+    expect(buildInvalidates(copies)).toEqual([
+      [PUBLISHERS, "detail", 1],
+      [PUBLISHERS, "list"],
+      [MEDIA, "list"],
+      [MEDIA, "detail", 5],
+      [COPIES, "detail", copyKey],
       [COPIES, "list"],
     ]);
   });

--- a/packages/odata-service/test/cacheKey/CacheKeyState.test.ts
+++ b/packages/odata-service/test/cacheKey/CacheKeyState.test.ts
@@ -98,7 +98,42 @@ describe("CacheKeyState", () => {
   test("an ancestor carries the entity set it belonged to, so a stale ancestor can invalidate that set's own list form too", () => {
     const parent = withKey(rootState(MEDIA, "list", { entitySetName: MEDIA }), 5, { Id: 5 });
     const state = hopState(parent, { name: "copies", kind: "list", entitySetName: COPIES });
-    expect(state.ancestors).toEqual([{ key: [MEDIA, "detail", 5], entitySetName: MEDIA }]);
+    expect(state.ancestors).toEqual([
+      { key: [MEDIA, "detail", 5], entitySetName: MEDIA, keyedEntitySetForm: [MEDIA, "detail", 5] },
+    ]);
+  });
+
+  test('a keyed ancestor also carries its own bare [entitySetName, "detail", key] form, for buildInvalidates to use in place of its (hierarchical, prefixed) own key', () => {
+    // "books" is the hop's own name, but it binds to entity set "Media" (not "Books") - withKey already
+    // renamed the segment by the time this ancestor is captured, so the short form uses "Media" too, not
+    // the hop's own diverging name
+    const publishers = withKey(rootState("Publishers", "list", { entitySetName: "Publishers" }), 1, { Id: 1 });
+    const books = withKey(hopState(publishers, { name: "books", kind: "list", entitySetName: MEDIA }), 5, {
+      Id: 5,
+    });
+    const state = hopState(books, { name: "copies", kind: "list", entitySetName: COPIES });
+
+    expect(state.ancestors).toEqual([
+      {
+        key: ["Publishers", "detail", 1],
+        entitySetName: "Publishers",
+        keyedEntitySetForm: ["Publishers", "detail", 1],
+      },
+      {
+        key: ["Publishers", "detail", 1, MEDIA, "detail", 5],
+        entitySetName: MEDIA,
+        keyedEntitySetForm: [MEDIA, "detail", 5],
+      },
+    ]);
+  });
+
+  test("an ancestor that was never narrowed by its own key carries no keyedEntitySetForm - there is nothing to derive it from", () => {
+    const copies = hopState(rootState(MEDIA, "list"), { name: "copies", kind: "list", entitySetName: COPIES });
+    const state = hopState(copies, { name: "condition", kind: "detail" });
+    expect(state.ancestors).toEqual([
+      { key: [MEDIA, "list"] },
+      { key: [MEDIA, "list", "copies", "list"], entitySetName: COPIES },
+    ]);
   });
 
   test("a hop to a contained property has no entity set, so entitySetName and canonicalIdFn stay undefined", () => {
@@ -139,7 +174,11 @@ describe("CacheKeyState", () => {
     ]);
     expect(condition.ancestors).toEqual([
       { key: [MEDIA, "detail", 5] },
-      { key: [MEDIA, "detail", 5, COPIES, "detail", { MediumId: 5, InventoryNumber: 7 }], entitySetName: COPIES },
+      {
+        key: [MEDIA, "detail", 5, COPIES, "detail", { MediumId: 5, InventoryNumber: 7 }],
+        entitySetName: COPIES,
+        keyedEntitySetForm: [COPIES, "detail", { MediumId: 5, InventoryNumber: 7 }],
+      },
     ]);
   });
 


### PR DESCRIPTION
An ancestor hop whose own name diverges from its entity set is still not renamed - extending this to every ancestor in `buildInvalidates` rule 4 (formerly rule 3) is this deliberately deferred follow-up.

`withKey` already renames the addressed (leaf) resource's own hop segment to its entity set's name, and `buildInvalidates` already adds that resource's own bare `[entitySetName, "detail", key]` form as an invalidation candidate - needed because a write's full hierarchical key can never be found by scanning a direct route's shorter, cached key on its own, only the bare form can.

The same gap existed one level up: an ancestor's own full key (`ancestor.key`) is itself hierarchical, prefixed by *its* ancestors in turn. A write three hops deep through an ancestor whose own name diverges from its entity set - `Publishers(1).Books(id).Copies(...)`, where `Books` binds to entity set `Media` - could not deterministically invalidate a *direct* `Media(id)` route's cached query, since neither `ancestor.key` (too long to match a shorter cached key) nor anything else produced the short `["Media","detail",id]` form for that ancestor.

`CacheKeyState.hopState` now precomputes each ancestor's own bare short form (where that ancestor was itself keyed), via a small shared `keyedEntitySetFormOf` helper also used by `buildInvalidates` for the addressed resource itself - one rule for deriving the form, in one place, consumed at both levels.

### Testing

- New unit tests in `CacheKeyState.test.ts` and `BuildCacheKey.test.ts` cover the three-hop, diverging-ancestor case at the unit level.
- **Proved over a real HTTP round trip too**: `int-test/asp-net`'s `CacheKeys.test.ts` now has a new test executing `Publishers(1).Books(id).Copies(...)` against a live server - asserting both the renamed cache-key shape and that a PATCH through it deterministically invalidates the ancestor's own direct `Media(id)` route. This needed a server route three hops deep through a diverging ancestor, which no existing route was - added in [test-server-asp-net#40](https://github.com/odata2ts/test-server-asp-net/pull/40), released as `0.5.0`. This branch merges in the pin bump ([#559](https://github.com/odata2ts/odata2ts/pull/559)) so the two land together; #559 can be closed once this merges, its content is fully subsumed here.
- Full suites green: `odata-service` 535 tests, `odata2ts` 786, workspace-wide `test-compile`, all three server int-tests against their current pins (asp-net 161/161 against the published `0.5.0` image, cap 223, olingo-v2 137).
- Reviewed via `/code-review` (Standards + Spec axes): one Standards judgement call (duplicated derivation logic between `hopState` and `buildInvalidates`) addressed by extracting `keyedEntitySetFormOf`; one Spec suggestion (guarding the new field at the root) declined, since the existing, documented rule 2 for the addressed resource already fires unconditionally at the root and relies on the redundancy pass to collapse the duplicate - gating only the ancestor case would have made it *less* consistent with that established design, not more.

