### PR TITLE
feat!: every keyless "detail" resource carries the "?" placeholder, not just $expand's

### DIFF
--- a/int-test/asp-net/test/feature/CacheKeys.test.ts
+++ b/int-test/asp-net/test/feature/CacheKeys.test.ts
@@ -32,6 +32,19 @@ describe("ASP.NET Library: cache keys", () => {
     expect(result.status).toBe(200);
   });
 
+  test("a singleton's 'detail' carries the unknown-id placeholder too - it has no key by definition, but the shape stays uniform with every other keyless 'detail'", async () => {
+    const request = LIBRARY.MainBranch().query();
+    expect(request.cacheKey).toEqual(["MainBranch", "detail", "?"]);
+
+    const result = await request.execute();
+    expect(result.status).toBe(200);
+
+    // patched to its own current value - a no-op change, so nothing needs restoring afterward
+    const patched = await LIBRARY.MainBranch().patch({ Name: result.data.Name }).execute();
+    expect(patched.status).toBe(204);
+    expect(patched.invalidates).toEqual([["MainBranch", "detail", "?"]]);
+  });
+
   test("a to-one hop off a real entity: /Copies(...)/Medium names itself by the navigation property, with no key of its own - a to-one hop never knows the target's key up front", async () => {
     const created = await LIBRARY.Copies()
       .create({
@@ -45,7 +58,7 @@ describe("ASP.NET Library: cache keys", () => {
     expect(created.status).toBe(201);
 
     const request = LIBRARY.Copies(copyKey).Medium().query();
-    expect(request.cacheKey).toEqual(["Copies", "detail", copyKey, "Medium", "detail"]);
+    expect(request.cacheKey).toEqual(["Copies", "detail", copyKey, "Medium", "detail", "?"]);
 
     const result = await request.execute();
     expect(result.status).toBe(200);
@@ -59,7 +72,9 @@ describe("ASP.NET Library: cache keys", () => {
       .patch({ Title: "Der Prozess" })
       .ignoreETag()
       .execute();
-    expect(patched.invalidates).toEqual(expect.arrayContaining([["Copies", "detail", copyKey, "Medium", "detail"]]));
+    expect(patched.invalidates).toEqual(
+      expect.arrayContaining([["Copies", "detail", copyKey, "Medium", "detail", "?"]]),
+    );
   });
 
   test("$expand produces a hop-shaped entry touchesResource can reach", async () => {

--- a/int-test/cap/test/feature/CacheKeys.test.ts
+++ b/int-test/cap/test/feature/CacheKeys.test.ts
@@ -59,7 +59,7 @@ describe("CAP Library: cache keys (V4)", () => {
 
   test("Members/IdDocument names itself by the navigation property, not by its target entity set's name", async () => {
     const request = LIBRARY.Members(MEMBER_ID).IdDocument().query();
-    expect(request.cacheKey).toEqual(["Members", "detail", MEMBER_ID, "IdDocument", "detail"]);
+    expect(request.cacheKey).toEqual(["Members", "detail", MEMBER_ID, "IdDocument", "detail", "?"]);
 
     // 204: this member has no IdDocument at all - the request itself is still well-formed
     const result = await request.execute();
@@ -107,7 +107,17 @@ describe("CAP Library: cache keys (V4)", () => {
     // test pins against regressing, distinct from ASP.NET's cast-qualified case (CAP's model is flat, no
     // BaseType hierarchy at all - see Subtypes.test.ts in the asp-net suite).
     const request = LIBRARY.Audiobooks(AUDIOBOOK).Chapters(1).up_().query();
-    expect(request.cacheKey).toEqual(["Audiobooks", "detail", AUDIOBOOK, "Chapters", "detail", 1, "up_", "detail"]);
+    expect(request.cacheKey).toEqual([
+      "Audiobooks",
+      "detail",
+      AUDIOBOOK,
+      "Chapters",
+      "detail",
+      1,
+      "up_",
+      "detail",
+      "?",
+    ]);
 
     const result = await request.execute();
     expect(result.status).toBe(200);

--- a/int-test/cap/test/v2/feature/CacheKeys.test.ts
+++ b/int-test/cap/test/v2/feature/CacheKeys.test.ts
@@ -59,7 +59,7 @@ describe("CAP Library: cache keys (V2)", () => {
     const loanId = loan.data.d.Id;
 
     const request = LIBRARY_V2.Loans(loanId).Copy().query();
-    expect(request.cacheKey).toEqual(["Loans", "detail", loanId, "Copy", "detail"]);
+    expect(request.cacheKey).toEqual(["Loans", "detail", loanId, "Copy", "detail", "?"]);
 
     const result = await request.execute();
     expect(result.status).toBe(200);

--- a/packages/odata-query-builder/src/CacheKeyParams.ts
+++ b/packages/odata-query-builder/src/CacheKeyParams.ts
@@ -1,4 +1,12 @@
 /**
+ * The literal placeholder standing in for a `"detail"` resource's id where no key can be determined at
+ * cache-key construction time - shared by every producer of one: `ExpandHop` below, a to-one navigation
+ * hop, and a singleton root (see `withUnknownId`, odata-service). Named rather than inlined so the three
+ * producers, spread across two packages, cannot drift onto different literals by accident.
+ */
+export const UNKNOWN_ID = "?" as const;
+
+/**
  * An expand entry once its navigation property is known: the *target's own entity set name* (never the
  * navigation property's own OData name, which need not match it) and kind - the same `(name, kind)` shape a
  * structured hop in the main key already uses, and specifically the shape `[entitySetName, "list"]` a
@@ -25,7 +33,7 @@
  */
 export type ExpandHop =
   | readonly [name: string, kind: "list", nested?: { expand?: Array<string | ExpandHop> }]
-  | readonly [name: string, kind: "detail", key: "?", nested?: { expand?: Array<string | ExpandHop> }];
+  | readonly [name: string, kind: "detail", key: typeof UNKNOWN_ID, nested?: { expand?: Array<string | ExpandHop> }];
 
 /**
  * The restrictions a query puts on a resource, computed here rather than parsed back out of a rendered URL

--- a/packages/odata-query-builder/src/ODataQueryBuilder.ts
+++ b/packages/odata-query-builder/src/ODataQueryBuilder.ts
@@ -11,7 +11,7 @@ import {
   QueryObjectModel,
   searchTerm,
 } from "@odata2ts/odata-query-objects";
-import { CacheKeyParams, ExpandHop, normalizeCacheKeyParams } from "./CacheKeyParams.js";
+import { CacheKeyParams, ExpandHop, normalizeCacheKeyParams, UNKNOWN_ID } from "./CacheKeyParams.js";
 import { ODataOperators } from "./ODataModel";
 import {
   ExpandingCollectionQueryBuilderV4,
@@ -536,8 +536,8 @@ export class ODataQueryBuilder<Q extends QueryObjectModel> {
         const expandHop: ExpandHop =
           kind === "detail"
             ? nested?.expand
-              ? [name, kind, "?", { expand: nested.expand }]
-              : [name, kind, "?"]
+              ? [name, kind, UNKNOWN_ID, { expand: nested.expand }]
+              : [name, kind, UNKNOWN_ID]
             : nested?.expand
               ? [name, kind, { expand: nested.expand }]
               : [name, kind];

--- a/packages/odata-query-builder/test/CacheKeyParams.test.ts
+++ b/packages/odata-query-builder/test/CacheKeyParams.test.ts
@@ -8,7 +8,7 @@ import {
   QueryObject,
 } from "@odata2ts/odata-query-objects";
 import { beforeEach, describe, expect, test } from "vitest";
-import { createExpandingQueryBuilderV4 } from "../src";
+import { createExpandingQueryBuilderV4, UNKNOWN_ID } from "../src";
 import { ODataQueryBuilder } from "../src/ODataQueryBuilder";
 import { QPerson, qPerson } from "./fixture/types/QSimplePersonModel";
 
@@ -98,7 +98,7 @@ describe("CacheKeyParams", () => {
 
     test("a to-one navigation property enriches with kind 'detail' and a '?' placeholder - its id is never known at cache-key construction time", () => {
       builder.expand(["bestFriend"]);
-      expect(builder.getCacheKeyParams()).toEqual({ expand: [["bestFriend", "detail", "?"]] });
+      expect(builder.getCacheKeyParams()).toEqual({ expand: [["bestFriend", "detail", UNKNOWN_ID]] });
     });
 
     test("addExpands() never enriches - it takes a raw path string, never a Q-object property, so there is no kind to read", () => {
@@ -120,7 +120,7 @@ describe("CacheKeyParams", () => {
       builder.expand(["friends", "bestFriend"]);
       expect(builder.getCacheKeyParams()).toEqual({
         expand: [
-          ["bestFriend", "detail", "?"],
+          ["bestFriend", "detail", UNKNOWN_ID],
           ["friends", "list"],
         ],
       });
@@ -145,7 +145,7 @@ describe("CacheKeyParams", () => {
         nested.expanding("bestFriend", () => {});
       });
       expect(builder.getCacheKeyParams()).toEqual({
-        expand: [["friends", "list", { expand: [["bestFriend", "detail", "?"]] }]],
+        expand: [["friends", "list", { expand: [["bestFriend", "detail", UNKNOWN_ID]] }]],
       });
     });
 
@@ -154,7 +154,7 @@ describe("CacheKeyParams", () => {
         nested.expanding("bestFriend", () => {});
       });
       expect(builder.getCacheKeyParams()).toEqual({
-        expand: [["bestFriend", "detail", "?", { expand: [["bestFriend", "detail", "?"]] }]],
+        expand: [["bestFriend", "detail", UNKNOWN_ID, { expand: [["bestFriend", "detail", UNKNOWN_ID]] }]],
       });
     });
 

--- a/packages/odata-service/src/cacheKey/CacheKeyState.ts
+++ b/packages/odata-service/src/cacheKey/CacheKeyState.ts
@@ -1,3 +1,4 @@
+import { UNKNOWN_ID } from "@odata2ts/odata-query-builder";
 import type { QueryObjectModel } from "@odata2ts/odata-query-objects";
 
 /** Whether a resource is a collection or a single entity / complex value. */
@@ -161,9 +162,31 @@ export function withKey(state: CacheKeyState, stepKey: unknown, id: unknown): Ca
     steps[state.kindIndex - 1] = state.entitySetName;
   }
   steps[state.kindIndex] = "detail";
+  // truncate anything past the kind marker before pushing the real key - a `withUnknownId` placeholder
+  // included, so it is replaced rather than left behind with the real key pushed past it. A no-op for the
+  // ordinary case, where nothing already follows the kind marker.
+  steps.length = state.kindIndex + 1;
   steps.push(stepKey);
 
   return { ...state, steps, key: id };
+}
+
+/**
+ * Marks the current `"detail"` resource as reachable with no key that can be determined - the literal
+ * `"?"`. `$expand` already needed this for a to-one expanded hop (see `ExpandHop`, odata-query-builder);
+ * this generalises it: the `"detail"` position is never short, it carries either a real key or this
+ * placeholder, at every level, on every route. Used for exactly two producers of a keyless `"detail"`
+ * resource - a to-one navigation hop (the target's key is never in the URL, only ever discoverable from
+ * the response) and a singleton root (which has no key by definition, OData singletons carry no key
+ * predicate) - never for a `"list"` kind, which has no singular id to place there, and never for a complex
+ * or operation hop, neither of which this rule reaches.
+ *
+ * Leaves `state.key` untouched (absent), exactly like an ordinary unnarrowed hop or root - so
+ * `keyedEntitySetFormOf` still derives no short form for it, and a later `withKey` (see above) replaces
+ * the placeholder rather than pushing a real key past it.
+ */
+export function withUnknownId(state: CacheKeyState): CacheKeyState {
+  return { ...state, steps: [...state.steps, UNKNOWN_ID] };
 }
 
 /** Adds a restriction the resource itself carries - a cast, a singleton marker, an operation. */

--- a/packages/odata-service/test/cacheKey/BuildCacheKey.test.ts
+++ b/packages/odata-service/test/cacheKey/BuildCacheKey.test.ts
@@ -1,5 +1,14 @@
+import { UNKNOWN_ID } from "@odata2ts/odata-query-builder";
 import { describe, expect, test } from "vitest";
-import { buildCacheKey, buildInvalidates, hopState, rootState, withKey, withParams } from "../../src/cacheKey";
+import {
+  buildCacheKey,
+  buildInvalidates,
+  hopState,
+  rootState,
+  withKey,
+  withParams,
+  withUnknownId,
+} from "../../src/cacheKey";
 
 const MEDIA = "Media";
 const COPIES = "Copies";
@@ -237,5 +246,25 @@ describe("buildInvalidates", () => {
   test("no crossRouteKeys given: behaves exactly as before", () => {
     const state = withKey(rootState(MEDIA, "list", { entitySetName: MEDIA }), 5, { Id: 5 });
     expect(buildInvalidates(state)).toEqual(buildInvalidates(state, []));
+  });
+
+  test("a write to a singleton (root-level, no ancestor) invalidates its own '?'-terminated key - nothing collapses it, and there is no list form to add", () => {
+    const state = withUnknownId(rootState("Me", "detail"));
+    expect(buildInvalidates(state)).toEqual([["Me", "detail", UNKNOWN_ID]]);
+  });
+
+  test("a write addressed through a keyless to-one hop: rules 2 and 4 stay silent - no short form is derived for a resource with no known key", () => {
+    const copy = withKey(rootState(COPIES, "list", { entitySetName: COPIES }), 5, { Id: 5 });
+    const medium = withUnknownId(hopState(copy, { name: "medium", kind: "detail", entitySetName: MEDIA }));
+    // the hop's own full key (rule 1) collapses under its ancestor's shorter prefix - exactly like any
+    // other hierarchical write (see "a hierarchical write's own key is a prefix-redundant..." above); what
+    // this pins is that nothing *extra* leaks in for the "?" case specifically - no keyedEntitySetForm for
+    // "Media" (rule 2/4 both require state.key, which a "?" resource never has), and no
+    // ["Media", "detail", "?"] short form either
+    expect(buildInvalidates(medium)).toEqual([
+      [COPIES, "detail", 5],
+      [COPIES, "list"],
+      [MEDIA, "list"],
+    ]);
   });
 });

--- a/packages/odata-service/test/cacheKey/CacheKeyState.test.ts
+++ b/packages/odata-service/test/cacheKey/CacheKeyState.test.ts
@@ -1,5 +1,15 @@
+import { UNKNOWN_ID } from "@odata2ts/odata-query-builder";
 import { describe, expect, test } from "vitest";
-import { CanonicalIdFn, hopState, QEntityFn, rootState, withKey, withParams } from "../../src/cacheKey";
+import {
+  CanonicalIdFn,
+  hopState,
+  keyedEntitySetFormOf,
+  QEntityFn,
+  rootState,
+  withKey,
+  withParams,
+  withUnknownId,
+} from "../../src/cacheKey";
 
 const MEDIA = "Media";
 const COPIES = "Copies";
@@ -267,6 +277,56 @@ describe("CacheKeyState", () => {
       const state = withKey(copies, 3, { InventoryNumber: 3 });
       expect(state.steps).toEqual(["detail", 5, COPIES, "detail", 3]);
       expect(state.params).toEqual({ cast: "Library.Catalog.SpecialCopy" });
+    });
+  });
+
+  describe("withUnknownId", () => {
+    test("appends the placeholder to a singleton root's steps", () => {
+      const state = withUnknownId(rootState("Me", "detail"));
+      expect(state.steps).toEqual(["detail", UNKNOWN_ID]);
+    });
+
+    test("appends the placeholder to a to-one hop's steps, alongside its own name and kind", () => {
+      const parent = withKey(rootState(COPIES, "list"), 5, { Id: 5 });
+      const state = withUnknownId(
+        hopState(parent, {
+          name: "medium",
+          kind: "detail",
+          entitySetName: MEDIA,
+          canonicalIdFn: canonicalIdOfMedia,
+          qEntityFn: qMedium,
+        }),
+      );
+      expect(state.steps).toEqual(["detail", 5, "medium", "detail", UNKNOWN_ID]);
+      // the response still recovers the real resource - only the key in the *route* is blind
+      expect(state.entitySetName).toBe(MEDIA);
+      expect(state.canonicalIdFn).toBe(canonicalIdOfMedia);
+    });
+
+    test("does not move the kind index - it still points at the kind marker, not the placeholder", () => {
+      const state = withUnknownId(rootState("Me", "detail"));
+      expect(state.kindIndex).toBe(0);
+      expect(state.steps[state.kindIndex]).toBe("detail");
+    });
+
+    test("leaves state.key untouched, so keyedEntitySetFormOf still derives no short form for it", () => {
+      const state = withUnknownId(
+        hopState(withKey(rootState(COPIES, "list"), 5, { Id: 5 }), {
+          name: "medium",
+          kind: "detail",
+          entitySetName: MEDIA,
+        }),
+      );
+      expect(state.key).toBeUndefined();
+      expect(keyedEntitySetFormOf(state)).toBeUndefined();
+    });
+
+    test("withKey after withUnknownId replaces the placeholder rather than pushing the real key past it", () => {
+      const parent = withKey(rootState(COPIES, "list"), 5, { Id: 5 });
+      const unknown = withUnknownId(hopState(parent, { name: "medium", kind: "detail", entitySetName: MEDIA }));
+      const state = withKey(unknown, 9, { Id: 9 });
+      expect(state.steps).toEqual(["detail", 5, MEDIA, "detail", 9]);
+      expect(state.key).toEqual({ Id: 9 });
     });
   });
 });

--- a/packages/odata-service/test/cacheKey/ObservedIdentity.test.ts
+++ b/packages/odata-service/test/cacheKey/ObservedIdentity.test.ts
@@ -1,12 +1,15 @@
+import { UNKNOWN_ID } from "@odata2ts/odata-query-builder";
 import { QBinding, QEntityCollectionPath, QId, QNumberParam, QueryObject } from "@odata2ts/odata-query-objects";
 import { describe, expect, test } from "vitest";
 import {
   CacheKeyState,
   evictObservedIdentity,
+  hopState,
   recordObservedIdentities,
   resolveCrossRouteInvalidates,
   rootState,
   withKey,
+  withUnknownId,
 } from "../../src/cacheKey";
 import { MockResourceIdentityHandler } from "../mock/MockClient";
 
@@ -80,6 +83,23 @@ describe("recordObservedIdentities", () => {
     const hierarchicalKey = ["Media", "detail", 5, { expand: [["copies", "list"]] }];
     recordObservedIdentities(handler, hierarchicalKey, state, { id: 5, title: "The Trial" });
     expect(handler.resolve("Media(5)")).toEqual([["Media", "detail", 5]]);
+  });
+
+  test("records under a '?'-terminated key from a to-one hop with no addressed key of its own - the route is still the route", () => {
+    const handler = new MockResourceIdentityHandler();
+    const parent = mediaDetailState();
+    const medium = withUnknownId(
+      hopState(parent, {
+        name: "medium",
+        kind: "detail",
+        entitySetName: "Media",
+        canonicalIdFn: (entity) => new QMediumId("Media").buildCanonicalId(entity),
+        qEntityFn: () => QMedium as any,
+      }),
+    );
+    const key = ["Media", "detail", 5, "medium", "detail", UNKNOWN_ID];
+    recordObservedIdentities(handler, key, medium, { id: 9, title: "Der Prozess" });
+    expect(handler.resolve("Media(9)")).toEqual([key]);
   });
 
   test("records every row of a list response, against the same key", () => {

--- a/packages/odata-service/test/cacheKey/TouchesResource.test.ts
+++ b/packages/odata-service/test/cacheKey/TouchesResource.test.ts
@@ -1,3 +1,4 @@
+import { UNKNOWN_ID } from "@odata2ts/odata-query-builder";
 import { describe, expect, test } from "vitest";
 import { touchesResource } from "../../src/cacheKey";
 
@@ -49,8 +50,19 @@ describe("touchesResource - array needle, top level", () => {
   test("a to-one hop with no addressed key of its own is not reachable by a keyed needle", () => {
     // /Copies(...)/Medium hierarchical: the hop only ever carries its own name and kind - never the
     // target's own key - so no needle carrying a key value can match it
-    const key = [COPIES, "detail", { MediumId: 5, InventoryNumber: 7 }, "medium", "detail"];
+    const key = [COPIES, "detail", { MediumId: 5, InventoryNumber: 7 }, "medium", "detail", UNKNOWN_ID];
     expect(touchesResource([MEDIA, "detail", 5], key)).toBe(false);
+  });
+
+  test("a bare 'detail' needle still matches a top-level (non-expand) '?'-terminated hop - withUnknownId's own producers, not just $expand's", () => {
+    const key = [COPIES, "detail", { MediumId: 5, InventoryNumber: 7 }, "medium", "detail", UNKNOWN_ID];
+    expect(touchesResource(["medium", "detail"], key)).toBe(true);
+  });
+
+  test("the '?' placeholder needle matches a top-level unknown-id hop, but a specific-key needle does not", () => {
+    const key = [COPIES, "detail", { MediumId: 5, InventoryNumber: 7 }, "medium", "detail", UNKNOWN_ID];
+    expect(touchesResource(["medium", "detail", UNKNOWN_ID], key)).toBe(true);
+    expect(touchesResource(["medium", "detail", 5], key)).toBe(false);
   });
 
   test("an unrelated name does not match", () => {
@@ -82,18 +94,18 @@ describe("touchesResource - expand entries, buried inside the trailing params ob
   test("a 'detail' hop's own '?' placeholder does not stand in the way of finding its nested params", () => {
     // the "?" placeholder pushes a "detail" hop's own nested params to its 4th element, not its 3rd - a
     // position shift that must not silently break recursion into it
-    const key = [MEDIA, "detail", 5, { expand: [["medium", "detail", "?", { expand: [["copies", "list"]] }]] }];
+    const key = [MEDIA, "detail", 5, { expand: [["medium", "detail", UNKNOWN_ID, { expand: [["copies", "list"]] }]] }];
     expect(touchesResource(["copies", "list"], key)).toBe(true);
   });
 
   test("a bare 'detail' hop needle (no key) matches the '?' placeholder form by prefix", () => {
-    const key = [MEDIA, "detail", 5, { expand: [["Publishers", "detail", "?"]] }];
+    const key = [MEDIA, "detail", 5, { expand: [["Publishers", "detail", UNKNOWN_ID]] }];
     expect(touchesResource(["Publishers", "detail"], key)).toBe(true);
   });
 
   test("the '?' placeholder needle matches only the unknown-id form, not a specific-key write's own entry", () => {
-    const key = [MEDIA, "detail", 5, { expand: [["Publishers", "detail", "?"]] }];
-    expect(touchesResource(["Publishers", "detail", "?"], key)).toBe(true);
+    const key = [MEDIA, "detail", 5, { expand: [["Publishers", "detail", UNKNOWN_ID]] }];
+    expect(touchesResource(["Publishers", "detail", UNKNOWN_ID], key)).toBe(true);
     expect(touchesResource(["Publishers", "detail", 5], key)).toBe(false);
   });
 

--- a/packages/odata2ts/src/generator/ServiceGenerator.ts
+++ b/packages/odata2ts/src/generator/ServiceGenerator.ts
@@ -121,6 +121,16 @@ class ServiceGenerator {
     return this.cacheKeysNamespace ? this.dataModel.getNamespacedName(fqName, name) : name;
   }
 
+  /**
+   * Wraps a `rootState`/`hopState` expression so the resource it builds is marked as reachable with no
+   * known key (see `withUnknownId`) - shared between the two producers of a keyless `"detail"` resource,
+   * a to-one navigation hop and a singleton root, so the wrapping itself cannot drift between them.
+   */
+  private wrapUnknownId(imports: ImportContainer, expr: string): string {
+    const withUnknownIdFn = imports.addServiceFunction("withUnknownId");
+    return `${withUnknownIdFn}(${expr})`;
+  }
+
   /** The root of a route: an entity set or a singleton. An operation with no declared result set is the one root with no type to head with - built as a plain object literal instead, see `emitUnboundOperationRootExpr`. */
   private emitRootStateExpr(
     imports: ImportContainer,
@@ -178,7 +188,14 @@ class ServiceGenerator {
     const qEntityFnEntry = `, qEntityFn: ${this.qEntityFnExpr(imports, elementType)}`;
 
     const hopStateFn = imports.addServiceFunction("hopState");
-    return `cacheKeyState && ${hopStateFn}(cacheKeyState, { name: "${navPropOdataName}", kind: "${kind}"${entitySetNameEntry}${canonicalIdFnEntry}${qEntityFnEntry} })`;
+    const hopExpr = `${hopStateFn}(cacheKeyState, { name: "${navPropOdataName}", kind: "${kind}"${entitySetNameEntry}${canonicalIdFnEntry}${qEntityFnEntry} })`;
+    // a to-one hop's target key is never in the URL - only ever discoverable from the response, the same
+    // gap `$expand` already has for the identical reason - so the "detail" position gets the same "?"
+    // placeholder rather than staying short (see `withUnknownId`)
+    if (kind === "detail") {
+      return `cacheKeyState && ${this.wrapUnknownId(imports, hopExpr)}`;
+    }
+    return `cacheKeyState && ${hopExpr}`;
   }
 
   /** A complex property hop: the same shape as a navigation hop, minus any entity-set identity - a complex value is never a navigation property and belongs to no entity set. */
@@ -659,7 +676,10 @@ class ServiceGenerator {
     // type-rooted shape, which had to smuggle it in since the root position was occupied by a type. No
     // `isEntitySet` either: a singleton is not itself a member of an entity set, so it has no "list" form
     // for `invalidates` to ever name.
-    const cacheKeyExpr = this.emitRootStateExpr(importContainer, odataName, "detail", entityType);
+    const rootStateExpr = this.emitRootStateExpr(importContainer, odataName, "detail", entityType);
+    // a singleton has no key by definition (OData singletons carry no key predicate), so the same "?"
+    // placeholder a keyless to-one hop gets applies here too (see `withUnknownId`)
+    const cacheKeyExpr = rootStateExpr ? this.wrapUnknownId(importContainer, rootStateExpr) : rootStateExpr;
 
     return {
       scope: Scope.Public,

--- a/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
@@ -301,8 +301,9 @@ describe("Service Generator Tests V4", () => {
         `rootState("Media", "list", { entitySetName: "Media", canonicalIdFn: (entity: unknown) => new QMediumId("Media").buildCanonicalId(entity), qEntityFn: () => QMedium })`,
       );
       // root: singleton getter - its own name directly, no params marker needed, no entitySetName (a
-      // singleton has no "list" form for `invalidates` to ever name)
-      expect(text).toContain(`rootState("MainBranch", "detail", { qEntityFn: () => QMedium })`);
+      // singleton has no "list" form for `invalidates` to ever name). Wrapped in withUnknownId: a
+      // singleton has no key by definition, so its "detail" position carries the "?" placeholder too
+      expect(text).toContain(`withUnknownId(rootState("MainBranch", "detail", { qEntityFn: () => QMedium }))`);
       // navigation hop with no Partner/ReferentialConstraint - irrelevant now, every navigation property
       // is handled the same way regardless of what metadata backs it
       expect(text).toContain(
@@ -314,8 +315,10 @@ describe("Service Generator Tests V4", () => {
       expect(text).toContain(
         `hopState(cacheKeyState, { name: "copies", kind: "list", entitySetName: "Copies", canonicalIdFn: (entity: unknown) => new QCopyId("Copies").buildCanonicalId(entity), qEntityFn: () => QCopy })`,
       );
+      // to-one hop: wrapped in withUnknownId - the target's key is never in the URL, only ever
+      // discoverable from the response (the same gap $expand has for the identical reason)
       expect(text).toContain(
-        `hopState(cacheKeyState, { name: "medium", kind: "detail", entitySetName: "Media", canonicalIdFn: (entity: unknown) => new QMediumId("Media").buildCanonicalId(entity), qEntityFn: () => QMedium })`,
+        `withUnknownId(hopState(cacheKeyState, { name: "medium", kind: "detail", entitySetName: "Media", canonicalIdFn: (entity: unknown) => new QMediumId("Media").buildCanonicalId(entity), qEntityFn: () => QMedium }))`,
       );
       expect(text).not.toContain("reRoot");
       // complex property: never a navigation property, no entity set, no Q-object factory of its own
@@ -342,6 +345,12 @@ describe("Service Generator Tests V4", () => {
       // no generated nav-hops table anywhere - removed along with type-rooted identity
       expect(text).not.toContain("CacheKeyNavHops");
       expect(text).not.toContain("CACHE_KEY_NAV_HOPS");
+      // the placeholder reaches exactly the singleton root and the to-one hop, nothing else with a
+      // "detail" kind: a complex hop and an unbound operation's own keyless root stay exactly as before -
+      // `.toContain` alone would miss an accidental extra wrap here, since the unwrapped form is always a
+      // substring of the wrapped one
+      expect(text).not.toContain(`withUnknownId(hopState(cacheKeyState, { name: "details"`);
+      expect(text).not.toContain(`withUnknownId(rootState("TotalCount"`);
     });
 
     test("createEntityService forwards the cache-key state it is handed, without computing one", async () => {
@@ -385,8 +394,9 @@ describe("Service Generator Tests V4", () => {
       expect(text).toContain(
         `rootState("Tester.Media", "list", { entitySetName: "Tester.Media", canonicalIdFn: (entity: unknown) => new QMediumId("Media").buildCanonicalId(entity), qEntityFn: () => QMedium })`,
       );
-      // singleton root: prefixed the same way, even though it has no entitySetName to also prefix
-      expect(text).toContain(`rootState("Tester.MainBranch", "detail", { qEntityFn: () => QMedium })`);
+      // singleton root: prefixed the same way, even though it has no entitySetName to also prefix - and
+      // still wrapped in withUnknownId, the namespace prefix does not disturb that
+      expect(text).toContain(`withUnknownId(rootState("Tester.MainBranch", "detail", { qEntityFn: () => QMedium }))`);
       // hierarchical hop: the hop's own step name ("reviews") is never prefixed - only entitySetName is,
       // since that is the value reused as a bare, cross-route identifier
       expect(text).toContain(


### PR DESCRIPTION
- Generalises the "?" placeholder $expand already uses for a to-one hop with an unknown key: the "detail" position is never short now, on any route - a to-one navigation hop and a singleton root gain it too, via a new `withUnknownId`.
- `withKey` now truncates anything past its kind marker before pushing a real key, so it replaces a placeholder rather than leaving it behind with the real key pushed past it.
- The placeholder is now a single named constant (`UNKNOWN_ID`, odata-query-builder) shared by all three producers and their own tests, instead of a bare `"?"` literal repeated at each site.
- Every integration suite with a keyless "detail" assertion is updated (asp-net, cap V4, cap V2); asp-net gains the first cache-key integration test for a singleton.
- BREAKING CHANGE: a cache key for a to-one navigation hop or a singleton root now ends in an extra "?" element - see the commit body for exact before/after shapes.

Implements spec/odata2ts-cache-key-unknown-id-placeholder.md.