### PR TITLE
fix(odata-service): strip params from recorded resource identity and evict it on delete

### DIFF
--- a/int-test/asp-net/test/feature/CacheKeys.test.ts
+++ b/int-test/asp-net/test/feature/CacheKeys.test.ts
@@ -200,7 +200,8 @@ describe("ASP.NET Library: cache keys", () => {
   });
 
   test("a read through a navigated route records the resource it served, so a later direct write to it also invalidates that route", async () => {
-    const navigated = await LIBRARY.Media(BOOK_DER_PROZESS).Copies().query().execute();
+    const request = LIBRARY.Media(BOOK_DER_PROZESS).Copies().query();
+    const navigated = await request.execute();
     expect(navigated.status).toBe(200);
     expect(navigated.data.value.some((copy) => copy.InventoryNumber === CACHE_KEY_COPY)).toBe(true);
 
@@ -210,9 +211,14 @@ describe("ASP.NET Library: cache keys", () => {
       expect.arrayContaining([
         ["Copies", "detail", copyKey],
         ["Copies", "list"],
-        ["Media", "detail", BOOK_DER_PROZESS, "Copies", "list"],
       ]),
     );
+    // the navigated route's own key need not appear verbatim: recording is params-stripped (see
+    // `recordObservedIdentities`), so the earlier "$expand produces a hop-shaped entry" test above -
+    // which observed this same copy through `Media(id)`'s bare, params-free key - already makes
+    // `buildInvalidates` collapse this route's own (longer) entry as a redundant prefix of that coarser
+    // one. Either way `invalidates` still reaches this route, which is what the test title claims
+    expect(patched.invalidates!.some((entry) => touchesResource(entry, request.cacheKey!))).toBe(true);
   });
 
   test("grade B: /Members(...)/Loans names itself by the navigation property", async () => {

--- a/packages/odata-service/src/cacheKey/ObservedIdentity.ts
+++ b/packages/odata-service/src/cacheKey/ObservedIdentity.ts
@@ -4,14 +4,21 @@ import { walkEntityGraph } from "./EntityGraphWalk";
 
 /**
  * Records every entity actually present in a *read's* response body against the request's own hierarchical
- * cache key - the directly addressed resource itself (every row, for a list response) plus every
- * `$expand`'d entity at any depth - so a write reached via a completely different route can later
- * `resolve()` its way back to this one (see `ResourceIdentityHandler`).
+ * cache key, **with its params object stripped** - the directly addressed resource itself (every row, for
+ * a list response) plus every `$expand`'d entity at any depth - so a write reached via a completely
+ * different route can later `resolve()` its way back to this one (see `ResourceIdentityHandler`).
  *
- * Read-only by construction, not by a special case here: `hierarchicalKey` is `RequestCmd.cacheKey`, which
- * is always `undefined` for a write (mirrors `undefined` right back), since a write was never itself
- * addressable under any read-shaped key for a route to reuse. What a write's own response teaches is
- * `invalidates`' concern instead - see {@link resolveCrossRouteInvalidates}.
+ * The recorded key is derived from `state` (`[state.name, ...state.steps]`) rather than built from a params
+ * object anyone has to remember to strip: params only ever enter via `buildCacheKey`, so this is already
+ * the params-free form, by construction - the same derivation `buildInvalidates` rule 1 uses. A
+ * params-carrying key would make every distinct `$filter`/`$top`/`$expand` combination reaching the same
+ * entity its own store entry, defeating the store's own per-resource route bound one level down, and would
+ * resolve cross-route invalidation to over-specific keys.
+ *
+ * Read-only by construction, not by a special case here: `hierarchicalKey` is `RequestCmd.cacheKey`, used
+ * purely as the read/write signal - it is always `undefined` for a write (mirrors `undefined` right back),
+ * since a write was never itself addressable under any read-shaped key for a route to reuse. What a write's
+ * own response teaches is `invalidates`' concern instead - see {@link resolveCrossRouteInvalidates}.
  *
  * A contained resource - `entitySetName`/`canonicalIdFn` both absent, on `state` or on a nested visit alike
  * - is never recorded: it has no canonical resource of its own to record against, by construction.
@@ -26,14 +33,16 @@ export function recordObservedIdentities(
     return;
   }
 
+  const recordedKey = [state.name, ...state.steps];
+
   const rows = extractRows(data);
   for (const row of rows) {
-    recordRow(resourceIdentity, hierarchicalKey, state.canonicalIdFn, row);
+    recordRow(resourceIdentity, recordedKey, state.canonicalIdFn, row);
 
     walkEntityGraph(
       state.qEntityFn,
       row,
-      (visit) => recordRow(resourceIdentity, hierarchicalKey, visit.buildCanonicalId, visit.data),
+      (visit) => recordRow(resourceIdentity, recordedKey, visit.buildCanonicalId, visit.data),
       { skipBindings: false },
     );
   }
@@ -90,17 +99,29 @@ function recordRow(
 }
 
 /**
- * Every hierarchical cache key ever `record()`ed as resolving to the very resource this *write* just
- * addressed - added to `invalidates` alongside the write's own route-derived entries (see
- * `buildInvalidates`), so a write reached via one route also invalidates a cache entry some other route
- * filled in.
- *
- * The write's own canonical id is built from whichever of two sources is actually available: `state.key` -
+ * The write's own canonical id, built from whichever of two sources is actually available: `state.key` -
  * the write's own address, always known, whatever the response says - wins where present (`PATCH`/`PUT`/
  * `DELETE`, already addressing one entity by key); the response body is the only source for a `POST` to a
  * collection, whose server-assigned key was never known beforehand - unwrapped from a V2 `{d: {...}}`
  * envelope first, the same one `ServiceStateHelperV2.etagOf` already unwraps for the identical reason. Never
  * both at once, and never a list body - a collection response names no single resource to resolve.
+ *
+ * Shared between {@link resolveCrossRouteInvalidates} and {@link evictObservedIdentity} so the one
+ * derivation cannot drift between the two call sites.
+ */
+function resolveCanonicalId(state: CacheKeyState, data: unknown): string | undefined {
+  if (!state.canonicalIdFn) {
+    return undefined;
+  }
+  const source = state.key ?? extractEntity(data);
+  return source === undefined ? undefined : state.canonicalIdFn(source);
+}
+
+/**
+ * Every hierarchical cache key ever `record()`ed as resolving to the very resource this *write* just
+ * addressed - added to `invalidates` alongside the write's own route-derived entries (see
+ * `buildInvalidates`), so a write reached via one route also invalidates a cache entry some other route
+ * filled in.
  *
  * Deliberately narrow: only the write's *own* resource is resolved here, never anything nested inside its
  * payload. A deep-inserted child is brand new - nothing could have cached a route to an entity that did not
@@ -111,15 +132,37 @@ export function resolveCrossRouteInvalidates(
   state: CacheKeyState,
   data: unknown,
 ): ReadonlyArray<ReadonlyArray<unknown>> {
-  if (!resourceIdentity || !state.canonicalIdFn) {
+  if (!resourceIdentity) {
     return [];
   }
-
-  const source = state.key ?? extractEntity(data);
-  if (source === undefined) {
-    return [];
-  }
-
-  const canonicalId = state.canonicalIdFn(source);
+  const canonicalId = resolveCanonicalId(state, data);
   return canonicalId ? resourceIdentity.resolve(canonicalId) : [];
+}
+
+/**
+ * Forgets every hierarchical key `record()`ed for the canonical resource a successful `DELETE` just
+ * removed (see `ResourceIdentityHandler.evict`) - without it, rule 6 of `buildInvalidates` keeps handing
+ * back routes to an entity that no longer exists, on every later write that happens to resolve to the same
+ * canonical id, until the store's own bound evicts them by age.
+ *
+ * Called only for a `DELETE` that actually succeeded - never for a `204` on `PATCH`/`PUT`, which is not a
+ * delete, and never for a failed `DELETE` (a `404` says nothing about whether the resource still exists to
+ * be evicted from the *store*; it is left to age out like any other stale entry).
+ *
+ * Shares canonical-id derivation with {@link resolveCrossRouteInvalidates} via {@link resolveCanonicalId} -
+ * `state.key` is exactly what makes this possible for a `DELETE`, whose response usually carries no body to
+ * read a canonical id from otherwise.
+ */
+export function evictObservedIdentity(
+  resourceIdentity: ResourceIdentityHandler | undefined,
+  state: CacheKeyState,
+  data: unknown,
+): void {
+  if (!resourceIdentity) {
+    return;
+  }
+  const canonicalId = resolveCanonicalId(state, data);
+  if (canonicalId) {
+    resourceIdentity.evict(canonicalId);
+  }
 }

--- a/packages/odata-service/src/request/RequestCmd.ts
+++ b/packages/odata-service/src/request/RequestCmd.ts
@@ -6,6 +6,7 @@ import {
   CacheKeyState,
   canonicalizeQueryString,
   captureQueryString,
+  evictObservedIdentity,
   recordObservedIdentities,
   resolveCrossRouteInvalidates,
 } from "../cacheKey/index.js";
@@ -293,7 +294,16 @@ export abstract class RequestCmd<
       recordObservedIdentities(this.client.resourceIdentity, this.cacheKey, request.cacheKeyState, converted.data);
     }
 
-    return this.withInvalidates(converted, request.cacheKeyState);
+    // built before evicting, deliberately: this DELETE's own `invalidates` should still carry whatever
+    // routes were recorded for the resource it just removed - eviction only has to stop a *later* write
+    // from resolving them again
+    const result = this.withInvalidates(converted, request.cacheKeyState);
+
+    if (this.method === ODataHttpMethods.Delete && request.cacheKeyState) {
+      evictObservedIdentity(this.client.resourceIdentity, request.cacheKeyState, converted.data);
+    }
+
+    return result;
   }
 
   /**

--- a/packages/odata-service/test/cacheKey/ObservedIdentity.test.ts
+++ b/packages/odata-service/test/cacheKey/ObservedIdentity.test.ts
@@ -1,6 +1,13 @@
 import { QBinding, QEntityCollectionPath, QId, QNumberParam, QueryObject } from "@odata2ts/odata-query-objects";
 import { describe, expect, test } from "vitest";
-import { CacheKeyState, recordObservedIdentities, resolveCrossRouteInvalidates, rootState } from "../../src/cacheKey";
+import {
+  CacheKeyState,
+  evictObservedIdentity,
+  recordObservedIdentities,
+  resolveCrossRouteInvalidates,
+  rootState,
+  withKey,
+} from "../../src/cacheKey";
 import { MockResourceIdentityHandler } from "../mock/MockClient";
 
 class QCopyId extends QId<any> {
@@ -40,6 +47,22 @@ function mediaState(overrides: Partial<CacheKeyState> = {}): CacheKeyState {
   };
 }
 
+/** A `Media(5)` detail state, key already threaded - `[state.name, ...state.steps]` is `["Media","detail",5]`. */
+function mediaDetailState(overrides: Partial<CacheKeyState> = {}): CacheKeyState {
+  return withKey(mediaState(overrides), 5, 5);
+}
+
+function mediaListState(overrides: Partial<CacheKeyState> = {}): CacheKeyState {
+  return {
+    ...rootState("Media", "list", {
+      entitySetName: "Media",
+      canonicalIdFn: (entity) => new QMediumId("Media").buildCanonicalId(entity),
+      qEntityFn: () => QMedium as any,
+    }),
+    ...overrides,
+  };
+}
+
 describe("recordObservedIdentities", () => {
   test("no resourceIdentity: harmless", () => {
     expect(() => recordObservedIdentities(undefined, ["Media", "detail", 5], mediaState(), { id: 5 })).not.toThrow();
@@ -51,50 +74,66 @@ describe("recordObservedIdentities", () => {
     expect(handler.store.size).toBe(0);
   });
 
-  test("records the directly addressed resource itself", () => {
+  test("records the directly addressed resource itself, under its own key with params stripped", () => {
     const handler = new MockResourceIdentityHandler();
-    const key = ["Media", "detail", 5];
-    recordObservedIdentities(handler, key, mediaState(), { id: 5, title: "The Trial" });
-    expect(handler.resolve("Media(5)")).toEqual([key]);
+    const state = mediaDetailState();
+    const hierarchicalKey = ["Media", "detail", 5, { expand: [["copies", "list"]] }];
+    recordObservedIdentities(handler, hierarchicalKey, state, { id: 5, title: "The Trial" });
+    expect(handler.resolve("Media(5)")).toEqual([["Media", "detail", 5]]);
   });
 
   test("records every row of a list response, against the same key", () => {
     // a real V4/V2 collection response is `{value: [...]}`, never a bare array itself
     const handler = new MockResourceIdentityHandler();
-    const key = ["Media", "list"];
-    recordObservedIdentities(handler, key, mediaState({ entitySetName: "Media" }), {
+    recordObservedIdentities(handler, ["Media", "list"], mediaListState(), {
       value: [{ id: 1 }, { id: 2 }],
     });
-    expect(handler.resolve("Media(1)")).toEqual([key]);
-    expect(handler.resolve("Media(2)")).toEqual([key]);
+    expect(handler.resolve("Media(1)")).toEqual([["Media", "list"]]);
+    expect(handler.resolve("Media(2)")).toEqual([["Media", "list"]]);
   });
 
   test("records every row of a V2-wrapped list response too (`{d: {results: [...]}}`)", () => {
     const handler = new MockResourceIdentityHandler();
-    const key = ["Media", "list"];
-    recordObservedIdentities(handler, key, mediaState({ entitySetName: "Media" }), {
+    recordObservedIdentities(handler, ["Media", "list"], mediaListState(), {
       d: { results: [{ id: 1 }, { id: 2 }] },
     });
-    expect(handler.resolve("Media(1)")).toEqual([key]);
-    expect(handler.resolve("Media(2)")).toEqual([key]);
+    expect(handler.resolve("Media(1)")).toEqual([["Media", "list"]]);
+    expect(handler.resolve("Media(2)")).toEqual([["Media", "list"]]);
   });
 
   test("records every row of a `{results: [...]}` list response too (V2 with the `d` envelope already stripped)", () => {
     const handler = new MockResourceIdentityHandler();
-    const key = ["Media", "list"];
-    recordObservedIdentities(handler, key, mediaState({ entitySetName: "Media" }), {
+    recordObservedIdentities(handler, ["Media", "list"], mediaListState(), {
       results: [{ id: 1 }],
     });
-    expect(handler.resolve("Media(1)")).toEqual([key]);
+    expect(handler.resolve("Media(1)")).toEqual([["Media", "list"]]);
   });
 
   test("records every $expand'd entity too, at the same outer key - not a synthesized one", () => {
     const handler = new MockResourceIdentityHandler();
-    const key = ["Media", "detail", 5, { expand: [["copies", "list"]] }];
-    recordObservedIdentities(handler, key, mediaState(), { id: 5, copies: [{ id: 1 }, { id: 2 }] });
-    expect(handler.resolve("Media(5)")).toEqual([key]);
-    expect(handler.resolve("Copies(1)")).toEqual([key]);
-    expect(handler.resolve("Copies(2)")).toEqual([key]);
+    const state = mediaDetailState();
+    const hierarchicalKey = ["Media", "detail", 5, { expand: [["copies", "list"]] }];
+    recordObservedIdentities(handler, hierarchicalKey, state, { id: 5, copies: [{ id: 1 }, { id: 2 }] });
+    expect(handler.resolve("Media(5)")).toEqual([["Media", "detail", 5]]);
+    expect(handler.resolve("Copies(1)")).toEqual([["Media", "detail", 5]]);
+    expect(handler.resolve("Copies(2)")).toEqual([["Media", "detail", 5]]);
+  });
+
+  test("params-stripped: two reads differing only by their params object record under the identical key", () => {
+    const handler = new MockResourceIdentityHandler();
+    const state = mediaListState();
+    recordObservedIdentities(handler, ["Media", "list", { filter: "Title eq 'x'" }], state, {
+      value: [{ id: 1 }],
+    });
+    recordObservedIdentities(handler, ["Media", "list", { filter: "Title eq 'y'" }], state, {
+      value: [{ id: 1 }],
+    });
+    // both calls land under the same params-free key - a real `ResourceIdentityHandler` dedupes these into
+    // one store entry (see `InMemoryResourceIdentityHandler`), out of scope for this package
+    expect(handler.resolve("Media(1)")).toEqual([
+      ["Media", "list"],
+      ["Media", "list"],
+    ]);
   });
 
   test("a contained resource is never recorded - no canonicalIdFn, nothing to record against", () => {
@@ -172,5 +211,56 @@ describe("resolveCrossRouteInvalidates", () => {
   test("nothing recorded for this canonical id yet: an empty array, not undefined", () => {
     const handler = new MockResourceIdentityHandler();
     expect(resolveCrossRouteInvalidates(handler, mediaState({ key: 5 }), undefined)).toEqual([]);
+  });
+});
+
+describe("evictObservedIdentity", () => {
+  test("no resourceIdentity: harmless", () => {
+    expect(() => evictObservedIdentity(undefined, mediaState({ key: 5 }), undefined)).not.toThrow();
+  });
+
+  test("no canonicalIdFn (a contained resource): nothing to evict", () => {
+    const handler = new MockResourceIdentityHandler();
+    handler.record("Media(5)", ["SomeOther", "detail", 9, "media", "detail", 5]);
+    const state: CacheKeyState = { ...mediaState({ key: 5 }), canonicalIdFn: undefined };
+
+    evictObservedIdentity(handler, state, undefined);
+
+    expect(handler.resolve("Media(5)")).toEqual([["SomeOther", "detail", 9, "media", "detail", 5]]);
+  });
+
+  test("uses state.key - a DELETE's own response usually carries no body", () => {
+    const handler = new MockResourceIdentityHandler();
+    handler.record("Media(5)", ["Media", "list"]);
+    handler.record("Media(5)", ["SomeOther", "detail", 9, "media", "detail", 5]);
+
+    evictObservedIdentity(handler, mediaState({ key: 5 }), undefined);
+
+    expect(handler.resolve("Media(5)")).toEqual([]);
+  });
+
+  test("falls back to the response body when state.key is absent", () => {
+    const handler = new MockResourceIdentityHandler();
+    handler.record("Media(5)", ["Media", "list"]);
+
+    evictObservedIdentity(handler, mediaState(), { id: 5, title: "The Trial" });
+
+    expect(handler.resolve("Media(5)")).toEqual([]);
+  });
+
+  test("evicting only clears the addressed canonical id, other resources are untouched", () => {
+    const handler = new MockResourceIdentityHandler();
+    handler.record("Media(5)", ["Media", "list"]);
+    handler.record("Media(6)", ["Media", "list"]);
+
+    evictObservedIdentity(handler, mediaState({ key: 5 }), undefined);
+
+    expect(handler.resolve("Media(5)")).toEqual([]);
+    expect(handler.resolve("Media(6)")).toEqual([["Media", "list"]]);
+  });
+
+  test("nothing recorded for this canonical id yet: harmless", () => {
+    const handler = new MockResourceIdentityHandler();
+    expect(() => evictObservedIdentity(handler, mediaState({ key: 5 }), undefined)).not.toThrow();
   });
 });

--- a/packages/odata-service/test/request/CacheKeyThreading.test.ts
+++ b/packages/odata-service/test/request/CacheKeyThreading.test.ts
@@ -279,9 +279,15 @@ describe("cache key threading", () => {
         5,
         5,
       );
-      const writeCmd = new UrlWriteRequestCmd(client, ODataHttpMethods.Patch, "Media(5)", { title: "y" }, {
-        cacheKeyState: writeState,
-      });
+      const writeCmd = new UrlWriteRequestCmd(
+        client,
+        ODataHttpMethods.Patch,
+        "Media(5)",
+        { title: "y" },
+        {
+          cacheKeyState: writeState,
+        },
+      );
 
       const response = await writeCmd.execute();
 
@@ -324,9 +330,15 @@ describe("cache key threading", () => {
         5,
         5,
       );
-      const patchCmd = new UrlWriteRequestCmd(client, ODataHttpMethods.Patch, "Media(5)", { title: "y" }, {
-        cacheKeyState: patchState,
-      });
+      const patchCmd = new UrlWriteRequestCmd(
+        client,
+        ODataHttpMethods.Patch,
+        "Media(5)",
+        { title: "y" },
+        {
+          cacheKeyState: patchState,
+        },
+      );
       client.responseStatus = 204;
       client.responseData = undefined;
 

--- a/packages/odata-service/test/request/CacheKeyThreading.test.ts
+++ b/packages/odata-service/test/request/CacheKeyThreading.test.ts
@@ -259,5 +259,80 @@ describe("cache key threading", () => {
 
       expect(response.invalidates).toEqual(expect.arrayContaining([otherRoute]));
     });
+
+    test("what gets recorded off a read is params-stripped, so a later write resolves it without params", async () => {
+      const readState = rootState("Media", "list", { entitySetName: "Media", canonicalIdFn: canonicalIdOfMedia });
+      const readCmd = new UrlGetRequestCmd(client, "Media?$top=10", {
+        cacheKeyState: readState,
+        queryParams: { top: 10 },
+      });
+      client.setModelResponse({ value: [{ id: 5 }] });
+      await readCmd.execute();
+
+      // the read's own cacheKey does carry the params...
+      expect(readCmd.cacheKey).toEqual(["Media", "list", { top: 10, query: "%24top=10" }]);
+      // ...but what got recorded against the canonical id does not
+      expect(client.resourceIdentity.resolve("Media(5)")).toEqual([["Media", "list"]]);
+
+      const writeState = withKey(
+        rootState("Media", "list", { entitySetName: "Media", canonicalIdFn: canonicalIdOfMedia }),
+        5,
+        5,
+      );
+      const writeCmd = new UrlWriteRequestCmd(client, ODataHttpMethods.Patch, "Media(5)", { title: "y" }, {
+        cacheKeyState: writeState,
+      });
+
+      const response = await writeCmd.execute();
+
+      expect(response.invalidates).toEqual(expect.arrayContaining([["Media", "list"]]));
+    });
+
+    test("a successful DELETE evicts the resource's recorded identity", async () => {
+      const readState = rootState("Media", "detail", { entitySetName: "Media", canonicalIdFn: canonicalIdOfMedia });
+      const readCmd = new UrlGetRequestCmd(client, "SomeOther(9)/media", { cacheKeyState: withKey(readState, 5, 5) });
+      client.setModelResponse({ id: 5, title: "The Trial" });
+      await readCmd.execute();
+      expect(client.resourceIdentity.resolve("Media(5)")).toEqual([readCmd.cacheKey]);
+
+      const deleteState = withKey(
+        rootState("Media", "detail", { entitySetName: "Media", canonicalIdFn: canonicalIdOfMedia }),
+        5,
+        5,
+      );
+      const deleteCmd = new UrlWriteRequestCmd(client, ODataHttpMethods.Delete, "Media(5)", undefined, {
+        cacheKeyState: deleteState,
+      });
+
+      const response = await deleteCmd.execute();
+
+      // the delete's own response still invalidates the route recorded via the other one...
+      expect(response.invalidates).toEqual(expect.arrayContaining([readCmd.cacheKey]));
+      // ...but nothing is left recorded for it afterwards, so a later write no longer resolves it either
+      expect(client.resourceIdentity.resolve("Media(5)")).toEqual([]);
+    });
+
+    test("a 204-answered PATCH does not evict - only DELETE does", async () => {
+      const readState = rootState("Media", "detail", { entitySetName: "Media", canonicalIdFn: canonicalIdOfMedia });
+      const readCmd = new UrlGetRequestCmd(client, "Media(5)", { cacheKeyState: withKey(readState, 5, 5) });
+      client.setModelResponse({ id: 5, title: "The Trial" });
+      await readCmd.execute();
+      expect(client.resourceIdentity.resolve("Media(5)")).toEqual([readCmd.cacheKey]);
+
+      const patchState = withKey(
+        rootState("Media", "detail", { entitySetName: "Media", canonicalIdFn: canonicalIdOfMedia }),
+        5,
+        5,
+      );
+      const patchCmd = new UrlWriteRequestCmd(client, ODataHttpMethods.Patch, "Media(5)", { title: "y" }, {
+        cacheKeyState: patchState,
+      });
+      client.responseStatus = 204;
+      client.responseData = undefined;
+
+      await patchCmd.execute();
+
+      expect(client.resourceIdentity.resolve("Media(5)")).toEqual([readCmd.cacheKey]);
+    });
   });
 });


### PR DESCRIPTION
- `recordObservedIdentities` now records the addressed resource under its own params-free key (`[state.name, ...state.steps]`) instead of the raw hierarchical key, which could carry a trailing `$filter`/`$top`/etc. params object
- added `evictObservedIdentity`, called from `RequestCmd.handleResponse` after a successful `DELETE` (never for a `204` PATCH/PUT or a failed DELETE), so a deleted entity's recorded routes no longer resolve forever into later writes' `invalidates`
- unit tests for both in `packages/odata-service/test/cacheKey/ObservedIdentity.test.ts` and `packages/odata-service/test/request/CacheKeyThreading.test.ts`