### PR TITLE
refactor(odata-service): collapse the cache-key re-derivations into ServiceStateHelper

### DIFF
--- a/packages/odata-service/src/ServiceStateHelper.ts
+++ b/packages/odata-service/src/ServiceStateHelper.ts
@@ -1,6 +1,6 @@
 import { ODataHttpClient } from "@odata2ts/http-client-api";
 import { ODataVersionV4 } from "@odata2ts/odata-core";
-import { CacheKeyState } from "./cacheKey/index.js";
+import { buildDeepEditHops, CacheKeyState, withParams } from "./cacheKey/index.js";
 import { ODataServiceOptionsInternal } from "./ODataServiceOptions";
 import { BIG_NUMBERS_HEADERS, DEFAULT_HEADERS, getODataVersionHeaders } from "./RequestHeaders.js";
 
@@ -15,8 +15,9 @@ export class ServiceStateHelper<V extends ODataVersionV4 = "4.0"> {
     /**
      * What resource this service addresses, in the form a cache key is built from.
      *
-     * Stored verbatim; nothing is computed from it here, and it is never derived from `name` or `path`:
-     * `name` for a `byId`-created service is the rendered key predicate, which must not appear in a key.
+     * Stored verbatim and never derived from `name` or `path`: `name` for a `byId`-created service is the
+     * rendered key predicate, which must not appear in a key. This helper owns the derivations the services
+     * used to repeat ({@link getEntitySetName}, {@link writeStateFor}).
      */
     public readonly cacheKeyState?: CacheKeyState,
   ) {
@@ -59,4 +60,25 @@ export class ServiceStateHelper<V extends ODataVersionV4 = "4.0"> {
   public isConcurrencyControlled = () => {
     return !!this.options.concurrencyControlled;
   };
+
+  /** The entity set this resource belongs to, by its own name - absent for a contained entity, a complex value, or a singleton. */
+  public getEntitySetName(): string | undefined {
+    return this.cacheKeyState?.entitySetName;
+  }
+
+  /**
+   * The state a write should carry: this service's own, plus whatever entity sets the given model
+   * deep-inserts into.
+   *
+   * The deep-inserted sets only ever feed `invalidates` - see {@link buildDeepEditHops} for what counts as
+   * a deep insertion and why a binding does not.
+   */
+  public writeStateFor(model: unknown): CacheKeyState | undefined {
+    const state = this.cacheKeyState;
+    if (!state) {
+      return undefined;
+    }
+    const deepEditHops = buildDeepEditHops(state.qEntityFn, model);
+    return deepEditHops ? withParams(state, { deepEdit: deepEditHops }) : state;
+  }
 }

--- a/packages/odata-service/src/StreamServiceBase.ts
+++ b/packages/odata-service/src/StreamServiceBase.ts
@@ -40,7 +40,7 @@ export abstract class StreamServiceBase<V extends ODataVersionV4 = "4.0"> {
 
   /** The entity set this resource belongs to, by its own name - absent for a contained entity, a complex value, or a singleton. */
   public getEntitySetName() {
-    return this.__base.cacheKeyState?.entitySetName;
+    return this.__base.getEntitySetName();
   }
 
   /**

--- a/packages/odata-service/src/v2/CollectionServiceV2.ts
+++ b/packages/odata-service/src/v2/CollectionServiceV2.ts
@@ -40,7 +40,7 @@ export class CollectionServiceV2<
 
   /** The entity set this resource belongs to, by its own name - absent for a contained entity, a complex value, or a singleton. */
   public getEntitySetName() {
-    return this.__base.cacheKeyState?.entitySetName;
+    return this.__base.getEntitySetName();
   }
 
   /**

--- a/packages/odata-service/src/v2/ComplexTypeServiceV2.ts
+++ b/packages/odata-service/src/v2/ComplexTypeServiceV2.ts
@@ -34,7 +34,7 @@ export class ComplexTypeServiceV2<T, UpdatableT, Q extends QueryObjectModel, AsV
 
   /** The entity set this resource belongs to, by its own name - absent for a contained entity, a complex value, or a singleton. */
   public getEntitySetName() {
-    return this.__base.cacheKeyState?.entitySetName;
+    return this.__base.getEntitySetName();
   }
 
   public patch(model: Partial<UpdatableT>, queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void) {

--- a/packages/odata-service/src/v2/EntitySetServiceV2.ts
+++ b/packages/odata-service/src/v2/EntitySetServiceV2.ts
@@ -12,7 +12,7 @@ import {
   QId,
   QueryObjectModel,
 } from "@odata2ts/odata-query-objects";
-import { buildDeepEditHops, CacheKeyState, withKey, withParams } from "../cacheKey/index.js";
+import { CacheKeyState, withKey } from "../cacheKey/index.js";
 import { getBodyETagV2, getBodyETagV4 } from "../ETagExtraction.js";
 import { ODataServiceOptionsInternalV2 } from "../ODataServiceOptions";
 import { ref } from "../ref.js";
@@ -55,7 +55,7 @@ export abstract class EntitySetServiceV2<
 
   /** The entity set this resource belongs to, by its own name - absent for a contained entity, a complex value, or a singleton. */
   public getEntitySetName() {
-    return this.__base.cacheKeyState?.entitySetName;
+    return this.__base.getEntitySetName();
   }
 
   /**
@@ -206,12 +206,10 @@ export abstract class EntitySetServiceV2<
   }
 
   public create(model: EditableT, queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void) {
-    const { client, qModel, getDefaultHeaders, createModelQueryBuilder, cacheKeyState } = this.__base;
+    const { client, qModel, getDefaultHeaders, createModelQueryBuilder } = this.__base;
     const builder = createModelQueryBuilder(queryFn);
 
-    const deepEditHops = cacheKeyState && buildDeepEditHops(cacheKeyState.qEntityFn, model);
-    const stateForRequest =
-      deepEditHops && cacheKeyState ? withParams(cacheKeyState, { deepEdit: deepEditHops }) : cacheKeyState;
+    const stateForRequest = this.__base.writeStateFor(model);
 
     return new UrlBuilderRequestCmdV2<
       AsV4 extends true ? ODataModelResponseV4<T> : ODataEntityModelResponseV2<T>,

--- a/packages/odata-service/src/v2/EntityTypeServiceV2.ts
+++ b/packages/odata-service/src/v2/EntityTypeServiceV2.ts
@@ -2,7 +2,7 @@ import { ODataHttpClient, ODataHttpMethods } from "@odata2ts/http-client-api";
 import { ODataEntityModelResponseV2, ODataModelResponseV4 } from "@odata2ts/odata-core";
 import { ModelQueryBuilderV2 } from "@odata2ts/odata-query-builder";
 import { EntityResponseConverterV2, QueryObjectModel } from "@odata2ts/odata-query-objects";
-import { buildDeepEditHops, CacheKeyState, withParams } from "../cacheKey/index.js";
+import { CacheKeyState } from "../cacheKey/index.js";
 import { ODataServiceOptionsInternalV2 } from "../ODataServiceOptions";
 import { UrlBuilderRequestCmdV2, UrlBuilderWriteRequestCmdV2, UrlWriteRequestCmd } from "../request";
 import { MERGE_HEADERS } from "../RequestHeaders.js";
@@ -34,7 +34,7 @@ export class EntityTypeServiceV2<T, UpdatableT, Q extends QueryObjectModel, AsV4
 
   /** The entity set this resource belongs to, by its own name - absent for a contained entity, a complex value, or a singleton. */
   public getEntitySetName() {
-    return this.__base.cacheKeyState?.entitySetName;
+    return this.__base.getEntitySetName();
   }
 
   /**
@@ -47,14 +47,11 @@ export class EntityTypeServiceV2<T, UpdatableT, Q extends QueryObjectModel, AsV4
    * @param model
    */
   public patch(model: Partial<UpdatableT>, queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void) {
-    const { client, qModel, getDefaultHeaders, createModelQueryBuilder, getConcurrencyOptions, cacheKeyState } =
-      this.__base;
+    const { client, qModel, getDefaultHeaders, createModelQueryBuilder, getConcurrencyOptions } = this.__base;
     // the If-Match header rides alongside the X-Http-Method one: a V2 patch travels as MERGE
     const headers = { ...getDefaultHeaders(), ...MERGE_HEADERS };
 
-    const deepEditHops = cacheKeyState && buildDeepEditHops(cacheKeyState.qEntityFn, model);
-    const stateForRequest =
-      deepEditHops && cacheKeyState ? withParams(cacheKeyState, { deepEdit: deepEditHops }) : cacheKeyState;
+    const stateForRequest = this.__base.writeStateFor(model);
 
     return new UrlBuilderWriteRequestCmdV2<undefined, Q, ModelQueryBuilderV2<Q>, Partial<UpdatableT>>(
       client,
@@ -80,12 +77,9 @@ export class EntityTypeServiceV2<T, UpdatableT, Q extends QueryObjectModel, AsV4
    * @param model
    */
   public update(model: UpdatableT, queryFn?: (builder: ModelQueryBuilderV2<Q>, qObject: Q) => void) {
-    const { client, qModel, getDefaultHeaders, createModelQueryBuilder, getConcurrencyOptions, cacheKeyState } =
-      this.__base;
+    const { client, qModel, getDefaultHeaders, createModelQueryBuilder, getConcurrencyOptions } = this.__base;
 
-    const deepEditHops = cacheKeyState && buildDeepEditHops(cacheKeyState.qEntityFn, model);
-    const stateForRequest =
-      deepEditHops && cacheKeyState ? withParams(cacheKeyState, { deepEdit: deepEditHops }) : cacheKeyState;
+    const stateForRequest = this.__base.writeStateFor(model);
 
     return new UrlBuilderWriteRequestCmdV2<undefined, Q, ModelQueryBuilderV2<Q>, UpdatableT>(
       client,

--- a/packages/odata-service/src/v2/PrimitiveTypeServiceV2.ts
+++ b/packages/odata-service/src/v2/PrimitiveTypeServiceV2.ts
@@ -69,7 +69,7 @@ export class PrimitiveTypeServiceV2<T, AsV4 extends boolean = false> {
 
   /** The entity set this resource belongs to, by its own name - absent for a contained entity, a complex value, or a singleton. */
   public getEntitySetName() {
-    return this.__base.cacheKeyState?.entitySetName;
+    return this.__base.getEntitySetName();
   }
 
   /**

--- a/packages/odata-service/src/v4/CollectionServiceV4.ts
+++ b/packages/odata-service/src/v4/CollectionServiceV4.ts
@@ -56,7 +56,7 @@ export class CollectionServiceV4<
 
   /** The entity set this resource belongs to, by its own name - absent for a contained entity, a complex value, or a singleton. */
   public getEntitySetName() {
-    return this.__base.cacheKeyState?.entitySetName;
+    return this.__base.getEntitySetName();
   }
 
   /**

--- a/packages/odata-service/src/v4/EntitySetServiceV4.ts
+++ b/packages/odata-service/src/v4/EntitySetServiceV4.ts
@@ -7,7 +7,7 @@ import {
   QId,
   QueryObjectModel,
 } from "@odata2ts/odata-query-objects";
-import { buildDeepEditHops, CacheKeyState, withKey, withParams } from "../cacheKey/index.js";
+import { CacheKeyState, withKey } from "../cacheKey/index.js";
 import { getBodyETagV4 } from "../ETagExtraction.js";
 import { ODataServiceOptionsInternal } from "../ODataServiceOptions";
 import { ref } from "../ref.js";
@@ -63,7 +63,7 @@ export abstract class EntitySetServiceV4<
 
   /** The entity set this resource belongs to, by its own name - absent for a contained entity, a complex value, or a singleton. */
   public getEntitySetName() {
-    return this.__base.cacheKeyState?.entitySetName;
+    return this.__base.getEntitySetName();
   }
 
   /**
@@ -254,25 +254,15 @@ export abstract class EntitySetServiceV4<
     createOptions?: SubtypeOptions,
     queryFn?: (builder: ModelQueryBuilderV4<Q>, qObject: Q) => void,
   ) {
-    const {
-      client,
-      basePath,
-      path,
-      getDefaultHeaders,
-      getVersionHeaders,
-      qModel,
-      createModelQueryBuilder,
-      cacheKeyState,
-    } = this.__base;
+    const { client, basePath, path, getDefaultHeaders, getVersionHeaders, qModel, createModelQueryBuilder } =
+      this.__base;
     const { dontUseCastPathSegment, useTypeCi } = this.__base.evaluateSubtypeOptions(createOptions);
 
     // add control info automatically, if required
     const data = useTypeCi ? this.__base.addTypeControlInfo(model) : model;
     const actualPath = dontUseCastPathSegment ? basePath : path;
 
-    const deepEditHops = cacheKeyState && buildDeepEditHops(cacheKeyState.qEntityFn, model);
-    const stateForRequest =
-      deepEditHops && cacheKeyState ? withParams(cacheKeyState, { deepEdit: deepEditHops }) : cacheKeyState;
+    const stateForRequest = this.__base.writeStateFor(model);
 
     return new UrlBuilderRequestCmdV4<
       EntityModificationResponseV4<Response, T, V>,

--- a/packages/odata-service/src/v4/EntityTypeServiceV4.ts
+++ b/packages/odata-service/src/v4/EntityTypeServiceV4.ts
@@ -2,7 +2,7 @@ import { ODataHttpClient, ODataHttpMethods } from "@odata2ts/http-client-api";
 import { ODataModelPayloadFor, ODataModelResponseFor, ODataVersionV4 } from "@odata2ts/odata-core";
 import { ModelQueryBuilderV4 } from "@odata2ts/odata-query-builder";
 import { ModelResponseConverterV4, QueryObjectModel } from "@odata2ts/odata-query-objects";
-import { buildDeepEditHops, CacheKeyState, withParams } from "../cacheKey/index.js";
+import { CacheKeyState } from "../cacheKey/index.js";
 import { ODataServiceOptionsInternal } from "../ODataServiceOptions";
 import { UrlBuilderRequestCmdV4, UrlBuilderWriteRequestCmdV4, UrlWriteRequestCmd } from "../request";
 import { EntityModificationResponseV4 } from "./ResponseTypeChoicesV4";
@@ -34,7 +34,7 @@ export class EntityTypeServiceV4<T, UpdatableT, Q extends QueryObjectModel, V ex
 
   /** The entity set this resource belongs to, by its own name - absent for a contained entity, a complex value, or a singleton. */
   public getEntitySetName() {
-    return this.__base.cacheKeyState?.entitySetName;
+    return this.__base.getEntitySetName();
   }
 
   /**
@@ -67,7 +67,6 @@ export class EntityTypeServiceV4<T, UpdatableT, Q extends QueryObjectModel, V ex
       getVersionHeaders,
       createModelQueryBuilder,
       getConcurrencyOptions,
-      cacheKeyState,
     } = this.__base;
     const { dontUseCastPathSegment, useTypeCi } = this.__base.evaluateSubtypeOptions(patchOptions);
 
@@ -76,9 +75,7 @@ export class EntityTypeServiceV4<T, UpdatableT, Q extends QueryObjectModel, V ex
     const actualPath = dontUseCastPathSegment ? basePath : path;
     const builder = createModelQueryBuilder(queryFn, actualPath);
 
-    const deepEditHops = cacheKeyState && buildDeepEditHops(cacheKeyState.qEntityFn, model);
-    const stateForRequest =
-      deepEditHops && cacheKeyState ? withParams(cacheKeyState, { deepEdit: deepEditHops }) : cacheKeyState;
+    const stateForRequest = this.__base.writeStateFor(model);
 
     return new UrlBuilderWriteRequestCmdV4<
       EntityModificationResponseV4<Response, T, V>,
@@ -124,7 +121,6 @@ export class EntityTypeServiceV4<T, UpdatableT, Q extends QueryObjectModel, V ex
       qModel,
       createModelQueryBuilder,
       getConcurrencyOptions,
-      cacheKeyState,
     } = this.__base;
     const { dontUseCastPathSegment, useTypeCi } = this.__base.evaluateSubtypeOptions(updateOptions);
 
@@ -132,9 +128,7 @@ export class EntityTypeServiceV4<T, UpdatableT, Q extends QueryObjectModel, V ex
     const data = useTypeCi ? this.__base.addTypeControlInfo(model) : model;
     const actualPath = dontUseCastPathSegment ? basePath : path;
 
-    const deepEditHops = cacheKeyState && buildDeepEditHops(cacheKeyState.qEntityFn, model);
-    const stateForRequest =
-      deepEditHops && cacheKeyState ? withParams(cacheKeyState, { deepEdit: deepEditHops }) : cacheKeyState;
+    const stateForRequest = this.__base.writeStateFor(model);
 
     return new UrlBuilderWriteRequestCmdV4<
       EntityModificationResponseV4<Response, T, V>,

--- a/packages/odata-service/src/v4/PrimitiveTypeServiceV4.ts
+++ b/packages/odata-service/src/v4/PrimitiveTypeServiceV4.ts
@@ -45,7 +45,7 @@ export class PrimitiveTypeServiceV4<T, V extends ODataVersionV4 = "4.0"> {
 
   /** The entity set this resource belongs to, by its own name - absent for a contained entity, a complex value, or a singleton. */
   public getEntitySetName() {
-    return this.__base.cacheKeyState?.entitySetName;
+    return this.__base.getEntitySetName();
   }
 
   /**


### PR DESCRIPTION
- ServiceStateHelper now owns the two cache-key derivations the services repeated by hand: getEntitySetName() (previously the same one-liner in ten service classes) and writeStateFor(model) (previously six verbatim copies of the buildDeepEditHops + withParams deep-edit block); the ten public getEntitySetName methods delegate to it.
- buildDeepEditHops is imported in exactly one place outside cacheKey/, and the fiddly double null-guard is gone.
- No behaviour, generated-output or test changes: constructor signatures are untouched (the generator emits them), generator snapshots are byte-identical, and the full unit suite plus all five int-test suites pass.
- The sketched requestOptions(extra) helper was left out deliberately: across the request-options literals the only field common to every one is cacheKeyState itself - headers, concurrency and converters differ per method, and the state helper cannot know the per-method response/data structures the literals are typed for.