### PR TITLE
fix: namespace the expand and deep-edit cache-key hops under cacheKeys.namespace

### DIFF
--- a/int-test/asp-net/test/feature/NamespaceAlias.test.ts
+++ b/int-test/asp-net/test/feature/NamespaceAlias.test.ts
@@ -1,5 +1,9 @@
+import { touchesResource } from "@odata2ts/odata-service";
 import { afterAll, describe, expect, test } from "vitest";
 import { BOOK_DER_PROZESS, LIBRARY_NAMESPACE_ALIAS } from "../LibraryTestConstants.js";
+
+/** A copy only this file touches, so a re-run against the same server does not collide. */
+const NAMESPACE_ALIAS_COPY = 8901;
 
 /**
  * `namespace.alias` and `cacheKeys.namespace`, against the one server whose reference model has all four
@@ -61,6 +65,96 @@ describe("ASP.NET Library: namespace aliasing", () => {
 
     const result = await request.execute();
     expect(result.status).toBe(200);
+  });
+
+  test("a $expand query and a write to the expanded set carry one and the same namespaced name - the matching pair touchesResource finds", async () => {
+    // the whole point of cacheKeys.namespace reaching the binding's generator-supplied cache-key name: the
+    // $expand's hop-shaped entry and the write's own rule-3 invalidation must carry the same prefixed name,
+    // or a write to the expanded set can never invalidate a cached expanded query (issue #536, gap 1).
+    // "Copies" is a navigation property of Medium (Library.Catalog), but it binds to the Copies entity set,
+    // whose type lives in Library.Circulation - so both the expand slot and the write's entry are prefixed
+    // with the *target* namespace's alias, Circulation.
+    const copyKey = { MediumId: BOOK_DER_PROZESS, InventoryNumber: NAMESPACE_ALIAS_COPY };
+    const created = await LIBRARY_NAMESPACE_ALIAS.Copies()
+      .create({
+        MediumId: BOOK_DER_PROZESS,
+        InventoryNumber: NAMESPACE_ALIAS_COPY,
+        Condition: 3,
+        IsLoanable: true,
+        WeightKg: 0.5,
+      })
+      .execute();
+    expect(created.status).toBe(201);
+
+    try {
+      const request = LIBRARY_NAMESPACE_ALIAS.Media(BOOK_DER_PROZESS).query((builder) => builder.expand("Copies"));
+      // the expand slot carries the target's namespaced entity-set name, not the bare navigation-property name
+      // and not the raw (unprefixed) entity-set name; the route root keeps the source type's alias
+      expect(request.cacheKey).toEqual([
+        "Catalog.Media",
+        "detail",
+        BOOK_DER_PROZESS,
+        { expand: [["Circulation.Copies", "list"]], query: "%24expand=Copies" },
+      ]);
+
+      const result = await request.execute();
+      expect(result.status).toBe(200);
+
+      const patched = await LIBRARY_NAMESPACE_ALIAS.Copies(copyKey).patch({ Condition: 4 }).ignoreETag().execute();
+      expect(patched.status).toBe(204);
+      // the write's own entries are namespaced too - one and the same name as the expand slot
+      expect(patched.invalidates).toEqual(
+        expect.arrayContaining([
+          ["Circulation.Copies", "detail", copyKey],
+          ["Circulation.Copies", "list"],
+        ]),
+      );
+
+      // the matching pair: the write's namespaced invalidation finds the query's namespaced expand slot
+      expect(touchesResource(["Circulation.Copies", "list"], request.cacheKey!)).toBe(true);
+    } finally {
+      await LIBRARY_NAMESPACE_ALIAS.Copies(copyKey).delete().ignoreETag().execute();
+    }
+  });
+
+  test("a deep-insert write's own rule-5 entry and a $expand of that set carry one and the same namespaced name", async () => {
+    // the same matching pair, one step further up: rule 5 (deep-edit) names the deep-inserted set the same
+    // way rule 3 and the $expand slot do - the binding's generator-supplied cache-key name. A deep-inserted
+    // Loan must invalidate a cached $expand=Loans query, and only a shared, prefixed name makes that match.
+    const created = await LIBRARY_NAMESPACE_ALIAS.Members()
+      .create({
+        Name: "NamespaceAlias deep-insert",
+        PreviousAddresses: [],
+        Loans: [{ LoanedAt: "2026-05-01T10:00:00Z", DueDate: "2026-06-01" }],
+      })
+      .execute();
+    expect(created.status).toBe(201);
+    const memberId = created.data.Id;
+
+    try {
+      // the deep-inserted Loan contributes its own bare, namespaced entity-set entry (rule 5), in addition
+      // to the write's own (rule 3)
+      expect(created.invalidates).toEqual([
+        ["Circulation.Members", "list"],
+        ["Circulation.Loans", "list"],
+      ]);
+
+      const request = LIBRARY_NAMESPACE_ALIAS.Members(memberId).query((builder) => builder.expand("Loans"));
+      expect(request.cacheKey).toEqual([
+        "Circulation.Members",
+        "detail",
+        memberId,
+        { expand: [["Circulation.Loans", "list"]], query: "%24expand=Loans" },
+      ]);
+
+      const result = await request.execute();
+      expect(result.status).toBe(200);
+
+      // the matching pair: the deep-insert's namespaced rule-5 entry finds the query's namespaced expand slot
+      expect(touchesResource(["Circulation.Loans", "list"], request.cacheKey!)).toBe(true);
+    } finally {
+      await LIBRARY_NAMESPACE_ALIAS.Members(memberId).delete().execute();
+    }
   });
 
   test("PublisherRegistry's project-configured alias has no cast or bound operation to prove itself through a cache-key literal - useAliasForFolderName is what proves it instead: this very import only resolves if the generated folder is really named `pub`, not `publisher-registry`", async () => {

--- a/packages/odata-query-builder/src/ODataQueryBuilder.ts
+++ b/packages/odata-query-builder/src/ODataQueryBuilder.ts
@@ -68,12 +68,14 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
    * apart from a hoisted one reconciled back from `expands` after `build()` has folded
    * `hoistedExpandsBucket` into it, without depending on whether that fold has happened yet.
    *
-   * `entitySetName` is the *target's* entity set name, read off the same nav property's own `getBinding()`
-   * (absent for a contained target, which has none) - this, not `path`, is what an `ExpandHop`'s own name
-   * must carry: `invalidates` (`buildInvalidates`, odata-service) registers a write under its bare
-   * `[entitySetName, "list"]` entry, and `touchesResource` finds an expand hop only by scanning for that
-   * exact shape - a nav property whose OData name differs from its target's entity set name (the common
-   * case) would otherwise never match, silently breaking invalidation through `$expand`.
+   * `entitySetName` is the *target's* entity set name as a cache key must carry it - the binding's cache-key
+   * name (`getBinding().getCacheKeyEntitySetName()`: the raw name, or the generator's prefixed one under
+   * `cacheKeys.namespace`), read off the same nav property's own `getBinding()` (absent for a contained
+   * target, which has none) - this, not `path`, is what an `ExpandHop`'s own name must carry: `invalidates`
+   * (`buildInvalidates`, odata-service) registers a write under its bare `[entitySetName, "list"]` entry,
+   * and `touchesResource` finds an expand hop only by scanning for that exact shape - a nav property whose
+   * OData name differs from its target's entity set name (the common case) would otherwise never match,
+   * silently breaking invalidation through `$expand`.
    */
   private expandEntries:
     | Array<{
@@ -242,7 +244,10 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
               ? ("list" as const)
               : ("detail" as const)
             : undefined;
-          const entitySetName = entityProp?.getBinding?.()?.getEntitySetName();
+          // the cache-key name, not the raw URL name: the write side's `[entitySetName, "list"]` invalidates
+          // entry carries the same (possibly `cacheKeys.namespace`-prefixed) name, so the two can only match
+          // if both read the binding's cache-key name (issue #536)
+          const entitySetName = entityProp?.getBinding?.()?.getCacheKeyEntitySetName();
           return { path, rawForm: path, kind, entitySetName };
         }),
       );
