### PR TITLE
fix(odata2ts): stop rooting a plain unbound action's cache key

### DIFF
--- a/packages/odata2ts/src/generator/ServiceGenerator.ts
+++ b/packages/odata2ts/src/generator/ServiceGenerator.ts
@@ -264,9 +264,17 @@ class ServiceGenerator {
       return "";
     }
 
+    const isFunc = op.type === OperationTypes.Function;
     const entitySet = entitySetOdataName
       ? Object.values(this.dataModel.getEntityContainer().entitySets).find((es) => es.odataName === entitySetOdataName)
       : undefined;
+    // an action with no declared result EntitySet is never cached under any key - it is always a write, so
+    // rooting it here would only ever feed a bogus, unmatchable invalidates entry (see the operation-keys
+    // spec, Part 1). A function keeps its root even without an EntitySet: unlike an action it defaults to
+    // GET, so its own root is a real, used cacheKey.
+    if (!isFunc && !entitySet) {
+      return "";
+    }
     const rootStateFn = imports.addServiceFunction("rootState");
     const kind = op.returnType?.isCollection ? "list" : "detail";
     const cacheKeyName = this.namespacedName(op.fqName, importOdataName);

--- a/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
+++ b/packages/odata2ts/test/generator/v4/ServiceGenerator.test.ts
@@ -272,7 +272,9 @@ describe("Service Generator Tests V4", () => {
         .addFunction("newReleases", `Collection(${withNs("Medium")})`, false)
         .addFunctionImport("NewReleases", withNs("newReleases"), "Media")
         .addFunction("totalCount", ODataTypesV4.Int32, false)
-        .addFunctionImport("TotalCount", withNs("totalCount"));
+        .addFunctionImport("TotalCount", withNs("totalCount"))
+        .addAction("ping", undefined, false)
+        .addActionImport("Ping", withNs("ping"));
     }
 
     async function generateWith(enabled: boolean) {
@@ -341,6 +343,10 @@ describe("Service Generator Tests V4", () => {
       );
       // unbound function with no EntitySet: rooted at its own import name too, no sentinel needed
       expect(text).toContain(`rootState("TotalCount", "detail")`);
+      // unbound action with no declared EntitySet: no cache key at all. An action is always a write, so
+      // nothing is ever stored under this name - unlike a function, rooting it here would only ever feed
+      // a bogus invalidates entry that can never match anything (see the operation-keys spec, Part 1)
+      expect(text).not.toContain(`rootState("Ping"`);
       expect(text).not.toContain("OPERATION_ROOT");
       // no generated nav-hops table anywhere - removed along with type-rooted identity
       expect(text).not.toContain("CacheKeyNavHops");
@@ -411,6 +417,9 @@ describe("Service Generator Tests V4", () => {
       );
       // unbound function with no EntitySet: the import's own root name is still prefixed
       expect(text).toContain(`rootState("Tester.TotalCount", "detail")`);
+      // unbound action with no EntitySet: still no cache key at all, namespaced or not
+      expect(text).not.toContain(`rootState("Ping"`);
+      expect(text).not.toContain(`rootState("Tester.Ping"`);
       // the cast and bound-operation literals are untouched by this option - they already carry their own
       // namespace unconditionally (the existing namespace.alias feature), with nothing new to add
       expect(text).toContain(`withParams(cacheKeyState, { cast: "${withNs("Book")}" })`);


### PR DESCRIPTION
## Summary

An unbound action with no declared result `EntitySet` is always a write, so nothing is ever cached under its `rootState`-derived key - but `emitUnboundOperationRootExpr` emitted one unconditionally anyway, feeding `buildInvalidates` a bogus, permanently-unmatchable entry into every such action's `invalidates` array. Reported by zinserjan in #536.

- An unbound action with no declared result EntitySet now emits no cache-key root at all.
- A function keeps its root unconditionally - it defaults to GET, so its root is a real, used `cacheKey`.
- An action that *does* declare a result EntitySet is unaffected: the existing `entitySetName`/`canonicalIdFn`/`qEntityFn` branch still fires, so `ResourceIdentityHandler` still records the entities such an action's response carries.

This is Part 1 of `spec/odata2ts-cache-key-operation-keys.md` (workspace-root repo), implemented as remedy (2) from that spec's two offered options. Part 2 (an opt-in cache key for actions, configurable cross-entity-set dependencies) is out of scope here - tracked as a separate decision in that same spec.

## Test plan

- [x] New test: an unbound action import with no result EntitySet emits no `rootState`/`cacheKeyState` at all (unnamespaced and namespaced variants).
- [x] Existing coverage confirms a function without a result EntitySet (`TotalCount`) is unaffected.
- [x] Full workspace test suite green (`yarn test`): 2193 tests passed across all four packages.
- [x] `yarn check-format` and `tsc --noEmit` clean.
- [x] Docker-based integration suites (asp-net/cap/olingo-v2) intentionally not run - none of their schemas declare an unbound action with no result set, so this code path is unreachable by those fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4jQzcdhZhGL4FkGXWGtCR