### PR TITLE
doc: fix stale references in cache-key comments and the int-test README

### DIFF
--- a/int-test/README.md
+++ b/int-test/README.md
@@ -75,7 +75,7 @@ Two rules hold for every test here:
   `expectTypeOf` evaluates its argument, so pass the method (`cmd.execute`), never a live call.
 
 These suites, not `examples/main`, are where important integration coverage belongs: everything in
-`examples/main` is optional (see the repository's AGENTS.md).
+`examples/main` is optional.
 
 ## Adding another test server
 

--- a/int-test/README.md
+++ b/int-test/README.md
@@ -75,7 +75,7 @@ Two rules hold for every test here:
   `expectTypeOf` evaluates its argument, so pass the method (`cmd.execute`), never a live call.
 
 These suites, not `examples/main`, are where important integration coverage belongs: everything in
-`examples/main` is optional (see the repository's CLAUDE.md).
+`examples/main` is optional (see the repository's AGENTS.md).
 
 ## Adding another test server
 

--- a/packages/odata-service/src/cacheKey/CacheKeyState.ts
+++ b/packages/odata-service/src/cacheKey/CacheKeyState.ts
@@ -27,7 +27,7 @@ export type CanonicalIdFn = (entity: unknown) => string | undefined;
  * `path` - `name` for a `byId`-created service is the rendered key predicate, which must not appear in a key.
  */
 export interface CacheKeyState {
-  /** The route's own root name - an entity set's, a singleton's, or `"$operation"`. Never a type. */
+  /** The route's own root name - an entity set's, a singleton's, or an unbound operation import's. Never a type. */
   readonly name: string;
   /** Hops and kind markers accumulated so far. */
   readonly steps: ReadonlyArray<unknown>;
@@ -78,9 +78,10 @@ export interface CacheKeyState {
   readonly key?: unknown;
   /**
    * A factory for the addressed resource's own Q-object, where it is an entity or complex type - absent for
-   * `"$operation"`, the one root with no type behind it at all. The one piece of type information this state
-   * still carries, deliberately never exposed in a cache key: it exists solely so a write's payload can be
-   * walked for deep-inserted entities (`buildDeepEditHops`) without a generated, type-keyed lookup table.
+   * an unbound operation, the one root with no type behind it at all. The one piece of type information this
+   * state still carries, deliberately never exposed in a cache key: it exists solely so a write's payload
+   * can be walked for deep-inserted entities (`buildDeepEditHops`) without a generated, type-keyed lookup
+   * table.
    */
   readonly qEntityFn?: QEntityFn;
 }

--- a/packages/odata-service/src/cacheKey/QueryStringCapture.ts
+++ b/packages/odata-service/src/cacheKey/QueryStringCapture.ts
@@ -6,8 +6,8 @@ import { GET_AS_POST_URL_SUFFIX } from "../request/RequestHelper.js";
  * just stored and compared as one opaque value, the same way an undecomposable filter already becomes a
  * `$raw` fragment. This is what makes cache-key identity complete for every query feature, present and
  * future, without a second, hand-maintained snapshot that has to be kept in sync with what `build()`
- * actually renders (see `spec/odata2ts-cache-key.md`, "Everything else collapses into one opaque string",
- * for the `$apply`/`groupBy` drift this replaces).
+ * actually renders (the `$apply`/`groupBy` drift this replaces is pinned by the `CacheKeys.test.ts`
+ * regression tests in `int-test/asp-net` and `int-test/cap`).
  *
  * `GetToPostConverter` (`RequestHelper.ts`) relocates a GET's query string into the POST body verbatim when
  * the URL would otherwise be too long, appending the literal `/$query` suffix to the URL. Reaching this

--- a/packages/odata-service/src/cacheKey/QueryStringCapture.ts
+++ b/packages/odata-service/src/cacheKey/QueryStringCapture.ts
@@ -6,8 +6,8 @@ import { GET_AS_POST_URL_SUFFIX } from "../request/RequestHelper.js";
  * just stored and compared as one opaque value, the same way an undecomposable filter already becomes a
  * `$raw` fragment. This is what makes cache-key identity complete for every query feature, present and
  * future, without a second, hand-maintained snapshot that has to be kept in sync with what `build()`
- * actually renders (see `docs/superpowers/specs/2026-09-05-cache-key-query-params-redesign.md` for the
- * `$apply`/`groupBy` drift this replaces).
+ * actually renders (see `spec/odata2ts-cache-key.md`, "Everything else collapses into one opaque string",
+ * for the `$apply`/`groupBy` drift this replaces).
  *
  * `GetToPostConverter` (`RequestHelper.ts`) relocates a GET's query string into the POST body verbatim when
  * the URL would otherwise be too long, appending the literal `/$query` suffix to the URL. Reaching this


### PR DESCRIPTION
- The odata-service cache-key doc comments no longer name the '$operation' root sentinel the cache-key redesign removed; the root is the import name rootState, which the comments already document.
- The QueryStringCapture comment no longer cites a spec file that ships with no package; the $apply/$groupBy drift it describes is pinned by the CacheKeys.test.ts regression tests in int-test/asp-net and int-test/cap.
- int-test/README.md no longer names the repository's local agent doc; the examples/main optionality stands on its own.