@@ -303,7 +308,9 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
         rawForm: content,
         kind: entityProp.isCollectionType() ? "list" : "detail",
         nestedBuilder: nestedEngine,
-        entitySetName: entityProp.getBinding?.()?.getEntitySetName(),
+        // the cache-key name, not the raw URL name - see the expand() entry: the write side's
+        // `[entitySetName, "list"]` invalidates entry carries the same name
+        entitySetName: entityProp.getBinding?.()?.getCacheKeyEntitySetName(),
       });
     }
     if (hoistedExpands.length) {

--- a/packages/odata-query-builder/test/CacheKeyParams.test.ts
+++ b/packages/odata-query-builder/test/CacheKeyParams.test.ts
@@ -36,6 +36,20 @@ class QMedia extends QueryObject {
   );
 }
 
+/**
+ * The same nav property as `QMedia.copies`, but with the generator-supplied, prefixed cache-key name
+ * a QBinding carries only under `cacheKeys.namespace`: the raw entity-set name ("Copies", what the URL
+ * still uses) and the cache-key name ("Circulation.Copies", what a cache key must use) diverge.
+ */
+class QMediaNamespacedBinding extends QueryObject {
+  public readonly id = new QNumberPath(this.withPrefix("Id"));
+  public readonly copies = new QEntityCollectionPath(
+    this.withPrefix("copies"),
+    () => QCopy,
+    new QBinding(() => new QCopyId("Copies"), "4.0", "Circulation.Copies"),
+  );
+}
+
 describe("CacheKeyParams", () => {
   let builder: ODataQueryBuilder<QPerson>;
 
@@ -154,6 +168,19 @@ describe("CacheKeyParams", () => {
       const media = new ODataQueryBuilder("Media", new QMedia());
       media.expanding(createExpandingQueryBuilderV4, "copies", () => {});
       expect(media.getCacheKeyParams()).toEqual({ expand: [["Copies", "list"]] });
+    });
+
+    test("a generator-supplied cache-key name on the binding is what the hop carries - the raw name stays where the URL needs it", () => {
+      // under `cacheKeys.namespace` the generator bakes the prefixed name into the QBinding itself: the
+      // hop must carry that name, or a write's namespaced `[entitySetName, "list"]` invalidates entry can
+      // never find it (the #536 gap this whole option exists to close)
+      const media = new ODataQueryBuilder("Media", new QMediaNamespacedBinding());
+      media.expand(["copies"]);
+      expect(media.getCacheKeyParams()).toEqual({ expand: [["Circulation.Copies", "list"]] });
+
+      const expanding = new ODataQueryBuilder("Media", new QMediaNamespacedBinding());
+      expanding.expanding(createExpandingQueryBuilderV4, "copies", () => {});
+      expect(expanding.getCacheKeyParams()).toEqual({ expand: [["Circulation.Copies", "list"]] });
     });
   });
 

