### PR TITLE
refactor: move the cache-key walk and query-param fold into the modules that own them

### DIFF
--- a/packages/odata-query-objects/src/index.ts
+++ b/packages/odata-query-objects/src/index.ts
@@ -55,6 +55,8 @@ export { QFlatComplexPath } from "./path/QFlatComplexPath";
 export { QComplexCollectionPath } from "./path/QComplexCollectionPath";
 export { QEntityPath } from "./path/QEntityPath";
 export { QEntityCollectionPath } from "./path/QEntityCollectionPath";
+export { walkEntityGraph, type EntityGraphVisit } from "./path/EntityGraphWalk";
+export type { QEntityFn } from "./path/QModelBasePath";
 export { QBinding, type BindingNotation } from "./path/QBinding";
 export * from "./path/QPathModel";
 

--- a/packages/odata-query-objects/src/path/EntityGraphWalk.ts
+++ b/packages/odata-query-objects/src/path/EntityGraphWalk.ts
@@ -1,18 +1,10 @@
-import type { QEntityFn } from "./CacheKeyState";
+import type { QBinding } from "./QBinding";
+import { ENTITY_COLLECTION_PATH_DISCRIMINATOR } from "./QEntityCollectionPath";
+import { ENTITY_PATH_DISCRIMINATOR } from "./QEntityPath";
+import type { QEntityFn } from "./QModelBasePath";
 
