### PR TITLE
fix(odata2ts): resolve a navigation binding declared on a base type for every subtype

### DIFF
--- a/int-test/asp-net/test/feature/CacheKeys.test.ts
+++ b/int-test/asp-net/test/feature/CacheKeys.test.ts
@@ -3,6 +3,7 @@ import { ODataModelResponseV4 } from "@odata2ts/odata-core";
 import { touchesResource } from "@odata2ts/odata-service";
 import { afterAll, describe, expect, expectTypeOf, test } from "vitest";
 import { Medium } from "../../src-generated/library/library-catalog/index.js";
+import { Copy } from "../../src-generated/library/library-circulation/index.js";
 import { expectODataError } from "../expectODataError.js";
 import { AUDIOBOOK, BOOK_DER_PROZESS, LIBRARY } from "../LibraryTestConstants.js";
 
@@ -234,6 +235,48 @@ describe("ASP.NET Library: cache keys", () => {
     // `buildInvalidates` collapse this route's own (longer) entry as a redundant prefix of that coarser
     // one. Either way `invalidates` still reaches this route, which is what the test title claims
     expect(patched.invalidates!.some((entry) => touchesResource(entry, request.cacheKey!))).toBe(true);
+  });
+
+  test("a read through a subtype's inherited navigated route records the resource it served, so a later direct write to it invalidates that route - the same assertion as above, through the subtype route the base test never reaches", async () => {
+    // `Copies` is declared on `Medium` and inherited by `Book`: before the fix the subtype service's hop
+    // carried no entitySetName/canonicalIdFn, so the copy this response served was never recorded against
+    // this route - the cross-route entry below could never be resolved.
+    // The spec's literal route Media(id).asBookService().Copies() 404s on this server - a cast segment on
+    // a single entity is not served here (pinned in Subtypes.test.ts) - and a to-many list three levels
+    // deep (Publishers(1)/Books(id)/Copies) 404s as well. So the assertion goes through the subtype hop
+    // this server does serve: `Books` addresses the subtype Book without a cast segment.
+    const navigated = await LIBRARY.Publishers(1).Books(BOOK_DER_PROZESS).Copies(copyKey).query().execute();
+    expect(navigated.status).toBe(200);
+    expectTypeOf(navigated).toEqualTypeOf<HttpResponseModel<ODataModelResponseV4<Copy>>>();
+    expect(navigated.data.InventoryNumber).toBe(CACHE_KEY_COPY);
+
+    const patched = await LIBRARY.Copies(copyKey).patch({ Condition: 4 }).ignoreETag().execute();
+    expect(patched.status).toBe(204);
+    expect(patched.invalidates).toEqual(
+      expect.arrayContaining([
+        ["Copies", "detail", copyKey],
+        ["Copies", "list"],
+        ["Publishers", "detail", 1, "Media", "detail", BOOK_DER_PROZESS, "Copies", "detail", copyKey],
+      ]),
+    );
+  });
+
+  test("a write through a subtype's inherited navigated route invalidates the target entity set's bare list - Publishers(1).Books(id).Copies(...)", async () => {
+    // buildInvalidates' own-entity-set rule needs the hop's entitySetName, which the fix is what the
+    // subtype's hop newly carries - without it the write only invalidates what its route itself names
+    const patched = await LIBRARY.Publishers(1)
+      .Books(BOOK_DER_PROZESS)
+      .Copies(copyKey)
+      .patch({ Condition: 5 })
+      .ignoreETag()
+      .execute();
+    expect(patched.status).toBe(204);
+    expect(patched.invalidates).toEqual(
+      expect.arrayContaining([
+        ["Copies", "detail", copyKey],
+        ["Copies", "list"],
+      ]),
+    );
   });
 
   test("grade B: /Members(...)/Loans names itself by the navigation property", async () => {

--- a/int-test/config-variants/test/variants.type-test.ts
+++ b/int-test/config-variants/test/variants.type-test.ts
@@ -13,6 +13,7 @@ import type {
   EditableAudiobookChapter as CompositionEditableAudiobookChapter,
   EditableBook as CompositionEditableBook,
 } from "../src-generated/deep-insert-composition/library-catalog/index.js";
+import type { CopyId as CompositionCopyId } from "../src-generated/deep-insert-composition/library-circulation/index.js";
 import type { PublisherId as CompositionPublisherId } from "../src-generated/deep-insert-composition/publisher-registry/index.js";
 import type { Amenities as NumericAmenities } from "../src-generated/enum-numeric/library-catalog/index.js";
 import type { Branch as NumericBranch } from "../src-generated/enum-numeric/library-circulation/index.js";
@@ -169,9 +170,15 @@ expectTypeOf<AllComputedEditableMedium>().not.toHaveProperty("PopularityScore");
 expectTypeOf<CompositionEditableAudiobook["Chapters"]>().toEqualTypeOf<
   Array<CompositionEditableAudiobookChapter> | undefined
 >();
-expectTypeOf<CompositionEditableAudiobook>().not.toHaveProperty("Copies");
+// `Copies` is plain navigation, so under this option it carries no deep insert; its binding (declared
+// for `Medium`, inherited by the subtypes) shows as the binding-reference shape only
+expectTypeOf<CompositionEditableAudiobook["Copies"]>().toEqualTypeOf<
+  Array<{ "@id": CompositionCopyId | string }> | undefined
+>();
 // nothing is contained anywhere else, so no editable model offers a deep insert at all
-expectTypeOf<CompositionEditableBook>().not.toHaveProperty("Copies");
+expectTypeOf<CompositionEditableBook["Copies"]>().toEqualTypeOf<
+  Array<{ "@id": CompositionCopyId | string }> | undefined
+>();
 // `Publisher` sits on `Book` only, reached via a cast-qualified binding path
 // (`Library.Catalog.Book/Publisher`) - resolving it needs DataModel.getNavPropBindingTarget to walk a
 // multi-segment path, so it keeps its binding-reference shape here exactly like CapEditableBooks["Publisher"]

--- a/packages/odata2ts/src/data-model/DataModel.ts
+++ b/packages/odata2ts/src/data-model/DataModel.ts
@@ -345,14 +345,15 @@ export class DataModel {
    * derived-type navigation property bound by a cast-qualified path; one reached only by first following a
    * contained collection).
    *
-   * A **plain, single-segment** binding's inherited navigation property is registered for the base type
-   * declaring it as well, since that is the model the property is generated into - `collectTypeHierarchy`
-   * climbs from the binding's own owning entity type toward its ancestors for this. A **multi-segment**
-   * path's resolved owner is registered for that type alone, deliberately without climbing any further:
-   * the walk in {@link resolveNavPropBindingPathOwner} can land on a type *below* the binding's own owning
-   * entity type (a cast to a subtype, or a hop to an unrelated type), and climbing from there would credit
-   * an ancestor with a property only the resolved subtype actually declares - e.g. a cast-qualified binding
-   * for a subtype-only navigation property must never resolve for that subtype's own base type.
+   * Each binding is registered under the type it is actually declared for - the set's own entity type for a
+   * plain, single-segment path; the type the final segment is declared on for a multi-segment path - and
+   * nothing else. The lookup does the hierarchy work instead: it walks the queried type's own ancestor
+   * chain, most derived first, and takes the first hit. A binding declared for a base type therefore
+   * serves every subtype - the navigation property is inherited, and the subtype's service needs the
+   * target exactly as the base type's does - while a subtype's own binding still wins over an inherited
+   * one, because its own type is tried first. A type that neither declares nor inherits a resolved
+   * binding gets none: an ancestor never borrows a more-derived set's target, since the binding is
+   * declared per entity set and the ancestor's own set is the only authority for its type.
    */
   public getNavPropBindingTarget(fqEntityTypeName: string, navPropOdataName: string): EntitySetType | undefined {
     if (!this.navPropBindings) {
@@ -368,10 +369,10 @@ export class DataModel {
         for (const { path, target } of source.navPropBinding ?? []) {
           const segments = path.split("/");
           const propName = segments[segments.length - 1];
-          const isMultiSegment = segments.length > 1;
-          const owner = isMultiSegment
-            ? this.resolveNavPropBindingPathOwner(source.entityType, segments.slice(0, -1))
-            : source.entityType;
+          const owner =
+            segments.length > 1
+              ? this.resolveNavPropBindingPathOwner(source.entityType, segments.slice(0, -1))
+              : source.entityType;
           if (!owner) {
             continue;
           }
@@ -382,18 +383,24 @@ export class DataModel {
             continue;
           }
 
-          const owningTypes = isMultiSegment ? [owner.fqName] : this.collectTypeHierarchy(owner);
-          for (const owningType of owningTypes) {
-            const key = `${owningType}|${propName}`;
-            if (!this.navPropBindings.has(key)) {
-              this.navPropBindings.set(key, targetSet);
-            }
+          const key = `${owner.fqName}|${propName}`;
+          if (!this.navPropBindings.has(key)) {
+            this.navPropBindings.set(key, targetSet);
           }
         }
       }
     }
 
-    return this.navPropBindings.get(`${fqEntityTypeName}|${navPropOdataName}`);
+    // an unknown type has no chain to walk: the direct lookup is all that can be tried
+    const queriedType = this.getEntityType(fqEntityTypeName);
+    const lookupChain = queriedType ? this.collectTypeHierarchy(queriedType) : [fqEntityTypeName];
+    for (const typeFqName of lookupChain) {
+      const hit = this.navPropBindings.get(`${typeFqName}|${navPropOdataName}`);
+      if (hit) {
+        return hit;
+      }
+    }
+    return undefined;
   }
 
   /**
@@ -444,7 +451,9 @@ export class DataModel {
   }
 
   /**
-   * The fully qualified names of an entity type and of all its base types.
+   * The fully qualified names of an entity type and of all its base types, most derived first - the order
+   * {@link getNavPropBindingTarget} relies on, so a type's own binding is always tried before any
+   * inherited one.
    */
   private collectTypeHierarchy(entityType: EntityType): Array<string> {
     const result: Array<string> = [];

--- a/packages/odata2ts/test/data-model/DataModel.test.ts
+++ b/packages/odata2ts/test/data-model/DataModel.test.ts
@@ -444,6 +444,87 @@ describe("Data Model Tests", function () {
 
       expect(dataModel.getNavPropBindingTarget(`${NS1}.Nonexistent`, "Publisher")).toBeUndefined();
     });
+
+    test("a single-segment binding declared for the base type resolves for every subtype - the inherited navigation property", () => {
+      // mirrors int-test/asp-net: the `Media` set (type `Medium`) binds `Copies`, while `Book` <-
+      // `PrintMedium` <- `Medium` all inherit the property only. The lookup must walk the queried type's
+      // own ancestor chain, or a subtype service's hop comes out without entitySetName/canonicalIdFn.
+      const medium = { fqName: `${NS1}.Medium`, baseClasses: [], props: [], baseProps: [] };
+      const printMedium = { fqName: `${NS1}.PrintMedium`, baseClasses: [`${NS1}.Medium`], props: [], baseProps: [] };
+      const book = { fqName: `${NS1}.Book`, baseClasses: [`${NS1}.PrintMedium`], props: [], baseProps: [] };
+      dataModel.addEntityType(
+        NS1,
+        "Medium",
+        // @ts-expect-error
+        medium,
+      );
+      dataModel.addEntityType(
+        NS1,
+        "PrintMedium",
+        // @ts-expect-error
+        printMedium,
+      );
+      dataModel.addEntityType(
+        NS1,
+        "Book",
+        // @ts-expect-error
+        book,
+      );
+      addEntitySet("Copies", { fqName: `${NS1}.Copy` }, []);
+      addEntitySet("Media", medium, [{ path: "Copies", target: "Copies" }]);
+
+      expect(dataModel.getNavPropBindingTarget(`${NS1}.Medium`, "Copies")?.odataName).toBe("Copies");
+      expect(dataModel.getNavPropBindingTarget(`${NS1}.PrintMedium`, "Copies")?.odataName).toBe("Copies");
+      expect(dataModel.getNavPropBindingTarget(`${NS1}.Book`, "Copies")?.odataName).toBe("Copies");
+    });
+
+    test("a subtype's own binding wins over the one inherited from its base type", () => {
+      const medium = { fqName: `${NS1}.Medium`, baseClasses: [], props: [], baseProps: [] };
+      const book = { fqName: `${NS1}.Book`, baseClasses: [`${NS1}.Medium`], props: [], baseProps: [] };
+      dataModel.addEntityType(
+        NS1,
+        "Medium",
+        // @ts-expect-error
+        medium,
+      );
+      dataModel.addEntityType(
+        NS1,
+        "Book",
+        // @ts-expect-error
+        book,
+      );
+      addEntitySet("MediumCopies", { fqName: `${NS1}.Copy` }, []);
+      addEntitySet("BookCopies", { fqName: `${NS1}.Copy` }, []);
+      addEntitySet("Media", medium, [{ path: "Copies", target: "MediumCopies" }]);
+      addEntitySet("Books", book, [{ path: "Copies", target: "BookCopies" }]);
+
+      expect(dataModel.getNavPropBindingTarget(`${NS1}.Book`, "Copies")?.odataName).toBe("BookCopies");
+      expect(dataModel.getNavPropBindingTarget(`${NS1}.Medium`, "Copies")?.odataName).toBe("MediumCopies");
+    });
+
+    test("an ancestor that does not bind the property itself does not borrow a derived set's target", () => {
+      // a set's binding serves its own type and its subtypes - never an ancestor's: the binding is
+      // declared per entity set, and the ancestor's own set is the only authority for its type
+      const baseMedium = { fqName: `${NS1}.BaseMedium`, baseClasses: [], props: [], baseProps: [] };
+      const medium = { fqName: `${NS1}.Medium`, baseClasses: [`${NS1}.BaseMedium`], props: [], baseProps: [] };
+      dataModel.addEntityType(
+        NS1,
+        "BaseMedium",
+        // @ts-expect-error
+        baseMedium,
+      );
+      dataModel.addEntityType(
+        NS1,
+        "Medium",
+        // @ts-expect-error
+        medium,
+      );
+      addEntitySet("Copies", { fqName: `${NS1}.Copy` }, []);
+      addEntitySet("Media", medium, [{ path: "Copies", target: "Copies" }]);
+
+      expect(dataModel.getNavPropBindingTarget(`${NS1}.Medium`, "Copies")?.odataName).toBe("Copies");
+      expect(dataModel.getNavPropBindingTarget(`${NS1}.BaseMedium`, "Copies")).toBeUndefined();
+    });
   });
 
   describe("getDisplayFqName", () => {


### PR DESCRIPTION
- A navigation binding declared for a base type (e.g. `Medium`'s `Copies`) now resolves for every subtype: `getNavPropBindingTarget` walks the queried type's ancestor chain, most derived first, instead of a single exact-name lookup; a subtype's own binding still wins over the inherited one.
- Generated subtype services (the nine ASP.NET `Book`/`PrintMedium`/… services) now carry the inherited hop's `entitySetName` and `canonicalIdFn`, restoring deterministic `invalidates` and response-observed identity; the subtype editable models likewise regain the inherited `Copies` binding in its `"@id"` reference shape (pinned in the config-variants type test); Olingo V2, CAP and Trippin output is unchanged.
- Int-test (asp-net): two new cache-key tests cover the inherited route end to end through `Publishers(1).Books(id).Copies(key)`; the literal cast route `Media(id).asBookService().Copies()` is not served by the reference server (pinned in `Subtypes.test.ts`).