--- a/packages/odata-query-objects/src/path/QBinding.ts
+++ b/packages/odata-query-objects/src/path/QBinding.ts
@@ -38,10 +38,14 @@ export class QBinding<Id> {
    * @param idFunctionFn returns the id function of the *target* entity set; a factory, so that a query
    *                     object and the id function of the entity it points to may live in the same module
    * @param notation the spelling of the targeted OData version
+   * @param cacheKeyEntitySetName the entity-set name as a cache key must carry it - the generator
+   *                     supplies it, already prefixed, only where `cacheKeys.namespace` is on; absent
+   *                     elsewhere, and exactly where it is, the raw name is the right one
    */
   constructor(
     private idFunctionFn: () => QId<Id>,
     private notation: BindingNotation = "4.0",
+    private cacheKeyEntitySetName?: string,
   ) {
     if (!idFunctionFn || typeof idFunctionFn !== "function") {
       throw new Error("Function which returns the id function must be supplied!");
@@ -55,9 +59,23 @@ export class QBinding<Id> {
   /**
    * The name of the entity set this binding's target belongs to - the same name {@link format} already
    * builds every URL from, exposed on its own for a caller after the resource's identity rather than a URL.
+   *
+   * This is always the raw name: it is a real OData URL segment, and it stays the server's own name
+   * wherever a {@link getCacheKeyEntitySetName cache-key name} carries a prefix this one must not.
    */
   public getEntitySetName(): string {
     return this.idFunctionFn().getName();
+  }
+
+  /**
+   * The name of the entity set this binding's target belongs to, as a cache key must carry it - the
+   * {@link getEntitySetName raw name} unless the generator supplied a prefixed one, which it does only
+   * under `cacheKeys.namespace` (the generator's own prefix rule, not re-derived here). Cache-key
+   * identity and URL building are different channels: everything that ends up in a URL keeps reading
+   * {@link getEntitySetName}, everything that ends up in a cache key reads this.
+   */
+  public getCacheKeyEntitySetName(): string {
+    return this.cacheKeyEntitySetName ?? this.idFunctionFn().getName();
   }
 
   /**

--- a/packages/odata-query-objects/test/QBinding.test.ts
+++ b/packages/odata-query-objects/test/QBinding.test.ts
@@ -135,6 +135,25 @@ describe("QBinding: binding by key", () => {
   test("buildCanonicalId is unaffected by the binding notation - it never wraps like format does", () => {
     expect(new QBinding(() => new QAuthorId("Authors"), "4.01").buildCanonicalId(3)).toBe("Authors(3)");
   });
+
+  test("getCacheKeyEntitySetName falls back to the raw entity-set name where no generator-supplied name is present", () => {
+    expect(new QBinding(() => new QAuthorId("Authors")).getCacheKeyEntitySetName()).toBe("Authors");
+  });
+
+  test("getCacheKeyEntitySetName returns the generator-supplied name where one is present", () => {
+    expect(new QBinding(() => new QAuthorId("Authors"), "4.0", "Lib.Authors").getCacheKeyEntitySetName()).toBe(
+      "Lib.Authors",
+    );
+  });
+
+  test("getEntitySetName keeps returning the raw name where a generator-supplied cache-key name is present - it builds URLs and must stay the server's own name", () => {
+    expect(new QBinding(() => new QAuthorId("Authors"), "4.0", "Lib.Authors").getEntitySetName()).toBe("Authors");
+  });
+
+  test("format and buildCanonicalId are unaffected by the generator-supplied cache-key name - the URL is still built from the raw name", () => {
+    expect(new QBinding(() => new QAuthorId("Authors"), "4.0", "Lib.Authors").format(3)).toBe("Authors(3)");
+    expect(new QBinding(() => new QAuthorId("Authors"), "4.0", "Lib.Authors").buildCanonicalId(3)).toBe("Authors(3)");
+  });
 });
 
 /**

--- a/packages/odata-service/src/cacheKey/EntityGraphWalk.ts
+++ b/packages/odata-service/src/cacheKey/EntityGraphWalk.ts
@@ -3,14 +3,24 @@ import type { QEntityFn } from "./CacheKeyState";
 /** The discriminators of a Q-object path wrapper that leads to another entity, as opposed to a complex value or a primitive property/collection - see `QEntityPath`/`QEntityCollectionPath`. */
 const ENTITY_DISCRIMINATORS = new Set(["EntityType", "EntitySet"]);
 
+/**
+ * What the walk reads off an entity nav property's QBinding. It is the cache-key name that is read - not
+ * the raw URL name: under `cacheKeys.namespace` the generator bakes a prefixed name into the QBinding's
+ * cache-key name, and this is what a deep insert's `invalidates` entry must carry to match the same name
+ * the write's own `[entitySetName, "list"]` rule registers (issue #536).
+ */
 interface EntityBinding {
-  getEntitySetName(): string;
+  getCacheKeyEntitySetName(): string;
   buildCanonicalId(entity: unknown): string | undefined;
 }
 
 /** One entity-shaped value found while walking a data object alongside its Q-object. */
 export interface EntityGraphVisit {
-  /** The entity set this entity belongs to - absent for a contained one, which has none of its own. */
+  /**
+   * The entity set this entity belongs to, as a cache key must carry it - the binding's cache-key name
+   * (the raw name, or the generator's prefixed one under `cacheKeys.namespace`). Absent for a contained
+   * one, which has none of its own.
+   */
   entitySetName: string | undefined;
   /** This entity's own canonical id, from its own data - absent exactly where `entitySetName` is. */
   buildCanonicalId: ((entity: unknown) => string | undefined) | undefined;
@@ -73,7 +83,8 @@ export function walkEntityGraph(
       }
       if (item && typeof item === "object") {
         visit({
-          entitySetName: binding?.getEntitySetName(),
+          // the cache-key name, not the raw URL name - see `EntityBinding`
+          entitySetName: binding?.getCacheKeyEntitySetName(),
           buildCanonicalId: binding && ((entity: unknown) => binding.buildCanonicalId(entity)),
           data: item as Record<string, unknown>,
           qEntityFn: nestedQEntityFn,

--- a/packages/odata-service/test/cacheKey/BuildDeepEdit.test.ts
+++ b/packages/odata-service/test/cacheKey/BuildDeepEdit.test.ts
@@ -2,9 +2,13 @@ import { QBinding, QEntityCollectionPath, QEntityPath, QId, QueryObject } from "
 import { describe, expect, test } from "vitest";
 import { buildDeepEditHops, QEntityFn } from "../../src/cacheKey";
 
-/** A binding whose only use here is `getEntitySetName()` - a real `QId` is more machinery than this needs. */
-function bindingTo(entitySetName: string): QBinding<any> {
-  return new QBinding(() => ({ getName: () => entitySetName }) as unknown as QId<any>, "4.0");
+/**
+ * A binding whose only use here is its entity-set name - a real `QId` is more machinery than this needs.
+ * The optional second argument stands in for the generator-supplied cache-key name a QBinding carries
+ * under `cacheKeys.namespace`: raw entity-set name and cache-key name diverging.
+ */
+function bindingTo(entitySetName: string, cacheKeyEntitySetName?: string): QBinding<any> {
+  return new QBinding(() => ({ getName: () => entitySetName }) as unknown as QId<any>, "4.0", cacheKeyEntitySetName);
 }
 
 class QCopy extends QueryObject {}
@@ -41,9 +45,23 @@ class QPersonWithMappedName extends QueryObject {
   public readonly friends = new QEntityCollectionPath(this.withPrefix("Friends"), () => QTrip, bindingTo("Trips"));
 }
 
+/**
+ * The same nav property as `QMember.Loans`, but with the generator-supplied, prefixed cache-key name a
+ * QBinding carries only under `cacheKeys.namespace`: the raw name ("Loans", the URL's) and the cache-key
+ * name ("Circulation.Loans", the cache key's) diverge.
+ */
+class QMemberNamespacedBinding extends QueryObject {
+  public readonly Loans = new QEntityCollectionPath(
+    this.withPrefix("Loans"),
+    () => QLoan,
+    bindingTo("Loans", "Circulation.Loans"),
+  );
+}
+
 const qMember: QEntityFn = () => QMember as any;
 const qMediumContainedOnly: QEntityFn = () => QMediumContainedOnly as any;
 const qPersonWithMappedName: QEntityFn = () => QPersonWithMappedName as any;
+const qMemberNamespacedBinding: QEntityFn = () => QMemberNamespacedBinding as any;
 
 describe("buildDeepEditHops", () => {
   test("no Q-object factory at all (e.g. an operation root): undefined", () => {
@@ -57,6 +75,14 @@ describe("buildDeepEditHops", () => {
   test("a plain deep insert contributes its entity set's name", () => {
     const data = { Name: "x", Loans: [{ LoanedAt: "2026-01-01" }] };
     expect(buildDeepEditHops(qMember, data)).toEqual(["Loans"]);
+  });
+
+  test("a generator-supplied cache-key name on the binding is what the hop carries - the raw name stays where the URL needs it", () => {
+    // under `cacheKeys.namespace` the generator bakes the prefixed name into the QBinding itself: a deep
+    // insert's `invalidates` entry must carry that same name, or the `["Circulation.Loans", "list"]`
+    // registered by the write's own rule 3 can never match what a `$expand` query carried (issue #536)
+    const data = { Name: "x", Loans: [{ LoanedAt: "2026-01-01" }] };
+    expect(buildDeepEditHops(qMemberNamespacedBinding, data)).toEqual(["Circulation.Loans"]);
   });
 
   test('a binding ({"@id": key}) is not a deep insert and contributes nothing', () => {

--- a/packages/odata2ts/src/FactoryFunctionModel.ts
+++ b/packages/odata2ts/src/FactoryFunctionModel.ts
@@ -49,6 +49,7 @@ export type GeneratorFunctionOptions = Pick<
   | "disableBindingProps"
   | "deepInsertProps"
   | "managedPropertyMode"
+  | "cacheKeys"
   | "v2"
   | "v4"
 >;

--- a/packages/odata2ts/src/OptionModel.ts
+++ b/packages/odata2ts/src/OptionModel.ts
@@ -248,19 +248,27 @@ export interface CacheKeysObjectOptions {
   enabled: boolean;
   /**
    * Prefixes every entity-set-derived identifier a cache key carries - a root's own name (an entity set's
-   * or singleton's), and `entitySetName` wherever a hop attaches one - with that type's own effective
-   * namespace (its alias if it has one, its real namespace otherwise; see `NamespaceAliasResolver`).
+   * or singleton's), a hop's `entitySetName` wherever one is attached, and the entity-set name a binding
+   * carries as its own cache-key name - with that type's own effective namespace (its alias if it has one,
+   * its real namespace otherwise; see `NamespaceAliasResolver`).
    *
    * Off by default: within one generated client, a route's own name is already enough to identify a
-   * resource. Turn this on when a single cache - an `HttpClient.resourceIdentity`, or an app-level query
-   * cache keyed by `cacheKey` - is shared across *multiple* generated clients whose entity-set names might
-   * otherwise collide (`["Media", "list"]` from one service is indistinguishable from another's).
+   * resource. Turn this on when a single cache - an app-level query cache keyed by `cacheKey` - is shared
+   * across *multiple* generated clients whose entity-set names might otherwise collide
+   * (`["Media", "list"]` from one service is indistinguishable from another's).
    *
    * Never reaches a hierarchical hop's own step name (a navigation property's odataName): that value is
    * already nested inside an array rooted at a namespaced name, so it is never compared as a standalone
    * identifier the way `entitySetName` is. Never reaches the raw name a `canonicalIdFn` bakes into
    * generated code for `QId`/URL building either - that string is a real OData URL segment and must stay
-   * exactly the server's own name regardless of this option.
+   * exactly the server's own name regardless of this option. Nor does it reach a binding's own
+   * `getEntitySetName()` (the name the URL is still built from), nor the canonical ids that key an
+   * `HttpClient.resourceIdentity` per-resource store - both are built from the raw name, so this option
+   * can never disambiguate them: a collision there needs a per-service store, not a prefixed key.
+   *
+   * One documented limitation: where a binding is suppressed entirely (`disableBindingProps` or
+   * `skipIdModels`), an `$expand` hop has no binding to read the name from and silently falls back to the
+   * bare navigation-property name - the pre-#536 broken shape, with no warning.
    */
   namespace?: boolean;
 }
@@ -279,12 +287,18 @@ export function resolveCacheKeysEnabled(options: CacheKeysOptions | undefined): 
   return options?.enabled ?? false;
 }
 
-/** Whether entity-set-derived cache-key identifiers carry their owning type's namespace - `false` for the bare boolean shorthand, since there is nowhere to state it. */
+/**
+ * Whether entity-set-derived cache-key identifiers carry their owning type's namespace - `false` for the
+ * bare boolean shorthand (there is nowhere to state it) and `false` whenever cache keys are off at all,
+ * since the prefix only has a use where a cache key is generated. This is the one shared gate for the
+ * prefixed name, so the emitters (`ServiceGenerator`'s routes, `QueryObjectGenerator`'s bindings) read the
+ * same predicate and cannot drift apart on whether it is in force.
+ */
 export function resolveCacheKeysNamespace(options: CacheKeysOptions | undefined): boolean {
   if (typeof options === "boolean") {
     return false;
   }
-  return options?.namespace ?? false;
+  return resolveCacheKeysEnabled(options) && (options?.namespace ?? false);
 }
 
 /**

--- a/packages/odata2ts/src/data-model/DataModel.ts
+++ b/packages/odata2ts/src/data-model/DataModel.ts
@@ -129,6 +129,19 @@ export class DataModel {
   }
 
   /**
+   * `name` (an entity set's, singleton's or unbound operation's own odataName) prefixed with the
+   * {@link getDisplayNamespace effective namespace} of its owning type `fqName` - the one rule
+   * `cacheKeys.namespace` applies, shared by every emitter of a prefixed cache-key identifier
+   * (`ServiceGenerator`'s routes, `QueryObjectGenerator`'s bindings) so the two cannot drift apart.
+   *
+   * The prefix alone is a pure function of the model and its aliases; *whether* a given identifier is
+   * prefixed at all is a decision the generator option makes at each emission site.
+   */
+  public getNamespacedName(fqName: string, name: string): string {
+    return `${this.getDisplayNamespace(fqName)}.${name}`;
+  }
+
+  /**
    * OData version: 2.0 or 4.0.
    * @returns
    */

--- a/packages/odata2ts/src/generator/QueryObjectGenerator.ts
+++ b/packages/odata2ts/src/generator/QueryObjectGenerator.ts
@@ -22,7 +22,7 @@ import {
 } from "../data-model/DataTypeModel.js";
 import { NamingHelper } from "../data-model/NamingHelper.js";
 import { EntityBasedGeneratorFunction, GeneratorFunctionOptions } from "../FactoryFunctionModel.js";
-import { Modes } from "../OptionModel.js";
+import { Modes, resolveCacheKeysNamespace } from "../OptionModel.js";
 import { FileHandler } from "../project/FileHandler.js";
 import { ProjectManager } from "../project/ProjectManager.js";
 import { QueryObjectImports } from "./import/ImportObjects.js";
@@ -57,6 +57,13 @@ class QueryObjectGenerator {
     private options: GeneratorFunctionOptions,
     private namingHelper: NamingHelper,
   ) {}
+
+  /**
+   * Whether a QBinding carries the generator-supplied, prefixed cache-key name as its third constructor
+   * argument - `cacheKeys.namespace` in force, the one shared gate `ServiceGenerator`'s own prefixed
+   * identifiers read (already `false` wherever cache keys are not generated at all).
+   */
+  private readonly cacheKeysNamespace = resolveCacheKeysNamespace(this.options.cacheKeys);
 
   private isV2AsV4() {
     return this.options.v2.responseAsV4 && this.version === ODataVersions.V2;
@@ -333,6 +340,12 @@ class QueryObjectGenerator {
    * Only generated where a service is generated - without one nothing would ever call the conversion, and
    * the models state the binding as it goes on the wire instead (see the model generator).
    *
+   * A third, cache-key-only argument joins the two always-present ones exactly where `cacheKeys.namespace`
+   * is in force: the entity set's own name, prefixed with its namespace. The raw name the id function
+   * carries stays the URL's; this one is what the cache-key side of the binding reads back
+   * (`QBinding.getCacheKeyEntitySetName()`), so an `$expand`'s and a deep edit's cache-key entries carry
+   * the same namespaced names a service route's `entitySetName` carries.
+   *
    * @returns the constructor argument including its leading comma, or an empty string
    */
   private generateBindingStmt(importContainer: ImportContainer, ownerFqName: string, prop: PropertyModel): string {
@@ -356,8 +369,13 @@ class QueryObjectGenerator {
     const qId = importContainer.addGeneratedQObject(target.id.fqName, target.id.qName);
     const notation =
       this.version === ODataVersions.V2 ? "V2" : this.options.v4.odataVersion === "4.01" ? "4.01" : "4.0";
-
-    return `, new ${qBinding}(() => new ${qId}("${targetSet.odataName}"), "${notation}")`;
+    // the generator-supplied cache-key name: the same prefixed name a service route's `entitySetName`
+    // carries under `cacheKeys.namespace` (the target's own namespace, per the one shared rule), absent
+    // everywhere else - the runtime falls back to the raw name wherever it is not present
+    const cacheKeyEntitySetName = this.cacheKeysNamespace
+      ? `, "${this.dataModel.getNamespacedName(targetSet.entityType.fqName, targetSet.odataName)}"`
+      : "";
+    return `, new ${qBinding}(() => new ${qId}("${targetSet.odataName}"), "${notation}"${cacheKeyEntitySetName})`;
   }
 
   /**

--- a/packages/odata2ts/src/generator/ServiceGenerator.ts
+++ b/packages/odata2ts/src/generator/ServiceGenerator.ts
@@ -112,12 +112,13 @@ class ServiceGenerator {
   }
 
   /**
-   * `name` (an entity set's or singleton's own odataName), prefixed with `entityType`'s own effective
-   * namespace when `cacheKeys.namespace` is on - see that option's own doc comment for what this guards
-   * against and what it deliberately never reaches (a hop's own step name, a canonicalIdFn's raw name).
+   * `name` (an entity set's, singleton's or unbound operation's own odataName), prefixed with the owning
+   * type's effective namespace (of `fqName`) when `cacheKeys.namespace` is on - see that option's own doc
+   * comment for what this guards against and what it deliberately never reaches (a hop's own step name, a
+   * canonicalIdFn's raw name).
    */
-  private namespacedName(entityType: EntityType, name: string): string {
-    return this.cacheKeysNamespace ? `${this.dataModel.getDisplayNamespace(entityType.fqName)}.${name}` : name;
+  private namespacedName(fqName: string, name: string): string {
+    return this.cacheKeysNamespace ? this.dataModel.getNamespacedName(fqName, name) : name;
   }
 
   /** The root of a route: an entity set or a singleton. An operation with no declared result set is the one root with no type to head with - built as a plain object literal instead, see `emitUnboundOperationRootExpr`. */
@@ -132,7 +133,7 @@ class ServiceGenerator {
       return "";
     }
     const rootStateFn = imports.addServiceFunction("rootState");
-    const cacheKeyName = this.namespacedName(entityType, name);
+    const cacheKeyName = this.namespacedName(entityType.fqName, name);
     const optionsEntries = [
       options?.paramsSource ? `params: ${options.paramsSource}` : "",
       options?.isEntitySet ? `entitySetName: "${cacheKeyName}"` : "",
@@ -169,7 +170,7 @@ class ServiceGenerator {
     // the hop's own step name (navPropOdataName) never carries this prefix - only entitySetName does, since
     // that is the value reused as a bare, cross-route identifier (invalidates, response-observed identity)
     const entitySetNameEntry = targetSet
-      ? `, entitySetName: "${this.namespacedName(targetSet.entityType, targetSet.odataName)}"`
+      ? `, entitySetName: "${this.namespacedName(targetSet.entityType.fqName, targetSet.odataName)}"`
       : "";
     const canonicalIdFnEntry = targetSet
       ? `, canonicalIdFn: ${this.canonicalIdFnExpr(imports, targetSet.entityType, targetSet.odataName)}`
@@ -251,9 +252,7 @@ class ServiceGenerator {
       : undefined;
     const rootStateFn = imports.addServiceFunction("rootState");
     const kind = op.returnType?.isCollection ? "list" : "detail";
-    const cacheKeyName = this.cacheKeysNamespace
-      ? `${this.dataModel.getDisplayNamespace(op.fqName)}.${importOdataName}`
-      : importOdataName;
+    const cacheKeyName = this.namespacedName(op.fqName, importOdataName);
     // nested under its own "params" key, never spread directly - a composable operation's cache key later
     // merges in real query params (select/filter/...) via buildCacheKey, and those must not collide with
     // the operation's own invocation arguments
@@ -262,7 +261,7 @@ class ServiceGenerator {
     if (entitySet) {
       const canonicalIdFnEntry = `canonicalIdFn: ${this.canonicalIdFnExpr(imports, entitySet.entityType, entitySet.odataName)}, `;
       const qEntityFnEntry = `qEntityFn: ${this.qEntityFnExpr(imports, entitySet.entityType)}`;
-      const namespacedEntitySetName = this.namespacedName(entitySet.entityType, entitySet.odataName);
+      const namespacedEntitySetName = this.namespacedName(entitySet.entityType.fqName, entitySet.odataName);
       return (
         `${rootStateFn}("${cacheKeyName}", "${kind}", ` +
         `{ ${paramsEntry}entitySetName: "${namespacedEntitySetName}", ${canonicalIdFnEntry}${qEntityFnEntry} })`

--- a/packages/odata2ts/test/fixture/generator/qobject/entity-binding-cache-key-namespace.ts
+++ b/packages/odata2ts/test/fixture/generator/qobject/entity-binding-cache-key-namespace.ts
@@ -1,0 +1,49 @@
+import {
+  QBinding,
+  QEntityCollectionPath,
+  QEntityPath,
+  QId,
+  QNumberParam,
+  QNumberPath,
+  QueryObject,
+} from "@odata2ts/odata-query-objects";
+// @ts-ignore
+import type { AuthorId, BookId } from "./TesterModel.js";
+
+export class QAuthor extends QueryObject {
+  public readonly id = new QNumberPath(this.withPrefix("id"));
+}
+
+export const qAuthor = new QAuthor();
+
+export class QAuthorId extends QId<AuthorId> {
+  private readonly params = [new QNumberParam("id")];
+
+  getParams() {
+    return this.params;
+  }
+}
+
+export class QBook extends QueryObject {
+  public readonly id = new QNumberPath(this.withPrefix("id"));
+  public readonly author = new QEntityPath(
+    this.withPrefix("author"),
+    () => QAuthor,
+    new QBinding(() => new QAuthorId("Authors"), "4.0", "Tester.Authors"),
+  );
+  public readonly relatedAuthors = new QEntityCollectionPath(
+    this.withPrefix("relatedAuthors"),
+    () => QAuthor,
+    new QBinding(() => new QAuthorId("Authors"), "4.0", "Tester.Authors"),
+  );
+}
+
+export const qBook = new QBook();
+
+export class QBookId extends QId<BookId> {
+  private readonly params = [new QNumberParam("id")];
+
+  getParams() {
+    return this.params;
+  }
+}

--- a/packages/odata2ts/test/generator/v4/QueryObjectGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/QueryObjectGenerator.test.ts
@@ -344,6 +344,23 @@ describe("Query Object Generator Tests V4", () => {
     });
   });
 
+  test(`${TEST_SUITE_NAME}: a namespaced cache key bakes its prefixed name into the binding`, async () => {
+    // given entities related to each other, reachable through entity sets
+    addRelatedEntities();
+    odataBuilder.addEntitySet("Authors", withNs("Author")).addEntitySet("Books", withNs(ENTITY_NAME), [
+      { path: "author", target: "Authors" },
+      { path: "relatedAuthors", target: "Authors" },
+    ]);
+
+    // when opting into namespaced cache keys
+    // then the q-paths' binding carries the entity set's name prefixed with its owning type's namespace as a
+    // third constructor argument - the raw name stays the QId's, so the URL is still the server's own
+    await generateAndCompare("entity-binding-cache-key-namespace.ts", {
+      skipIdModels: false,
+      cacheKeys: { enabled: true, namespace: true },
+    });
+  });
+
   test(`${TEST_SUITE_NAME}: no binding without a NavigationPropertyBinding`, async () => {
     // given entities related to each other, but no entity set stating where the navigation leads
     addRelatedEntities();


### PR DESCRIPTION
- `cacheKeys.namespace` now prefixes the entity-set name at the two producers it missed: the `$expand` hops (odata-query-builder) and the deep-edit hops (odata-service). They read the raw `QBinding.getEntitySetName()`, so with the option on a write's namespaced `[entitySetName, "list"]` invalidates entry could never match the raw-named expand slot or deep-edit entry - silently breaking cache invalidation through `$expand` and deep inserts (issue #536, gap 1).
- `QBinding` carries a second, generator-supplied, cache-key-only name (`getCacheKeyEntitySetName`), falling back to the raw name where absent; `getEntitySetName()` / `format` / `buildCanonicalId` stay raw for URL building.
- `QueryObjectGenerator` emits it as a third constructor argument only when `cacheKeys.namespace` is in force, so generated output is byte-identical for everyone else.
- The one prefix rule lives in `DataModel.getNamespacedName`, shared by both emitters; the `cacheKeys.namespace` gate is single-sourced in `resolveCacheKeysNamespace`.
- Int-test: two matching-pair cases in the ASP.NET namespace-alias suite assert `touchesResource(invalidatesEntry, cacheKey)` for a `$expand`+write and a deep-insert write.