-/** The discriminators of a Q-object path wrapper that leads to another entity, as opposed to a complex value or a primitive property/collection - see `QEntityPath`/`QEntityCollectionPath`. */
-const ENTITY_DISCRIMINATORS = new Set(["EntityType", "EntitySet"]);
-
-/**
- * What the walk reads off an entity nav property's QBinding. It is the cache-key name that is read - not
- * the raw URL name: under `cacheKeys.namespace` the generator bakes a prefixed name into the QBinding's
- * cache-key name, and this is what a deep insert's `invalidates` entry must carry to match the same name
- * the write's own `[entitySetName, "list"]` rule registers (issue #536).
- */
-interface EntityBinding {
-  getCacheKeyEntitySetName(): string;
-  buildCanonicalId(entity: unknown): string | undefined;
-}
+/** The discriminators of the Q-object path wrappers that lead to another entity - `QEntityPath`'s and `QEntityCollectionPath`'s own, so a wrapper added there cannot fail to be seen here without touching this package. */
+const ENTITY_DISCRIMINATORS = new Set([ENTITY_PATH_DISCRIMINATOR, ENTITY_COLLECTION_PATH_DISCRIMINATOR]);
 
 /** One entity-shaped value found while walking a data object alongside its Q-object. */
 export interface EntityGraphVisit {
@@ -64,7 +56,7 @@ export function walkEntityGraph(
   const qEntity = new (qEntityFn())() as unknown as Record<string, unknown>;
   for (const key in qEntity) {
     const prop = qEntity[key] as
-      { discriminator?: string; getEntityFn(): QEntityFn; getBinding?(): EntityBinding | undefined } | undefined;
+      { discriminator?: string; getEntityFn(): QEntityFn; getBinding?(): QBinding<any> | undefined } | undefined;
     if (!prop || typeof prop.discriminator !== "string" || !ENTITY_DISCRIMINATORS.has(prop.discriminator)) {
       continue;
     }
@@ -83,7 +75,7 @@ export function walkEntityGraph(
       }
       if (item && typeof item === "object") {
         visit({
-          // the cache-key name, not the raw URL name - see `EntityBinding`
+          // the cache-key name, not the raw URL name - see `QBinding.getCacheKeyEntitySetName`
           entitySetName: binding?.getCacheKeyEntitySetName(),
           buildCanonicalId: binding && ((entity: unknown) => binding.buildCanonicalId(entity)),
           data: item as Record<string, unknown>,
@@ -95,7 +87,7 @@ export function walkEntityGraph(
   }
 }
 
-/** `{"@id": key}` and nothing else - the editable model's shape for "link an existing entity". */
+/** `{"@id": key}` and nothing else - the editable model's shape for "link an existing entity", i.e. exactly what `QBinding.format` yields for the `4.01` notation. */
 function isBinding(item: unknown): boolean {
   return typeof item === "object" && item !== null && Object.keys(item).length === 1 && "@id" in item;
 }

--- a/packages/odata-query-objects/src/path/QEntityCollectionPath.ts
+++ b/packages/odata-query-objects/src/path/QEntityCollectionPath.ts
@@ -1,6 +1,9 @@
 import { QueryObject } from "../QueryObject";
 import { QModelCollectionBasePath } from "./QModelCollectionBasePath";
 
+/** The discriminator of a Q-object property path that leads to a collection of entities - as opposed to a complex value or a primitive property/collection. */
+export const ENTITY_COLLECTION_PATH_DISCRIMINATOR = "EntitySet";
+
 export class QEntityCollectionPath<Q extends QueryObject> extends QModelCollectionBasePath<Q> {
-  public readonly discriminator = "EntitySet";
+  public readonly discriminator = ENTITY_COLLECTION_PATH_DISCRIMINATOR;
 }

--- a/packages/odata-query-objects/src/path/QEntityPath.ts
+++ b/packages/odata-query-objects/src/path/QEntityPath.ts
@@ -1,6 +1,9 @@
 import { QueryObject } from "../QueryObject";
 import { QModelBasePath } from "./QModelBasePath";
 
+/** The discriminator of a Q-object property path that leads to another single entity - as opposed to a complex value or a primitive property/collection. */
+export const ENTITY_PATH_DISCRIMINATOR = "EntityType";
+
 export class QEntityPath<Q extends QueryObject> extends QModelBasePath<Q> {
-  public readonly discriminator = "EntityType";
+  public readonly discriminator = ENTITY_PATH_DISCRIMINATOR;
 }

--- a/packages/odata-query-objects/src/path/QModelBasePath.ts
+++ b/packages/odata-query-objects/src/path/QModelBasePath.ts
@@ -1,6 +1,14 @@
 import { QueryObject } from "../QueryObject";
+import type { QueryObjectModel } from "../QueryObjectModel";
 import { QBinding } from "./QBinding";
 import { QEntityPathModel } from "./QPathModel";
+
+/**
+ * A factory for a fresh, unprefixed Q-object instance of one entity/complex type - the same shape this
+ * class's own `qEntityFn` constructor argument uses (modulo the specific `Q` it yields), named so a write's
+ * payload or a read's response can be walked for the entities it embeds without any generated lookup table.
+ */
+export type QEntityFn = () => new (prefix?: string, separator?: string) => QueryObjectModel;
 
 export class QModelBasePath<Q extends QueryObject> implements QEntityPathModel<Q> {
   /**

--- a/packages/odata-service/src/cacheKey/BuildDeepEdit.ts
+++ b/packages/odata-service/src/cacheKey/BuildDeepEdit.ts
@@ -1,5 +1,5 @@
+import { walkEntityGraph } from "@odata2ts/odata-query-objects";
 import type { QEntityFn } from "./CacheKeyState";
-import { walkEntityGraph } from "./EntityGraphWalk";
 
 /**
  * The entity sets a write's own payload deep-inserts into, one entry per deep-inserted entity found - never

--- a/packages/odata-service/src/cacheKey/CacheKeyState.ts
+++ b/packages/odata-service/src/cacheKey/CacheKeyState.ts
@@ -1,11 +1,10 @@
 import { UNKNOWN_ID } from "@odata2ts/odata-query-builder";
-import type { QueryObjectModel } from "@odata2ts/odata-query-objects";
+import type { QEntityFn } from "@odata2ts/odata-query-objects";
+
+export type { QEntityFn };
 
 /** Whether a resource is a collection or a single entity / complex value. */
 export type CacheKeyKind = "list" | "detail";
-
-/** A factory for a fresh, unprefixed Q-object instance of one entity/complex type - the same shape a Q-object's own nav-property wrappers already use (`QModelBasePath`'s `qEntityFn`), reused here so a write's payload can be walked without any generated lookup table. */
-export type QEntityFn = () => new (prefix?: string, separator?: string) => QueryObjectModel;
 
 /**
  * Builds the addressed resource's own canonical id - entity-set name plus key predicate, e.g. `Copies(3)`.

--- a/packages/odata-service/src/cacheKey/ObservedIdentity.ts
+++ b/packages/odata-service/src/cacheKey/ObservedIdentity.ts
@@ -1,6 +1,6 @@
 import type { ResourceIdentityHandler } from "@odata2ts/http-client-api";
+import { walkEntityGraph } from "@odata2ts/odata-query-objects";
 import type { CacheKeyState } from "./CacheKeyState";
-import { walkEntityGraph } from "./EntityGraphWalk";
 
 /**
  * Records every entity actually present in a *read's* response body against the request's own hierarchical

--- a/packages/odata-service/src/cacheKey/QueryStringCapture.ts
+++ b/packages/odata-service/src/cacheKey/QueryStringCapture.ts
@@ -86,3 +86,39 @@ export function canonicalizeQueryString(query: string, filter?: string, search?:
   const canonical = params.toString();
   return canonical.length ? canonical : undefined;
 }
+
+/**
+ * The `queryParams` object `buildCacheKey` should receive for one converted request: the builder's own
+ * cache-key params with their `filter`/`search` pulled out and folded into the request's own rendered query
+ * string (`captureQueryString` + `canonicalizeQueryString`) rather than sitting beside it.
+ *
+ * The pull and the strip are one decision spelled in two halves - `filter`/`search` leave the params
+ * object exactly where `STRIPPED_QUERY_OPTIONS` removes the raw text - so they live side by side here,
+ * where their agreement is visible: change one without the other and a filter either double-counts in the
+ * key or disappears from it, silently, with no type error to catch the drift.
+ *
+ * `filter`/`search` are the canonical strings `ODataQueryBuilder.getCacheKeyParams()` computed for this
+ * same request - `undefined` where the query had none - and are only folded in as strings: a value of any
+ * other shape is dropped, mirroring the `string | undefined` the builder actually produces. `query`
+ * itself is dropped again where nothing is left, mirroring "empty entries are dropped" for the rest of the
+ * params object.
+ */
+export function buildCacheKeyQueryParams(
+  method: ODataHttpMethods,
+  url: string,
+  data: unknown,
+  cacheKeyParams: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  const { filter, search, ...restQueryParams } = cacheKeyParams ?? {};
+  const rawQuery = captureQueryString(method, url, data);
+  const query =
+    rawQuery !== undefined
+      ? canonicalizeQueryString(
+          rawQuery,
+          typeof filter === "string" ? filter : undefined,
+          typeof search === "string" ? search : undefined,
+        )
+      : undefined;
+
+  return query !== undefined ? { ...restQueryParams, query } : restQueryParams;
+}

--- a/packages/odata-service/src/cacheKey/index.ts
+++ b/packages/odata-service/src/cacheKey/index.ts
@@ -1,7 +1,6 @@
 export * from "./CacheKeyState";
 export * from "./BuildCacheKey";
 export * from "./BuildDeepEdit";
-export * from "./EntityGraphWalk";
 export * from "./ObservedIdentity";
 export * from "./TouchesResource";
 export * from "./QueryStringCapture";

--- a/packages/odata-service/src/request/RequestCmd.ts
+++ b/packages/odata-service/src/request/RequestCmd.ts
@@ -2,10 +2,9 @@ import { HttpResponseModel, ODataHttpClient, ODataHttpMethods, ODataRequestConfi
 import { MainResponseConverter } from "@odata2ts/odata-query-objects";
 import {
   buildCacheKey,
+  buildCacheKeyQueryParams,
   buildInvalidates,
   CacheKeyState,
-  canonicalizeQueryString,
-  captureQueryString,
   evictObservedIdentity,
   recordObservedIdentities,
   resolveCrossRouteInvalidates,
@@ -153,12 +152,12 @@ export abstract class RequestCmd<
    * constructor, because subclasses overriding it read parameter-property fields TypeScript assigns only
    * after `super()` returns.
    *
-   * The request's own rendered query string is captured off that same converted state, canonicalized (see
-   * `canonicalizeQueryString`) - `ODataQueryBuilder`'s own `filter`/`search` output is folded into that same
-   * opaque string rather than surfaced as separate params-object entries, so `expand`/`select` are the only
-   * two structured entries `queryParams` still contributes as-is - for exactly the same reason
-   * `cacheKeyState` is read post-conversion: `GetToPostConverter` relocates the query string into the body,
-   * and only the converted state has it in the right place (see `QueryStringCapture.ts`).
+   * The request's own rendered query string is captured off that same converted state, and `ODataQueryBuilder`'s
+   * own `filter`/`search` output is folded into that same opaque string rather than surfaced as separate
+   * params-object entries (see `buildCacheKeyQueryParams`) - so `expand`/`select` are the only two structured
+   * entries `queryParams` still contributes as-is - for exactly the same reason `cacheKeyState` is read
+   * post-conversion: `GetToPostConverter` relocates the query string into the body, and only the converted
+   * state has it in the right place (see `QueryStringCapture.ts`).
    *
    * `undefined` also means this client was not generated with `cacheKeys` - which a consuming application
    * has to handle anyway when it is shared across services.
@@ -168,13 +167,7 @@ export abstract class RequestCmd<
       if (this.method === ODataHttpMethods.Get) {
         const info = this.getInfoConverted();
         const state = info.cacheKeyState;
-        const rawQuery = captureQueryString(info.method, info.url, info.data);
-        const { filter, search, ...restQueryParams } = this.options.queryParams ?? {};
-        const query =
-          rawQuery !== undefined
-            ? canonicalizeQueryString(rawQuery, filter as string | undefined, search as string | undefined)
-            : undefined;
-        const queryParams = query !== undefined ? { ...restQueryParams, query } : restQueryParams;
+        const queryParams = buildCacheKeyQueryParams(info.method, info.url, info.data, this.options.queryParams);
         this.cachedCacheKey = state && buildCacheKey(state, queryParams);
       }
       this.cacheKeyComputed = true;


### PR DESCRIPTION
- walkEntityGraph/EntityGraphVisit move from odata-service's cacheKey module into odata-query-objects, next to QBinding and the path wrappers: the walk now uses the real QBinding and the real discriminators (new consts the two entity path wrappers themselves use), instead of a structural re-declaration and a hard-coded Set. QEntityFn moves with it to QModelBasePath and is re-exported from odata-service's CacheKeyState, so no import or definition changes.
- Surface note: walkEntityGraph/EntityGraphVisit are no longer re-exported from @odata2ts/odata-service (internal cache-key wiring - import them from @odata2ts/odata-query-objects).
- The $filter/$search fold that was split across RequestCmd and QueryStringCapture (pull-out + strip list + canonicalize) becomes one buildCacheKeyQueryParams in QueryStringCapture.ts: RequestCmd.cacheKey calls it, destructures nothing, and carries no 'as string' casts; the strip list and the substitution now sit side by side where their agreement is visible.
- No behaviour change: no test changes, STRIPPED_QUERY_OPTIONS (including the deliberate $expand exclusion) untouched, and all unit + int-test suites pass.